### PR TITLE
Add support for debug objects.

### DIFF
--- a/docs/release-logs/0.3.1.md
+++ b/docs/release-logs/0.3.1.md
@@ -9,4 +9,5 @@
 - Backends can now be switched at runtime. Samples have been updated to work on both backends, if they are built. ([See PR #66](https://github.com/crud89/LiteFX/pull/66))
 - Pipeline layouts can now be defined using shader reflection. ([See PR #68](https://github.com/crud89/LiteFX/pull/68))
 - It is now possible to initialize a descriptor with a static/immutable sampler state. ([See PR #68](https://github.com/crud89/LiteFX/pull/68))
+- Debugging has been improved with support for debug objects for DirectX 12 ❎ and Vulkan 🌋. ([See PR #70](https://github.com/crud89/LiteFX/pull/70))
 - Vulkan 🌋: If the DX12 backend is available, the Vulkan uses an interop swap chain to support flip-model swap effects for lower latencies. ([See PR #66](https://github.com/crud89/LiteFX/pull/66))

--- a/src/Backends/DirectX12/include/litefx/backends/dx12.hpp
+++ b/src/Backends/DirectX12/include/litefx/backends/dx12.hpp
@@ -922,9 +922,6 @@ namespace LiteFX::Rendering::Backends {
 		// Pipeline interface.
 	public:
 		/// <inheritdoc />
-		virtual const String& name() const noexcept override;
-
-		/// <inheritdoc />
 		virtual SharedPtr<const DirectX12ShaderProgram> program() const noexcept override;
 
 		/// <inheritdoc />

--- a/src/Backends/DirectX12/include/litefx/backends/dx12_builders.hpp
+++ b/src/Backends/DirectX12/include/litefx/backends/dx12_builders.hpp
@@ -466,13 +466,25 @@ namespace LiteFX::Rendering::Backends {
 		virtual DirectX12RenderPassBuilder& renderTarget(const RenderTargetType& type, const Format& format, const Vector4f& clearValues = { 0.0f, 0.0f, 0.0f, 0.0f }, bool clearColor = true, bool clearStencil = true, bool isVolatile = false) override;
 
 		/// <inheritdoc />
+		virtual DirectX12RenderPassBuilder& renderTarget(const String& name, const RenderTargetType& type, const Format& format, const Vector4f& clearValues = { 0.0f, 0.0f, 0.0f, 0.0f }, bool clearColor = true, bool clearStencil = true, bool isVolatile = false) override;
+
+		/// <inheritdoc />
 		virtual DirectX12RenderPassBuilder& renderTarget(const UInt32& location, const RenderTargetType& type, const Format& format, const Vector4f& clearValues = { 0.0f, 0.0f, 0.0f, 0.0f }, bool clearColor = true, bool clearStencil = true, bool isVolatile = false) override;
+
+		/// <inheritdoc />
+		virtual DirectX12RenderPassBuilder& renderTarget(const String& name, const UInt32& location, const RenderTargetType& type, const Format& format, const Vector4f& clearValues = { 0.0f, 0.0f, 0.0f, 0.0f }, bool clearColor = true, bool clearStencil = true, bool isVolatile = false) override;
 
 		/// <inheritdoc />
 		virtual DirectX12RenderPassBuilder& renderTarget(DirectX12InputAttachmentMapping& output, const RenderTargetType& type, const Format& format, const Vector4f& clearValues = { 0.0f, 0.0f, 0.0f, 0.0f }, bool clearColor = true, bool clearStencil = true, bool isVolatile = false) override;
 
 		/// <inheritdoc />
+		virtual DirectX12RenderPassBuilder& renderTarget(const String& name, DirectX12InputAttachmentMapping& output, const RenderTargetType& type, const Format& format, const Vector4f& clearValues = { 0.0f, 0.0f, 0.0f, 0.0f }, bool clearColor = true, bool clearStencil = true, bool isVolatile = false) override;
+
+		/// <inheritdoc />
 		virtual DirectX12RenderPassBuilder& renderTarget(DirectX12InputAttachmentMapping& output, const UInt32& location, const RenderTargetType& type, const Format& format, const Vector4f& clearValues = { 0.0f, 0.0f, 0.0f, 0.0f }, bool clearColor = true, bool clearStencil = true, bool isVolatile = false) override;
+
+		/// <inheritdoc />
+		virtual DirectX12RenderPassBuilder& renderTarget(const String& name, DirectX12InputAttachmentMapping& output, const UInt32& location, const RenderTargetType& type, const Format& format, const Vector4f& clearValues = { 0.0f, 0.0f, 0.0f, 0.0f }, bool clearColor = true, bool clearStencil = true, bool isVolatile = false) override;
 
 		/// <inheritdoc />
 		virtual DirectX12RenderPassBuilder& inputAttachment(const DirectX12InputAttachmentMapping& inputAttachment) override;

--- a/src/Backends/DirectX12/src/backend.cpp
+++ b/src/Backends/DirectX12/src/backend.cpp
@@ -123,6 +123,10 @@ void DirectX12Backend::registerDevice(String name, UniquePtr<DirectX12Device>&& 
     if (m_impl->m_devices.contains(name)) [[unlikely]]
         throw InvalidArgumentException("The backend already contains a device with the name \"{0}\".", name);
 
+#ifndef NDEBUG
+    std::as_const(*device).handle()->SetName(Widen(name).c_str());
+#endif
+
     m_impl->m_devices.insert(std::make_pair(name, std::move(device)));
 }
 

--- a/src/Backends/DirectX12/src/buffer.cpp
+++ b/src/Backends/DirectX12/src/buffer.cpp
@@ -37,7 +37,13 @@ DirectX12Buffer::DirectX12Buffer(ComPtr<ID3D12Resource>&& buffer, const BufferTy
 	this->handle() = std::move(buffer);
 
 	if (!name.empty())
+	{
 		this->name() = name;
+
+#ifndef NDEBUG
+		this->handle()->SetName(Widen(name).c_str());
+#endif
+	}
 }
 
 DirectX12Buffer::~DirectX12Buffer() noexcept = default;

--- a/src/Backends/DirectX12/src/image.cpp
+++ b/src/Backends/DirectX12/src/image.cpp
@@ -42,7 +42,13 @@ DirectX12Image::DirectX12Image(const DirectX12Device& device, ComPtr<ID3D12Resou
 	this->handle() = std::move(image);
 
 	if (!name.empty())
+	{
 		this->name() = name;
+
+#ifndef NDEBUG
+		this->handle()->SetName(Widen(name).c_str());
+#endif
+	}
 }
 
 DirectX12Image::~DirectX12Image() noexcept = default;

--- a/src/Backends/DirectX12/src/render_pass.cpp
+++ b/src/Backends/DirectX12/src/render_pass.cpp
@@ -284,7 +284,12 @@ void DirectX12RenderPass::begin(const UInt32& buffer)
     m_impl->m_beginCommandBuffer->barrier(transitionBarrier);
 
 #ifndef NDEBUG
-    if (!m_impl->m_name.empty())
+    // NOTE: Using those APIs is fine, however they trigger an annoying warning in the debug layer about using PIXBeginEvent/PIXEndEvent instead. To do 
+    //       this, it is required to link against the PIX runtime, which I don't want to just to be able to have debug events. Unfortunately, the error
+    //       ID is CORRUPTED_PARAMETER2, which should not be filtered out. To fix this issue, we should provide "compatible" PIX metadata instead of 
+    //       plain strings. For now, we simply check if a debugger is attached and in this case do not call those APIs, which should silence the info 
+    //       queue.
+    if (!::IsDebuggerPresent() && !m_impl->m_name.empty())
         m_impl->m_device.graphicsQueue().handle()->BeginEvent(1, m_impl->m_name.c_str(), m_impl->m_name.size());
 #endif
 
@@ -358,7 +363,7 @@ void DirectX12RenderPass::end() const
     m_impl->m_activeFrameBuffer->lastFence() = m_impl->m_device.graphicsQueue().submit(commandBuffers);
 
 #ifndef NDEBUG
-    if (!m_impl->m_name.empty())
+    if (!::IsDebuggerPresent() && !m_impl->m_name.empty())
         m_impl->m_device.graphicsQueue().handle()->EndEvent();
 #endif
 

--- a/src/Backends/DirectX12/src/render_pass.cpp
+++ b/src/Backends/DirectX12/src/render_pass.cpp
@@ -437,12 +437,24 @@ DirectX12RenderPassBuilder& DirectX12RenderPassBuilder::renderTarget(const Rende
 {
     // TODO: This might be invalid, if another target is already defined with a custom location, however in this case we have no guarantee that the location range will be contiguous
     //       until the render pass is initialized, so we silently ignore this for now.
-    return this->renderTarget(static_cast<UInt32>(m_impl->m_renderTargets.size()), type, format, clearValues, clear, clearStencil, isVolatile);
+    return this->renderTarget("", static_cast<UInt32>(m_impl->m_renderTargets.size()), type, format, clearValues, clear, clearStencil, isVolatile);
+}
+
+DirectX12RenderPassBuilder& DirectX12RenderPassBuilder::renderTarget(const String& name, const RenderTargetType& type, const Format& format, const Vector4f& clearValues, bool clear, bool clearStencil, bool isVolatile)
+{
+    // TODO: This might be invalid, if another target is already defined with a custom location, however in this case we have no guarantee that the location range will be contiguous
+    //       until the render pass is initialized, so we silently ignore this for now.
+    return this->renderTarget(name, static_cast<UInt32>(m_impl->m_renderTargets.size()), type, format, clearValues, clear, clearStencil, isVolatile);
 }
 
 DirectX12RenderPassBuilder& DirectX12RenderPassBuilder::renderTarget(const UInt32& location, const RenderTargetType& type, const Format& format, const Vector4f& clearValues, bool clear, bool clearStencil, bool isVolatile)
 {
-    m_impl->m_renderTargets.push_back(RenderTarget(location, type, format, clear, clearValues, clearStencil, isVolatile));
+    return this->renderTarget("", location, type, format, clearValues, clear, clearStencil, isVolatile);
+}
+
+DirectX12RenderPassBuilder& DirectX12RenderPassBuilder::renderTarget(const String& name, const UInt32& location, const RenderTargetType& type, const Format& format, const Vector4f& clearValues, bool clear, bool clearStencil, bool isVolatile)
+{
+    m_impl->m_renderTargets.push_back(RenderTarget(name, location, type, format, clear, clearValues, clearStencil, isVolatile));
     return *this;
 }
 
@@ -450,12 +462,24 @@ DirectX12RenderPassBuilder& DirectX12RenderPassBuilder::renderTarget(DirectX12In
 {
     // TODO: This might be invalid, if another target is already defined with a custom location, however in this case we have no guarantee that the location range will be contiguous
     //       until the render pass is initialized, so we silently ignore this for now.
-    return this->renderTarget(output, static_cast<UInt32>(m_impl->m_renderTargets.size()), type, format, clearValues, clear, clearStencil, isVolatile);
+    return this->renderTarget("", output, static_cast<UInt32>(m_impl->m_renderTargets.size()), type, format, clearValues, clear, clearStencil, isVolatile);
+}
+
+DirectX12RenderPassBuilder& DirectX12RenderPassBuilder::renderTarget(const String& name, DirectX12InputAttachmentMapping& output, const RenderTargetType& type, const Format& format, const Vector4f& clearValues, bool clear, bool clearStencil, bool isVolatile)
+{
+    // TODO: This might be invalid, if another target is already defined with a custom location, however in this case we have no guarantee that the location range will be contiguous
+    //       until the render pass is initialized, so we silently ignore this for now.
+    return this->renderTarget(name, output, static_cast<UInt32>(m_impl->m_renderTargets.size()), type, format, clearValues, clear, clearStencil, isVolatile);
 }
 
 DirectX12RenderPassBuilder& DirectX12RenderPassBuilder::renderTarget(DirectX12InputAttachmentMapping& output, const UInt32& location, const RenderTargetType& type, const Format& format, const Vector4f& clearValues, bool clear, bool clearStencil, bool isVolatile)
 {
-    auto renderTarget = RenderTarget(location, type, format, clear, clearValues, clearStencil, isVolatile);
+    return this->renderTarget("", output, location, type, format, clearValues, clear, clearStencil, isVolatile);
+}
+
+DirectX12RenderPassBuilder& DirectX12RenderPassBuilder::renderTarget(const String& name, DirectX12InputAttachmentMapping& output, const UInt32& location, const RenderTargetType& type, const Format& format, const Vector4f& clearValues, bool clear, bool clearStencil, bool isVolatile)
+{
+    auto renderTarget = RenderTarget(name, location, type, format, clear, clearValues, clearStencil, isVolatile);
     output = std::move(DirectX12InputAttachmentMapping(*this->instance(), renderTarget, location));
     m_impl->m_renderTargets.push_back(renderTarget);
     return *this;

--- a/src/Backends/DirectX12/src/render_pipeline.cpp
+++ b/src/Backends/DirectX12/src/render_pipeline.cpp
@@ -214,6 +214,10 @@ public:
 		// Create the pipeline state instance.
 		ComPtr<ID3D12PipelineState> pipelineState;
 		raiseIfFailed<RuntimeException>(m_renderPass.device().handle()->CreateGraphicsPipelineState(&pipelineStateDescription, IID_PPV_ARGS(&pipelineState)), "Unable to create render pipeline state.");
+		
+#ifndef NDEBUG
+		pipelineState->SetName(Widen(m_parent->name()).c_str());
+#endif
 
 		return pipelineState;
 	}
@@ -226,10 +230,10 @@ public:
 DirectX12RenderPipeline::DirectX12RenderPipeline(const DirectX12RenderPass& renderPass, SharedPtr<DirectX12PipelineLayout> layout, SharedPtr<DirectX12ShaderProgram> shaderProgram, SharedPtr<DirectX12InputAssembler> inputAssembler, SharedPtr<DirectX12Rasterizer> rasterizer, Array<SharedPtr<IViewport>>&& viewports, Array<SharedPtr<IScissor>>&& scissors, const bool enableAlphaToCoverage, const String& name) :
 	m_impl(makePimpl<DirectX12RenderPipelineImpl>(this, renderPass, enableAlphaToCoverage, layout, shaderProgram, inputAssembler, rasterizer, std::move(viewports), std::move(scissors))), DirectX12PipelineState(nullptr)
 {
-	this->handle() = m_impl->initialize();
-
 	if (!name.empty())
 		this->name() = name;
+
+	this->handle() = m_impl->initialize();
 }
 
 DirectX12RenderPipeline::DirectX12RenderPipeline(const DirectX12RenderPass& renderPass, const String& name) noexcept :

--- a/src/Backends/Vulkan/include/litefx/backends/vulkan.hpp
+++ b/src/Backends/Vulkan/include/litefx/backends/vulkan.hpp
@@ -955,9 +955,6 @@ namespace LiteFX::Rendering::Backends {
 		// Pipeline interface.
 	public:
 		/// <inheritdoc />
-		virtual const String& name() const noexcept override;
-
-		/// <inheritdoc />
 		virtual SharedPtr<const VulkanShaderProgram> program() const noexcept override;
 
 		/// <inheritdoc />

--- a/src/Backends/Vulkan/include/litefx/backends/vulkan.hpp
+++ b/src/Backends/Vulkan/include/litefx/backends/vulkan.hpp
@@ -1483,6 +1483,18 @@ namespace LiteFX::Rendering::Backends {
 		/// <returns>A reference to the array that stores the extensions that were used to initialize the device.</returns>
 		virtual Span<const String> enabledExtensions() const noexcept;
 
+		/// <summary>
+		/// Sets the debug name for an object.
+		/// </summary>
+		/// <remarks>
+		/// This function sets the debug name for an object to make it easier to identify when using an external debugger. This function will do nothing
+		/// in release mode or if the device extension VK_EXT_debug_marker is not available.
+		/// </remarks>
+		/// <param name="objectHandle">The handle of the object casted to an integer.</param>
+		/// <param name="objectType">The type of the object.</param>
+		/// <param name="name">The debug name of the object.</param>
+		virtual void setDebugName(UInt64 objectHandle, VkDebugReportObjectTypeEXT objectType, StringView name) const noexcept;
+
 		// GraphicsDevice interface.
 	public:
 		/// <inheritdoc />
@@ -1521,7 +1533,6 @@ namespace LiteFX::Rendering::Backends {
 		/// <inheritdoc />
 		virtual MultiSamplingLevel maximumMultiSamplingLevel(const Format& format) const noexcept override;
 
-	public:
 		/// <inheritdoc />
 		virtual void wait() const override;
 

--- a/src/Backends/Vulkan/include/litefx/backends/vulkan_builders.hpp
+++ b/src/Backends/Vulkan/include/litefx/backends/vulkan_builders.hpp
@@ -469,13 +469,25 @@ namespace LiteFX::Rendering::Backends {
 		virtual VulkanRenderPassBuilder& renderTarget(const RenderTargetType& type, const Format& format, const Vector4f& clearValues = { 0.0f, 0.0f, 0.0f, 0.0f }, bool clearColor = true, bool clearStencil = true, bool isVolatile = false) override;
 
 		/// <inheritdoc />
+		virtual VulkanRenderPassBuilder& renderTarget(const String& name, const RenderTargetType& type, const Format& format, const Vector4f& clearValues = { 0.0f, 0.0f, 0.0f, 0.0f }, bool clearColor = true, bool clearStencil = true, bool isVolatile = false) override;
+
+		/// <inheritdoc />
 		virtual VulkanRenderPassBuilder& renderTarget(const UInt32& location, const RenderTargetType& type, const Format& format, const Vector4f& clearValues = { 0.0f, 0.0f, 0.0f, 0.0f }, bool clearColor = true, bool clearStencil = true, bool isVolatile = false) override;
+
+		/// <inheritdoc />
+		virtual VulkanRenderPassBuilder& renderTarget(const String& name, const UInt32& location, const RenderTargetType& type, const Format& format, const Vector4f& clearValues = { 0.0f, 0.0f, 0.0f, 0.0f }, bool clearColor = true, bool clearStencil = true, bool isVolatile = false) override;
 
 		/// <inheritdoc />
 		virtual VulkanRenderPassBuilder& renderTarget(VulkanInputAttachmentMapping& output, const RenderTargetType& type, const Format& format, const Vector4f& clearValues = { 0.0f, 0.0f, 0.0f, 0.0f }, bool clearColor = true, bool clearStencil = true, bool isVolatile = false) override;
 
 		/// <inheritdoc />
+		virtual VulkanRenderPassBuilder& renderTarget(const String& name, VulkanInputAttachmentMapping& output, const RenderTargetType& type, const Format& format, const Vector4f& clearValues = { 0.0f, 0.0f, 0.0f, 0.0f }, bool clearColor = true, bool clearStencil = true, bool isVolatile = false) override;
+
+		/// <inheritdoc />
 		virtual VulkanRenderPassBuilder& renderTarget(VulkanInputAttachmentMapping& output, const UInt32& location, const RenderTargetType& type, const Format& format, const Vector4f& clearValues = { 0.0f, 0.0f, 0.0f, 0.0f }, bool clearColor = true, bool clearStencil = true, bool isVolatile = false) override;
+
+		/// <inheritdoc />
+		virtual VulkanRenderPassBuilder& renderTarget(const String& name, VulkanInputAttachmentMapping& output, const UInt32& location, const RenderTargetType& type, const Format& format, const Vector4f& clearValues = { 0.0f, 0.0f, 0.0f, 0.0f }, bool clearColor = true, bool clearStencil = true, bool isVolatile = false) override;
 
 		/// <inheritdoc />
 		virtual VulkanRenderPassBuilder& inputAttachment(const VulkanInputAttachmentMapping& inputAttachment) override;

--- a/src/Backends/Vulkan/src/backend.cpp
+++ b/src/Backends/Vulkan/src/backend.cpp
@@ -230,6 +230,10 @@ void VulkanBackend::registerDevice(String name, UniquePtr<VulkanDevice>&& device
     if (m_impl->m_devices.contains(name))
         throw InvalidArgumentException("The backend already contains a device with the name \"{0}\".", name);
 
+#ifndef NDEBUG
+    device->setDebugName(*reinterpret_cast<const UInt64*>(&std::as_const(*device).handle()), VK_DEBUG_REPORT_OBJECT_TYPE_DEVICE_EXT, name);
+#endif
+
     m_impl->m_devices.insert(std::make_pair(name, std::move(device)));
 }
 

--- a/src/Backends/Vulkan/src/compute_pipeline.cpp
+++ b/src/Backends/Vulkan/src/compute_pipeline.cpp
@@ -54,6 +54,10 @@ public:
 		VkPipeline pipeline;
 		raiseIfFailed<RuntimeException>(::vkCreateComputePipelines(m_device.handle(), VK_NULL_HANDLE, 1, &pipelineInfo, nullptr, &pipeline), "Unable to create compute pipeline.");
 
+#ifndef NDEBUG
+		m_device.setDebugName(*reinterpret_cast<const UInt64*>(&pipeline), VK_DEBUG_REPORT_OBJECT_TYPE_PIPELINE_EXT, m_parent->name());
+#endif
+
 		return pipeline;
 	}
 };

--- a/src/Backends/Vulkan/src/render_pass.cpp
+++ b/src/Backends/Vulkan/src/render_pass.cpp
@@ -257,7 +257,11 @@ public:
             int renderTarget = 0;
 
             for (auto& image : images)
-                m_device.setDebugName(*reinterpret_cast<const UInt64*>(&std::as_const(*image).handle()), VK_DEBUG_REPORT_OBJECT_TYPE_IMAGE_EXT, m_renderTargets[renderTarget++].name());
+                if (renderTarget < m_renderTargets.size())  // Resolve target is not included in render targets, but appended to the image list in the frame buffer.
+                    m_device.setDebugName(*reinterpret_cast<const UInt64*>(&std::as_const(*image).handle()), VK_DEBUG_REPORT_OBJECT_TYPE_IMAGE_EXT, m_renderTargets[renderTarget++].name());
+                else
+                    m_device.setDebugName(*reinterpret_cast<const UInt64*>(&std::as_const(*image).handle()), VK_DEBUG_REPORT_OBJECT_TYPE_IMAGE_EXT, "Multisampling Resolve");
+
 
             auto secondaryCommandBuffers = frameBuffer->commandBuffers();
             int commandBuffer = 0;

--- a/src/Backends/Vulkan/src/render_pass.cpp
+++ b/src/Backends/Vulkan/src/render_pass.cpp
@@ -236,6 +236,10 @@ public:
         VkRenderPass renderPass;
         raiseIfFailed<RuntimeException>(::vkCreateRenderPass(m_device.handle(), &renderPassState, nullptr, &renderPass), "Unable to create render pass.");
 
+#ifndef NDEBUG
+        m_device.setDebugName(*reinterpret_cast<const UInt64*>(&renderPass), VK_DEBUG_REPORT_OBJECT_TYPE_RENDER_PASS_EXT, m_parent->name());
+#endif
+
         return renderPass;
     }
 };

--- a/src/Backends/Vulkan/src/render_pipeline.cpp
+++ b/src/Backends/Vulkan/src/render_pipeline.cpp
@@ -229,6 +229,10 @@ public:
 		VkPipeline pipeline;
 		raiseIfFailed<RuntimeException>(::vkCreateGraphicsPipelines(m_renderPass.device().handle(), VK_NULL_HANDLE, 1, &pipelineInfo, nullptr, &pipeline), "Unable to create render pipeline.");
 
+#ifndef NDEBUG
+		m_renderPass.device().setDebugName(*reinterpret_cast<const UInt64*>(&pipeline), VK_DEBUG_REPORT_OBJECT_TYPE_PIPELINE_EXT, m_parent->name());
+#endif
+
 		return pipeline;
 	}
 };

--- a/src/Backends/Vulkan/src/shader_module.cpp
+++ b/src/Backends/Vulkan/src/shader_module.cpp
@@ -51,6 +51,10 @@ public:
 		if (::vkCreateShaderModule(m_device.handle(), &createInfo, nullptr, &module) != VK_SUCCESS)
 			throw std::runtime_error("Unable to compile shader file.");
 
+#ifndef NDEBUG
+		m_device.setDebugName(*reinterpret_cast<const UInt64*>(&module), VK_DEBUG_REPORT_OBJECT_TYPE_SHADER_MODULE_EXT, fmt::format("{0}: {1}", m_fileName, m_entryPoint));
+#endif
+
 		return module;
 	}
 };

--- a/src/Rendering/include/litefx/rendering_api.hpp
+++ b/src/Rendering/include/litefx/rendering_api.hpp
@@ -1884,6 +1884,12 @@ namespace LiteFX::Rendering {
 
     public:
         /// <summary>
+        /// Returns the name of the render target.
+        /// </summary>
+        /// <returns>The name of the render target.</returns>
+        virtual const String& name() const noexcept = 0;
+
+        /// <summary>
         /// Returns the location of the render target output attachment within the fragment shader.
         /// </summary>
         /// <remarks>
@@ -1975,6 +1981,20 @@ namespace LiteFX::Rendering {
         /// <param name="isVolatile"><c>true</c>, if the target should not be made persistent for access after the render pass has finished.</param>
         /// <param name="blendState">The render target blend state.</param>
         explicit RenderTarget(const UInt32& location, const RenderTargetType& type, const Format& format, const bool& clearBuffer, const Vector4f& clearValues = { 0.f , 0.f, 0.f, 0.f }, const bool& clearStencil = true, const bool& isVolatile = false, const BlendState& blendState = {});
+
+        /// <summary>
+        /// Initializes the render target.
+        /// </summary>
+        /// <param name="location">The name of the render target.</param>
+        /// <param name="location">The location of the render target output attachment.</param>
+        /// <param name="type">The type of the render target.</param>
+        /// <param name="format">The format of the render target.</param>
+        /// <param name="clearBuffer"><c>true</c>, if the render target should be cleared, when a render pass is started.</param>
+        /// <param name="clearValues">The values with which the render target gets cleared.</param>
+        /// <param name="clearStencil"><c>true</c>, if the render target stencil should be cleared, when a render pass is started.</param>
+        /// <param name="isVolatile"><c>true</c>, if the target should not be made persistent for access after the render pass has finished.</param>
+        /// <param name="blendState">The render target blend state.</param>
+        explicit RenderTarget(const String& name, const UInt32& location, const RenderTargetType& type, const Format& format, const bool& clearBuffer, const Vector4f& clearValues = { 0.f , 0.f, 0.f, 0.f }, const bool& clearStencil = true, const bool& isVolatile = false, const BlendState& blendState = {});
         RenderTarget(const RenderTarget&) noexcept;
         RenderTarget(RenderTarget&&) noexcept;
         virtual ~RenderTarget() noexcept;
@@ -1984,6 +2004,9 @@ namespace LiteFX::Rendering {
         inline RenderTarget& operator=(RenderTarget&&) noexcept;
 
     public:
+        /// <inheritdoc />
+        virtual const String& name() const noexcept override;
+
         /// <inheritdoc />
         virtual const UInt32& location() const noexcept override;
 

--- a/src/Rendering/include/litefx/rendering_builders.hpp
+++ b/src/Rendering/include/litefx/rendering_builders.hpp
@@ -499,6 +499,18 @@ namespace LiteFX::Rendering {
         virtual TDerived& renderTarget(const RenderTargetType& type, const Format& format, const Vector4f& clearValues = { 0.0f, 0.0f, 0.0f, 0.0f }, bool clearColor = true, bool clearStencil = true, bool isVolatile = false) = 0;
 
         /// <summary>
+        /// Adds a render target to the render pass by assigning it an incremental location number.
+        /// </summary>
+        /// <param name="name">The name of the render target.</param>
+        /// <param name="type">The type of the render target.</param>
+        /// <param name="format">The color format of the render target.</param>
+        /// <param name="clearValues">The fixed clear value for the render target.</param>
+        /// <param name="clearColor"><c>true</c>, if the render target color or depth should be cleared.</param>
+        /// <param name="clearStencil"><c>true</c>, if the render target stencil should be cleared.</param>
+        /// <param name="isVolatile"><c>true</c> to mark the render target as volatile, so is not required to be preserved after the render pass has ended.</param>
+        virtual TDerived& renderTarget(const String& name, const RenderTargetType& type, const Format& format, const Vector4f& clearValues = { 0.0f, 0.0f, 0.0f, 0.0f }, bool clearColor = true, bool clearStencil = true, bool isVolatile = false) = 0;
+
+        /// <summary>
         /// Adds a render target to the render pass.
         /// </summary>
         /// <param name="location">The location of the render target.</param>
@@ -509,6 +521,19 @@ namespace LiteFX::Rendering {
         /// <param name="clearStencil"><c>true</c>, if the render target stencil should be cleared.</param>
         /// <param name="isVolatile"><c>true</c> to mark the render target as volatile, so is not required to be preserved after the render pass has ended.</param>
         virtual TDerived& renderTarget(const UInt32& location, const RenderTargetType& type, const Format& format, const Vector4f& clearValues = { 0.0f, 0.0f, 0.0f, 0.0f }, bool clearColor = true, bool clearStencil = true, bool isVolatile = false) = 0;
+
+        /// <summary>
+        /// Adds a render target to the render pass.
+        /// </summary>
+        /// <param name="name">The name of the render target.</param>
+        /// <param name="location">The location of the render target.</param>
+        /// <param name="type">The type of the render target.</param>
+        /// <param name="format">The color format of the render target.</param>
+        /// <param name="clearValues">The fixed clear value for the render target.</param>
+        /// <param name="clearColor"><c>true</c>, if the render target color or depth should be cleared.</param>
+        /// <param name="clearStencil"><c>true</c>, if the render target stencil should be cleared.</param>
+        /// <param name="isVolatile"><c>true</c> to mark the render target as volatile, so is not required to be preserved after the render pass has ended.</param>
+        virtual TDerived& renderTarget(const String& name, const UInt32& location, const RenderTargetType& type, const Format& format, const Vector4f& clearValues = { 0.0f, 0.0f, 0.0f, 0.0f }, bool clearColor = true, bool clearStencil = true, bool isVolatile = false) = 0;
 
         /// <summary>
         /// Adds a render target to the render pass, that maps to an input attachment of another render pass. The location is assigned incrementally.
@@ -523,6 +548,19 @@ namespace LiteFX::Rendering {
         virtual TDerived& renderTarget(input_attachment_mapping_type& output, const RenderTargetType& type, const Format& format, const Vector4f& clearValues = { 0.0f, 0.0f, 0.0f, 0.0f }, bool clearColor = true, bool clearStencil = true, bool isVolatile = false) = 0;
 
         /// <summary>
+        /// Adds a render target to the render pass, that maps to an input attachment of another render pass. The location is assigned incrementally.
+        /// </summary>
+        /// <param name="name">The name of the render target.</param>
+        /// <param name="output">The input attachment mapping to map to.</param>
+        /// <param name="type">The type of the render target.</param>
+        /// <param name="format">The color format of the render target.</param>
+        /// <param name="clearValues">The fixed clear value for the render target.</param>
+        /// <param name="clearColor"><c>true</c>, if the render target color or depth should be cleared.</param>
+        /// <param name="clearStencil"><c>true</c>, if the render target stencil should be cleared.</param>
+        /// <param name="isVolatile"><c>true</c> to mark the render target as volatile, so is not required to be preserved after the render pass has ended.</param>
+        virtual TDerived& renderTarget(const String& name, input_attachment_mapping_type& output, const RenderTargetType& type, const Format& format, const Vector4f& clearValues = { 0.0f, 0.0f, 0.0f, 0.0f }, bool clearColor = true, bool clearStencil = true, bool isVolatile = false) = 0;
+
+        /// <summary>
         /// Adds a render target to the render pass, that maps to an input attachment of another render pass.
         /// </summary>
         /// <param name="output">The input attachment mapping to map to.</param>
@@ -534,6 +572,20 @@ namespace LiteFX::Rendering {
         /// <param name="clearStencil"><c>true</c>, if the render target stencil should be cleared.</param>
         /// <param name="isVolatile"><c>true</c> to mark the render target as volatile, so is not required to be preserved after the render pass has ended.</param>
         virtual TDerived& renderTarget(input_attachment_mapping_type& output, const UInt32& location, const RenderTargetType& type, const Format& format, const Vector4f& clearValues = { 0.0f, 0.0f, 0.0f, 0.0f }, bool clearColor = true, bool clearStencil = true, bool isVolatile = false) = 0;
+
+        /// <summary>
+        /// Adds a render target to the render pass, that maps to an input attachment of another render pass.
+        /// </summary>
+        /// <param name="name">The name of the render target.</param>
+        /// <param name="output">The input attachment mapping to map to.</param>
+        /// <param name="location">The location of the render target.</param>
+        /// <param name="type">The type of the render target.</param>
+        /// <param name="format">The color format of the render target.</param>
+        /// <param name="clearValues">The fixed clear value for the render target.</param>
+        /// <param name="clearColor"><c>true</c>, if the render target color or depth should be cleared.</param>
+        /// <param name="clearStencil"><c>true</c>, if the render target stencil should be cleared.</param>
+        /// <param name="isVolatile"><c>true</c> to mark the render target as volatile, so is not required to be preserved after the render pass has ended.</param>
+        virtual TDerived& renderTarget(const String& name, input_attachment_mapping_type& output, const UInt32& location, const RenderTargetType& type, const Format& format, const Vector4f& clearValues = { 0.0f, 0.0f, 0.0f, 0.0f }, bool clearColor = true, bool clearStencil = true, bool isVolatile = false) = 0;
         
         /// <summary>
         /// Adds an input attachment to the render pass.

--- a/src/Rendering/src/render_target.cpp
+++ b/src/Rendering/src/render_target.cpp
@@ -17,10 +17,11 @@ private:
     Vector4f m_clearValues;
     UInt32 m_location;
     BlendState m_blendState;
+    String m_name;
 
 public:
-    RenderTargetImpl(RenderTarget* parent, const UInt32& location, const RenderTargetType& type, const Format& format, const bool& clearBuffer, const Vector4f& clearValues, const bool& clearStencil, const bool& isVolatile, const BlendState& blendState) :
-        base(parent), m_location(location), m_type(type), m_format(format), m_clearBuffer(clearBuffer), m_clearValues(clearValues), m_clearStencil(clearStencil), m_volatile(isVolatile), m_blendState(blendState)
+    RenderTargetImpl(RenderTarget* parent, const String& name, const UInt32& location, const RenderTargetType& type, const Format& format, const bool& clearBuffer, const Vector4f& clearValues, const bool& clearStencil, const bool& isVolatile, const BlendState& blendState) :
+        base(parent), m_name(name), m_location(location), m_type(type), m_format(format), m_clearBuffer(clearBuffer), m_clearValues(clearValues), m_clearStencil(clearStencil), m_volatile(isVolatile), m_blendState(blendState)
     {
     }
 };
@@ -30,22 +31,27 @@ public:
 // ------------------------------------------------------------------------------------------------
 
 RenderTarget::RenderTarget() noexcept :
-    m_impl(makePimpl<RenderTargetImpl>(this, 0, RenderTargetType::Color, Format::None, false, Vector4f { 0.f, 0.f, 0.f, 0.f }, false, false, BlendState{}))
+    RenderTarget(0, RenderTargetType::Color, Format::None, false, Vector4f{0.f, 0.f, 0.f, 0.f}, false, false, BlendState{})
 {
 }
 
 RenderTarget::RenderTarget(const UInt32& location, const RenderTargetType& type, const Format& format, const bool& clearBuffer, const Vector4f& clearValues, const bool& clearStencil, const bool& isVolatile, const BlendState& blendState) :
-    m_impl(makePimpl<RenderTargetImpl>(this, location, type, format, clearBuffer, clearValues, clearStencil, isVolatile, blendState))
+    RenderTarget("", location, type, format, clearBuffer, clearValues, clearStencil, isVolatile, blendState)
+{
+}
+
+RenderTarget::RenderTarget(const String& name, const UInt32& location, const RenderTargetType& type, const Format& format, const bool& clearBuffer, const Vector4f& clearValues, const bool& clearStencil, const bool& isVolatile, const BlendState& blendState) :
+    m_impl(makePimpl<RenderTargetImpl>(this, name, location, type, format, clearBuffer, clearValues, clearStencil, isVolatile, blendState))
 {
 }
 
 RenderTarget::RenderTarget(const RenderTarget& _other) noexcept :
-    m_impl(makePimpl<RenderTargetImpl>(this, _other.location(), _other.type(), _other.format(), _other.clearBuffer(), _other.clearValues(), _other.clearStencil(), _other.isVolatile(), _other.blendState()))
+    m_impl(makePimpl<RenderTargetImpl>(this, _other.name(), _other.location(), _other.type(), _other.format(), _other.clearBuffer(), _other.clearValues(), _other.clearStencil(), _other.isVolatile(), _other.blendState()))
 {
 }
 
 RenderTarget::RenderTarget(RenderTarget&& _other) noexcept :
-    m_impl(makePimpl<RenderTargetImpl>(this, std::move(_other.m_impl->m_location), std::move(_other.m_impl->m_type), std::move(_other.m_impl->m_format), std::move(_other.m_impl->m_clearBuffer), std::move(_other.m_impl->m_clearValues), std::move(_other.m_impl->m_clearStencil), std::move(_other.m_impl->m_volatile), std::move(_other.m_impl->m_blendState)))
+    m_impl(makePimpl<RenderTargetImpl>(this, std::move(_other.m_impl->m_name), std::move(_other.m_impl->m_location), std::move(_other.m_impl->m_type), std::move(_other.m_impl->m_format), std::move(_other.m_impl->m_clearBuffer), std::move(_other.m_impl->m_clearValues), std::move(_other.m_impl->m_clearStencil), std::move(_other.m_impl->m_volatile), std::move(_other.m_impl->m_blendState)))
 {
 }
 
@@ -53,6 +59,7 @@ RenderTarget::~RenderTarget() noexcept = default;
 
 RenderTarget& RenderTarget::operator=(const RenderTarget& _other) noexcept
 {
+    m_impl->m_name = _other.m_impl->m_name;
     m_impl->m_location = _other.m_impl->m_location;
     m_impl->m_type = _other.m_impl->m_type;
     m_impl->m_format = _other.m_impl->m_format;
@@ -67,6 +74,7 @@ RenderTarget& RenderTarget::operator=(const RenderTarget& _other) noexcept
 
 RenderTarget& RenderTarget::operator=(RenderTarget&& _other) noexcept
 {
+    m_impl->m_name = std::move(_other.m_impl->m_name);
     m_impl->m_location = std::move(_other.m_impl->m_location);
     m_impl->m_type = std::move(_other.m_impl->m_type);
     m_impl->m_format = std::move(_other.m_impl->m_format);
@@ -77,6 +85,11 @@ RenderTarget& RenderTarget::operator=(RenderTarget&& _other) noexcept
     m_impl->m_blendState = std::move(_other.m_impl->m_blendState);
     
     return *this;
+}
+
+const String& RenderTarget::name() const noexcept
+{
+    return m_impl->m_name;
 }
 
 const UInt32& RenderTarget::location() const noexcept

--- a/src/Samples/BasicRendering/src/sample.cpp
+++ b/src/Samples/BasicRendering/src/sample.cpp
@@ -65,8 +65,8 @@ void initRenderGraph(TRenderBackend* backend, SharedPtr<IViewport> viewport, Sha
 
     // Create a geometry render pass.
     UniquePtr<RenderPass> renderPass = device->buildRenderPass("Opaque")
-        .renderTarget(RenderTargetType::Present, Format::B8G8R8A8_UNORM, { 0.1f, 0.1f, 0.1f, 1.f }, true, false, false)
-        .renderTarget(RenderTargetType::DepthStencil, Format::D32_SFLOAT, { 1.f, 0.f, 0.f, 0.f }, true, false, false);
+        .renderTarget("Color Target", RenderTargetType::Present, Format::B8G8R8A8_UNORM, {0.1f, 0.1f, 0.1f, 1.f}, true, false, false)
+        .renderTarget("Depth/Stencil Target", RenderTargetType::DepthStencil, Format::D32_SFLOAT, {1.f, 0.f, 0.f, 0.f}, true, false, false);
 
     // Create the shader program.
     SharedPtr<ShaderProgram> shaderProgram = device->buildShaderProgram()

--- a/src/Samples/Multisampling/src/sample.cpp
+++ b/src/Samples/Multisampling/src/sample.cpp
@@ -65,8 +65,8 @@ void initRenderGraph(TRenderBackend* backend, SharedPtr<IViewport> viewport, Sha
 
     // Create a geometry render pass.
     UniquePtr<RenderPass> renderPass = device->buildRenderPass("Opaque", MultiSamplingLevel::x4)
-        .renderTarget(RenderTargetType::Present, Format::B8G8R8A8_UNORM, { 0.1f, 0.1f, 0.1f, 1.f }, true, false, false)
-        .renderTarget(RenderTargetType::DepthStencil, Format::D32_SFLOAT, { 1.f, 0.f, 0.f, 0.f }, true, false, false);
+        .renderTarget("Color Target", RenderTargetType::Present, Format::B8G8R8A8_UNORM, { 0.1f, 0.1f, 0.1f, 1.f }, true, false, false)
+        .renderTarget("Depth/Stencil Target", RenderTargetType::DepthStencil, Format::D32_SFLOAT, {1.f, 0.f, 0.f, 0.f}, true, false, false);
 
     // Create a shader program.
     SharedPtr<ShaderProgram> shaderProgram = device->buildShaderProgram()

--- a/src/Samples/Multithreading/src/sample.cpp
+++ b/src/Samples/Multithreading/src/sample.cpp
@@ -78,8 +78,8 @@ void initRenderGraph(TRenderBackend* backend, SharedPtr<IViewport> viewport, Sha
 
     // Create a geometry render pass.
     UniquePtr<RenderPass> renderPass = device->buildRenderPass("Opaque", MultiSamplingLevel::x1, NUM_WORKERS)
-        .renderTarget(RenderTargetType::Present, Format::B8G8R8A8_UNORM, { 0.1f, 0.1f, 0.1f, 1.f }, true, false, false)
-        .renderTarget(RenderTargetType::DepthStencil, Format::D32_SFLOAT, { 1.f, 0.f, 0.f, 0.f }, true, false, false);
+        .renderTarget("Color Target", RenderTargetType::Present, Format::B8G8R8A8_UNORM, { 0.1f, 0.1f, 0.1f, 1.f }, true, false, false)
+        .renderTarget("Depth/Stencil Target", RenderTargetType::DepthStencil, Format::D32_SFLOAT, {1.f, 0.f, 0.f, 0.f}, true, false, false);
 
     // Create a shader program.
     SharedPtr<ShaderProgram> shaderProgram = device->buildShaderProgram()

--- a/src/Samples/PushConstants/src/sample.cpp
+++ b/src/Samples/PushConstants/src/sample.cpp
@@ -92,8 +92,8 @@ void initRenderGraph(TRenderBackend* backend, SharedPtr<IViewport> viewport, Sha
 
     // Create a geometry render pass.
     UniquePtr<RenderPass> renderPass = device->buildRenderPass("Opaque")
-        .renderTarget(RenderTargetType::Present, Format::B8G8R8A8_UNORM, { 0.1f, 0.1f, 0.1f, 1.f }, true, false, false)
-        .renderTarget(RenderTargetType::DepthStencil, Format::D32_SFLOAT, { 1.f, 0.f, 0.f, 0.f }, true, false, false);
+        .renderTarget("Color Target", RenderTargetType::Present, Format::B8G8R8A8_UNORM, { 0.1f, 0.1f, 0.1f, 1.f }, true, false, false)
+        .renderTarget("Depth/Stencil Target", RenderTargetType::DepthStencil, Format::D32_SFLOAT, { 1.f, 0.f, 0.f, 0.f }, true, false, false);
 
     // Create a shader program.
     SharedPtr<ShaderProgram> shaderProgram = device->buildShaderProgram()

--- a/src/Samples/RenderPasses/shaders/lighting_pass_fs.hlsl
+++ b/src/Samples/RenderPasses/shaders/lighting_pass_fs.hlsl
@@ -18,7 +18,7 @@ struct FragmentData
 #elif DXIL
 Texture2D gDiffuse : register(t0, space0);
 Texture2D gDepth : register(t1, space0);
-SamplerState gBuffer : register(s0);
+SamplerState gBuffer : register(s2);
 #endif
 
 FragmentData main(VertexData input)

--- a/src/Samples/RenderPasses/shaders/lighting_pass_vs.hlsl
+++ b/src/Samples/RenderPasses/shaders/lighting_pass_vs.hlsl
@@ -5,7 +5,7 @@
     "RootFlags(ALLOW_INPUT_ASSEMBLER_INPUT_LAYOUT), " \
     "SRV(t0, space = 0, flags = DATA_STATIC_WHILE_SET_AT_EXECUTE), " \
     "SRV(t1, space = 0, flags = DATA_STATIC_WHILE_SET_AT_EXECUTE), " \
-    "StaticSampler(s0, filter = FILTER_MIN_MAG_MIP_LINEAR)"
+    "StaticSampler(s2, filter = FILTER_MIN_MAG_MIP_LINEAR)"
 
 struct VertexData 
 {

--- a/src/Samples/Textures/src/sample.cpp
+++ b/src/Samples/Textures/src/sample.cpp
@@ -70,8 +70,8 @@ void initRenderGraph(TRenderBackend* backend, SharedPtr<IViewport> viewport, Sha
 
     // Create a geometry render pass.
     UniquePtr<RenderPass> renderPass = device->buildRenderPass("Opaque")
-        .renderTarget(RenderTargetType::Present, Format::B8G8R8A8_UNORM, { 0.1f, 0.1f, 0.1f, 1.f }, true, false, false)
-        .renderTarget(RenderTargetType::DepthStencil, Format::D32_SFLOAT, { 1.f, 0.f, 0.f, 0.f }, true, false, false);
+        .renderTarget("Color Target", RenderTargetType::Present, Format::B8G8R8A8_UNORM, { 0.1f, 0.1f, 0.1f, 1.f }, true, false, false)
+        .renderTarget("Depth/Stencil Target", RenderTargetType::DepthStencil, Format::D32_SFLOAT, { 1.f, 0.f, 0.f, 0.f }, true, false, false);
 
     // Create a shader program.
     SharedPtr<ShaderProgram> shaderProgram = device->buildShaderProgram()

--- a/src/Samples/UniformArrays/src/sample.cpp
+++ b/src/Samples/UniformArrays/src/sample.cpp
@@ -102,8 +102,8 @@ void initRenderGraph(TRenderBackend* backend, SharedPtr<IViewport> viewport, Sha
 
     // Create a geometry render pass.
     UniquePtr<RenderPass> renderPass = device->buildRenderPass("Opaque")
-        .renderTarget(RenderTargetType::Present, Format::B8G8R8A8_UNORM, { 0.1f, 0.1f, 0.1f, 1.f }, true, false, false)
-        .renderTarget(RenderTargetType::DepthStencil, Format::D32_SFLOAT, { 1.f, 0.f, 0.f, 0.f }, true, false, false);
+        .renderTarget("Color Target", RenderTargetType::Present, Format::B8G8R8A8_UNORM, { 0.1f, 0.1f, 0.1f, 1.f }, true, false, false)
+        .renderTarget("Depth/Stencil Target", RenderTargetType::DepthStencil, Format::D32_SFLOAT, { 1.f, 0.f, 0.f, 0.f }, true, false, false);
 
     // Create a shader program.
     SharedPtr<ShaderProgram> shaderProgram = device->buildShaderProgram()


### PR DESCRIPTION
**Describe the pull request**

This PR implements support for various debug interfaces for both APIs. In Vulkan it adds support to name most object types. In DirectX12 it does the same and also adds debug markers for render passes, as long as the application is not running with an active debugger connected (i.e. Visual Studio). This is due to a limitation in the D3D12 debug layers, which will raise a warning, if the debug marker API is not called from PIX. It works fine, when connected to RenderDoc.

**Related issues**

Implements #15. 