### PR TITLE
Create Pipeline Layouts from Shader Reflection

### DIFF
--- a/docs/release-logs/0.3.1.md
+++ b/docs/release-logs/0.3.1.md
@@ -8,4 +8,5 @@
 - Backend and device states help to automatically manage resources over multiple backend instances. ([See PR #66](https://github.com/crud89/LiteFX/pull/66))
 - Backends can now be switched at runtime. Samples have been updated to work on both backends, if they are built. ([See PR #66](https://github.com/crud89/LiteFX/pull/66))
 - Pipeline layouts can now be defined using shader reflection. ([See PR #68](https://github.com/crud89/LiteFX/pull/68))
+- It is now possible to initialize a descriptor with a static/immutable sampler state. ([See PR #68](https://github.com/crud89/LiteFX/pull/68))
 - Vulkan 🌋: If the DX12 backend is available, the Vulkan uses an interop swap chain to support flip-model swap effects for lower latencies. ([See PR #66](https://github.com/crud89/LiteFX/pull/66))

--- a/docs/release-logs/0.3.1.md
+++ b/docs/release-logs/0.3.1.md
@@ -7,4 +7,5 @@
   - Child builders use other naming convention for `.go` (`.add`) to improve readability.
 - Backend and device states help to automatically manage resources over multiple backend instances. ([See PR #66](https://github.com/crud89/LiteFX/pull/66))
 - Backends can now be switched at runtime. Samples have been updated to work on both backends, if they are built. ([See PR #66](https://github.com/crud89/LiteFX/pull/66))
-- If the DX12 backend is available, the Vulkan uses an interop swap chain to support flip-model swap effects for lower latencies. ([See PR #66](https://github.com/crud89/LiteFX/pull/66))
+- Pipeline layouts can now be defined using shader reflection. ([See PR #68](https://github.com/crud89/LiteFX/pull/68))
+- Vulkan 🌋: If the DX12 backend is available, the Vulkan uses an interop swap chain to support flip-model swap effects for lower latencies. ([See PR #66](https://github.com/crud89/LiteFX/pull/66))

--- a/docs/tutorials/quick-start.markdown
+++ b/docs/tutorials/quick-start.markdown
@@ -394,7 +394,7 @@ The shader helper attempts to find the *GLSLC* and *DXC* compilers automatically
 
 Using `TARGET_LINK_SHADERS` we setup a dependency for between the shaders and our application, so that the shaders are copied to the build directory properly. Note that by default, the shaders are copied into a `shaders/` subdirectory. You can change this subdirectory by changing the `SHADER_DEFAULT_SUBDIR` variable. Keep in mind to also update the pipeline state definition, if you do change the directory.
 
-For more information on how to use the helpers, refer to the [project wiki](https://github.com/crud89/LiteFX/wiki/Shader-Module-Targets).
+**NOTE:** If you want to learn more about how to write portable shaders, refer to the [shader development guide](https://github.com/crud89/LiteFX/wiki/Shader-Development). For more information on how to use the helpers, refer to the [shader module targets](https://github.com/crud89/LiteFX/wiki/Shader-Module-Targets) page in the project wiki.
 
 ### Creating and Managing Buffers
 

--- a/src/Backends/DirectX12/CMakeLists.txt
+++ b/src/Backends/DirectX12/CMakeLists.txt
@@ -83,7 +83,7 @@ TARGET_INCLUDE_DIRECTORIES(${PROJECT_NAME}
 
 # Link project dependencies.
 TARGET_LINK_LIBRARIES(${PROJECT_NAME}
-    PUBLIC LiteFX.Core LiteFX.Math LiteFX.Rendering LiteFX.AppModel Microsoft::DirectX-Headers Microsoft::DirectX-Guids d3d12 dxcore dxgi d3dcompiler
+    PUBLIC LiteFX.Core LiteFX.Math LiteFX.Rendering LiteFX.AppModel Microsoft::DirectX-Headers Microsoft::DirectX-Guids d3d12 dxcore dxgi dxcompiler
     PRIVATE unofficial::d3d12-memory-allocator
 )
 

--- a/src/Backends/DirectX12/include/litefx/backends/dx12.hpp
+++ b/src/Backends/DirectX12/include/litefx/backends/dx12.hpp
@@ -302,21 +302,6 @@ namespace LiteFX::Rendering::Backends {
 
 		/// <inheritdoc />
 		virtual const ShaderStage& type() const noexcept override;
-
-	public:
-		/// <summary>
-		/// Suppresses the warning that is issued, if no root signature is found on a shader module when calling <see cref="reflectPipelineLayout" />.
-		/// </summary>
-		/// <remarks>
-		/// When a shader program is asked to build a pipeline layout, it first checks if a root signature is provided within the shader bytecode. If no root signature could 
-		/// be found, it falls back to using plain reflection to extract the descriptor sets. This has the drawback, that some features are not or only partially supported.
-		/// Most notably, it is not possible to reflect a pipeline layout that uses push constants this way. To ensure that you are not missing the root signature by accident,
-		/// the engine warns you when it encounters this situation. However, if you are only using plain descriptor sets, this can result in noise warnings that clutter the 
-		/// log. You can call this function to disable the warnings explicitly.
-		/// </remarks>
-		/// <param name="disableWarning"><c>true</c> to stop issuing the warning or <c>false</c> to continue.</param>
-		/// <seealso cref="reflectPipelineLayout" />
-		static void suppressMissingRootSignatureWarning(bool disableWarning = true) noexcept;
 	};
 
 	/// <summary>
@@ -357,6 +342,21 @@ namespace LiteFX::Rendering::Backends {
 		virtual SharedPtr<IPipelineLayout> parsePipelineLayout() const override {
 			return std::static_pointer_cast<IPipelineLayout>(this->reflectPipelineLayout());
 		}
+
+	public:
+		/// <summary>
+		/// Suppresses the warning that is issued, if no root signature is found on a shader module when calling <see cref="reflectPipelineLayout" />.
+		/// </summary>
+		/// <remarks>
+		/// When a shader program is asked to build a pipeline layout, it first checks if a root signature is provided within the shader bytecode. If no root signature could 
+		/// be found, it falls back to using plain reflection to extract the descriptor sets. This has the drawback, that some features are not or only partially supported.
+		/// Most notably, it is not possible to reflect a pipeline layout that uses push constants this way. To ensure that you are not missing the root signature by accident,
+		/// the engine warns you when it encounters this situation. However, if you are only using plain descriptor sets, this can result in noise warnings that clutter the 
+		/// log. You can call this function to disable the warnings explicitly.
+		/// </remarks>
+		/// <param name="disableWarning"><c>true</c> to stop issuing the warning or <c>false</c> to continue.</param>
+		/// <seealso cref="reflectPipelineLayout" />
+		static void suppressMissingRootSignatureWarning(bool disableWarning = true) noexcept;
 	};
 
 	/// <summary>

--- a/src/Backends/DirectX12/include/litefx/backends/dx12.hpp
+++ b/src/Backends/DirectX12/include/litefx/backends/dx12.hpp
@@ -83,65 +83,6 @@ namespace LiteFX::Rendering::Backends {
 	};
 
 	/// <summary>
-	/// Implements a DirectX 12 <see cref="IDescriptorLayout" />
-	/// </summary>
-	/// <seealso cref="IDirectX12Buffer" />
-	/// <seealso cref="IDirectX12Image" />
-	/// <seealso cref="IDirectX12Sampler" />
-	/// <seealso cref="DirectX12DescriptorSet" />
-	/// <seealso cref="DirectX12DescriptorSetLayout" />
-	class LITEFX_DIRECTX12_API DirectX12DescriptorLayout : public IDescriptorLayout {
-		LITEFX_IMPLEMENTATION(DirectX12DescriptorLayoutImpl);
-
-	public:
-		/// <summary>
-		/// Initializes a new DirectX 12 descriptor layout.
-		/// </summary>
-		/// <param name="type">The type of the descriptor.</param>
-		/// <param name="binding">The binding point for the descriptor.</param>
-		/// <param name="elementSize">The size of the descriptor.</param>
-		/// <param name="elementSize">The number of descriptors in the descriptor array.</param>
-		explicit DirectX12DescriptorLayout(const DescriptorType& type, const UInt32& binding, const size_t& elementSize, const UInt32& descriptors = 1);
-
-		/// <summary>
-		/// Initializes a new DirectX 12 descriptor layout for a static sampler.
-		/// </summary>
-		/// <param name="staticSampler">The static sampler to initialize the state with.</param>
-		/// <param name="binding">The binding point for the descriptor.</param>
-		explicit DirectX12DescriptorLayout(UniquePtr<IDirectX12Sampler>&& staticSampler, const UInt32& binding);
-		DirectX12DescriptorLayout(DirectX12DescriptorLayout&&) = delete;
-		DirectX12DescriptorLayout(const DirectX12DescriptorLayout&) = delete;
-		virtual ~DirectX12DescriptorLayout() noexcept;
-
-		// IDescriptorLayout interface.
-	public:
-		/// <inheritdoc />
-		virtual const DescriptorType& descriptorType() const noexcept override;
-
-		/// <inheritdoc />
-		virtual const UInt32& descriptors() const noexcept override;
-
-		// IBufferLayout interface.
-	public:
-		/// <inheritdoc />
-		virtual size_t elementSize() const noexcept override;
-
-		/// <inheritdoc />
-		virtual const UInt32& binding() const noexcept override;
-
-		/// <inheritdoc />
-		virtual const BufferType& type() const noexcept override;
-
-		// DirectX 12 descriptor layout.
-	public:
-		/// <summary>
-		/// If the descriptor describes a static sampler, this method returns the state of the sampler. Otherwise, it returns <c>nullptr</c>.
-		/// </summary>
-		/// <returns>The state of the static sampler, or <c>nullptr</c>, if the descriptor is not a static sampler.</returns>
-		virtual const IDirectX12Sampler* staticSampler() const noexcept;
-	};
-
-	/// <summary>
 	/// Represents the base interface for a DirectX 12 buffer implementation.
 	/// </summary>
 	/// <seealso cref="DirectX12DescriptorSet" />
@@ -413,6 +354,61 @@ namespace LiteFX::Rendering::Backends {
 	};
 
 	/// <summary>
+	/// Implements a DirectX 12 <see cref="IDescriptorLayout" />
+	/// </summary>
+	/// <seealso cref="IDirectX12Buffer" />
+	/// <seealso cref="IDirectX12Image" />
+	/// <seealso cref="IDirectX12Sampler" />
+	/// <seealso cref="DirectX12DescriptorSet" />
+	/// <seealso cref="DirectX12DescriptorSetLayout" />
+	class LITEFX_DIRECTX12_API DirectX12DescriptorLayout : public IDescriptorLayout {
+		LITEFX_IMPLEMENTATION(DirectX12DescriptorLayoutImpl);
+
+	public:
+		/// <summary>
+		/// Initializes a new DirectX 12 descriptor layout.
+		/// </summary>
+		/// <param name="type">The type of the descriptor.</param>
+		/// <param name="binding">The binding point for the descriptor.</param>
+		/// <param name="elementSize">The size of the descriptor.</param>
+		/// <param name="elementSize">The number of descriptors in the descriptor array.</param>
+		explicit DirectX12DescriptorLayout(const DescriptorType& type, const UInt32& binding, const size_t& elementSize, const UInt32& descriptors = 1);
+
+		/// <summary>
+		/// Initializes a new DirectX 12 descriptor layout for a static sampler.
+		/// </summary>
+		/// <param name="staticSampler">The static sampler to initialize the state with.</param>
+		/// <param name="binding">The binding point for the descriptor.</param>
+		explicit DirectX12DescriptorLayout(UniquePtr<IDirectX12Sampler>&& staticSampler, const UInt32& binding);
+
+		DirectX12DescriptorLayout(DirectX12DescriptorLayout&&) = delete;
+		DirectX12DescriptorLayout(const DirectX12DescriptorLayout&) = delete;
+		virtual ~DirectX12DescriptorLayout() noexcept;
+
+		// IDescriptorLayout interface.
+	public:
+		/// <inheritdoc />
+		virtual const DescriptorType& descriptorType() const noexcept override;
+
+		/// <inheritdoc />
+		virtual const UInt32& descriptors() const noexcept override;
+
+		/// <inheritdoc />
+		virtual const IDirectX12Sampler* staticSampler() const noexcept override;
+
+		// IBufferLayout interface.
+	public:
+		/// <inheritdoc />
+		virtual size_t elementSize() const noexcept override;
+
+		/// <inheritdoc />
+		virtual const UInt32& binding() const noexcept override;
+
+		/// <inheritdoc />
+		virtual const BufferType& type() const noexcept override;
+	};
+
+	/// <summary>
 	/// Implements a DirectX 12 <see cref="DescriptorSetLayout" />.
 	/// </summary>
 	/// <seealso cref="DirectX12DescriptorSet" />
@@ -498,6 +494,9 @@ namespace LiteFX::Rendering::Backends {
 
 		/// <inheritdoc />
 		virtual UInt32 samplers() const noexcept override;
+
+		/// <inheritdoc />
+		virtual UInt32 staticSamplers() const noexcept override;
 
 		/// <inheritdoc />
 		virtual UInt32 inputAttachments() const noexcept override;

--- a/src/Backends/DirectX12/include/litefx/backends/dx12.hpp
+++ b/src/Backends/DirectX12/include/litefx/backends/dx12.hpp
@@ -315,6 +315,14 @@ namespace LiteFX::Rendering::Backends {
 	public:
 		/// <inheritdoc />
 		virtual Array<const DirectX12ShaderModule*> modules() const noexcept override;
+
+		/// <inheritdoc />
+		virtual SharedPtr<DirectX12PipelineLayout> reflectPipelineLayout() const;
+
+	private:
+		virtual SharedPtr<IPipelineLayout> parsePipelineLayout() const override {
+			return std::static_pointer_cast<IPipelineLayout>(this->reflectPipelineLayout());
+		}
 	};
 
 	/// <summary>

--- a/src/Backends/DirectX12/include/litefx/backends/dx12_api.hpp
+++ b/src/Backends/DirectX12/include/litefx/backends/dx12_api.hpp
@@ -23,6 +23,7 @@
 #include <directx/d3dx12.h>
 #include <dxguids/dxguids.h>
 #include <dxgi1_6.h>
+#include <dxcapi.h>
 #include <comdef.h>
 
 #include <wrl.h>

--- a/src/Backends/DirectX12/include/litefx/backends/dx12_builders.hpp
+++ b/src/Backends/DirectX12/include/litefx/backends/dx12_builders.hpp
@@ -219,6 +219,9 @@ namespace LiteFX::Rendering::Backends {
 		/// <inheritdoc />
 		virtual DirectX12DescriptorSetLayoutBuilder& withDescriptor(const DescriptorType& type, const UInt32& binding, const UInt32& descriptorSize, const UInt32& descriptors = 1) override;
 
+		/// <inheritdoc />
+		virtual DirectX12DescriptorSetLayoutBuilder& withStaticSampler(const UInt32& binding, const FilterMode& magFilter = FilterMode::Nearest, const FilterMode& minFilter = FilterMode::Nearest, const BorderMode& borderU = BorderMode::Repeat, const BorderMode& borderV = BorderMode::Repeat, const BorderMode& borderW = BorderMode::Repeat, const MipMapMode& mipMapMode = MipMapMode::Nearest, const Float& mipMapBias = 0.f, const Float& minLod = 0.f, const Float& maxLod = std::numeric_limits<Float>::max(), const Float& anisotropy = 0.f) override;
+
 		// DirectX12DescriptorSetLayoutBuilder.
 	public:
 		/// <summary>

--- a/src/Backends/DirectX12/src/descriptor_layout.cpp
+++ b/src/Backends/DirectX12/src/descriptor_layout.cpp
@@ -16,6 +16,7 @@ private:
     DescriptorType m_descriptorType;
     BufferType m_bufferType;
     UInt32 m_descriptors;
+    UniquePtr<IDirectX12Sampler> m_staticSampler;
 
 public:
     DirectX12DescriptorLayoutImpl(DirectX12DescriptorLayout* parent, const DescriptorType& type, const UInt32& binding, const size_t& elementSize, const UInt32& descriptors) :
@@ -31,6 +32,12 @@ public:
         default:                            m_bufferType = BufferType::Other; break;
         }
     }
+
+    DirectX12DescriptorLayoutImpl(DirectX12DescriptorLayout* parent, UniquePtr<IDirectX12Sampler>&& staticSampler, const UInt32& binding) :
+        DirectX12DescriptorLayoutImpl(parent, DescriptorType::Sampler, binding, 0, 1)
+    {
+        m_staticSampler = std::move(staticSampler);
+    }
 };
 
 // ------------------------------------------------------------------------------------------------
@@ -40,6 +47,13 @@ public:
 DirectX12DescriptorLayout::DirectX12DescriptorLayout(const DescriptorType& type, const UInt32& binding, const size_t& elementSize, const UInt32& descriptors) :
     m_impl(makePimpl<DirectX12DescriptorLayoutImpl>(this, type, binding, elementSize, descriptors))
 {
+}
+
+DirectX12DescriptorLayout::DirectX12DescriptorLayout(UniquePtr<IDirectX12Sampler>&& staticSampler, const UInt32& binding) :
+    m_impl(makePimpl<DirectX12DescriptorLayoutImpl>(this, std::move(staticSampler), binding))
+{
+    if (staticSampler == nullptr)
+        throw ArgumentNotInitializedException("The static sampler must be initialized.");
 }
 
 DirectX12DescriptorLayout::~DirectX12DescriptorLayout() noexcept = default;
@@ -67,4 +81,9 @@ const BufferType& DirectX12DescriptorLayout::type() const noexcept
 const DescriptorType& DirectX12DescriptorLayout::descriptorType() const noexcept
 {
     return m_impl->m_descriptorType;
+}
+
+const IDirectX12Sampler* DirectX12DescriptorLayout::staticSampler() const noexcept
+{
+    return m_impl->m_staticSampler.get();
 }

--- a/src/Backends/DirectX12/src/descriptor_layout.cpp
+++ b/src/Backends/DirectX12/src/descriptor_layout.cpp
@@ -36,6 +36,9 @@ public:
     DirectX12DescriptorLayoutImpl(DirectX12DescriptorLayout* parent, UniquePtr<IDirectX12Sampler>&& staticSampler, const UInt32& binding) :
         DirectX12DescriptorLayoutImpl(parent, DescriptorType::Sampler, binding, 0, 1)
     {
+        if (staticSampler == nullptr)
+            throw ArgumentNotInitializedException("The static sampler must be initialized.");
+
         m_staticSampler = std::move(staticSampler);
     }
 };
@@ -52,8 +55,6 @@ DirectX12DescriptorLayout::DirectX12DescriptorLayout(const DescriptorType& type,
 DirectX12DescriptorLayout::DirectX12DescriptorLayout(UniquePtr<IDirectX12Sampler>&& staticSampler, const UInt32& binding) :
     m_impl(makePimpl<DirectX12DescriptorLayoutImpl>(this, std::move(staticSampler), binding))
 {
-    if (staticSampler == nullptr)
-        throw ArgumentNotInitializedException("The static sampler must be initialized.");
 }
 
 DirectX12DescriptorLayout::~DirectX12DescriptorLayout() noexcept = default;

--- a/src/Backends/DirectX12/src/descriptor_set.cpp
+++ b/src/Backends/DirectX12/src/descriptor_set.cpp
@@ -42,18 +42,18 @@ public:
         }
     }
 
-      D3D12_TEXTURE_ADDRESS_MODE getBorderMode(const BorderMode& mode)
-      {
-          switch (mode)
-          {
-          case BorderMode::Repeat: return D3D12_TEXTURE_ADDRESS_MODE_WRAP;
-          case BorderMode::ClampToEdge: return D3D12_TEXTURE_ADDRESS_MODE_CLAMP;
-          case BorderMode::ClampToBorder: return D3D12_TEXTURE_ADDRESS_MODE_BORDER;
-          case BorderMode::RepeatMirrored: return D3D12_TEXTURE_ADDRESS_MODE_MIRROR;
-          case BorderMode::ClampToEdgeMirrored: return D3D12_TEXTURE_ADDRESS_MODE_MIRROR_ONCE;
-          default: throw std::invalid_argument("Invalid border mode.");
-          }
-      }
+    D3D12_TEXTURE_ADDRESS_MODE getBorderMode(const BorderMode& mode)
+    {
+        switch (mode)
+        {
+        case BorderMode::Repeat: return D3D12_TEXTURE_ADDRESS_MODE_WRAP;
+        case BorderMode::ClampToEdge: return D3D12_TEXTURE_ADDRESS_MODE_CLAMP;
+        case BorderMode::ClampToBorder: return D3D12_TEXTURE_ADDRESS_MODE_BORDER;
+        case BorderMode::RepeatMirrored: return D3D12_TEXTURE_ADDRESS_MODE_MIRROR;
+        case BorderMode::ClampToEdgeMirrored: return D3D12_TEXTURE_ADDRESS_MODE_MIRROR_ONCE;
+        default: throw std::invalid_argument("Invalid border mode.");
+        }
+    }
 };
 
 // ------------------------------------------------------------------------------------------------

--- a/src/Backends/DirectX12/src/descriptor_set_layout.cpp
+++ b/src/Backends/DirectX12/src/descriptor_set_layout.cpp
@@ -192,6 +192,11 @@ UInt32 DirectX12DescriptorSetLayout::samplers() const noexcept
     return std::ranges::count_if(m_impl->m_layouts, [](const UniquePtr<DirectX12DescriptorLayout>& layout) { return layout->descriptorType() == DescriptorType::Sampler && layout->staticSampler() == nullptr; });
 }
 
+UInt32 DirectX12DescriptorSetLayout::staticSamplers() const noexcept
+{
+    return std::ranges::count_if(m_impl->m_layouts, [](const UniquePtr<DirectX12DescriptorLayout>& layout) { return layout->descriptorType() == DescriptorType::Sampler && layout->staticSampler() != nullptr; });
+}
+
 UInt32 DirectX12DescriptorSetLayout::inputAttachments() const noexcept
 {
     return std::ranges::count_if(m_impl->m_layouts, [](const UniquePtr<DirectX12DescriptorLayout>& layout) { return layout->descriptorType() == DescriptorType::InputAttachment; });

--- a/src/Backends/DirectX12/src/descriptor_set_layout.cpp
+++ b/src/Backends/DirectX12/src/descriptor_set_layout.cpp
@@ -1,5 +1,6 @@
 #include <litefx/backends/dx12.hpp>
 #include <litefx/backends/dx12_builders.hpp>
+#include "image.h"
 
 using namespace LiteFX::Rendering::Backends;
 
@@ -275,6 +276,11 @@ DirectX12DescriptorSetLayoutBuilder& DirectX12DescriptorSetLayoutBuilder::withDe
 DirectX12DescriptorSetLayoutBuilder& DirectX12DescriptorSetLayoutBuilder::withDescriptor(const DescriptorType& type, const UInt32& binding, const UInt32& descriptorSize, const UInt32& descriptors)
 {
     return this->withDescriptor(makeUnique<DirectX12DescriptorLayout>(type, binding, descriptorSize, descriptors));
+}
+
+DirectX12DescriptorSetLayoutBuilder& DirectX12DescriptorSetLayoutBuilder::withStaticSampler(const UInt32& binding, const FilterMode& magFilter, const FilterMode& minFilter, const BorderMode& borderU, const BorderMode& borderV, const BorderMode& borderW, const MipMapMode& mipMapMode, const Float& mipMapBias, const Float& minLod, const Float& maxLod, const Float& anisotropy)
+{
+    return this->withDescriptor(makeUnique<DirectX12DescriptorLayout>(makeUnique<DirectX12Sampler>(this->parent().device(), magFilter, minFilter, borderU, borderV, borderW, mipMapMode, mipMapBias, minLod, maxLod, anisotropy), binding));
 }
 
 DirectX12DescriptorSetLayoutBuilder& DirectX12DescriptorSetLayoutBuilder::space(const UInt32& space) noexcept

--- a/src/Backends/DirectX12/src/descriptor_set_layout.cpp
+++ b/src/Backends/DirectX12/src/descriptor_set_layout.cpp
@@ -46,8 +46,12 @@ public:
             
             if (layout->descriptorType() == DescriptorType::Sampler)
             {
-                m_bindingToDescriptor[layout->binding()] = m_samplers;
-                m_samplers += layout->descriptors();
+                // Only count dynamic samplers.
+                if (layout->staticSampler() == nullptr)
+                {
+                    m_bindingToDescriptor[layout->binding()] = m_samplers;
+                    m_samplers += layout->descriptors();
+                }
             }
             else
             {
@@ -185,7 +189,7 @@ UInt32 DirectX12DescriptorSetLayout::images() const noexcept
 
 UInt32 DirectX12DescriptorSetLayout::samplers() const noexcept
 {
-    return std::ranges::count_if(m_impl->m_layouts, [](const UniquePtr<DirectX12DescriptorLayout>& layout) { return layout->descriptorType() == DescriptorType::Sampler; });
+    return std::ranges::count_if(m_impl->m_layouts, [](const UniquePtr<DirectX12DescriptorLayout>& layout) { return layout->descriptorType() == DescriptorType::Sampler && layout->staticSampler() == nullptr; });
 }
 
 UInt32 DirectX12DescriptorSetLayout::inputAttachments() const noexcept

--- a/src/Backends/DirectX12/src/device.cpp
+++ b/src/Backends/DirectX12/src/device.cpp
@@ -124,7 +124,7 @@ public:
 
 			// Try to register event callback.
 			if (FAILED(infoQueue.As(&m_eventQueue)))
-				LITEFX_WARNING(DIRECTX12_LOG, "Unable to query debug message callback queue. Native event logging will be disabled. Note that it requires Windows 10 SDK 10.0.20236 or later.");
+				LITEFX_WARNING(DIRECTX12_LOG, "Unable to query debug message callback queue. Native event logging will be disabled. Note that it requires at least Windows 11.");
 			else if (FAILED(m_eventQueue->RegisterMessageCallback(&DirectX12Device::DirectX12DeviceImpl::onDebugMessage, D3D12_MESSAGE_CALLBACK_FLAGS::D3D12_MESSAGE_CALLBACK_IGNORE_FILTERS, nullptr, &m_debugCallbackCookie)))
 				LITEFX_WARNING(DIRECTX12_LOG, "Unable to register debug message callback with info queue. Native event logging will be disabled.");
 		}
@@ -179,7 +179,7 @@ public:
 			// Allocate shader module.
 			Array<UniquePtr<DirectX12ShaderModule>> modules;
 			modules.push_back(std::move(makeUnique<DirectX12ShaderModule>(*m_parent, ShaderStage::Compute, "shaders/blit.dxi", "main")));
-			auto shaderProgram = makeShared<DirectX12ShaderProgram>(std::move(modules));
+			auto shaderProgram = makeShared<DirectX12ShaderProgram>(*m_parent, std::move(modules));
 
 			// Allocate descriptor set layouts.
 			UniquePtr<DirectX12PushConstantsLayout> pushConstantsLayout = nullptr;

--- a/src/Backends/DirectX12/src/shader_program.cpp
+++ b/src/Backends/DirectX12/src/shader_program.cpp
@@ -108,15 +108,10 @@ public:
             }
 
             // Find the sampler for the register and overwrite it. If it does not exist, create it.
-            if (auto match = std::ranges::find_if(descriptorSetLayouts[staticSampler.RegisterSpace].descriptors, [&staticSampler](const auto& descriptor) { return descriptor.location == staticSampler.ShaderRegister; }); match == descriptorSetLayouts[staticSampler.RegisterSpace].descriptors.end())
+            if (auto match = std::ranges::find_if(descriptorSetLayouts[staticSampler.RegisterSpace].descriptors, [&staticSampler](const auto& descriptor) { return descriptor.type == DescriptorType::Sampler && descriptor.location == staticSampler.ShaderRegister; }); match == descriptorSetLayouts[staticSampler.RegisterSpace].descriptors.end())
                 descriptorSetLayouts[staticSampler.RegisterSpace].descriptors.push_back(DescriptorInfo{ .location = staticSampler.ShaderRegister, .elementSize = 0, .elements = 1, .type = DescriptorType::Sampler, .staticSamplerState = staticSampler });
             else
-            {
-                if (match->type != DescriptorType::Sampler) [[unlikely]]
-                    throw InvalidArgumentException("Type mismatch detected between root signature definition and shader reflection at binding point {0}, space {1}. Expected sampler, but found {2}.", staticSampler.ShaderRegister, staticSampler.RegisterSpace, match->type);
-
                 match->staticSamplerState = staticSampler;
-            }
         }
 
         // Iterate the root parameters.

--- a/src/Backends/DirectX12/src/shader_program.cpp
+++ b/src/Backends/DirectX12/src/shader_program.cpp
@@ -356,7 +356,7 @@ public:
     }
 };
 
-static void suppressMissingRootSignatureWarning(bool disableWarning) noexcept
+void DirectX12ShaderProgram::suppressMissingRootSignatureWarning(bool disableWarning) noexcept
 {
     SUPPRESS_MISSING_ROOT_SIGNATURE_WARNING = disableWarning;
 }

--- a/src/Backends/DirectX12/src/shader_program.cpp
+++ b/src/Backends/DirectX12/src/shader_program.cpp
@@ -1,11 +1,34 @@
 #include <litefx/backends/dx12.hpp>
 #include <litefx/backends/dx12_builders.hpp>
+#include <d3d12shader.h>
+#include <numeric>
+#include "image.h"
 
 using namespace LiteFX::Rendering::Backends;
 
 // ------------------------------------------------------------------------------------------------
 // Implementation.
 // ------------------------------------------------------------------------------------------------
+
+consteval UInt32 FOUR_CC(char ch0, char ch1, char ch2, char ch3) 
+{
+    return static_cast<UInt32>((Byte)ch0) | static_cast<UInt32>((Byte)ch1) << 8 | static_cast<UInt32>((Byte)ch2) << 16 | static_cast<UInt32>((Byte)ch3) << 24;
+}
+
+static bool SUPPRESS_MISSING_ROOT_SIGNATURE_WARNING = false;
+
+constexpr BorderMode DECODE_BORDER_MODE(D3D12_TEXTURE_ADDRESS_MODE addressMode) noexcept
+{
+    switch (addressMode)
+    {
+    default:
+    case D3D12_TEXTURE_ADDRESS_MODE_WRAP:           return BorderMode::Repeat;
+    case D3D12_TEXTURE_ADDRESS_MODE_CLAMP:          return BorderMode::ClampToEdge;
+    case D3D12_TEXTURE_ADDRESS_MODE_BORDER:         return BorderMode::ClampToBorder;
+    case D3D12_TEXTURE_ADDRESS_MODE_MIRROR:         return BorderMode::RepeatMirrored;
+    case D3D12_TEXTURE_ADDRESS_MODE_MIRROR_ONCE:    return BorderMode::ClampToEdgeMirrored;
+    }
+}
 
 class DirectX12ShaderProgram::DirectX12ShaderProgramImpl : public Implement<DirectX12ShaderProgram> {
 public:
@@ -14,30 +37,341 @@ public:
 
 private:
     Array<UniquePtr<DirectX12ShaderModule>> m_modules;
+    const DirectX12Device& m_device;
+
+private:
+    struct DescriptorInfo {
+    public:
+        UInt32 location;
+        UInt32 elementSize;
+        UInt32 elements;
+        DescriptorType type;
+        Optional<D3D12_STATIC_SAMPLER_DESC> staticSamplerState;
+
+        bool equals(const DescriptorInfo& rhs)
+        {
+            return
+                this->location == rhs.location &&
+                this->elements == rhs.elements &&
+                this->elementSize == rhs.elementSize &&
+                this->type == rhs.type;
+        }
+    };
+
+    struct DescriptorSetInfo {
+    public:
+        UInt32 space;
+        ShaderStage stage;
+        Array<DescriptorInfo> descriptors;
+    };
+
+    struct PushConstantRangeInfo {
+    public:
+        ShaderStage stage;
+        UInt32 offset;
+        UInt32 size;
+        UInt32 location;
+        UInt32 space;
+    };
 
 public:
-    DirectX12ShaderProgramImpl(DirectX12ShaderProgram* parent, Array<UniquePtr<DirectX12ShaderModule>>&& modules) :
-        base(parent), m_modules(std::move(modules))
+    DirectX12ShaderProgramImpl(DirectX12ShaderProgram* parent, const DirectX12Device& device, Array<UniquePtr<DirectX12ShaderModule>>&& modules) :
+        base(parent), m_modules(std::move(modules)), m_device(device)
     {
     }
 
-    DirectX12ShaderProgramImpl(DirectX12ShaderProgram* parent) :
-        base(parent)
+    DirectX12ShaderProgramImpl(DirectX12ShaderProgram* parent, const DirectX12Device& device) :
+        base(parent), m_device(device)
     {
     }
+
+public:
+    void reflectRootSignature(ComPtr<ID3D12RootSignatureDeserializer> deserializer, Dictionary<UInt32, DescriptorSetInfo>& descriptorSetLayouts, Array<PushConstantRangeInfo>& pushConstantRanges)
+    {
+        // Collect the shader stages.
+        ShaderStage stages{ };
+        std::ranges::for_each(m_modules, [&stages](const auto& shaderModule) { stages = stages | shaderModule->type(); });
+
+        // Get the root signature description.
+        auto description = deserializer->GetRootSignatureDesc();
+
+        // Iterate the static samplers.
+        for (int i(0); i < description->NumStaticSamplers; ++i)
+        {
+            auto staticSampler = description->pStaticSamplers[i];
+
+            // If the descriptor space 
+            if (!descriptorSetLayouts.contains(staticSampler.RegisterSpace)) [[unlikely]]
+            {
+                LITEFX_DEBUG(DIRECTX12_LOG, "The root signature of the shader defines a descriptor set at space {0}, which the reflection did not find.", staticSampler.RegisterSpace);
+                descriptorSetLayouts.insert(std::make_pair(staticSampler.RegisterSpace, DescriptorSetInfo{ .space = staticSampler.RegisterSpace, .stage = stages }));
+            }
+
+            // Find the sampler for the register and overwrite it. If it does not exist, create it.
+            if (auto match = std::ranges::find_if(descriptorSetLayouts[staticSampler.RegisterSpace].descriptors, [&staticSampler](const auto& descriptor) { return descriptor.location == staticSampler.ShaderRegister; }); match == descriptorSetLayouts[staticSampler.RegisterSpace].descriptors.end())
+                descriptorSetLayouts[staticSampler.RegisterSpace].descriptors.push_back(DescriptorInfo{ .location = staticSampler.ShaderRegister, .elementSize = 0, .elements = 1, .type = DescriptorType::Sampler, .staticSamplerState = staticSampler });
+            else
+            {
+                if (match->type != DescriptorType::Sampler) [[unlikely]]
+                    throw InvalidArgumentException("Type mismatch detected between root signature definition and shader reflection at binding point {0}, space {1}. Expected sampler, but found {2}.", staticSampler.ShaderRegister, staticSampler.RegisterSpace, match->type);
+
+                match->staticSamplerState = staticSampler;
+            }
+        }
+
+        // Iterate the root parameters.
+        UInt32 pushConstantOffset = 0;
+
+        for (int i(0); i < description->NumParameters; ++i)
+        {
+            auto rootParameter = description->pParameters[i];
+
+            // Check if there's a descriptor set for the space.
+            if (!descriptorSetLayouts.contains(rootParameter.Descriptor.RegisterSpace)) [[unlikely]]
+            {
+                // NOTE: This is only ever valid for static samplers, since other descriptors cannot be defined this way (they would be missing array and element sizes). The descriptor set must stay empty.
+                LITEFX_DEBUG(DIRECTX12_LOG, "The root signature of the shader defines a descriptor set at space {0}, which the reflection did not find.", rootParameter.Descriptor.RegisterSpace);
+                descriptorSetLayouts.insert(std::make_pair(rootParameter.Descriptor.RegisterSpace, DescriptorSetInfo{ .space = rootParameter.Descriptor.RegisterSpace, .stage = stages }));
+            }
+
+            switch (rootParameter.ParameterType)
+            {
+            case D3D12_ROOT_PARAMETER_TYPE_32BIT_CONSTANTS: 
+                // Find the descriptor.
+                if (auto match = std::ranges::find_if(descriptorSetLayouts[rootParameter.Descriptor.RegisterSpace].descriptors, [&rootParameter](const auto& descriptor) { return descriptor.location == rootParameter.Descriptor.ShaderRegister; }); match == descriptorSetLayouts[rootParameter.Descriptor.RegisterSpace].descriptors.end()) [[unlikely]]
+                    LITEFX_WARNING(DIRECTX12_LOG, "The root signature defines a descriptor at {0} (space {1}), which the shader reflection did not find. The descriptor will be ignored.", rootParameter.Descriptor.ShaderRegister, rootParameter.Descriptor.RegisterSpace);
+                else
+                {
+                    // Convert the descriptor to a push constant range.
+                    ShaderStage stage{ };
+
+                    switch (rootParameter.ShaderVisibility)
+                    {
+                    case D3D12_SHADER_VISIBILITY_VERTEX:        stage = ShaderStage::Vertex; break;
+                    case D3D12_SHADER_VISIBILITY_HULL:          stage = ShaderStage::TessellationControl; break;
+                    case D3D12_SHADER_VISIBILITY_DOMAIN:        stage = ShaderStage::TessellationEvaluation; break;
+                    case D3D12_SHADER_VISIBILITY_GEOMETRY:      stage = ShaderStage::Geometry; break;
+                    case D3D12_SHADER_VISIBILITY_PIXEL:         stage = ShaderStage::Fragment; break;
+                    case D3D12_SHADER_VISIBILITY_ALL:
+                    case D3D12_SHADER_VISIBILITY_AMPLIFICATION:
+                    case D3D12_SHADER_VISIBILITY_MESH:
+                    default: throw InvalidArgumentException("The push constants for a shader are defined for invalid or unsupported shader stages. Note that a push constant must only be defined for a single shader stage.");
+                    }
+
+                    pushConstantRanges.push_back(PushConstantRangeInfo{ .stage = stage, .offset = pushConstantOffset, .size = rootParameter.Constants.Num32BitValues * 4, .location = rootParameter.Descriptor.ShaderRegister, .space = rootParameter.Descriptor.RegisterSpace });
+                    pushConstantOffset += rootParameter.Constants.Num32BitValues * 4;
+                    
+                    // Remove the descriptor from the descriptor set.
+                    descriptorSetLayouts[rootParameter.Descriptor.RegisterSpace].descriptors.erase(match);
+
+                    // Remove the descriptor set, if it is empty.
+                    if (descriptorSetLayouts[rootParameter.Descriptor.RegisterSpace].descriptors.empty())
+                        descriptorSetLayouts.erase(rootParameter.Descriptor.RegisterSpace);
+                }
+
+                break;
+            case D3D12_ROOT_PARAMETER_TYPE_CBV:
+            case D3D12_ROOT_PARAMETER_TYPE_SRV:
+            case D3D12_ROOT_PARAMETER_TYPE_UAV:
+                // Check if the descriptor is defined.
+                if (auto match = std::ranges::find_if(descriptorSetLayouts[rootParameter.Descriptor.RegisterSpace].descriptors, [&rootParameter](const auto& descriptor) { return descriptor.location == rootParameter.Descriptor.ShaderRegister; }); match == descriptorSetLayouts[rootParameter.Descriptor.RegisterSpace].descriptors.end()) [[unlikely]]
+                    LITEFX_WARNING(DIRECTX12_LOG, "The root signature defines a descriptor at {0} (space {1}), which the shader reflection did not find. The descriptor will be ignored.", rootParameter.Descriptor.ShaderRegister, rootParameter.Descriptor.RegisterSpace);
+
+                break;
+            case D3D12_ROOT_PARAMETER_TYPE_DESCRIPTOR_TABLE:
+                throw InvalidArgumentException("The shader modules root signature defines a descriptor table for parameter {0}, which is currently not supported. Convert each parameter of the table into a separate root parameter.", i);
+            default: 
+                throw InvalidArgumentException("The shader modules root signature exposes an unknown root parameter type {1} for parameter {0}.", i, rootParameter.ParameterType);
+            }
+        }
+    }
+
+    SharedPtr<DirectX12PipelineLayout> reflectPipelineLayout()
+    {
+        // First, filter the descriptor sets and push constant ranges.
+        Dictionary<UInt32, DescriptorSetInfo> descriptorSetLayouts;
+        Array<PushConstantRangeInfo> pushConstantRanges;
+
+        // Extract reflection data from all shader modules.
+        std::ranges::for_each(m_modules, [this, &descriptorSetLayouts](UniquePtr<DirectX12ShaderModule>& shaderModule) {
+            // Load the shader reflection.
+            ComPtr<IDxcContainerReflection> reflection;
+            raiseIfFailed<RuntimeException>(::DxcCreateInstance(CLSID_DxcContainerReflection, IID_PPV_ARGS(&reflection)), "Unable to access DirectX shader reflection.");
+            raiseIfFailed<RuntimeException>(reflection->Load(std::as_const(*shaderModule).handle().Get()), "Unable to load reflection from shader module.");
+
+            // Verify reflection and get the actual shader reflection interface.
+            UINT32 shaderIdx;
+            ComPtr<ID3D12ShaderReflection> shaderReflection;
+            raiseIfFailed<RuntimeException>(reflection->FindFirstPartKind(FOUR_CC('D', 'X', 'I', 'L'), &shaderIdx), "The shader module does not contain a valid DXIL shader.");
+            raiseIfFailed<RuntimeException>(reflection->GetPartReflection(shaderIdx, IID_PPV_ARGS(&shaderReflection)), "Unable to query shader reflection from DXIL module.");
+
+            // Get the shader description from the reflection.
+            D3D12_SHADER_DESC shaderInfo;
+            raiseIfFailed<RuntimeException>(shaderReflection->GetDesc(&shaderInfo), "Unable to acquire meta-data from shader module.");
+
+            // Iterate the bound resources to extract the descriptor sets.
+            for (int i(0); i < shaderInfo.BoundResources; ++i)
+            {
+                // Get the bound resource description.
+                D3D12_SHADER_INPUT_BIND_DESC inputDesc;
+                shaderReflection->GetResourceBindingDesc(i, &inputDesc);
+
+                // First, create a description of the descriptor.
+                DescriptorType type;
+                UInt32 elementSize = 0;
+
+                switch (inputDesc.Type)
+                {
+                case D3D_SIT_CBUFFER: 
+                {
+                    D3D12_SHADER_BUFFER_DESC bufferDesc;
+                    auto constantBuffer = shaderReflection->GetConstantBufferByName(inputDesc.Name);
+                    raiseIfFailed<RuntimeException>(constantBuffer->GetDesc(&bufferDesc), "Unable to query constant buffer \"{0}\" from shader module {1}.", inputDesc.Name, shaderModule->type());
+                    
+                    elementSize = bufferDesc.Size;
+                    type = DescriptorType::Uniform;
+                    break;
+                }
+                case D3D_SIT_TBUFFER:
+                case D3D_SIT_STRUCTURED:
+                case D3D_SIT_UAV_RWSTRUCTURED:
+                {
+                    auto variable = shaderReflection->GetVariableByName(inputDesc.Name);
+
+                    if (variable == nullptr) [[unlikely]]
+                        throw RuntimeException("The shader variable \"{0}\" could not be queried.", inputDesc.Name);
+
+                    D3D12_SHADER_VARIABLE_DESC desc;
+                    raiseIfFailed<RuntimeException>(variable->GetDesc(&desc), "Unable to query variable \"{0}\" from shader module {1}.", inputDesc.Name, shaderModule->type());
+                    
+                    elementSize = desc.Size;
+                    type = inputDesc.Type == D3D_SIT_UAV_RWSTRUCTURED ? DescriptorType::WritableStorage : DescriptorType::Storage;
+                    break;
+                }
+                case D3D_SIT_UAV_CONSUME_STRUCTURED:
+                case D3D_SIT_UAV_APPEND_STRUCTURED:
+                case D3D_SIT_UAV_RWSTRUCTURED_WITH_COUNTER:
+                {
+                    auto variable = shaderReflection->GetVariableByName(inputDesc.Name);
+
+                    if (variable == nullptr) [[unlikely]]
+                        throw RuntimeException("The shader variable \"{0}\" could not be queried.", inputDesc.Name);
+
+                    D3D12_SHADER_VARIABLE_DESC desc;
+                    raiseIfFailed<RuntimeException>(variable->GetDesc(&desc), "Unable to query variable \"{0}\" from shader module {1}.", inputDesc.Name, shaderModule->type());
+
+                    elementSize = desc.Size;
+                    type = inputDesc.Type == D3D_SIT_UAV_CONSUME_STRUCTURED ? DescriptorType::Buffer : DescriptorType::WritableBuffer;
+                    break;
+                }
+                case D3D_SIT_TEXTURE:     type = DescriptorType::Texture; break;
+                case D3D_SIT_UAV_RWTYPED: type = DescriptorType::WritableTexture; break;
+                case D3D_SIT_SAMPLER:     type = DescriptorType::Sampler; break;
+                case D3D_SIT_BYTEADDRESS:
+                case D3D_SIT_UAV_RWBYTEADDRESS:
+                case D3D_SIT_RTACCELERATIONSTRUCTURE:
+                case D3D_SIT_UAV_FEEDBACKTEXTURE: throw RuntimeException("The shader exposes an unsupported resource of type {1} at binding point {0}.", i, inputDesc.Type);
+                default: throw RuntimeException("The shader exposes an unknown resource type in binding {0}.", i);
+                }
+
+                auto descriptor = DescriptorInfo{
+                    .location = inputDesc.BindPoint,
+                    .elementSize = elementSize,
+                    .elements = inputDesc.BindCount,
+                    .type = type
+                };
+
+                // Check if a descriptor set has already been defined for the space.
+                if (!descriptorSetLayouts.contains(inputDesc.Space))
+                    descriptorSetLayouts.insert(std::make_pair(inputDesc.Space, DescriptorSetInfo{ .space = inputDesc.Space, .stage = shaderModule->type(), .descriptors = { descriptor } }));
+                else
+                {
+                    auto& descriptorSetLayout = descriptorSetLayouts[inputDesc.Space];
+                    descriptorSetLayout.stage = descriptorSetLayouts[inputDesc.Space].stage | shaderModule->type();
+                    descriptorSetLayout.descriptors.push_back(descriptor);
+                }
+            }
+        });
+
+        // Attempt to find a shader module that exports a root signature. If none is found, issue a warning.
+        // NOTE: Root signature is only ever expected to be provided in one shader module. If multiple are provided, it is not defined, which one will be picked.
+        bool hasRootSignature = false;
+
+        for (const auto& shaderModule : m_modules)
+        {
+            ComPtr<ID3D12RootSignatureDeserializer> deserializer;
+
+            if (SUCCEEDED(::D3D12CreateRootSignatureDeserializer(std::as_const(*shaderModule).handle()->GetBufferPointer(), std::as_const(*shaderModule).handle()->GetBufferSize(), IID_PPV_ARGS(&deserializer))))
+            {
+                // Reflect the root signature in order to define static samplers and push constants.
+                LITEFX_TRACE(DIRECTX12_LOG, "Found root signature in shader module {0}.", shaderModule->type());
+                this->reflectRootSignature(deserializer, descriptorSetLayouts, pushConstantRanges);
+                hasRootSignature = true;
+                break;
+            }
+        }
+
+        // Otherwise, fall back to traditional reflection to acquire the root signature.
+        if (!hasRootSignature && !SUPPRESS_MISSING_ROOT_SIGNATURE_WARNING)
+            LITEFX_WARNING(DIRECTX12_LOG, "None of the provided shader modules exports a root signature. Descriptor sets will be acquired using reflection. Some features (such as root/push constants) are not supported.");
+
+        // Create the descriptor set layouts.
+        Array<UniquePtr<DirectX12DescriptorSetLayout>> descriptorSets(descriptorSetLayouts.size());
+        std::ranges::generate(descriptorSets, [this, &descriptorSetLayouts, i = 0]() mutable {
+            // Get the descriptor set layout.
+            auto it = descriptorSetLayouts.begin();
+            std::advance(it, i++);
+            auto& descriptorSet = it->second;
+
+            // Create the descriptor layouts.
+            Array<UniquePtr<DirectX12DescriptorLayout>> descriptors(descriptorSet.descriptors.size());
+            std::ranges::generate(descriptors, [this, &descriptorSet, j = 0]() mutable {
+                auto& descriptor = descriptorSet.descriptors[j++];
+
+                return descriptor.staticSamplerState.has_value() ?
+                    makeUnique<DirectX12DescriptorLayout>(makeUnique<DirectX12Sampler>(m_device,
+                        D3D12_DECODE_MAG_FILTER(descriptor.staticSamplerState->Filter) == D3D12_FILTER_TYPE_POINT ? FilterMode::Nearest : FilterMode::Linear,
+                        D3D12_DECODE_MIN_FILTER(descriptor.staticSamplerState->Filter) == D3D12_FILTER_TYPE_POINT ? FilterMode::Nearest : FilterMode::Linear,
+                        DECODE_BORDER_MODE(descriptor.staticSamplerState->AddressU), DECODE_BORDER_MODE(descriptor.staticSamplerState->AddressV), DECODE_BORDER_MODE(descriptor.staticSamplerState->AddressW),
+                        D3D12_DECODE_MIP_FILTER(descriptor.staticSamplerState->Filter) == D3D12_FILTER_TYPE_POINT ? MipMapMode::Nearest : MipMapMode::Linear,
+                        descriptor.staticSamplerState->MipLODBias, descriptor.staticSamplerState->MinLOD, descriptor.staticSamplerState->MaxLOD, static_cast<Float>(descriptor.staticSamplerState->MaxAnisotropy)), descriptor.location) :
+                    makeUnique<DirectX12DescriptorLayout>(descriptor.type, descriptor.location, descriptor.elementSize, descriptor.elements);
+            });
+
+            return makeUnique<DirectX12DescriptorSetLayout>(m_device, std::move(descriptors), descriptorSet.space, descriptorSet.stage);
+        });
+
+        // Create the push constants layout.
+        Array<UniquePtr<DirectX12PushConstantsRange>> pushConstants(pushConstantRanges.size());
+        std::ranges::generate(pushConstants, [&pushConstantRanges, i = 0]() mutable {
+            auto& range = pushConstantRanges[i++];
+            return makeUnique<DirectX12PushConstantsRange>(range.stage, range.offset, range.size, range.space, range.location);
+        });
+
+        auto overallSize = std::accumulate(pushConstantRanges.begin(), pushConstantRanges.end(), 0, [](UInt32 currentSize, const auto& range) { return currentSize + range.size; });
+        auto pushConstantsLayout = makeUnique<DirectX12PushConstantsLayout>(std::move(pushConstants), overallSize);
+
+        // Return the pipeline layout.
+        return makeShared<DirectX12PipelineLayout>(m_device, std::move(descriptorSets), std::move(pushConstantsLayout));
+    }
 };
+
+static void suppressMissingRootSignatureWarning(bool disableWarning) noexcept
+{
+    SUPPRESS_MISSING_ROOT_SIGNATURE_WARNING = disableWarning;
+}
 
 // ------------------------------------------------------------------------------------------------
 // Interface.
 // ------------------------------------------------------------------------------------------------
 
-DirectX12ShaderProgram::DirectX12ShaderProgram(Array<UniquePtr<DirectX12ShaderModule>>&& modules) noexcept :
-    m_impl(makePimpl<DirectX12ShaderProgramImpl>(this, std::move(modules)))
+DirectX12ShaderProgram::DirectX12ShaderProgram(const DirectX12Device& device, Array<UniquePtr<DirectX12ShaderModule>>&& modules) noexcept :
+    m_impl(makePimpl<DirectX12ShaderProgramImpl>(this, device, std::move(modules)))
 {
 }
 
-DirectX12ShaderProgram::DirectX12ShaderProgram() noexcept :
-    m_impl(makePimpl<DirectX12ShaderProgramImpl>(this))
+DirectX12ShaderProgram::DirectX12ShaderProgram(const DirectX12Device& device) noexcept :
+    m_impl(makePimpl<DirectX12ShaderProgramImpl>(this, device))
 {
 }
 
@@ -52,7 +386,7 @@ Array<const DirectX12ShaderModule*> DirectX12ShaderProgram::modules() const noex
 
 SharedPtr<DirectX12PipelineLayout> DirectX12ShaderProgram::reflectPipelineLayout() const
 {
-    throw;
+    return m_impl->reflectPipelineLayout();
 }
 
 #if defined(BUILD_DEFINE_BUILDERS)
@@ -80,7 +414,7 @@ public:
 // ------------------------------------------------------------------------------------------------
 
 DirectX12ShaderProgramBuilder::DirectX12ShaderProgramBuilder(const DirectX12Device& device) :
-    m_impl(makePimpl<DirectX12ShaderProgramBuilderImpl>(this, device)), ShaderProgramBuilder(UniquePtr<DirectX12ShaderProgram>(new DirectX12ShaderProgram()))
+    m_impl(makePimpl<DirectX12ShaderProgramBuilderImpl>(this, device)), ShaderProgramBuilder(UniquePtr<DirectX12ShaderProgram>(new DirectX12ShaderProgram(device)))
 {
 }
 

--- a/src/Backends/DirectX12/src/shader_program.cpp
+++ b/src/Backends/DirectX12/src/shader_program.cpp
@@ -50,6 +50,11 @@ Array<const DirectX12ShaderModule*> DirectX12ShaderProgram::modules() const noex
         ranges::to<Array<const DirectX12ShaderModule*>>();
 }
 
+SharedPtr<DirectX12PipelineLayout> DirectX12ShaderProgram::reflectPipelineLayout() const
+{
+    throw;
+}
+
 #if defined(BUILD_DEFINE_BUILDERS)
 // ------------------------------------------------------------------------------------------------
 // Shader program builder implementation.

--- a/src/Backends/Vulkan/CMakeLists.txt
+++ b/src/Backends/Vulkan/CMakeLists.txt
@@ -10,6 +10,7 @@ MESSAGE(STATUS "Initializing: ${PROJECT_NAME}...")
 # Resolve package dependencies.
 FIND_PACKAGE(Vulkan REQUIRED)
 FIND_PACKAGE(unofficial-vulkan-memory-allocator CONFIG REQUIRED)
+FIND_PACKAGE(unofficial-spirv-reflect CONFIG REQUIRED)
 
 # Collect header & source files.
 SET(VULKAN_BACKEND_HEADERS
@@ -84,7 +85,7 @@ TARGET_INCLUDE_DIRECTORIES(${PROJECT_NAME}
 # Link project dependencies.
 TARGET_LINK_LIBRARIES(${PROJECT_NAME}
     PUBLIC LiteFX.Core LiteFX.Math LiteFX.Rendering LiteFX.AppModel Vulkan::Vulkan 
-    PRIVATE unofficial::vulkan-memory-allocator::vulkan-memory-allocator
+    PRIVATE unofficial::vulkan-memory-allocator::vulkan-memory-allocator unofficial::spirv-reflect::spirv-reflect
 )
 
 # Link against D3D12 to enable flip-model swap chains.

--- a/src/Backends/Vulkan/include/litefx/backends/vulkan.hpp
+++ b/src/Backends/Vulkan/include/litefx/backends/vulkan.hpp
@@ -287,6 +287,7 @@ namespace LiteFX::Rendering::Backends {
 	/// </summary>
 	/// <seealso cref="VulkanShaderProgram" />
 	/// <seealso cref="VulkanDevice" />
+	/// <seealso href="https://github.com/crud89/LiteFX/wiki/Shader-Development" />
 	class LITEFX_VULKAN_API VulkanShaderModule : public IShaderModule, public Resource<VkShaderModule> {
 		LITEFX_IMPLEMENTATION(VulkanShaderModuleImpl);
 
@@ -327,6 +328,7 @@ namespace LiteFX::Rendering::Backends {
 	/// </summary>
 	/// <seealso cref="VulkanShaderProgramBuilder" />
 	/// <seealso cref="VulkanShaderModule" />
+	/// <seealso href="https://github.com/crud89/LiteFX/wiki/Shader-Development" />
 	class LITEFX_VULKAN_API VulkanShaderProgram : public ShaderProgram<VulkanShaderModule> {
 		LITEFX_IMPLEMENTATION(VulkanShaderProgramImpl);
 		LITEFX_BUILDER(VulkanShaderProgramBuilder);
@@ -346,6 +348,7 @@ namespace LiteFX::Rendering::Backends {
 		/// <summary>
 		/// Initializes a new Vulkan shader program.
 		/// </summary>
+		/// <param name="device">The parent device of the shader program.</param>
 		explicit VulkanShaderProgram(const VulkanDevice& device) noexcept;
 
 	public:

--- a/src/Backends/Vulkan/include/litefx/backends/vulkan.hpp
+++ b/src/Backends/Vulkan/include/litefx/backends/vulkan.hpp
@@ -83,50 +83,6 @@ namespace LiteFX::Rendering::Backends {
 	};
 
 	/// <summary>
-	/// Implements a Vulkan <see cref="IDescriptorLayout" />
-	/// </summary>
-	/// <seealso cref="IVulkanBuffer" />
-	/// <seealso cref="IVulkanImage" />
-	/// <seealso cref="IVulkanSampler" />
-	/// <seealso cref="VulkanDescriptorSet" />
-	/// <seealso cref="VulkanDescriptorSetLayout" />
-	class LITEFX_VULKAN_API VulkanDescriptorLayout : public IDescriptorLayout {
-		LITEFX_IMPLEMENTATION(VulkanDescriptorLayoutImpl);
-
-	public:
-		/// <summary>
-		/// Initializes a new Vulkan descriptor layout.
-		/// </summary>
-		/// <param name="type">The type of the descriptor.</param>
-		/// <param name="binding">The binding point for the descriptor.</param>
-		/// <param name="elementSize">The size of the descriptor.</param>
-		/// <param name="elementSize">The number of descriptors in the descriptor array.</param>
-		explicit VulkanDescriptorLayout(const DescriptorType& type, const UInt32& binding, const size_t& elementSize, const UInt32& descriptors = 1);
-		VulkanDescriptorLayout(VulkanDescriptorLayout&&) = delete;
-		VulkanDescriptorLayout(const VulkanDescriptorLayout&) = delete;
-		virtual ~VulkanDescriptorLayout() noexcept;
-
-		// IDescriptorLayout interface.
-	public:
-		/// <inheritdoc />
-		virtual const DescriptorType& descriptorType() const noexcept override;
-
-		/// <inheritdoc />
-		virtual const UInt32& descriptors() const noexcept override;
-
-		// IBufferLayout interface.
-	public:
-		/// <inheritdoc />
-		virtual size_t elementSize() const noexcept override;
-
-		/// <inheritdoc />
-		virtual const UInt32& binding() const noexcept override;
-
-		/// <inheritdoc />
-		virtual const BufferType& type() const noexcept override;
-	};
-
-	/// <summary>
 	/// Represents the base interface for a Vulkan buffer implementation.
 	/// </summary>
 	/// <seealso cref="VulkanDescriptorSet" />
@@ -404,6 +360,61 @@ namespace LiteFX::Rendering::Backends {
 	};
 
 	/// <summary>
+	/// Implements a Vulkan <see cref="IDescriptorLayout" />
+	/// </summary>
+	/// <seealso cref="IVulkanBuffer" />
+	/// <seealso cref="IVulkanImage" />
+	/// <seealso cref="IVulkanSampler" />
+	/// <seealso cref="VulkanDescriptorSet" />
+	/// <seealso cref="VulkanDescriptorSetLayout" />
+	class LITEFX_VULKAN_API VulkanDescriptorLayout : public IDescriptorLayout {
+		LITEFX_IMPLEMENTATION(VulkanDescriptorLayoutImpl);
+
+	public:
+		/// <summary>
+		/// Initializes a new Vulkan descriptor layout.
+		/// </summary>
+		/// <param name="type">The type of the descriptor.</param>
+		/// <param name="binding">The binding point for the descriptor.</param>
+		/// <param name="elementSize">The size of the descriptor.</param>
+		/// <param name="elementSize">The number of descriptors in the descriptor array.</param>
+		explicit VulkanDescriptorLayout(const DescriptorType& type, const UInt32& binding, const size_t& elementSize, const UInt32& descriptors = 1);
+
+		/// <summary>
+		/// Initializes a new Vulkan descriptor layout for a static sampler.
+		/// </summary>
+		/// <param name="staticSampler">The static sampler to initialize the state with.</param>
+		/// <param name="binding">The binding point for the descriptor.</param>
+		explicit VulkanDescriptorLayout(UniquePtr<IVulkanSampler>&& staticSampler, const UInt32& binding);
+
+		VulkanDescriptorLayout(VulkanDescriptorLayout&&) = delete;
+		VulkanDescriptorLayout(const VulkanDescriptorLayout&) = delete;
+		virtual ~VulkanDescriptorLayout() noexcept;
+
+		// IDescriptorLayout interface.
+	public:
+		/// <inheritdoc />
+		virtual const DescriptorType& descriptorType() const noexcept override;
+
+		/// <inheritdoc />
+		virtual const UInt32& descriptors() const noexcept override;
+
+		/// <inheritdoc />
+		virtual const IVulkanSampler* staticSampler() const noexcept override;
+
+		// IBufferLayout interface.
+	public:
+		/// <inheritdoc />
+		virtual size_t elementSize() const noexcept override;
+
+		/// <inheritdoc />
+		virtual const UInt32& binding() const noexcept override;
+
+		/// <inheritdoc />
+		virtual const BufferType& type() const noexcept override;
+	};
+
+	/// <summary>
 	/// Implements a Vulkan <see cref="DescriptorSetLayout" />.
 	/// </summary>
 	/// <seealso cref="VulkanDescriptorSet" />
@@ -467,6 +478,9 @@ namespace LiteFX::Rendering::Backends {
 
 		/// <inheritdoc />
 		virtual UInt32 samplers() const noexcept override;
+
+		/// <inheritdoc />
+		virtual UInt32 staticSamplers() const noexcept override;
 
 		/// <inheritdoc />
 		virtual UInt32 inputAttachments() const noexcept override;

--- a/src/Backends/Vulkan/include/litefx/backends/vulkan.hpp
+++ b/src/Backends/Vulkan/include/litefx/backends/vulkan.hpp
@@ -335,8 +335,9 @@ namespace LiteFX::Rendering::Backends {
 		/// <summary>
 		/// Initializes a new Vulkan shader program.
 		/// </summary>
+		/// <param name="device">The parent device of the shader program.</param>
 		/// <param name="modules">The shader modules used by the shader program.</param>
-		explicit VulkanShaderProgram(Array<UniquePtr<VulkanShaderModule>>&& modules);
+		explicit VulkanShaderProgram(const VulkanDevice& device, Array<UniquePtr<VulkanShaderModule>>&& modules);
 		VulkanShaderProgram(VulkanShaderProgram&&) noexcept = delete;
 		VulkanShaderProgram(const VulkanShaderProgram&) noexcept = delete;
 		virtual ~VulkanShaderProgram() noexcept;
@@ -345,11 +346,19 @@ namespace LiteFX::Rendering::Backends {
 		/// <summary>
 		/// Initializes a new Vulkan shader program.
 		/// </summary>
-		explicit VulkanShaderProgram() noexcept;
+		explicit VulkanShaderProgram(const VulkanDevice& device) noexcept;
 
 	public:
 		/// <inheritdoc />
 		virtual Array<const VulkanShaderModule*> modules() const noexcept override;
+
+		/// <inheritdoc />
+		virtual SharedPtr<VulkanPipelineLayout> reflectPipelineLayout() const;
+
+	private:
+		virtual SharedPtr<IPipelineLayout> parsePipelineLayout() const override {
+			return std::static_pointer_cast<IPipelineLayout>(this->reflectPipelineLayout());
+		}
 	};
 
 	/// <summary>

--- a/src/Backends/Vulkan/include/litefx/backends/vulkan_builders.hpp
+++ b/src/Backends/Vulkan/include/litefx/backends/vulkan_builders.hpp
@@ -220,6 +220,9 @@ namespace LiteFX::Rendering::Backends {
 		/// <inheritdoc />
 		virtual VulkanDescriptorSetLayoutBuilder& withDescriptor(const DescriptorType& type, const UInt32& binding, const UInt32& descriptorSize, const UInt32& descriptors = 1) override;
 
+		/// <inheritdoc />
+		virtual VulkanDescriptorSetLayoutBuilder& withStaticSampler(const UInt32& binding, const FilterMode& magFilter = FilterMode::Nearest, const FilterMode& minFilter = FilterMode::Nearest, const BorderMode& borderU = BorderMode::Repeat, const BorderMode& borderV = BorderMode::Repeat, const BorderMode& borderW = BorderMode::Repeat, const MipMapMode& mipMapMode = MipMapMode::Nearest, const Float& mipMapBias = 0.f, const Float& minLod = 0.f, const Float& maxLod = std::numeric_limits<Float>::max(), const Float& anisotropy = 0.f) override;
+
 		// VulkanDescriptorSetLayoutBuilder.
 	public:
 		/// <summary>

--- a/src/Backends/Vulkan/src/descriptor_set_layout.cpp
+++ b/src/Backends/Vulkan/src/descriptor_set_layout.cpp
@@ -106,7 +106,7 @@ public:
             default: LITEFX_WARNING(VULKAN_LOG, "The descriptor type is unsupported. Binding will be skipped.");    return;
             }
 
-            if (type == DescriptorType::Sampler && layout->staticSampler() != nullptr)
+            if (type != DescriptorType::Sampler || (type == DescriptorType::Sampler && layout->staticSampler() == nullptr))
                 m_poolSizes[m_poolSizeMapping[binding.descriptorType]].descriptorCount++;
             else
                 binding.pImmutableSamplers = &layout->staticSampler()->handle();

--- a/src/Backends/Vulkan/src/descriptor_set_layout.cpp
+++ b/src/Backends/Vulkan/src/descriptor_set_layout.cpp
@@ -1,5 +1,6 @@
 #include <litefx/backends/vulkan.hpp>
 #include <litefx/backends/vulkan_builders.hpp>
+#include "image.h"
 
 using namespace LiteFX::Rendering::Backends;
 
@@ -349,6 +350,11 @@ VulkanDescriptorSetLayoutBuilder& VulkanDescriptorSetLayoutBuilder::withDescript
 VulkanDescriptorSetLayoutBuilder& VulkanDescriptorSetLayoutBuilder::withDescriptor(const DescriptorType& type, const UInt32& binding, const UInt32& descriptorSize, const UInt32& descriptors)
 {
     return this->withDescriptor(makeUnique<VulkanDescriptorLayout>(type, binding, descriptorSize, descriptors));
+}
+
+VulkanDescriptorSetLayoutBuilder& VulkanDescriptorSetLayoutBuilder::withStaticSampler(const UInt32& binding, const FilterMode& magFilter, const FilterMode& minFilter, const BorderMode& borderU, const BorderMode& borderV, const BorderMode& borderW, const MipMapMode& mipMapMode, const Float& mipMapBias, const Float& minLod, const Float& maxLod, const Float& anisotropy)
+{
+    return this->withDescriptor(makeUnique<VulkanDescriptorLayout>(makeUnique<VulkanSampler>(this->parent().device(), magFilter, minFilter, borderU, borderV, borderW, mipMapMode, mipMapBias, minLod, maxLod, anisotropy), binding));
 }
 
 VulkanDescriptorSetLayoutBuilder& VulkanDescriptorSetLayoutBuilder::space(const UInt32& space) noexcept

--- a/src/Backends/Vulkan/src/pipeline_layout.cpp
+++ b/src/Backends/Vulkan/src/pipeline_layout.cpp
@@ -31,6 +31,9 @@ public:
 public:
     VkPipelineLayout initialize()
     {
+        // Since Vulkan does not know spaces, descriptor sets are mapped to their indices based on the order they are defined. Hence we need to sort the descriptor set layouts accordingly.
+        std::ranges::sort(m_descriptorSetLayouts, [](const UniquePtr<VulkanDescriptorSetLayout>& a, const UniquePtr<VulkanDescriptorSetLayout>& b) { return a->space() < b->space(); });
+
         // Store the pipeline layout on the push constants.
         if (m_pushConstantsLayout != nullptr)
             m_pushConstantsLayout->pipelineLayout(*this->m_parent);

--- a/src/Backends/Vulkan/src/shader_module.cpp
+++ b/src/Backends/Vulkan/src/shader_module.cpp
@@ -25,7 +25,7 @@ public:
 
 private:
 	String readFileContents(const String& fileName) {
-		std::ifstream file(m_fileName, std::ios::in | std::ios::binary);
+		std::ifstream file(fileName, std::ios::in | std::ios::binary);
 
 		if (!file.is_open())
 			throw std::runtime_error("Unable to open shader file.");

--- a/src/Backends/Vulkan/src/shader_program.cpp
+++ b/src/Backends/Vulkan/src/shader_program.cpp
@@ -1,5 +1,8 @@
 #include <litefx/backends/vulkan.hpp>
 #include <litefx/backends/vulkan_builders.hpp>
+#include <spirv_reflect.h>
+#include <fstream>
+#include <numeric>
 
 using namespace LiteFX::Rendering::Backends;
 
@@ -14,16 +17,199 @@ public:
 
 private:
     Array<UniquePtr<VulkanShaderModule>> m_modules;
+    const VulkanDevice& m_device;
+
+private:
+    struct DescriptorInfo {
+    public:
+        UInt32 location;
+        UInt32 elementSize;
+        UInt32 elements;
+        DescriptorType type;
+
+        bool equals(const DescriptorInfo& rhs)
+        {
+            return
+                this->location == rhs.location &&
+                this->elements == rhs.elements &&
+                this->elementSize == rhs.elementSize &&
+                this->type == rhs.type;
+        }
+    };
+
+    struct DescriptorSetInfo {
+    public:
+        UInt32 space;
+        ShaderStage stage;
+        Array<DescriptorInfo> descriptors;
+    };
+
+    struct PushConstantRangeInfo {
+    public:
+        ShaderStage stage;
+        UInt32 offset;
+        UInt32 size;
+    };
 
 public:
-    VulkanShaderProgramImpl(VulkanShaderProgram* parent, Array<UniquePtr<VulkanShaderModule>>&& modules) :
-        base(parent), m_modules(std::move(modules))
+    VulkanShaderProgramImpl(VulkanShaderProgram* parent, const VulkanDevice& device, Array<UniquePtr<VulkanShaderModule>>&& modules) :
+        base(parent), m_device(device), m_modules(std::move(modules))
     {
     }
 
-    VulkanShaderProgramImpl(VulkanShaderProgram* parent) :
-        base(parent)
+    VulkanShaderProgramImpl(VulkanShaderProgram* parent, const VulkanDevice& device) :
+        base(parent), m_device(device)
     {
+    }
+
+public:
+    String readFileContents(const String& fileName) {
+        std::ifstream file(fileName, std::ios::in | std::ios::binary);
+
+        if (!file.is_open())
+            throw std::runtime_error("Unable to open shader file.");
+
+        std::stringstream buffer;
+        buffer << file.rdbuf();
+
+        return buffer.str();
+    }
+
+    SharedPtr<VulkanPipelineLayout> reflectPipelineLayout()
+    {
+        // First, filter the descriptor sets and push constant ranges.
+        Dictionary<UInt32, DescriptorSetInfo> descriptorSetLayouts;
+        Array<PushConstantRangeInfo> pushConstantRanges;
+
+        // Extract reflection data from all shader modules.
+        std::ranges::for_each(m_modules, [this, &descriptorSetLayouts, &pushConstantRanges](UniquePtr<VulkanShaderModule>& shaderModule) {
+            // Read the file and initialize a reflection module.
+            auto contents = this->readFileContents(shaderModule->fileName());
+            spv_reflect::ShaderModule reflection(contents.size(), contents.c_str());
+            auto result = reflection.GetResult();
+
+            if (result != SPV_REFLECT_RESULT_SUCCESS) [[unlikely]]
+                throw RuntimeException("Unable to reflect shader module (Error {0}).", reflection.GetResult());
+
+            // Get the number of descriptor sets and push constants.
+            UInt32 descriptorSetCount, pushConstantCount;
+
+            if ((result = reflection.EnumerateDescriptorSets(&descriptorSetCount, nullptr)) != SPV_REFLECT_RESULT_SUCCESS) [[unlikely]]
+                throw RuntimeException("Unable to get descriptor set count (Error {0}).", result);
+
+            if ((result = reflection.EnumeratePushConstants(&pushConstantCount, nullptr)) != SPV_REFLECT_RESULT_SUCCESS) [[unlikely]]
+                throw RuntimeException("Unable to get push constants count (Error {0}).", result);
+
+            // Acquire the descriptor sets and push constants.
+            Array<SpvReflectDescriptorSet*> descriptorSets(descriptorSetCount);
+            Array<SpvReflectBlockVariable*> pushConstants(pushConstantCount);
+
+            if ((result = reflection.EnumerateDescriptorSets(&descriptorSetCount, descriptorSets.data())) != SPV_REFLECT_RESULT_SUCCESS) [[unlikely]]
+                throw RuntimeException("Unable to enumerate descriptor sets (Error {0}).", result);
+
+            if ((result = reflection.EnumeratePushConstants(&pushConstantCount, pushConstants.data())) != SPV_REFLECT_RESULT_SUCCESS) [[unlikely]]
+                throw RuntimeException("Unable to enumerate push constants (Error {0}).", result);
+
+            // Parse the descriptor sets.
+            std::ranges::for_each(descriptorSets, [this, &shaderModule, &reflection, &descriptorSetLayouts](const SpvReflectDescriptorSet* descriptorSet) {
+                // Get all descriptor layouts.
+                Array<DescriptorInfo> descriptors(descriptorSet->binding_count);
+
+                std::ranges::generate(descriptors, [&descriptorSet, i = 0]() mutable {
+                    auto descriptor = descriptorSet->bindings[i++];
+
+                    // Filter the descriptor type.
+                    DescriptorType type;
+
+                    switch (descriptor->descriptor_type)
+                    {
+                    case SPV_REFLECT_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER:    throw RuntimeException("The shader exposes a combined image samplers, which is currently not supported.");
+                    case SPV_REFLECT_TYPE_FLAG_EXTERNAL_ACCELERATION_STRUCTURE: throw RuntimeException("The shader exposes an acceleration structure, which is currently not supported.");
+                    case SPV_REFLECT_DESCRIPTOR_TYPE_UNIFORM_BUFFER_DYNAMIC:
+                    case SPV_REFLECT_DESCRIPTOR_TYPE_STORAGE_BUFFER_DYNAMIC:    throw RuntimeException("The shader exposes a dynamic buffer, which is currently not supported.");
+                    case SPV_REFLECT_DESCRIPTOR_TYPE_SAMPLER:                   type = DescriptorType::Sampler; break;
+                    case SPV_REFLECT_DESCRIPTOR_TYPE_SAMPLED_IMAGE:             type = DescriptorType::Texture; break;
+                    case SPV_REFLECT_DESCRIPTOR_TYPE_STORAGE_IMAGE:             type = DescriptorType::WritableTexture; break;
+                    case SPV_REFLECT_DESCRIPTOR_TYPE_UNIFORM_TEXEL_BUFFER:      type = DescriptorType::Buffer; break;  // NOTE: Maps back to STORAGE_TEXEL_BUFFER, which might cause issues.
+                    case SPV_REFLECT_DESCRIPTOR_TYPE_STORAGE_TEXEL_BUFFER:      type = DescriptorType::WritableBuffer; break;
+                    case SPV_REFLECT_DESCRIPTOR_TYPE_UNIFORM_BUFFER:            type = DescriptorType::Uniform; break;
+                    case SPV_REFLECT_DESCRIPTOR_TYPE_STORAGE_BUFFER:            type = DescriptorType::Storage; break; // NOTE: There does not seem to be a representation for `WritableStorage`.
+                    case SPV_REFLECT_DESCRIPTOR_TYPE_INPUT_ATTACHMENT:          type = DescriptorType::InputAttachment; break;
+                    }
+
+                    // Count the array elements.
+                    UInt32 descriptors = 1;
+
+                    for (int i(0); i < descriptor->array.dims_count; ++i)
+                        descriptors *= descriptor->array.dims[i];
+
+                    // Create the descriptor layout.
+                    return DescriptorInfo{ .location = descriptor->binding, .elementSize = descriptor->block.padded_size, .elements = descriptors, .type = type };
+                });
+
+                if (!descriptorSetLayouts.contains(descriptorSet->set))
+                    descriptorSetLayouts.insert(std::make_pair(descriptorSet->set, DescriptorSetInfo{ .space = descriptorSet->set, .stage = shaderModule->type(), .descriptors = descriptors}));
+                else
+                {
+                    // If the set already exists in another stage, merge it.
+                    auto& layout = descriptorSetLayouts[descriptorSet->set];
+
+                    for (auto& descriptor : descriptors)
+                    {
+                        // Add the descriptor, if no other descriptor has been bound to the location. Otherwise, check if the descriptors are equal and drop it, if they aren't.
+                        if (auto match = std::ranges::find_if(layout.descriptors, [&descriptor](const DescriptorInfo& element) { return element.location == descriptor.location; }); match == layout.descriptors.end())
+                            layout.descriptors.push_back(descriptor);
+                        else if (!descriptor.equals(*match))
+                            LITEFX_WARNING(VULKAN_LOG, "Mismatching descriptors detected: the descriptor at location {0} ({3} elements with size of {4} bytes) of the descriptor set {1} in shader stage {2} conflicts with a descriptor from at least one other shader stage and will be dropped (conflicts with descriptor of type {9} in stage/s {6} with {7} elements of {8} bytes).",
+                                descriptor.location, descriptorSet->set, shaderModule->type(), descriptor.elements, descriptor.elementSize, layout.stage, match->elements, match->elementSize, match->type);
+                    }
+
+                    // Store the stage.
+                    layout.stage = shaderModule->type() | layout.stage;
+                }
+            });
+
+            // Parse push constants.
+            // NOTE: Block variables are not exposing the shader stage, they are used from. If there are two shader modules created from the same source, but with different 
+            //       entry points, each using their own push constants, it would be valid, but we are not able to tell which push constant range belongs to which stage.
+            if (pushConstantCount > 1)
+                LITEFX_WARNING(VULKAN_LOG, "More than one push constant range detected for shader stage {0}. If you have multiple entry points, you may be able to split them up into different shader files.", shaderModule->type());
+
+            std::ranges::for_each(pushConstants, [this, &shaderModule, &reflection, &pushConstantRanges](const SpvReflectBlockVariable* pushConstant) {
+                pushConstantRanges.push_back(PushConstantRangeInfo{ .stage = shaderModule->type(), .offset = pushConstant->absolute_offset, .size = pushConstant->padded_size });
+            });
+        });
+
+        // Create the descriptor set layouts.
+        Array<UniquePtr<VulkanDescriptorSetLayout>> descriptorSets(descriptorSetLayouts.size());
+        std::ranges::generate(descriptorSets, [this, &descriptorSetLayouts, i = 0]() mutable {
+            // Get the descriptor set layout.
+            auto it = descriptorSetLayouts.begin();
+            std::advance(it, i++);
+            auto& descriptorSet = it->second;
+
+            // Create the descriptor layouts.
+            Array<UniquePtr<VulkanDescriptorLayout>> descriptors(descriptorSet.descriptors.size());
+            std::ranges::generate(descriptors, [&descriptorSet, j = 0]() mutable {
+                auto& descriptor = descriptorSet.descriptors[j++];
+                return makeUnique<VulkanDescriptorLayout>(descriptor.type, descriptor.location, descriptor.elementSize, descriptor.elements);
+            });
+
+            return makeUnique<VulkanDescriptorSetLayout>(m_device, std::move(descriptors), descriptorSet.space, descriptorSet.stage);
+        });
+
+        // Create the push constants layout.
+        Array<UniquePtr<VulkanPushConstantsRange>> pushConstants(pushConstantRanges.size());
+        std::ranges::generate(pushConstants, [&pushConstantRanges, i = 0]() mutable {
+            auto& range = pushConstantRanges[i++];
+            return makeUnique<VulkanPushConstantsRange>(range.stage, range.offset, range.size, 0, 0);   // No space or binding for Vulkan push constants.
+        });
+
+        auto overallSize = std::accumulate(pushConstantRanges.begin(), pushConstantRanges.end(), 0, [](UInt32 currentSize, const auto& range) { return currentSize + range.size; });
+        auto pushConstantsLayout = makeUnique<VulkanPushConstantsLayout>(std::move(pushConstants), overallSize);
+
+        // Return the pipeline layout.
+        return makeShared<VulkanPipelineLayout>(m_device, std::move(descriptorSets), std::move(pushConstantsLayout));
     }
 };
 
@@ -31,13 +217,13 @@ public:
 // Interface.
 // ------------------------------------------------------------------------------------------------
 
-VulkanShaderProgram::VulkanShaderProgram(Array<UniquePtr<VulkanShaderModule>>&& modules) :
-    m_impl(makePimpl<VulkanShaderProgramImpl>(this, std::move(modules)))
+VulkanShaderProgram::VulkanShaderProgram(const VulkanDevice& device, Array<UniquePtr<VulkanShaderModule>>&& modules) :
+    m_impl(makePimpl<VulkanShaderProgramImpl>(this, device, std::move(modules)))
 {
 }
 
-VulkanShaderProgram::VulkanShaderProgram() noexcept :
-    m_impl(makePimpl<VulkanShaderProgramImpl>(this))
+VulkanShaderProgram::VulkanShaderProgram(const VulkanDevice& device) noexcept :
+    m_impl(makePimpl<VulkanShaderProgramImpl>(this, device))
 {
 }
 
@@ -48,6 +234,11 @@ Array<const VulkanShaderModule*> VulkanShaderProgram::modules() const noexcept
     return m_impl->m_modules |
         std::views::transform([](const UniquePtr<VulkanShaderModule>& shader) { return shader.get(); }) |
         ranges::to<Array<const VulkanShaderModule*>>();
+}
+
+SharedPtr<VulkanPipelineLayout> VulkanShaderProgram::reflectPipelineLayout() const
+{
+    return m_impl->reflectPipelineLayout();
 }
 
 #if defined(BUILD_DEFINE_BUILDERS)
@@ -75,7 +266,7 @@ public:
 // ------------------------------------------------------------------------------------------------
 
 VulkanShaderProgramBuilder::VulkanShaderProgramBuilder(const VulkanDevice& device) :
-    m_impl(makePimpl<VulkanShaderProgramBuilderImpl>(this, device)), ShaderProgramBuilder(SharedPtr<VulkanShaderProgram>(new VulkanShaderProgram()))
+    m_impl(makePimpl<VulkanShaderProgramBuilderImpl>(this, device)), ShaderProgramBuilder(SharedPtr<VulkanShaderProgram>(new VulkanShaderProgram(device)))
 {
 }
 

--- a/src/Rendering/include/litefx/rendering.hpp
+++ b/src/Rendering/include/litefx/rendering.hpp
@@ -315,6 +315,7 @@ namespace LiteFX::Rendering {
     /// Represents a shader program, consisting of multiple <see cref="IShaderModule" />s.
     /// </summary>
     /// <typeparam name="TShaderModule">The type of the shader module. Must implement <see cref="IShaderModule"/>.</typeparam>
+    /// <seealso href="https://github.com/crud89/LiteFX/wiki/Shader-Development" />
     template <typename TShaderModule> requires
         rtti::implements<TShaderModule, IShaderModule>
     class ShaderProgram : public IShaderProgram {

--- a/src/Rendering/include/litefx/rendering_api.hpp
+++ b/src/Rendering/include/litefx/rendering_api.hpp
@@ -3260,8 +3260,17 @@ namespace LiteFX::Rendering {
             return this->getModules();
         }
 
+        /// <summary>
+        /// Uses shader reflection to extract the pipeline layout of a shader. May not be available in all backends.
+        /// </summary>
+        /// <returns>The pipeline layout extracted from shader reflection.</returns>
+        SharedPtr<IPipelineLayout> reflectPipelineLayout() const {
+            return this->parsePipelineLayout();
+        };
+
     private:
         virtual Array<const IShaderModule*> getModules() const noexcept = 0;
+        virtual SharedPtr<IPipelineLayout> parsePipelineLayout() const = 0;
     };
 
     /// <summary>

--- a/src/Rendering/include/litefx/rendering_api.hpp
+++ b/src/Rendering/include/litefx/rendering_api.hpp
@@ -1795,6 +1795,7 @@ namespace LiteFX::Rendering {
     /// <remarks>
     /// A shader module corresponds to a single shader source file.
     /// </remarks>
+    /// <seealso href="https://github.com/crud89/LiteFX/wiki/Shader-Development" />
     class LITEFX_RENDERING_API IShaderModule {
     public:
         virtual ~IShaderModule() noexcept = default;
@@ -3247,6 +3248,7 @@ namespace LiteFX::Rendering {
     /// <summary>
     /// The interface for a shader program.
     /// </summary>
+    /// <seealso href="https://github.com/crud89/LiteFX/wiki/Shader-Development" />
     class LITEFX_RENDERING_API IShaderProgram {
     public:
         virtual ~IShaderProgram() noexcept = default;
@@ -3263,7 +3265,12 @@ namespace LiteFX::Rendering {
         /// <summary>
         /// Uses shader reflection to extract the pipeline layout of a shader. May not be available in all backends.
         /// </summary>
+        /// <remarks>
+        /// Note that shader reflection may not yield different results than you would expect, especially when using DirectX 12. For more information on how to use shader
+        /// reflection and how to write portable shaders, refer to the [shader development guide](https://github.com/crud89/LiteFX/wiki/Shader-Development) in the wiki.
+        /// </remarks>
         /// <returns>The pipeline layout extracted from shader reflection.</returns>
+        /// <seealso href="https://github.com/crud89/LiteFX/wiki/Shader-Development" />
         SharedPtr<IPipelineLayout> reflectPipelineLayout() const {
             return this->parsePipelineLayout();
         };
@@ -3567,6 +3574,9 @@ namespace LiteFX::Rendering {
         void use(const IPipeline& pipeline) const noexcept {
             this->cmdUse(pipeline);
         }
+
+        // TODO: Allow bind to last used pipeline (throw, if no pipeline is in use.
+        //void bind(const IDescriptorSet& descriptorSet) const;
 
         /// <summary>
         /// Binds the provided descriptor set to the provided pipeline.

--- a/src/Rendering/include/litefx/rendering_api.hpp
+++ b/src/Rendering/include/litefx/rendering_api.hpp
@@ -2557,6 +2557,17 @@ namespace LiteFX::Rendering {
         /// </summary>
         /// <returns>The number of descriptors in the descriptor array.</returns>
         virtual const UInt32& descriptors() const noexcept = 0;
+
+        /// <summary>
+        /// If the descriptor describes a static sampler, this method returns the state of the sampler. Otherwise, it returns <c>nullptr</c>.
+        /// </summary>
+        /// <remarks>
+        /// Static samplers are called immutable samplers in Vulkan and describe sampler states, that are defined along the pipeline layout. While they do
+        /// occupy a descriptor, they must not be bound explicitly. Instead, static samplers are automatically bound if the pipeline gets used. If a static
+        /// sampler is set, the <see cref="descriptorType" /> must be set to <see cref="DescriptorType::Sampler" />.
+        /// </remarks>
+        /// <returns>The state of the static sampler, or <c>nullptr</c>, if the descriptor is not a static sampler.</returns>
+        virtual const ISampler* staticSampler() const noexcept = 0;
     };
 
     /// <summary>
@@ -3114,10 +3125,18 @@ namespace LiteFX::Rendering {
         virtual UInt32 buffers() const noexcept = 0;
 
         /// <summary>
-        /// Returns the number of sampler descriptors within the descriptor set.
+        /// Returns the number of dynamic sampler descriptors within the descriptor set.
         /// </summary>
-        /// <returns>The number of sampler descriptors.</returns>
+        /// <returns>The number of dynamic sampler descriptors.</returns>
+        /// <seealso cref="staticSamplers" />
         virtual UInt32 samplers() const noexcept = 0;
+
+        /// <summary>
+        /// Returns the number of static or immutable sampler descriptors within the descriptor set.
+        /// </summary>
+        /// <returns>The number of static or immutable sampler descriptors.</returns>
+        /// <seealso cref="samplers" />
+        virtual UInt32 staticSamplers() const noexcept = 0;
 
         /// <summary>
         /// Returns the number of input attachment descriptors within the descriptor set.

--- a/src/Rendering/include/litefx/rendering_api.hpp
+++ b/src/Rendering/include/litefx/rendering_api.hpp
@@ -3287,6 +3287,21 @@ namespace LiteFX::Rendering {
         /// <remarks>
         /// Note that shader reflection may not yield different results than you would expect, especially when using DirectX 12. For more information on how to use shader
         /// reflection and how to write portable shaders, refer to the [shader development guide](https://github.com/crud89/LiteFX/wiki/Shader-Development) in the wiki.
+        /// 
+        /// In particular, shader reflection is not able to restore:
+        /// 
+        /// <list type="bullet">
+        /// <item>
+        /// <description>
+        /// Input attachments in DirectX. Instead, input attachments are treated as <c>DescriptorType::Texture</c>. This is usually not a problem, since DirectX does not
+        /// have a concept of render pass outputs/inputs anyway. However, keep this in mind, if you want to filter descriptors based on their type, for example.
+        /// </description>
+        /// <description>
+        /// Immutable sampler states in Vulkan. Those are only restored in DirectX, if an explicit root signature has been provided. For this reason, it is best not to use
+        /// them, if you want to use shader reflection.
+        /// </description>
+        /// </item>
+        /// </list>
         /// </remarks>
         /// <returns>The pipeline layout extracted from shader reflection.</returns>
         /// <seealso href="https://github.com/crud89/LiteFX/wiki/Shader-Development" />

--- a/src/Rendering/include/litefx/rendering_builders.hpp
+++ b/src/Rendering/include/litefx/rendering_builders.hpp
@@ -182,6 +182,22 @@ namespace LiteFX::Rendering {
         /// <param name="descriptors">The number of descriptors to bind.</param>
         virtual TDerived& withDescriptor(const DescriptorType& type, const UInt32& binding, const UInt32& descriptorSize, const UInt32& descriptors = 1) = 0;
 
+        /// <summary>
+        /// Defines a static sampler at the descriptor bound to <see cref="binding" />.
+        /// </summary>
+        /// <param name="binding">The binding point for the descriptor.</param>
+        /// <param name="magFilter">The magnifying filter operation.</param>
+        /// <param name="minFilter">The minifying filter operation.</param>
+        /// <param name="borderU">The border address mode into U direction.</param>
+        /// <param name="borderV">The border address mode into V direction.</param>
+        /// <param name="borderW">The border address mode into W direction.</param>
+        /// <param name="mipMapMode">The mip map filter operation.</param>
+        /// <param name="mipMapBias">The mip map bias.</param>
+        /// <param name="minLod">The closest mip map distance level.</param>
+        /// <param name="maxLod">The furthest mip map distance level. </param>
+        /// <param name="anisotropy">The maximum anisotropy.</param>
+        virtual TDerived& withStaticSampler(const UInt32& binding, const FilterMode& magFilter = FilterMode::Nearest, const FilterMode& minFilter = FilterMode::Nearest, const BorderMode& borderU = BorderMode::Repeat, const BorderMode& borderV = BorderMode::Repeat, const BorderMode& borderW = BorderMode::Repeat, const MipMapMode& mipMapMode = MipMapMode::Nearest, const Float& mipMapBias = 0.f, const Float& minLod = 0.f, const Float& maxLod = std::numeric_limits<Float>::max(), const Float& anisotropy = 0.f) = 0;
+
     public:
         /// <summary>
         /// Adds an uniform/constant buffer descriptor.

--- a/src/Samples/BasicRendering/src/sample.cpp
+++ b/src/Samples/BasicRendering/src/sample.cpp
@@ -48,7 +48,6 @@ void initRenderGraph(TRenderBackend* backend, SharedPtr<IViewport> viewport, Sha
     using ShaderProgram = TRenderBackend::shader_program_type;
     using InputAssembler = TRenderBackend::input_assembler_type;
     using Rasterizer = TRenderBackend::rasterizer_type;
-    using ShaderProgram = TRenderBackend::shader_program_type;
 
     // Get the default device.
     auto device = backend->device("Default");
@@ -206,6 +205,9 @@ void SampleApp::run()
 #endif // BUILD_VULKAN_BACKEND
 
 #ifdef BUILD_DIRECTX_12_BACKEND
+    // We do not need to provide a root signature for shader reflection (refer to the project wiki for more information: https://github.com/crud89/LiteFX/wiki/Shader-Development).
+    DirectX12ShaderProgram::suppressMissingRootSignatureWarning();
+
     // Register the DirectX 12 backend de-/initializer.
     this->onBackendStart<DirectX12Backend>(startCallback);
     this->onBackendStop<DirectX12Backend>(stopCallback);

--- a/src/Samples/BasicRendering/src/sample.cpp
+++ b/src/Samples/BasicRendering/src/sample.cpp
@@ -48,6 +48,7 @@ void initRenderGraph(TRenderBackend* backend, SharedPtr<IViewport> viewport, Sha
     using ShaderProgram = TRenderBackend::shader_program_type;
     using InputAssembler = TRenderBackend::input_assembler_type;
     using Rasterizer = TRenderBackend::rasterizer_type;
+    using ShaderProgram = TRenderBackend::shader_program_type;
 
     // Get the default device.
     auto device = backend->device("Default");
@@ -68,6 +69,11 @@ void initRenderGraph(TRenderBackend* backend, SharedPtr<IViewport> viewport, Sha
         .renderTarget(RenderTargetType::Present, Format::B8G8R8A8_UNORM, { 0.1f, 0.1f, 0.1f, 1.f }, true, false, false)
         .renderTarget(RenderTargetType::DepthStencil, Format::D32_SFLOAT, { 1.f, 0.f, 0.f, 0.f }, true, false, false);
 
+    // Create the shader program.
+    SharedPtr<ShaderProgram> shaderProgram = device->buildShaderProgram()
+        .withVertexShaderModule("shaders/basic_vs." + FileExtensions<TRenderBackend>::SHADER)
+        .withFragmentShaderModule("shaders/basic_fs." + FileExtensions<TRenderBackend>::SHADER);
+
     // Create a render pipeline.
     UniquePtr<RenderPipeline> renderPipeline = device->buildRenderPipeline(*renderPass, "Geometry")
         .viewport(viewport)
@@ -78,16 +84,8 @@ void initRenderGraph(TRenderBackend* backend, SharedPtr<IViewport> viewport, Sha
             .cullMode(CullMode::BackFaces)
             .cullOrder(CullOrder::ClockWise)
             .lineWidth(1.f))
-        .layout(device->buildPipelineLayout()
-            .descriptorSet(DescriptorSets::Constant, ShaderStage::Vertex | ShaderStage::Fragment)
-                .withUniform(0, sizeof(CameraBuffer))
-                .add()
-            .descriptorSet(DescriptorSets::PerFrame, ShaderStage::Vertex)
-                .withUniform(0, sizeof(TransformBuffer))
-                .add())
-        .shaderProgram(device->buildShaderProgram()
-            .withVertexShaderModule("shaders/basic_vs." + FileExtensions<TRenderBackend>::SHADER)
-            .withFragmentShaderModule("shaders/basic_fs." + FileExtensions<TRenderBackend>::SHADER));
+        .layout(shaderProgram->reflectPipelineLayout())
+        .shaderProgram(shaderProgram);
 
     // Add the resources to the device state.
     device->state().add(std::move(renderPass));

--- a/src/Samples/Multisampling/src/sample.cpp
+++ b/src/Samples/Multisampling/src/sample.cpp
@@ -68,6 +68,11 @@ void initRenderGraph(TRenderBackend* backend, SharedPtr<IViewport> viewport, Sha
         .renderTarget(RenderTargetType::Present, Format::B8G8R8A8_UNORM, { 0.1f, 0.1f, 0.1f, 1.f }, true, false, false)
         .renderTarget(RenderTargetType::DepthStencil, Format::D32_SFLOAT, { 1.f, 0.f, 0.f, 0.f }, true, false, false);
 
+    // Create a shader program.
+    SharedPtr<ShaderProgram> shaderProgram = device->buildShaderProgram()
+        .withVertexShaderModule("shaders/basic_vs." + FileExtensions<TRenderBackend>::SHADER)
+        .withFragmentShaderModule("shaders/basic_fs." + FileExtensions<TRenderBackend>::SHADER);
+
     // Create a render pipeline.
     UniquePtr<RenderPipeline> renderPipeline = device->buildRenderPipeline(*renderPass, "Geometry")
         .viewport(viewport)
@@ -78,16 +83,8 @@ void initRenderGraph(TRenderBackend* backend, SharedPtr<IViewport> viewport, Sha
             .cullMode(CullMode::BackFaces)
             .cullOrder(CullOrder::ClockWise)
             .lineWidth(1.f))
-        .layout(device->buildPipelineLayout()
-            .descriptorSet(DescriptorSets::Constant, ShaderStage::Vertex | ShaderStage::Fragment)
-                .withUniform(0, sizeof(CameraBuffer))
-                .add()
-            .descriptorSet(DescriptorSets::PerFrame, ShaderStage::Vertex)
-                .withUniform(0, sizeof(TransformBuffer))
-                .add())
-        .shaderProgram(device->buildShaderProgram()
-            .withVertexShaderModule("shaders/basic_vs." + FileExtensions<TRenderBackend>::SHADER)
-            .withFragmentShaderModule("shaders/basic_fs." + FileExtensions<TRenderBackend>::SHADER));
+        .layout(shaderProgram->reflectPipelineLayout())
+        .shaderProgram(shaderProgram);
 
     // Add the resources to the device state.
     device->state().add(std::move(renderPass));
@@ -208,6 +205,9 @@ void SampleApp::run()
 #endif // BUILD_VULKAN_BACKEND
 
 #ifdef BUILD_DIRECTX_12_BACKEND
+    // We do not need to provide a root signature for shader reflection (refer to the project wiki for more information: https://github.com/crud89/LiteFX/wiki/Shader-Development).
+    DirectX12ShaderProgram::suppressMissingRootSignatureWarning();
+
     // Register the DirectX 12 backend de-/initializer.
     this->onBackendStart<DirectX12Backend>(startCallback);
     this->onBackendStop<DirectX12Backend>(stopCallback);

--- a/src/Samples/PushConstants/shaders/push_constants_vs.hlsl
+++ b/src/Samples/PushConstants/shaders/push_constants_vs.hlsl
@@ -1,5 +1,11 @@
 #pragma pack_matrix(row_major)
 
+// For DXIL we need to define a root signature, in order for shader reflection to properly pick up the push constants.
+#define ROOT_SIGNATURE \
+    "RootFlags(ALLOW_INPUT_ASSEMBLER_INPUT_LAYOUT), " \
+    "CBV(b0, space = 0, flags = DATA_STATIC_WHILE_SET_AT_EXECUTE), " \
+    "RootConstants(num32BitConstants = 20, b0, space = 1, visibility = SHADER_VISIBILITY_VERTEX)"
+
 struct VertexData 
 {
     float4 Position : SV_POSITION;
@@ -31,6 +37,7 @@ ConstantBuffer<CameraData>    camera    : register(b0, space0);
 ConstantBuffer<TransformData> transform : register(b0, space1);
 #endif
 
+[RootSignature(ROOT_SIGNATURE)]
 VertexData main(in VertexInput input)
 {
     VertexData vertex;

--- a/src/Samples/PushConstants/src/sample.cpp
+++ b/src/Samples/PushConstants/src/sample.cpp
@@ -75,7 +75,6 @@ void initRenderGraph(TRenderBackend* backend, SharedPtr<IViewport> viewport, Sha
     using ShaderProgram = TRenderBackend::shader_program_type;
     using InputAssembler = TRenderBackend::input_assembler_type;
     using Rasterizer = TRenderBackend::rasterizer_type;
-    using ShaderProgram = TRenderBackend::shader_program_type;
 
     // Get the default device.
     auto device = backend->device("Default");
@@ -112,13 +111,6 @@ void initRenderGraph(TRenderBackend* backend, SharedPtr<IViewport> viewport, Sha
             .cullOrder(CullOrder::ClockWise)
             .lineWidth(1.f)
             .depthState(DepthStencilState::DepthState{ .Operation = CompareOperation::LessEqual }))
-        //.layout(device->buildPipelineLayout()
-        //    .descriptorSet(DescriptorSets::Constant, ShaderStage::Vertex | ShaderStage::Fragment)
-        //        .withUniform(0, sizeof(CameraBuffer))
-        //        .add()
-        //    .pushConstants(sizeof(ObjectBuffer))
-        //        .withRange(ShaderStage::Vertex, 0, sizeof(ObjectBuffer), 1, 0)
-        //        .add())
         .layout(shaderProgram->reflectPipelineLayout())
         .shaderProgram(shaderProgram);
 

--- a/src/Samples/RenderPasses/shaders/geometry_pass_vs.hlsl
+++ b/src/Samples/RenderPasses/shaders/geometry_pass_vs.hlsl
@@ -1,5 +1,11 @@
 #pragma pack_matrix(row_major)
 
+// For DXIL we need to define a root signature, in order for shader reflection to properly pick up the push constants.
+#define ROOT_SIGNATURE \
+    "RootFlags(ALLOW_INPUT_ASSEMBLER_INPUT_LAYOUT), " \
+    "CBV(b0, space = 0, flags = DATA_STATIC_WHILE_SET_AT_EXECUTE), " \
+    "CBV(b0, space = 1, flags = DATA_STATIC_WHILE_SET_AT_EXECUTE)"
+
 struct VertexData 
 {
     float4 Position : SV_POSITION;
@@ -28,6 +34,7 @@ struct TransformData
 ConstantBuffer<CameraData>    camera    : register(b0, space0);
 ConstantBuffer<TransformData> transform : register(b0, space1);
 
+[RootSignature(ROOT_SIGNATURE)]
 VertexData main(in VertexInput input)
 {
     VertexData vertex;

--- a/src/Samples/RenderPasses/shaders/lighting_pass_fs.hlsl
+++ b/src/Samples/RenderPasses/shaders/lighting_pass_fs.hlsl
@@ -9,6 +9,7 @@ struct VertexData
 struct FragmentData
 {
     float4 Color : SV_TARGET0;
+    float Depth : SV_DEPTH;
 };
 
 #ifdef SPIRV
@@ -26,8 +27,10 @@ FragmentData main(VertexData input)
 
 #ifdef SPIRV  
     fragment.Color = gDiffuse.SubpassLoad();
+    fragment.Depth = gDepth.SubpassLoad();
 #elif DXIL
     fragment.Color = gDiffuse.Sample(gBuffer, input.TextureCoordinate).rgba;
+    fragment.Depth = gDepth.Sample(gBuffer, input.TextureCoordinate).r;
 #endif
     
     return fragment;

--- a/src/Samples/RenderPasses/shaders/lighting_pass_vs.hlsl
+++ b/src/Samples/RenderPasses/shaders/lighting_pass_vs.hlsl
@@ -1,5 +1,12 @@
 #pragma pack_matrix(row_major)
 
+// For DXIL we need to define a root signature, in order for shader reflection to properly pick up the push constants.
+#define ROOT_SIGNATURE \
+    "RootFlags(ALLOW_INPUT_ASSEMBLER_INPUT_LAYOUT), " \
+    "SRV(t0, space = 0, flags = DATA_STATIC_WHILE_SET_AT_EXECUTE), " \
+    "SRV(t1, space = 0, flags = DATA_STATIC_WHILE_SET_AT_EXECUTE), " \
+    "StaticSampler(s0, filter = FILTER_MIN_MAG_MIP_LINEAR)"
+
 struct VertexData 
 {
     float4 Position : SV_POSITION;
@@ -18,6 +25,7 @@ struct VertexInput
     float2 TextureCoordinate : TEXCOORD0;
 };
 
+[RootSignature(ROOT_SIGNATURE)]
 VertexData main(in VertexInput input)
 {
     VertexData vertex;

--- a/src/Samples/UniformArrays/src/sample.cpp
+++ b/src/Samples/UniformArrays/src/sample.cpp
@@ -105,6 +105,11 @@ void initRenderGraph(TRenderBackend* backend, SharedPtr<IViewport> viewport, Sha
         .renderTarget(RenderTargetType::Present, Format::B8G8R8A8_UNORM, { 0.1f, 0.1f, 0.1f, 1.f }, true, false, false)
         .renderTarget(RenderTargetType::DepthStencil, Format::D32_SFLOAT, { 1.f, 0.f, 0.f, 0.f }, true, false, false);
 
+    // Create a shader program.
+    SharedPtr<ShaderProgram> shaderProgram = device->buildShaderProgram()
+        .withVertexShaderModule("shaders/ubo_array_vs." + FileExtensions<TRenderBackend>::SHADER)
+        .withFragmentShaderModule("shaders/ubo_array_fs." + FileExtensions<TRenderBackend>::SHADER);
+
     // Create a render pipeline.
     UniquePtr<RenderPipeline> renderPipeline = device->buildRenderPipeline(*renderPass, "Geometry")
         .viewport(viewport)
@@ -115,17 +120,8 @@ void initRenderGraph(TRenderBackend* backend, SharedPtr<IViewport> viewport, Sha
             .cullMode(CullMode::BackFaces)
             .cullOrder(CullOrder::ClockWise)
             .lineWidth(1.f))
-        .layout(device->buildPipelineLayout()
-            .descriptorSet(DescriptorSets::Constant, ShaderStage::Vertex | ShaderStage::Fragment)
-                .withUniform(0, sizeof(CameraBuffer))
-                .withUniform(1, sizeof(LightBuffer), LIGHT_SOURCES)
-                .add()
-            .descriptorSet(DescriptorSets::PerFrame, ShaderStage::Vertex)
-                .withUniform(0, sizeof(TransformBuffer))
-                .add())
-        .shaderProgram(device->buildShaderProgram()
-            .withVertexShaderModule("shaders/ubo_array_vs." + FileExtensions<TRenderBackend>::SHADER)
-            .withFragmentShaderModule("shaders/ubo_array_fs." + FileExtensions<TRenderBackend>::SHADER));
+        .layout(shaderProgram->reflectPipelineLayout())
+        .shaderProgram(shaderProgram);
 
     // Add the resources to the device state.
     device->state().add(std::move(renderPass));
@@ -272,6 +268,9 @@ void SampleApp::run()
 #endif // BUILD_VULKAN_BACKEND
 
 #ifdef BUILD_DIRECTX_12_BACKEND
+    // We do not need to provide a root signature for shader reflection (refer to the project wiki for more information: https://github.com/crud89/LiteFX/wiki/Shader-Development).
+    DirectX12ShaderProgram::suppressMissingRootSignatureWarning();
+
     // Register the DirectX 12 backend de-/initializer.
     this->onBackendStart<DirectX12Backend>(startCallback);
     this->onBackendStop<DirectX12Backend>(stopCallback);

--- a/src/vcpkg.json
+++ b/src/vcpkg.json
@@ -18,6 +18,7 @@
     "spdlog",
     "stb",
     "vulkan",
+    "spirv-reflect",
     "vulkan-memory-allocator",
     "d3d12-memory-allocator"
   ]


### PR DESCRIPTION
**Describe the pull request**

This PR adds support for creating pipeline layouts from shader reflection. Currently pipeline layouts need to be explicitly defined in code:

```cxx
SharedPtr<ShaderProgram> shaderProgram = device->buildShaderProgram()
    .withVertexShaderModule("shaders/basic_vs." + FileExtensions<TRenderBackend>::SHADER)
    .withFragmentShaderModule("shaders/basic_fs." + FileExtensions<TRenderBackend>::SHADER)); 

UniquePtr<RenderPipeline> renderPipeline = device->buildRenderPipeline(*renderPass, "Pipeline")
    .layout(device->buildPipelineLayout()
        .descriptorSet(DescriptorSets::Constant, ShaderStage::Vertex | ShaderStage::Fragment)
            .withUniform(0, sizeof(CameraBuffer))
            .add()
        .descriptorSet(DescriptorSets::PerFrame, ShaderStage::Vertex)
            .withUniform(0, sizeof(TransformBuffer))
            .add())
    .shaderProgram(shaderProgram);
```

With this PR, it is possible to generate a layout directly from the shader program by calling `reflectPipelineLayout` on it:

```cxx
SharedPtr<ShaderProgram> shaderProgram = device->buildShaderProgram()
    .withVertexShaderModule("shaders/basic_vs." + FileExtensions<TRenderBackend>::SHADER)
    .withFragmentShaderModule("shaders/basic_fs." + FileExtensions<TRenderBackend>::SHADER)); 

UniquePtr<RenderPipeline> renderPipeline = device->buildRenderPipeline(*renderPass, "Pipeline")
    .layout(shaderProgram->reflectPipelineLayout())
    .shaderProgram(shaderProgram);
```

Additionally, in DirectX, it is not possible to define input attachments as subpass references. Instead the engine automatically defines a static sampler at register `s0` of space 0. With reflection, render targets are being treated as normal texture descriptors, since it is not possible to tell them apart based on their usage. The static sampler, however, is currently not supported to be de-serialized. To solve this, the pipeline layout is improved with support for static samplers.

**Related issues**

- [x] Fixes #5.
- [x] Fixes #69. 

A designated topic regarding shaders can be found [in the project wiki](https://github.com/crud89/LiteFX/wiki/Shader-Development).