### PR TITLE
Add `COMPILE_OPTIONS` option to shader targets.

### DIFF
--- a/docs/release-logs/0.3.1.md
+++ b/docs/release-logs/0.3.1.md
@@ -20,4 +20,5 @@
   - Support for unbounded descriptor arrays has been added.
 - Allow samples to toggle full-screen mode by pressing `F8`. ([See PR #77](https://github.com/crud89/LiteFX/pull/77))
 - Add handler to samples for exit when pressing `ESC`. ([See PR #77](https://github.com/crud89/LiteFX/pull/77))
+- Build 🛠: Shader targets can now receive additional compiler arguments using the `COMPILE_OPTIONS` parameter. ([See PR #78](https://github.com/crud89/LiteFX/pull/78))
 - Vulkan 🌋: If the DX12 backend is available, the Vulkan uses an interop swap chain to support flip-model swap effects for lower latencies. ([See PR #66](https://github.com/crud89/LiteFX/pull/66))


### PR DESCRIPTION
**Describe the pull request**

This PR allows shader targets to specify additional command line options for shader compilers using the `COMPILE_OPTIONS` parameter:

```cmake
ADD_SHADER_MODULE(my_shader 
  SOURCE "my_shader.hlsl" 
  LANGUAGE HLSL 
  TYPE VERTEX 
  COMPILE_AS SPIRV 
  SHADER_MODEL "6_3" 
  COMPILER DXC
  COMPILE_OPTIONS "-O0 -fvk-s-shift 10 0"
)
```

It is not valid to overwrite default parameters generated by the shader target command. Default parameters are: 

- DXC: `-T`, `-E`, `-spirv`, `-Fo`, `-Zi`, `-Qembed_debug`, `-Qstrip_debug`, `-fvk-invert-y`
- GLSLC: `-mfmt`, `-x`, `-fshader_stage`, `-c`, `-o`, `-MD`, `-finvert-y`

**Related issues**

- Closes #76. 
