### PR TITLE
Update vcpkg to 2022.02.23.

### DIFF
--- a/src/Rendering/include/litefx/rendering.hpp
+++ b/src/Rendering/include/litefx/rendering.hpp
@@ -4,7 +4,6 @@
 #include <litefx/math.hpp>
 #include <litefx/rendering_api.hpp>
 #include <litefx/rendering_formatters.hpp>
-#include <litefx/rendering.hpp>
 
 namespace LiteFX::Rendering {
     using namespace LiteFX;

--- a/src/Rendering/src/convert.cpp
+++ b/src/Rendering/src/convert.cpp
@@ -1,4 +1,5 @@
 #include <litefx/rendering_api.hpp>
+#include <litefx/rendering_formatters.hpp>
 
 using namespace LiteFX::Rendering;
 


### PR DESCRIPTION
This updates vcpkg to the latest release and fixes issues with some updated packages. Namely, *fmt* broke the build, because it was not able to delay binding some types. This was fixed by rearranging the order of including some files.