### PR TITLE
Improve resource allocation and binding.

### DIFF
--- a/docs/release-logs/0.4.1.md
+++ b/docs/release-logs/0.4.1.md
@@ -5,3 +5,6 @@
   - Add support for user-defined debug markers. 
   - Use official PIX event runtime for DX12 x64 debug builds.
   - `VK_EXT_debug_utils` is now enabled by default for the Vulkan backend in debug builds.
+- Improved resource allocation and binding: ([See PR #83](https://github.com/crud89/LiteFX/pull/83))
+  - Resources can now be created without querying the descriptor set layout or descriptor layout in advance.
+  - When allocating descriptor sets, default bindings can be provided to make bind-once scenarios more straightforward.

--- a/docs/tutorials/quick-start.markdown
+++ b/docs/tutorials/quick-start.markdown
@@ -546,7 +546,7 @@ auto& transformBindingLayout = m_pipeline->layout()->descriptorSet(1);
 auto& transformBufferLayout = transformBindingLayout.descriptor(0);
 m_perFrameBindings = transformBindingLayout.allocateMultiple(3);
 m_transformBuffer = m_device->factory().createBuffer(transformBufferLayout.type(), BufferUsage::Dynamic, transformBufferLayout.elementSize(), 3);
-std::ranges::for_each(m_perFrameBindings, [this, &transformBufferLayout, i = 0](const auto& descriptorSet) mutable { descriptorSet->update(transformBufferLayout.binding(), *m_transformBuffer, i++); });
+std::ranges::for_each(m_perFrameBindings, [this, &transformBufferLayout, i = 0](const auto& descriptorSet) mutable { descriptorSet->update(transformBufferLayout.binding(), *m_transformBuffer, i++, 1); });
 ```
 
 ### Drawing Frames

--- a/src/Backends/DirectX12/include/litefx/backends/dx12.hpp
+++ b/src/Backends/DirectX12/include/litefx/backends/dx12.hpp
@@ -338,7 +338,7 @@ namespace LiteFX::Rendering::Backends {
 
 	public:
 		/// <inheritdoc />
-		virtual void update(const UInt32& binding, const IDirectX12Buffer& buffer, const UInt32& bufferElement = 0, const UInt32& elements = 1, const UInt32& firstDescriptor = 0) const override;
+		virtual void update(const UInt32& binding, const IDirectX12Buffer& buffer, const UInt32& bufferElement = 0, const UInt32& elements = 0, const UInt32& firstDescriptor = 0) const override;
 
 		/// <inheritdoc />
 		virtual void update(const UInt32& binding, const IDirectX12Image& texture, const UInt32& descriptor = 0, const UInt32& firstLevel = 0, const UInt32& levels = 0, const UInt32& firstLayer = 0, const UInt32& layers = 0) const override;

--- a/src/Backends/DirectX12/src/command_buffer.cpp
+++ b/src/Backends/DirectX12/src/command_buffer.cpp
@@ -152,7 +152,7 @@ void DirectX12CommandBuffer::generateMipMaps(IDirectX12Image& image) noexcept
 		for (UInt32 i(1); i < image.levels(); ++i, size /= 2)
 		{
 			// Update the invocation parameters.
-			resourceBindings[resource]->update(parametersLayout.binding(), *parameters, i);
+			resourceBindings[resource]->update(parametersLayout.binding(), *parameters, i, 1);
 
 			// Bind the previous mip map level to the SRV at binding point 1.
 			resourceBindings[resource]->update(1, image, 0, i - 1, 1, l, 1);

--- a/src/Backends/Vulkan/include/litefx/backends/vulkan.hpp
+++ b/src/Backends/Vulkan/include/litefx/backends/vulkan.hpp
@@ -363,7 +363,7 @@ namespace LiteFX::Rendering::Backends {
 
 	public:
 		/// <inheritdoc />
-		virtual void update(const UInt32& binding, const IVulkanBuffer& buffer, const UInt32& bufferElement = 0, const UInt32& elements = 1, const UInt32& firstDescriptor = 0) const override;
+		virtual void update(const UInt32& binding, const IVulkanBuffer& buffer, const UInt32& bufferElement = 0, const UInt32& elements = 0, const UInt32& firstDescriptor = 0) const override;
 
 		/// <inheritdoc />
 		virtual void update(const UInt32& binding, const IVulkanImage& texture, const UInt32& descriptor = 0, const UInt32& firstLevel = 0, const UInt32& levels = 0, const UInt32& firstLayer = 0, const UInt32& layers = 0) const override;

--- a/src/Backends/Vulkan/src/descriptor_set.cpp
+++ b/src/Backends/Vulkan/src/descriptor_set.cpp
@@ -59,15 +59,16 @@ void VulkanDescriptorSet::update(const UInt32& binding, const IVulkanBuffer& buf
 
     auto& descriptorLayout = m_impl->m_layout.descriptor(binding);
     Array<VkDescriptorBufferInfo> bufferInfos;
+    UInt32 elementCount = elements > 0 ? elements : buffer.elements() - bufferElement;
 
     switch (descriptorLayout.descriptorType())
     {
     case DescriptorType::ConstantBuffer:
     {
-        descriptorWrite.descriptorCount = elements;
+        descriptorWrite.descriptorCount = elementCount;
         descriptorWrite.descriptorType = VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER;
 
-        bufferInfos.resize(elements);
+        bufferInfos.resize(elementCount);
         std::ranges::generate(bufferInfos, [&buffer, &bufferElement, i = 0]() mutable {
             return VkDescriptorBufferInfo {
                 .buffer = buffer.handle(),
@@ -84,10 +85,10 @@ void VulkanDescriptorSet::update(const UInt32& binding, const IVulkanBuffer& buf
     case DescriptorType::ByteAddressBuffer:
     case DescriptorType::RWByteAddressBuffer:
     {
-        descriptorWrite.descriptorCount = elements;
+        descriptorWrite.descriptorCount = elementCount;
         descriptorWrite.descriptorType = VK_DESCRIPTOR_TYPE_STORAGE_BUFFER;
 
-        bufferInfos.resize(elements);
+        bufferInfos.resize(elementCount);
         std::ranges::generate(bufferInfos, [&buffer, &bufferElement, i = 0]() mutable {
             return VkDescriptorBufferInfo {
                 .buffer = buffer.handle(),
@@ -110,7 +111,7 @@ void VulkanDescriptorSet::update(const UInt32& binding, const IVulkanBuffer& buf
             .buffer = buffer.handle(),
             .format = VK_FORMAT_UNDEFINED,
             .offset = buffer.alignedElementSize() * bufferElement,     // TODO: Handle alignment properly, as texel buffers do not need to be aligned (afaik).
-            .range = buffer.alignedElementSize() * elements
+            .range = buffer.alignedElementSize() * elementCount
         };
 
         VkBufferView bufferView;
@@ -131,7 +132,7 @@ void VulkanDescriptorSet::update(const UInt32& binding, const IVulkanBuffer& buf
             .buffer = buffer.handle(),
             .format = VK_FORMAT_UNDEFINED,
             .offset = buffer.alignedElementSize() * bufferElement,     // TODO: Handle alignment properly, as texel buffers do not need to be aligned (afaik).
-            .range = buffer.alignedElementSize() * elements
+            .range = buffer.alignedElementSize() * elementCount
         };
 
         VkBufferView bufferView;

--- a/src/Core/include/litefx/containers.hpp
+++ b/src/Core/include/litefx/containers.hpp
@@ -115,6 +115,21 @@ namespace LiteFX {
 	using Variant = std::variant<T...>;
 
 	/// <summary>
+	/// A switch that can be used to select a callable from a parameter type.
+	/// </summary>
+	template<class... TArgs> 
+	struct type_switch : TArgs... { 
+		using TArgs::operator()...; 
+	};
+
+	/// <summary>
+	/// Represents a copyable and assignable reference wrapper.
+	/// </summary>
+	/// <typeparam name="T">The base type of the reference.</typeparam>
+	template <class T>
+	using Ref = std::reference_wrapper<T>;
+
+	/// <summary>
 	/// Creates a new unique pointer.
 	/// </summary>
 	/// <typeparam name="T">The type of the object, the pointer points to.</typeparam>

--- a/src/Rendering/include/litefx/rendering.hpp
+++ b/src/Rendering/include/litefx/rendering.hpp
@@ -177,7 +177,7 @@ namespace LiteFX::Rendering {
 
     public:
         /// <inheritdoc />
-        virtual void update(const UInt32& binding, const buffer_type& buffer, const UInt32& bufferElement = 0, const UInt32& elements = 1, const UInt32& firstDescriptor = 0) const = 0;
+        virtual void update(const UInt32& binding, const buffer_type& buffer, const UInt32& bufferElement = 0, const UInt32& elements = 0, const UInt32& firstDescriptor = 0) const = 0;
 
         /// <inheritdoc />
         virtual void update(const UInt32& binding, const image_type& texture, const UInt32& descriptor = 0, const UInt32& firstLevel = 0, const UInt32& levels = 0, const UInt32& firstLayer = 0, const UInt32& layers = 0) const = 0;

--- a/src/Rendering/include/litefx/rendering_api.hpp
+++ b/src/Rendering/include/litefx/rendering_api.hpp
@@ -4369,6 +4369,34 @@ namespace LiteFX::Rendering {
         };
 
         /// <summary>
+        /// Creates a buffer that can be bound to a specific descriptor.
+        /// </summary>
+        /// <param name="descriptorSet">The layout of the descriptors parent descriptor set.</param>
+        /// <param name="binding">The binding point of the descriptor within the parent descriptor set.</param>
+        /// <param name="usage">The buffer usage.</param>
+        /// <param name="elements">The number of elements in the buffer (in case the buffer is an array).</param>
+        /// <param name="allowWrite">Allows the resource to be bound to a read/write descriptor.</param>
+        /// <returns>The instance of the buffer.</returns>
+        UniquePtr<IBuffer> createBuffer(const IDescriptorSetLayout& descriptorSet, const UInt32& binding, const BufferUsage& usage, const UInt32& elements = 1, const bool& allowWrite = false) const {
+            auto& descriptor = descriptorSet.descriptor(binding);
+            return this->createBuffer(descriptor.type(), usage, descriptor.elementSize(), elements, allowWrite);
+        };
+
+        /// <summary>
+        /// Creates a buffer that can be bound to a descriptor of a specific descriptor set.
+        /// </summary>
+        /// <param name="pipeline">The pipeline that provides the descriptor set.</param>
+        /// <param name="space">The space, the descriptor set is bound to.</param>
+        /// <param name="binding">The binding point of the descriptor within the parent descriptor set.</param>
+        /// <param name="usage">The buffer usage.</param>
+        /// <param name="elements">The number of elements in the buffer (in case the buffer is an array).</param>
+        /// <param name="allowWrite">Allows the resource to be bound to a read/write descriptor.</param>
+        /// <returns>The instance of the buffer.</returns>
+        UniquePtr<IBuffer> createBuffer(const IPipeline& pipeline, const UInt32& space, const UInt32& binding, const BufferUsage& usage, const UInt32& elements = 1, const bool& allowWrite = false) const {
+            return this->createBuffer(pipeline.layout()->descriptorSet(space), binding, usage, elements, allowWrite);
+        };
+
+        /// <summary>
         /// Creates a buffer of type <paramref name="type" />.
         /// </summary>
         /// <param name="name">The name of the buffer.</param>
@@ -4380,6 +4408,36 @@ namespace LiteFX::Rendering {
         /// <returns>The instance of the buffer.</returns>
         UniquePtr<IBuffer> createBuffer(const String& name, const BufferType& type, const BufferUsage& usage, const size_t& elementSize, const UInt32& elements = 1, const bool& allowWrite = false) const {
             return this->getBuffer(name, type, usage, elementSize, elements, allowWrite);
+        };
+
+        /// <summary>
+        /// Creates a buffer that can be bound to a specific descriptor.
+        /// </summary>
+        /// <param name="name">The name of the buffer.</param>
+        /// <param name="descriptorSet">The layout of the descriptors parent descriptor set.</param>
+        /// <param name="binding">The binding point of the descriptor within the parent descriptor set.</param>
+        /// <param name="usage">The buffer usage.</param>
+        /// <param name="elements">The number of elements in the buffer (in case the buffer is an array).</param>
+        /// <param name="allowWrite">Allows the resource to be bound to a read/write descriptor.</param>
+        /// <returns>The instance of the buffer.</returns>
+        UniquePtr<IBuffer> createBuffer(const String& name, const IDescriptorSetLayout& descriptorSet, const UInt32& binding, const BufferUsage& usage, const UInt32& elements = 1, const bool& allowWrite = false) const {
+            auto& descriptor = descriptorSet.descriptor(binding);
+            return this->createBuffer(name, descriptor.type(), usage, descriptor.elementSize(), elements, allowWrite);
+        };
+
+        /// <summary>
+        /// Creates a buffer that can be bound to a descriptor of a specific descriptor set.
+        /// </summary>
+        /// <param name="name">The name of the buffer.</param>
+        /// <param name="pipeline">The pipeline that provides the descriptor set.</param>
+        /// <param name="space">The space, the descriptor set is bound to.</param>
+        /// <param name="binding">The binding point of the descriptor within the parent descriptor set.</param>
+        /// <param name="usage">The buffer usage.</param>
+        /// <param name="elements">The number of elements in the buffer (in case the buffer is an array).</param>
+        /// <param name="allowWrite">Allows the resource to be bound to a read/write descriptor.</param>
+        /// <returns>The instance of the buffer.</returns>
+        UniquePtr<IBuffer> createBuffer(const String& name, const IPipeline& pipeline, const UInt32& space, const UInt32& binding, const BufferUsage& usage, const UInt32& elements = 1, const bool& allowWrite = false) const {
+            return this->createBuffer(name, pipeline.layout()->descriptorSet(space), binding, usage, elements, allowWrite);
         };
 
         /// <summary>

--- a/src/Rendering/include/litefx/rendering_api.hpp
+++ b/src/Rendering/include/litefx/rendering_api.hpp
@@ -1,4 +1,4 @@
-﻿#pragma once
+#pragma once
 
 #if !defined (LITEFX_RENDERING_API)
 #  if defined(LiteFX_Rendering_EXPORTS) && (defined _WIN32 || defined WINCE)
@@ -3080,9 +3080,9 @@ namespace LiteFX::Rendering {
         /// <param name="binding">The buffer binding point.</param>
         /// <param name="buffer">The constant buffer to write to the descriptor set.</param>
         /// <param name="bufferElement">The index of the first element in the buffer to bind to the descriptor set.</param>
-        /// <param name="elements">The number of elements from the buffer to bind to the descriptor set.</param>
+        /// <param name="elements">The number of elements from the buffer to bind to the descriptor set. A value of `0` binds all available elements, starting at <paramref name="bufferElement" />.</param>
         /// <param name="firstDescriptor">The index of the first descriptor in the descriptor array to update.</param>
-        void update(const UInt32& binding, const IBuffer& buffer, const UInt32& bufferElement = 0, const UInt32& elements = 1, const UInt32& firstDescriptor = 0) const {
+        void update(const UInt32& binding, const IBuffer& buffer, const UInt32& bufferElement = 0, const UInt32& elements = 0, const UInt32& firstDescriptor = 0) const {
             this->doUpdate(binding, buffer, bufferElement, elements, firstDescriptor);
         }
 

--- a/src/Rendering/include/litefx/rendering_api.hpp
+++ b/src/Rendering/include/litefx/rendering_api.hpp
@@ -4526,7 +4526,7 @@ namespace LiteFX::Rendering {
         /// <param name="elements">The number of elements in the buffer (in case the buffer is an array).</param>
         /// <param name="allowWrite">Allows the resource to be bound to a read/write descriptor.</param>
         /// <returns>The instance of the buffer.</returns>
-        UniquePtr<IBuffer> createBuffer(const String& name, const BufferType& type, const BufferUsage& usage, const size_t& elementSize, const UInt32& elements = 1, const bool& allowWrite = false) const {
+        UniquePtr<IBuffer> createBuffer(const String& name, const BufferType& type, const BufferUsage& usage, const size_t& elementSize, const UInt32& elements, const bool& allowWrite = false) const {
             return this->getBuffer(name, type, usage, elementSize, elements, allowWrite);
         };
 
@@ -4544,6 +4544,22 @@ namespace LiteFX::Rendering {
             auto& descriptor = descriptorSet.descriptor(binding);
             return this->createBuffer(name, descriptor.type(), usage, descriptor.elementSize(), elements, allowWrite);
         };
+        
+        /// <summary>
+        /// Creates a buffer that can be bound to a specific descriptor.
+        /// </summary>
+        /// <param name="name">The name of the buffer.</param>
+        /// <param name="descriptorSet">The layout of the descriptors parent descriptor set.</param>
+        /// <param name="binding">The binding point of the descriptor within the parent descriptor set.</param>
+        /// <param name="usage">The buffer usage.</param>
+        /// <param name="elementSize">The size of an element in the buffer (in bytes).</param>
+        /// <param name="elements">The number of elements in the buffer (in case the buffer is an array).</param>
+        /// <param name="allowWrite">Allows the resource to be bound to a read/write descriptor.</param>
+        /// <returns>The instance of the buffer.</returns>
+        UniquePtr<IBuffer> createBuffer(const String& name, const IDescriptorSetLayout& descriptorSet, const UInt32& binding, const BufferUsage& usage, const size_t& elementSize, const UInt32& elements, const bool& allowWrite = false) const {
+            auto& descriptor = descriptorSet.descriptor(binding);
+            return this->createBuffer(name, descriptor.type(), usage, elementSize, elements, allowWrite);
+        };
 
         /// <summary>
         /// Creates a buffer that can be bound to a descriptor of a specific descriptor set.
@@ -4558,6 +4574,22 @@ namespace LiteFX::Rendering {
         /// <returns>The instance of the buffer.</returns>
         UniquePtr<IBuffer> createBuffer(const String& name, const IPipeline& pipeline, const UInt32& space, const UInt32& binding, const BufferUsage& usage, const UInt32& elements = 1, const bool& allowWrite = false) const {
             return this->createBuffer(name, pipeline.layout()->descriptorSet(space), binding, usage, elements, allowWrite);
+        };
+
+        /// <summary>
+        /// Creates a buffer that can be bound to a descriptor of a specific descriptor set.
+        /// </summary>
+        /// <param name="name">The name of the buffer.</param>
+        /// <param name="pipeline">The pipeline that provides the descriptor set.</param>
+        /// <param name="space">The space, the descriptor set is bound to.</param>
+        /// <param name="binding">The binding point of the descriptor within the parent descriptor set.</param>
+        /// <param name="usage">The buffer usage.</param>
+        /// <param name="elementSize">The size of an element in the buffer (in bytes).</param>
+        /// <param name="elements">The number of elements in the buffer (in case the buffer is an array).</param>
+        /// <param name="allowWrite">Allows the resource to be bound to a read/write descriptor.</param>
+        /// <returns>The instance of the buffer.</returns>
+        UniquePtr<IBuffer> createBuffer(const String& name, const IPipeline& pipeline, const UInt32& space, const UInt32& binding, const BufferUsage& usage, const size_t& elementSize, const UInt32& elements = 1, const bool& allowWrite = false) const {
+            return this->createBuffer(name, pipeline.layout()->descriptorSet(space), binding, usage, elementSize, elements, allowWrite);
         };
 
         /// <summary>

--- a/src/Samples/BasicRendering/src/sample.cpp
+++ b/src/Samples/BasicRendering/src/sample.cpp
@@ -101,7 +101,7 @@ void SampleApp::initBuffers(IRenderBackend* backend)
     //       whole buffer.
     auto stagedVertices = m_device->factory().createVertexBuffer(m_inputAssembler->vertexBufferLayout(0), BufferUsage::Staging, vertices.size());
     stagedVertices->map(vertices.data(), vertices.size() * sizeof(::Vertex), 0);
-    
+
     // Create the actual vertex buffer and transfer the staging buffer into it.
     auto vertexBuffer = m_device->factory().createVertexBuffer("Vertex Buffer", m_inputAssembler->vertexBufferLayout(0), BufferUsage::Resource, vertices.size());
     commandBuffer->transfer(*stagedVertices, *vertexBuffer, 0, 0, vertices.size());
@@ -135,7 +135,7 @@ void SampleApp::initBuffers(IRenderBackend* backend)
     auto& transformBufferLayout = transformBindingLayout.descriptor(0);
     auto transformBindings = transformBindingLayout.allocateMultiple(3);
     auto transformBuffer = m_device->factory().createBuffer("Transform", transformBufferLayout.type(), BufferUsage::Dynamic, transformBufferLayout.elementSize(), 3);
-    std::ranges::for_each(transformBindings, [&transformBufferLayout, &transformBuffer, i = 0](const auto& descriptorSet) mutable { descriptorSet->update(transformBufferLayout.binding(), *transformBuffer, i++); });
+    std::ranges::for_each(transformBindings, [&transformBufferLayout, &transformBuffer, i = 0](const auto& descriptorSet) mutable { descriptorSet->update(transformBufferLayout.binding(), *transformBuffer, i++, 1); });
     
     // End and submit the command buffer.
     auto fence = m_device->bufferQueue().submit(*commandBuffer);

--- a/src/Samples/BasicRendering/src/sample.cpp
+++ b/src/Samples/BasicRendering/src/sample.cpp
@@ -118,13 +118,9 @@ void SampleApp::initBuffers(IRenderBackend* backend)
     // write-once/read-multiple scenario, we also transfer the buffer to the more efficient memory heap on the GPU.
     auto& geometryPipeline = m_device->state().pipeline("Geometry");
     auto& cameraBindingLayout = geometryPipeline.layout()->descriptorSet(DescriptorSets::Constant);
-    auto& cameraBufferLayout = cameraBindingLayout.descriptor(0);
-    auto cameraStagingBuffer = m_device->factory().createBuffer("Camera Staging", cameraBufferLayout.type(), BufferUsage::Staging, cameraBufferLayout.elementSize(), 1);
-    auto cameraBuffer = m_device->factory().createBuffer("Camera", cameraBufferLayout.type(), BufferUsage::Resource, cameraBufferLayout.elementSize(), 1);
-
-    // Allocate the descriptor set and bind the camera buffer to it.
-    auto cameraBindings = cameraBindingLayout.allocate();
-    cameraBindings->update(cameraBufferLayout.binding(), *cameraBuffer, 0);
+    auto cameraStagingBuffer = m_device->factory().createBuffer("Camera Staging", cameraBindingLayout, 0, BufferUsage::Staging);
+    auto cameraBuffer = m_device->factory().createBuffer("Camera", cameraBindingLayout, 0, BufferUsage::Resource);
+    auto cameraBindings = cameraBindingLayout.allocate({ { 0, *cameraBuffer } });
 
     // Update the camera. Since the descriptor set already points to the proper buffer, all changes are implicitly visible.
     this->updateCamera(*commandBuffer, *cameraStagingBuffer, *cameraBuffer);
@@ -132,10 +128,12 @@ void SampleApp::initBuffers(IRenderBackend* backend)
     // Next, we create the descriptor sets for the transform buffer. The transform changes with every frame. Since we have three frames in flight, we
     // create a buffer with three elements and bind the appropriate element to the descriptor set for every frame.
     auto& transformBindingLayout = geometryPipeline.layout()->descriptorSet(DescriptorSets::PerFrame);
-    auto& transformBufferLayout = transformBindingLayout.descriptor(0);
-    auto transformBindings = transformBindingLayout.allocateMultiple(3);
-    auto transformBuffer = m_device->factory().createBuffer("Transform", transformBufferLayout.type(), BufferUsage::Dynamic, transformBufferLayout.elementSize(), 3);
-    std::ranges::for_each(transformBindings, [&transformBufferLayout, &transformBuffer, i = 0](const auto& descriptorSet) mutable { descriptorSet->update(transformBufferLayout.binding(), *transformBuffer, i++, 1); });
+    auto transformBuffer = m_device->factory().createBuffer("Transform", transformBindingLayout, 0, BufferUsage::Dynamic, 3);
+    auto transformBindings = transformBindingLayout.allocateMultiple(3, {
+        { { .binding = 0, .resource = *transformBuffer, .firstElement = 0, .elements = 1 } },
+        { { .binding = 0, .resource = *transformBuffer, .firstElement = 1, .elements = 1 } },
+        { { .binding = 0, .resource = *transformBuffer, .firstElement = 2, .elements = 1 } }
+    });
     
     // End and submit the command buffer.
     auto fence = m_device->bufferQueue().submit(*commandBuffer);
@@ -331,7 +329,8 @@ void SampleApp::keyDown(int key, int scancode, int action, int mods)
             windowRect = clientRect;
 
             // Switch to fullscreen.
-            ::glfwSetWindowMonitor(m_window.get(), currentMonitor, 0, 0, currentVideoMode->width, currentVideoMode->height, currentVideoMode->refreshRate);
+            if (currentVideoMode != nullptr)
+                ::glfwSetWindowMonitor(m_window.get(), currentMonitor, 0, 0, currentVideoMode->width, currentVideoMode->height, currentVideoMode->refreshRate);
         }
         else
         {

--- a/src/Samples/Bindless/src/sample.cpp
+++ b/src/Samples/Bindless/src/sample.cpp
@@ -165,7 +165,7 @@ void SampleApp::initBuffers(IRenderBackend* backend)
     auto& drawDataBufferLayout = drawDataBindingLayout.descriptor(0);
     auto drawDataBindings = drawDataBindingLayout.allocateMultiple(3);
     auto drawDataBuffer = m_device->factory().createBuffer("Draw Data", drawDataBufferLayout.type(), BufferUsage::Dynamic, drawDataBufferLayout.elementSize(), 3);
-    std::ranges::for_each(drawDataBindings, [&drawDataBufferLayout, &drawDataBuffer, i = 0](const auto& descriptorSet) mutable { descriptorSet->update(drawDataBufferLayout.binding(), *drawDataBuffer, i++); });
+    std::ranges::for_each(drawDataBindings, [&drawDataBufferLayout, &drawDataBuffer, i = 0](const auto& descriptorSet) mutable { descriptorSet->update(drawDataBufferLayout.binding(), *drawDataBuffer, i++, 1); });
 
     // Next, we create the descriptor set for the instance buffer. The shader is designed to handle an arbitrary number of instances using an unbounded buffer array, so
     // we have to specify how many instances we are actually allocating. We do this only once and then bind this array to all command buffers, since we do not need to 
@@ -180,7 +180,7 @@ void SampleApp::initBuffers(IRenderBackend* backend)
     // Since we are using an unstructured storage buffer, we need to specify the element size manually.
     auto instanceStagingBuffer = m_device->factory().createBuffer("Instance Staging", instanceBufferLayout.type(), BufferUsage::Staging, sizeof(InstanceBuffer), NUM_INSTANCES);
     auto instanceBuffer = m_device->factory().createBuffer("Instance Buffer", instanceBufferLayout.type(), BufferUsage::Resource, sizeof(InstanceBuffer), NUM_INSTANCES);
-    instanceBinding->update(instanceBufferLayout.binding(), *instanceBuffer, 0, NUM_INSTANCES);
+    instanceBinding->update(instanceBufferLayout.binding(), *instanceBuffer, 0);
     instanceStagingBuffer->map(reinterpret_cast<const void*>(&instanceData), sizeof(instanceData));
     commandBuffer->transfer(*instanceStagingBuffer, *instanceBuffer, 0, 0, NUM_INSTANCES);
 

--- a/src/Samples/Bindless/src/sample.cpp
+++ b/src/Samples/Bindless/src/sample.cpp
@@ -149,23 +149,21 @@ void SampleApp::initBuffers(IRenderBackend* backend)
     // write-once/read-multiple scenario, we also transfer the buffer to the more efficient memory heap on the GPU.
     auto& geometryPipeline = m_device->state().pipeline("Geometry");
     auto& cameraBindingLayout = geometryPipeline.layout()->descriptorSet(DescriptorSets::CameraData);
-    auto& cameraBufferLayout = cameraBindingLayout.descriptor(0);
-    auto cameraStagingBuffer = m_device->factory().createBuffer("Camera Staging", cameraBufferLayout.type(), BufferUsage::Staging, cameraBufferLayout.elementSize(), 1);
-    auto cameraBuffer = m_device->factory().createBuffer("Camera", cameraBufferLayout.type(), BufferUsage::Resource, cameraBufferLayout.elementSize(), 1);
-
-    // Allocate the descriptor set and bind the camera buffer to it.
-    auto cameraBindings = cameraBindingLayout.allocate();
-    cameraBindings->update(cameraBufferLayout.binding(), *cameraBuffer, 0);
+    auto cameraStagingBuffer = m_device->factory().createBuffer("Camera Staging", cameraBindingLayout, 0, BufferUsage::Staging);
+    auto cameraBuffer = m_device->factory().createBuffer("Camera", cameraBindingLayout, 0, BufferUsage::Resource);
+    auto cameraBindings = cameraBindingLayout.allocate({ { 0, *cameraBuffer } });
 
     // Update the camera. Since the descriptor set already points to the proper buffer, all changes are implicitly visible.
     this->updateCamera(*commandBuffer, *cameraStagingBuffer, *cameraBuffer);
 
     // Next, we create the descriptor sets for the draw-data buffer
     auto& drawDataBindingLayout = geometryPipeline.layout()->descriptorSet(DescriptorSets::DrawData);
-    auto& drawDataBufferLayout = drawDataBindingLayout.descriptor(0);
-    auto drawDataBindings = drawDataBindingLayout.allocateMultiple(3);
-    auto drawDataBuffer = m_device->factory().createBuffer("Draw Data", drawDataBufferLayout.type(), BufferUsage::Dynamic, drawDataBufferLayout.elementSize(), 3);
-    std::ranges::for_each(drawDataBindings, [&drawDataBufferLayout, &drawDataBuffer, i = 0](const auto& descriptorSet) mutable { descriptorSet->update(drawDataBufferLayout.binding(), *drawDataBuffer, i++, 1); });
+    auto drawDataBuffer = m_device->factory().createBuffer("Draw Data", drawDataBindingLayout, 0, BufferUsage::Dynamic, 3);
+    auto drawDataBindings = drawDataBindingLayout.allocateMultiple(3, {
+        { {.binding = 0, .resource = *drawDataBuffer, .firstElement = 0, .elements = 1 } },
+        { {.binding = 0, .resource = *drawDataBuffer, .firstElement = 1, .elements = 1 } },
+        { {.binding = 0, .resource = *drawDataBuffer, .firstElement = 2, .elements = 1 } },
+    });
 
     // Next, we create the descriptor set for the instance buffer. The shader is designed to handle an arbitrary number of instances using an unbounded buffer array, so
     // we have to specify how many instances we are actually allocating. We do this only once and then bind this array to all command buffers, since we do not need to 
@@ -174,13 +172,11 @@ void SampleApp::initBuffers(IRenderBackend* backend)
     // to the indices currently not in use (i.e. each instance buffer needs to be inside the array multiple times, once for each frame in flight). This is allowed for 
     // unbounded descriptor arrays, as long as we ensure, not to overwrite descriptors that are currently in use.
     auto& instanceBindingLayout = geometryPipeline.layout()->descriptorSet(DescriptorSets::InstanceData);
-    auto& instanceBufferLayout = instanceBindingLayout.descriptor(0);
-    auto instanceBinding = instanceBindingLayout.allocate(NUM_INSTANCES);
 
     // Since we are using an unstructured storage buffer, we need to specify the element size manually.
-    auto instanceStagingBuffer = m_device->factory().createBuffer("Instance Staging", instanceBufferLayout.type(), BufferUsage::Staging, sizeof(InstanceBuffer), NUM_INSTANCES);
-    auto instanceBuffer = m_device->factory().createBuffer("Instance Buffer", instanceBufferLayout.type(), BufferUsage::Resource, sizeof(InstanceBuffer), NUM_INSTANCES);
-    instanceBinding->update(instanceBufferLayout.binding(), *instanceBuffer, 0);
+    auto instanceStagingBuffer = m_device->factory().createBuffer("Instance Staging", instanceBindingLayout, 0, BufferUsage::Staging, sizeof(InstanceBuffer), NUM_INSTANCES);
+    auto instanceBuffer = m_device->factory().createBuffer("Instance Buffer", instanceBindingLayout, 0, BufferUsage::Resource, sizeof(InstanceBuffer), NUM_INSTANCES);
+    auto instanceBinding = instanceBindingLayout.allocate(NUM_INSTANCES, { { 0, *instanceBuffer } });
     instanceStagingBuffer->map(reinterpret_cast<const void*>(&instanceData), sizeof(instanceData));
     commandBuffer->transfer(*instanceStagingBuffer, *instanceBuffer, 0, 0, NUM_INSTANCES);
 
@@ -383,7 +379,8 @@ void SampleApp::keyDown(int key, int scancode, int action, int mods)
             windowRect = clientRect;
 
             // Switch to fullscreen.
-            ::glfwSetWindowMonitor(m_window.get(), currentMonitor, 0, 0, currentVideoMode->width, currentVideoMode->height, currentVideoMode->refreshRate);
+            if (currentVideoMode != nullptr)
+                ::glfwSetWindowMonitor(m_window.get(), currentMonitor, 0, 0, currentVideoMode->width, currentVideoMode->height, currentVideoMode->refreshRate);
         }
         else
         {

--- a/src/Samples/Multisampling/src/sample.cpp
+++ b/src/Samples/Multisampling/src/sample.cpp
@@ -135,7 +135,7 @@ void SampleApp::initBuffers(IRenderBackend* backend)
     auto& transformBufferLayout = transformBindingLayout.descriptor(0);
     auto transformBindings = transformBindingLayout.allocateMultiple(3);
     auto transformBuffer = m_device->factory().createBuffer("Transform", transformBufferLayout.type(), BufferUsage::Dynamic, transformBufferLayout.elementSize(), 3);
-    std::ranges::for_each(transformBindings, [&transformBufferLayout, &transformBuffer, i = 0](const auto& descriptorSet) mutable { descriptorSet->update(transformBufferLayout.binding(), *transformBuffer, i++); });
+    std::ranges::for_each(transformBindings, [&transformBufferLayout, &transformBuffer, i = 0](const auto& descriptorSet) mutable { descriptorSet->update(transformBufferLayout.binding(), *transformBuffer, i++, 1); });
     
     // End and submit the command buffer.
     auto fence = m_device->bufferQueue().submit(*commandBuffer);

--- a/src/Samples/Multithreading/src/sample.cpp
+++ b/src/Samples/Multithreading/src/sample.cpp
@@ -155,7 +155,7 @@ void SampleApp::initBuffers(IRenderBackend* backend)
     
     for (int s(0); s < 3; ++s)
         for (int i(0); i < NUM_WORKERS; ++i)
-            transformBindings[(s * NUM_WORKERS) + i]->update(transformBufferLayout.binding(), *transformBuffers[i], s);
+            transformBindings[(s * NUM_WORKERS) + i]->update(transformBufferLayout.binding(), *transformBuffers[i], s, 1);
     
     // End and submit the command buffer.
     auto fence = m_device->bufferQueue().submit(*commandBuffer);

--- a/src/Samples/PushConstants/src/sample.cpp
+++ b/src/Samples/PushConstants/src/sample.cpp
@@ -146,13 +146,9 @@ void SampleApp::initBuffers(IRenderBackend* backend)
     // write-once/read-multiple scenario, we also transfer the buffer to the more efficient memory heap on the GPU.
     auto& geometryPipeline = m_device->state().pipeline("Geometry");
     auto& cameraBindingLayout = geometryPipeline.layout()->descriptorSet(DescriptorSets::Constant);
-    auto& cameraBufferLayout = cameraBindingLayout.descriptor(0);
-    auto cameraStagingBuffer = m_device->factory().createBuffer("Camera Staging", cameraBufferLayout.type(), BufferUsage::Staging, cameraBufferLayout.elementSize(), 1);
-    auto cameraBuffer = m_device->factory().createBuffer("Camera", cameraBufferLayout.type(), BufferUsage::Resource, cameraBufferLayout.elementSize(), 1);
-
-    // Allocate the descriptor set and bind the camera buffer to it.
-    auto cameraBindings = cameraBindingLayout.allocate();
-    cameraBindings->update(cameraBufferLayout.binding(), *cameraBuffer, 0);
+    auto cameraStagingBuffer = m_device->factory().createBuffer("Camera Staging", cameraBindingLayout, 0, BufferUsage::Staging);
+    auto cameraBuffer = m_device->factory().createBuffer("Camera", cameraBindingLayout, 0, BufferUsage::Resource);
+    auto cameraBindings = cameraBindingLayout.allocate({ { 0, *cameraBuffer } });
 
     // Update the camera. Since the descriptor set already points to the proper buffer, all changes are implicitly visible.
     this->updateCamera(*commandBuffer, *cameraStagingBuffer, *cameraBuffer);
@@ -346,7 +342,8 @@ void SampleApp::keyDown(int key, int scancode, int action, int mods)
             windowRect = clientRect;
 
             // Switch to fullscreen.
-            ::glfwSetWindowMonitor(m_window.get(), currentMonitor, 0, 0, currentVideoMode->width, currentVideoMode->height, currentVideoMode->refreshRate);
+            if (currentVideoMode != nullptr)
+                ::glfwSetWindowMonitor(m_window.get(), currentMonitor, 0, 0, currentVideoMode->width, currentVideoMode->height, currentVideoMode->refreshRate);
         }
         else
         {

--- a/src/Samples/RenderPasses/src/sample.cpp
+++ b/src/Samples/RenderPasses/src/sample.cpp
@@ -171,7 +171,7 @@ void SampleApp::initBuffers(IRenderBackend* backend)
     auto& transformBufferLayout = transformBindingLayout.descriptor(0);
     auto transformBindings = transformBindingLayout.allocateMultiple(3);
     auto transformBuffer = m_device->factory().createBuffer("Transform", transformBufferLayout.type(), BufferUsage::Dynamic, transformBufferLayout.elementSize(), 3);
-    std::ranges::for_each(transformBindings, [&transformBufferLayout, &transformBuffer, i = 0](const auto& descriptorSet) mutable { descriptorSet->update(transformBufferLayout.binding(), *transformBuffer, i++); });
+    std::ranges::for_each(transformBindings, [&transformBufferLayout, &transformBuffer, i = 0](const auto& descriptorSet) mutable { descriptorSet->update(transformBufferLayout.binding(), *transformBuffer, i++, 1); });
 
     // Create buffers for lighting pass, i.e. the view plane vertex and index buffers.
     auto stagedViewPlaneVertices = m_device->factory().createVertexBuffer(m_inputAssembler->vertexBufferLayout(0), BufferUsage::Staging, viewPlaneVertices.size());

--- a/src/Samples/Textures/src/sample.cpp
+++ b/src/Samples/Textures/src/sample.cpp
@@ -151,7 +151,7 @@ void SampleApp::initBuffers(IRenderBackend* backend)
     auto& transformBufferLayout = transformBindingLayout.descriptor(0);
     auto transformBindings = transformBindingLayout.allocateMultiple(3);
     auto transformBuffer = m_device->factory().createBuffer("Transform", transformBufferLayout.type(), BufferUsage::Dynamic, transformBufferLayout.elementSize(), 3);
-    std::ranges::for_each(transformBindings, [&transformBufferLayout, &transformBuffer, i = 0](const auto& descriptorSet) mutable { descriptorSet->update(transformBufferLayout.binding(), *transformBuffer, i++); });
+    std::ranges::for_each(transformBindings, [&transformBufferLayout, &transformBuffer, i = 0](const auto& descriptorSet) mutable { descriptorSet->update(transformBufferLayout.binding(), *transformBuffer, i++, 1); });
 
     // End and submit the command buffer.
     auto fence = m_device->bufferQueue().submit(*commandBuffer);

--- a/src/Samples/UniformArrays/src/sample.cpp
+++ b/src/Samples/UniformArrays/src/sample.cpp
@@ -171,7 +171,7 @@ void SampleApp::initBuffers(IRenderBackend* backend)
     auto& lightsBufferLayout = staticBindingLayout.descriptor(1);
     auto lightsStagingBuffer = m_device->factory().createBuffer("Lights Staging", lightsBufferLayout.type(), BufferUsage::Staging, lightsBufferLayout.elementSize(), LIGHT_SOURCES);
     auto lightsBuffer = m_device->factory().createBuffer("Lights", lightsBufferLayout.type(), BufferUsage::Resource, lightsBufferLayout.elementSize(), LIGHT_SOURCES);
-    staticBindings->update(lightsBufferLayout.binding(), *lightsBuffer, 0, LIGHT_SOURCES);
+    staticBindings->update(lightsBufferLayout.binding(), *lightsBuffer, 0);
 
     auto lightsData = lights | std::views::transform([](const LightBuffer& light) { return reinterpret_cast<const void*>(&light); }) | ranges::to<Array<const void*>>();
     lightsStagingBuffer->map(lightsData, sizeof(LightBuffer));
@@ -183,7 +183,7 @@ void SampleApp::initBuffers(IRenderBackend* backend)
     auto& transformBufferLayout = transformBindingLayout.descriptor(0);
     auto transformBindings = transformBindingLayout.allocateMultiple(3);
     auto transformBuffer = m_device->factory().createBuffer("Transform", transformBufferLayout.type(), BufferUsage::Dynamic, transformBufferLayout.elementSize(), 3);
-    std::ranges::for_each(transformBindings, [&transformBufferLayout, &transformBuffer, i = 0](const auto& descriptorSet) mutable { descriptorSet->update(transformBufferLayout.binding(), *transformBuffer, i++); });
+    std::ranges::for_each(transformBindings, [&transformBufferLayout, &transformBuffer, i = 0](const auto& descriptorSet) mutable { descriptorSet->update(transformBufferLayout.binding(), *transformBuffer, i++, 1); });
     
     // End and submit the command buffer.
     auto fence = m_device->bufferQueue().submit(*commandBuffer);


### PR DESCRIPTION
**Describe the pull request**

This PR improves allocation and binding of resources. When creating buffers, it is no longer required to query the descriptor layout in advance. For example, the following versions are now all equal:

```cxx
// Current way of allocating buffer for descriptor:
auto& pipeline= m_device->state().pipeline("Pipeline");
auto& descriptorSetLayout = pipeline.layout()->descriptorSet(space);
auto& descriptorLayout = descriptorSetLayout.descriptor(descriptor);
auto buffer = m_device->factory().createBuffer("Buffer", descriptorLayout.type(), BufferUsage::Resource, descriptorLayout.elementSize());

// New way using descriptor set layout:
auto& pipeline= m_device->state().pipeline("Pipeline");
auto& descriptorSetLayout = pipeline.layout()->descriptorSet(space);
auto buffer = m_device->factory().createBuffer("Buffer", descriptorSetLayout, descriptor, BufferUsage::Resource);

// New way using only pipeline:
auto& pipeline= m_device->state().pipeline("Pipeline");
auto buffer = m_device->factory().createBuffer("Buffer", pipeline, space, descriptor, BufferUsage::Resource);
```

Additionally, when allocating descriptor sets, it is now possible to provide default bindings, removing the need to call `update` for each resource to bind:

```cxx
// Current style:
auto& pipeline= m_device->state().pipeline("Pipeline");
auto& descriptorSetLayout = pipeline.layout()->descriptorSet(space);
auto descriptorSet = descriptorSetLayout.allocate();
descriptorSet->update(descriptorA, *bufferA, 0, 1);
descriptorSet->update(descriptorB, *bufferB, 0, 1);

// New style using default binding: 
auto& pipeline= m_device->state().pipeline("Pipeline");
auto& descriptorSetLayout = pipeline.layout()->descriptorSet(space);
auto descriptorSet = descriptorSetLayout.allocate({ { descriptorA, *bufferA, 0, 1 }, { descriptorB, *bufferB, 0, 1 } });
```

When allocating multiple descriptor sets, this can get hard to read and repetitive. Thus there is another new overload, accepting a factory method for default descriptor bindings:

```cxx
auto& pipeline= m_device->state().pipeline("Pipeline");
auto& descriptorSetLayout = pipeline.layout()->descriptorSet(space);
auto descriptorSets = descriptorSetLayout.allocateMultiple(3, [&](const UInt32& setId) -> Array<DescriptorBinding> {
    return { { descriptorA, *buffers[setId], 0, 1 }, { descriptorB, *textures[setId], 0, 1 } };
});
```

This also allows to mass-generate bindings efficiently using ranges:

```cxx
auto descriptorSets = descriptorSetLayout.allocateMultiple(3, [&](const UInt32& setId) { 
    // Generate bindings for binding points 0 - 7.
    return std::views::iota(0, 7) | 
        std::views::transform([&](const auto& binding) { return DescriptorBinding { binding, *buffers[binding], 0, 1 }; }) |
        ranges::to<Array<DescriptorBinding>>();
});
```

All samples have been updated to use some form of the new interface.