### PR TITLE
Dynamic pipeline state

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,13 +71,13 @@ You can also build the sources on your own. Currently only MSVC builds under Win
 In order for the project to be built, there are a few prerequisites that need to be present on your environment:
 
 - [CMake](https://cmake.org/download/) (version 3.20 or higher). †
-- Optional: [LunarG Vulkan SDK](https://vulkan.lunarg.com/) 1.2.148.0 or later (required to build the Vulkan backend).
+- Optional: [LunarG Vulkan SDK](https://vulkan.lunarg.com/) 1.3.204.1 or later (required to build the Vulkan backend).
 - Optional: Custom [DXC](https://github.com/microsoft/DirectXShaderCompiler) build (required to build shaders for DirectX backend). ‡
 - Optional: Windows 10 SDK 10.0.19041.0 or later (required to build DirectX backend).
 
 † CMake 3.20 is part of Visual Studio 2019 version 16.10 and above. When using older Visual Studio versions, consider installing CMake manually.
 
-‡ Note that the LunarG Vulkan SDK (1.2.141.0 and above) ships with a pre-built DXC binary, that supports DXIL and SPIR-V code generation and thus should be favored over the DXC binary shipped with the Windows SDK, which only supports DXIL.
+‡ Note that the LunarG Vulkan SDK (1.3.204.1 and above) ships with a pre-built DXC binary, that supports DXIL and SPIR-V code generation and thus should be favored over the DXC binary shipped with the Windows SDK, which only supports DXIL.
 
 #### Cloning the Repository
 
@@ -129,7 +129,7 @@ You can customize the engine build, according to your specific needs. The most s
 
 Within the cache variables, you can override the build options, LiteFX exports. All customizable options have the `BUILD_` prefix and are described in detail below:
 
-- `BUILD_VULKAN_BACKEND` (default: `ON`): builds the Vulkan 🌋 backend (requires [LunarG Vulkan SDK](https://vulkan.lunarg.com/) 1.2.148.0 or later to be installed on your system).
+- `BUILD_VULKAN_BACKEND` (default: `ON`): builds the Vulkan 🌋 backend (requires [LunarG Vulkan SDK](https://vulkan.lunarg.com/) 1.3.204.1 or later to be installed on your system).
 - `BUILD_DX12_BACKEND` (default: `ON`): builds the DirectX 12 ❎ backend.
 - `BUILD_DEFINE_BUILDERS` (default: `ON`): enables the [builder architecture](https://github.com/crud89/LiteFX/wiki/Builders) for backends.
 - `BUILD_WITH_GLM` (default: `ON`): adds [glm](https://glm.g-truc.net/0.9.9/index.html) converters to math types. †

--- a/docs/release-logs/0.4.1.md
+++ b/docs/release-logs/0.4.1.md
@@ -8,3 +8,5 @@
 - Improved resource allocation and binding: ([See PR #83](https://github.com/crud89/LiteFX/pull/83))
   - Resources can now be created without querying the descriptor set layout or descriptor layout in advance.
   - When allocating descriptor sets, default bindings can be provided to make bind-once scenarios more straightforward.
+- Raise minimum Vulkan SDK version to 1.3.204.1. ([See PR #86](https://github.com/crud89/LiteFX/pull/86))
+- Make most of the render pipeline state dynamic. ([See PR #86](https://github.com/crud89/LiteFX/pull/86))

--- a/src/Backends/DirectX12/include/litefx/backends/dx12.hpp
+++ b/src/Backends/DirectX12/include/litefx/backends/dx12.hpp
@@ -871,7 +871,7 @@ namespace LiteFX::Rendering::Backends {
 		/// <param name="rasterizer">The rasterizer state of the pipeline.</param>
 		/// <param name="name">The optional name of the render pipeline.</param>
 		/// <param name="enableAlphaToCoverage">Whether or not to enable Alpha-to-Coverage multi-sampling.</param>
-		explicit DirectX12RenderPipeline(const DirectX12RenderPass& renderPass, SharedPtr<DirectX12PipelineLayout> layout, SharedPtr<DirectX12ShaderProgram> shaderProgram, SharedPtr<DirectX12InputAssembler> inputAssembler, SharedPtr<DirectX12Rasterizer> rasterizer, Array<SharedPtr<IViewport>>&& viewports, Array<SharedPtr<IScissor>>&& scissors, const bool enableAlphaToCoverage = false, const String& name = "");
+		explicit DirectX12RenderPipeline(const DirectX12RenderPass& renderPass, SharedPtr<DirectX12PipelineLayout> layout, SharedPtr<DirectX12ShaderProgram> shaderProgram, SharedPtr<DirectX12InputAssembler> inputAssembler, SharedPtr<DirectX12Rasterizer> rasterizer, const bool enableAlphaToCoverage = false, const String& name = "");
 		DirectX12RenderPipeline(DirectX12RenderPipeline&&) noexcept = delete;
 		DirectX12RenderPipeline(const DirectX12RenderPipeline&) noexcept = delete;
 		virtual ~DirectX12RenderPipeline() noexcept;
@@ -899,18 +899,6 @@ namespace LiteFX::Rendering::Backends {
 
 		/// <inheritdoc />
 		virtual SharedPtr<DirectX12Rasterizer> rasterizer() const noexcept override;
-
-		/// <inheritdoc />
-		virtual Array<const IViewport*> viewports() const noexcept override;
-
-		/// <inheritdoc />
-		virtual Array<const IScissor*> scissors() const noexcept override;
-
-		/// <inheritdoc />
-		virtual UInt32& stencilRef() const noexcept override;
-
-		/// <inheritdoc />
-		virtual Vector4f& blendFactors() const noexcept override;
 
 		/// <inheritdoc />
 		virtual const bool& alphaToCoverage() const noexcept override;

--- a/src/Backends/DirectX12/include/litefx/backends/dx12.hpp
+++ b/src/Backends/DirectX12/include/litefx/backends/dx12.hpp
@@ -809,6 +809,18 @@ namespace LiteFX::Rendering::Backends {
 		virtual void end() const override;
 
 		/// <inheritdoc />
+		virtual void setViewports(Span<const IViewport*> viewports) const noexcept override;
+
+		/// <inheritdoc />
+		virtual void setScissors(Span<const IScissor*> scissors) const noexcept override;
+
+		/// <inheritdoc />
+		virtual void setBlendFactors(const Vector4f& blendFactors) const noexcept override;
+
+		/// <inheritdoc />
+		virtual void setStencilRef(const UInt32& stencilRef) const noexcept override;
+
+		/// <inheritdoc />
 		virtual void generateMipMaps(IDirectX12Image& image) noexcept override;
 
 		/// <inheritdoc />

--- a/src/Backends/DirectX12/include/litefx/backends/dx12.hpp
+++ b/src/Backends/DirectX12/include/litefx/backends/dx12.hpp
@@ -812,7 +812,13 @@ namespace LiteFX::Rendering::Backends {
 		virtual void setViewports(Span<const IViewport*> viewports) const noexcept override;
 
 		/// <inheritdoc />
+		virtual void setViewports(const IViewport* viewport) const noexcept override;
+
+		/// <inheritdoc />
 		virtual void setScissors(Span<const IScissor*> scissors) const noexcept override;
+
+		/// <inheritdoc />
+		virtual void setScissors(const IScissor* scissor) const noexcept override;
 
 		/// <inheritdoc />
 		virtual void setBlendFactors(const Vector4f& blendFactors) const noexcept override;

--- a/src/Backends/DirectX12/include/litefx/backends/dx12_builders.hpp
+++ b/src/Backends/DirectX12/include/litefx/backends/dx12_builders.hpp
@@ -387,12 +387,6 @@ namespace LiteFX::Rendering::Backends {
 		virtual DirectX12RenderPipelineBuilder& inputAssembler(SharedPtr<DirectX12InputAssembler> inputAssembler) override;
 
 		/// <inheritdoc />
-		virtual DirectX12RenderPipelineBuilder& viewport(SharedPtr<IViewport> viewport) override;
-
-		/// <inheritdoc />
-		virtual DirectX12RenderPipelineBuilder& scissor(SharedPtr<IScissor> scissor) override;
-
-		/// <inheritdoc />
 		virtual DirectX12RenderPipelineBuilder& enableAlphaToCoverage(const bool& enable = true) override;
 	};
 

--- a/src/Backends/DirectX12/src/command_buffer.cpp
+++ b/src/Backends/DirectX12/src/command_buffer.cpp
@@ -95,6 +95,34 @@ void DirectX12CommandBuffer::end() const
 	m_impl->m_recording = false;
 }
 
+void DirectX12CommandBuffer::setViewports(Span<const IViewport*> viewports) const noexcept
+{
+	auto vps = viewports |
+		std::views::transform([](const auto& viewport) { return CD3DX12_VIEWPORT(viewport->getRectangle().x(), viewport->getRectangle().y(), viewport->getRectangle().width(), viewport->getRectangle().height(), viewport->getMinDepth(), viewport->getMaxDepth()); }) |
+		ranges::to<Array<D3D12_VIEWPORT>>();
+
+	this->handle()->RSSetViewports(vps.size(), vps.data());
+}
+
+void DirectX12CommandBuffer::setScissors(Span<const IScissor*> scissors) const noexcept
+{
+	auto scs = scissors |
+		std::views::transform([](const auto& scissor) { return CD3DX12_RECT(scissor->getRectangle().x(), scissor->getRectangle().y(), scissor->getRectangle().width(), scissor->getRectangle().height()); }) |
+		ranges::to<Array<D3D12_RECT>>();
+
+	this->handle()->RSSetScissorRects(scs.size(), scs.data());
+}
+
+void DirectX12CommandBuffer::setBlendFactors(const Vector4f& blendFactors) const noexcept
+{
+	this->handle()->OMSetBlendFactor(&blendFactors[0]);
+}
+
+void DirectX12CommandBuffer::setStencilRef(const UInt32& stencilRef) const noexcept
+{
+	this->handle()->OMSetStencilRef(stencilRef);
+}
+
 void DirectX12CommandBuffer::generateMipMaps(IDirectX12Image& image) noexcept
 {
 	struct Parameters {

--- a/src/Backends/DirectX12/src/command_buffer.cpp
+++ b/src/Backends/DirectX12/src/command_buffer.cpp
@@ -104,6 +104,12 @@ void DirectX12CommandBuffer::setViewports(Span<const IViewport*> viewports) cons
 	this->handle()->RSSetViewports(vps.size(), vps.data());
 }
 
+void DirectX12CommandBuffer::setViewports(const IViewport* viewport) const noexcept
+{
+	auto vp = CD3DX12_VIEWPORT(viewport->getRectangle().x(), viewport->getRectangle().y(), viewport->getRectangle().width(), viewport->getRectangle().height(), viewport->getMinDepth(), viewport->getMaxDepth());
+	this->handle()->RSSetViewports(1, &vp);
+}
+
 void DirectX12CommandBuffer::setScissors(Span<const IScissor*> scissors) const noexcept
 {
 	auto scs = scissors |
@@ -111,6 +117,12 @@ void DirectX12CommandBuffer::setScissors(Span<const IScissor*> scissors) const n
 		ranges::to<Array<D3D12_RECT>>();
 
 	this->handle()->RSSetScissorRects(scs.size(), scs.data());
+}
+
+void DirectX12CommandBuffer::setScissors(const IScissor* scissor) const noexcept
+{
+	auto s = CD3DX12_RECT(scissor->getRectangle().x(), scissor->getRectangle().y(), scissor->getRectangle().width(), scissor->getRectangle().height());
+	this->handle()->RSSetScissorRects(1, &s);
 }
 
 void DirectX12CommandBuffer::setBlendFactors(const Vector4f& blendFactors) const noexcept

--- a/src/Backends/Vulkan/include/litefx/backends/vulkan.hpp
+++ b/src/Backends/Vulkan/include/litefx/backends/vulkan.hpp
@@ -834,7 +834,13 @@ namespace LiteFX::Rendering::Backends {
 		virtual void setViewports(Span<const IViewport*> viewports) const noexcept override;
 
 		/// <inheritdoc />
+		virtual void setViewports(const IViewport* viewport) const noexcept override;
+
+		/// <inheritdoc />
 		virtual void setScissors(Span<const IScissor*> scissors) const noexcept override;
+
+		/// <inheritdoc />
+		virtual void setScissors(const IScissor* scissor) const noexcept override;
 
 		/// <inheritdoc />
 		virtual void setBlendFactors(const Vector4f& blendFactors) const noexcept override;

--- a/src/Backends/Vulkan/include/litefx/backends/vulkan.hpp
+++ b/src/Backends/Vulkan/include/litefx/backends/vulkan.hpp
@@ -831,6 +831,18 @@ namespace LiteFX::Rendering::Backends {
 		virtual void end() const override;
 
 		/// <inheritdoc />
+		virtual void setViewports(Span<const IViewport*> viewports) const noexcept override;
+
+		/// <inheritdoc />
+		virtual void setScissors(Span<const IScissor*> scissors) const noexcept override;
+
+		/// <inheritdoc />
+		virtual void setBlendFactors(const Vector4f& blendFactors) const noexcept override;
+
+		/// <inheritdoc />
+		virtual void setStencilRef(const UInt32& stencilRef) const noexcept override;
+
+		/// <inheritdoc />
 		virtual void generateMipMaps(IVulkanImage& image) noexcept override;
 
 		/// <inheritdoc />

--- a/src/Backends/Vulkan/include/litefx/backends/vulkan.hpp
+++ b/src/Backends/Vulkan/include/litefx/backends/vulkan.hpp
@@ -893,7 +893,7 @@ namespace LiteFX::Rendering::Backends {
 		/// <param name="rasterizer">The rasterizer state of the pipeline.</param>
 		/// <param name="name">The optional name of the render pipeline.</param>
 		/// <param name="enableAlphaToCoverage">Whether or not to enable Alpha-to-Coverage multi-sampling.</param>
-		explicit VulkanRenderPipeline(const VulkanRenderPass& renderPass, SharedPtr<VulkanShaderProgram> shaderProgram, SharedPtr<VulkanPipelineLayout> layout, SharedPtr<VulkanInputAssembler> inputAssembler, SharedPtr<VulkanRasterizer> rasterizer, Array<SharedPtr<IViewport>> viewports, Array<SharedPtr<IScissor>> scissors, const bool& enableAlphaToCoverage = false, const String& name = "");
+		explicit VulkanRenderPipeline(const VulkanRenderPass& renderPass, SharedPtr<VulkanShaderProgram> shaderProgram, SharedPtr<VulkanPipelineLayout> layout, SharedPtr<VulkanInputAssembler> inputAssembler, SharedPtr<VulkanRasterizer> rasterizer, const bool& enableAlphaToCoverage = false, const String& name = "");
 		VulkanRenderPipeline(VulkanRenderPipeline&&) noexcept = delete;
 		VulkanRenderPipeline(const VulkanRenderPipeline&) noexcept = delete;
 		virtual ~VulkanRenderPipeline() noexcept;
@@ -921,18 +921,6 @@ namespace LiteFX::Rendering::Backends {
 
 		/// <inheritdoc />
 		virtual SharedPtr<VulkanRasterizer> rasterizer() const noexcept override;
-
-		/// <inheritdoc />
-		virtual Array<const IViewport*> viewports() const noexcept override;
-
-		/// <inheritdoc />
-		virtual Array<const IScissor*> scissors() const noexcept override;
-
-		/// <inheritdoc />
-		virtual UInt32& stencilRef() const noexcept override;
-
-		/// <inheritdoc />
-		virtual Vector4f& blendFactors() const noexcept override;
 
 		/// <inheritdoc />
 		virtual const bool& alphaToCoverage() const noexcept override;

--- a/src/Backends/Vulkan/include/litefx/backends/vulkan_builders.hpp
+++ b/src/Backends/Vulkan/include/litefx/backends/vulkan_builders.hpp
@@ -391,12 +391,6 @@ namespace LiteFX::Rendering::Backends {
 		virtual VulkanRenderPipelineBuilder& inputAssembler(SharedPtr<VulkanInputAssembler> inputAssembler) override;
 
 		/// <inheritdoc />
-		virtual VulkanRenderPipelineBuilder& viewport(SharedPtr<IViewport> viewport) override;
-
-		/// <inheritdoc />
-		virtual VulkanRenderPipelineBuilder& scissor(SharedPtr<IScissor> scissor) override;
-
-		/// <inheritdoc />
 		virtual VulkanRenderPipelineBuilder& enableAlphaToCoverage(const bool& enable = true) override;
 	};
 

--- a/src/Backends/Vulkan/src/command_buffer.cpp
+++ b/src/Backends/Vulkan/src/command_buffer.cpp
@@ -127,6 +127,34 @@ void VulkanCommandBuffer::end() const
 	m_impl->m_recording = false;
 }
 
+void VulkanCommandBuffer::setViewports(Span<const IViewport*> viewports) const noexcept
+{
+	auto vps = viewports |
+		std::views::transform([](const auto& viewport) { return VkViewport{ .x = viewport->getRectangle().x(), .y = viewport->getRectangle().y(), .width = viewport->getRectangle().width(), .height = viewport->getRectangle().height(), .minDepth = viewport->getMinDepth(), .maxDepth = viewport->getMaxDepth() }; }) |
+		ranges::to<Array<VkViewport>>();
+
+	::vkCmdSetViewportWithCount(this->handle(), static_cast<UInt32>(vps.size()), vps.data());
+}
+
+void VulkanCommandBuffer::setScissors(Span<const IScissor*> scissors) const noexcept
+{
+	auto scs = scissors |
+		std::views::transform([](const auto& scissor) { return VkRect2D{ VkOffset2D{.x = static_cast<Int32>(scissor->getRectangle().x()), .y = static_cast<Int32>(scissor->getRectangle().y())}, VkExtent2D{.width = static_cast<UInt32>(scissor->getRectangle().width()), .height = static_cast<UInt32>(scissor->getRectangle().height())} }; }) |
+		ranges::to<Array<VkRect2D>>();
+
+	::vkCmdSetScissorWithCount(this->handle(), static_cast<UInt32>(scs.size()), scs.data());
+}
+
+void VulkanCommandBuffer::setBlendFactors(const Vector4f& blendFactors) const noexcept
+{
+	::vkCmdSetBlendConstants(this->handle(), &blendFactors[0]);
+}
+
+void VulkanCommandBuffer::setStencilRef(const UInt32& stencilRef) const noexcept
+{
+	::vkCmdSetStencilReference(this->handle(), VK_STENCIL_FACE_FRONT_AND_BACK, stencilRef);
+}
+
 void VulkanCommandBuffer::generateMipMaps(IVulkanImage& image) noexcept
 {
 	// Use a native barrier for improved performance (we update it for each level).

--- a/src/Backends/Vulkan/src/command_buffer.cpp
+++ b/src/Backends/Vulkan/src/command_buffer.cpp
@@ -136,6 +136,12 @@ void VulkanCommandBuffer::setViewports(Span<const IViewport*> viewports) const n
 	::vkCmdSetViewportWithCount(this->handle(), static_cast<UInt32>(vps.size()), vps.data());
 }
 
+void VulkanCommandBuffer::setViewports(const IViewport* viewport) const noexcept
+{
+	auto vp = VkViewport{ .x = viewport->getRectangle().x(), .y = viewport->getRectangle().y(), .width = viewport->getRectangle().width(), .height = viewport->getRectangle().height(), .minDepth = viewport->getMinDepth(), .maxDepth = viewport->getMaxDepth() };
+	::vkCmdSetViewportWithCount(this->handle(), 1, &vp);
+}
+
 void VulkanCommandBuffer::setScissors(Span<const IScissor*> scissors) const noexcept
 {
 	auto scs = scissors |
@@ -143,6 +149,12 @@ void VulkanCommandBuffer::setScissors(Span<const IScissor*> scissors) const noex
 		ranges::to<Array<VkRect2D>>();
 
 	::vkCmdSetScissorWithCount(this->handle(), static_cast<UInt32>(scs.size()), scs.data());
+}
+
+void VulkanCommandBuffer::setScissors(const IScissor* scissor) const noexcept
+{
+	auto s = VkRect2D{ VkOffset2D{.x = static_cast<Int32>(scissor->getRectangle().x()), .y = static_cast<Int32>(scissor->getRectangle().y())}, VkExtent2D{.width = static_cast<UInt32>(scissor->getRectangle().width()), .height = static_cast<UInt32>(scissor->getRectangle().height())} };
+	::vkCmdSetScissorWithCount(this->handle(), 1, &s);
 }
 
 void VulkanCommandBuffer::setBlendFactors(const Vector4f& blendFactors) const noexcept

--- a/src/Backends/Vulkan/src/command_buffer.cpp
+++ b/src/Backends/Vulkan/src/command_buffer.cpp
@@ -145,7 +145,7 @@ void VulkanCommandBuffer::setViewports(const IViewport* viewport) const noexcept
 void VulkanCommandBuffer::setScissors(Span<const IScissor*> scissors) const noexcept
 {
 	auto scs = scissors |
-		std::views::transform([](const auto& scissor) { return VkRect2D{ VkOffset2D{.x = static_cast<Int32>(scissor->getRectangle().x()), .y = static_cast<Int32>(scissor->getRectangle().y())}, VkExtent2D{.width = static_cast<UInt32>(scissor->getRectangle().width()), .height = static_cast<UInt32>(scissor->getRectangle().height())} }; }) |
+		std::views::transform([](const auto& scissor) { return VkRect2D{ { .x = static_cast<Int32>(scissor->getRectangle().x()), .y = static_cast<Int32>(scissor->getRectangle().y())}, { .width = static_cast<UInt32>(scissor->getRectangle().width()), .height = static_cast<UInt32>(scissor->getRectangle().height())} }; }) |
 		ranges::to<Array<VkRect2D>>();
 
 	::vkCmdSetScissorWithCount(this->handle(), static_cast<UInt32>(scs.size()), scs.data());
@@ -153,7 +153,7 @@ void VulkanCommandBuffer::setScissors(Span<const IScissor*> scissors) const noex
 
 void VulkanCommandBuffer::setScissors(const IScissor* scissor) const noexcept
 {
-	auto s = VkRect2D{ VkOffset2D{.x = static_cast<Int32>(scissor->getRectangle().x()), .y = static_cast<Int32>(scissor->getRectangle().y())}, VkExtent2D{.width = static_cast<UInt32>(scissor->getRectangle().width()), .height = static_cast<UInt32>(scissor->getRectangle().height())} };
+	auto s = VkRect2D{ { .x = static_cast<Int32>(scissor->getRectangle().x()), .y = static_cast<Int32>(scissor->getRectangle().y())},  { .width = static_cast<UInt32>(scissor->getRectangle().width()), .height = static_cast<UInt32>(scissor->getRectangle().height())} };
 	::vkCmdSetScissorWithCount(this->handle(), 1, &s);
 }
 

--- a/src/Backends/Vulkan/src/device.cpp
+++ b/src/Backends/Vulkan/src/device.cpp
@@ -209,7 +209,7 @@ public:
 		// Allow geometry and tessellation shader stages.
 		VkPhysicalDeviceFeatures deviceFeatures = {
 			.geometryShader = true,
-			.tessellationShader = true,
+			.tessellationShader = true
 		};
 
 		VkPhysicalDeviceVulkan12Features deviceFeatures12 = { 
@@ -238,10 +238,17 @@ public:
 			.timelineSemaphore = true
 		};
 
+		// Enable extended dynamic state.
+		VkPhysicalDeviceExtendedDynamicStateFeaturesEXT extendedDynamicStateFeatures = {
+			.sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_EXTENDED_DYNAMIC_STATE_FEATURES_EXT,
+			.pNext = &deviceFeatures12,
+			.extendedDynamicState = true
+		};
+
 		// Define the device itself.
 		VkDeviceCreateInfo createInfo = {};
 		createInfo.sType = VK_STRUCTURE_TYPE_DEVICE_CREATE_INFO;
-		createInfo.pNext = &deviceFeatures12;
+		createInfo.pNext = &extendedDynamicStateFeatures;
 		createInfo.queueCreateInfoCount = static_cast<UInt32>(queueCreateInfos.size());
 		createInfo.pQueueCreateInfos = queueCreateInfos.data();
 		createInfo.pEnabledFeatures = &deviceFeatures;

--- a/src/Backends/Vulkan/src/render_pipeline.cpp
+++ b/src/Backends/Vulkan/src/render_pipeline.cpp
@@ -114,6 +114,10 @@ public:
 		inputState.vertexAttributeDescriptionCount = static_cast<UInt32>(vertexInputAttributes.size());
 		inputState.pVertexAttributeDescriptions = vertexInputAttributes.data();
 
+		// Setup viewport state (still required, even if all viewports and scissors are dynamic).
+		VkPipelineViewportStateCreateInfo viewportState = {};
+		viewportState.sType = VK_STRUCTURE_TYPE_PIPELINE_VIEWPORT_STATE_CREATE_INFO;
+
 		// Setup dynamic state.
 		Array<VkDynamicState> dynamicStates { 
 			VkDynamicState::VK_DYNAMIC_STATE_VIEWPORT_WITH_COUNT, 
@@ -197,7 +201,7 @@ public:
 		pipelineInfo.sType = VK_STRUCTURE_TYPE_GRAPHICS_PIPELINE_CREATE_INFO;
 		pipelineInfo.pVertexInputState = &inputState;
 		pipelineInfo.pInputAssemblyState = &inputAssembly;
-		pipelineInfo.pViewportState = nullptr;
+		pipelineInfo.pViewportState = &viewportState;
 		pipelineInfo.pRasterizationState = &rasterizerState;
 		pipelineInfo.pMultisampleState = &multisampling;
 		pipelineInfo.pColorBlendState = &colorBlending;

--- a/src/Backends/Vulkan/src/render_pipeline.cpp
+++ b/src/Backends/Vulkan/src/render_pipeline.cpp
@@ -17,16 +17,12 @@ private:
 	SharedPtr<VulkanShaderProgram> m_program;
 	SharedPtr<VulkanInputAssembler> m_inputAssembler;
 	SharedPtr<VulkanRasterizer> m_rasterizer;
-	Array<SharedPtr<IViewport>> m_viewports;
-	Array<SharedPtr<IScissor>> m_scissors;
-	Vector4f m_blendFactors{ 0.f, 0.f, 0.f, 0.f };
-	UInt32 m_stencilRef{ 0 };
 	bool m_alphaToCoverage{ false };
 	const VulkanRenderPass& m_renderPass;
 
 public:
-	VulkanRenderPipelineImpl(VulkanRenderPipeline* parent, const VulkanRenderPass& renderPass, const bool& alphaToCoverage, SharedPtr<VulkanPipelineLayout> layout, SharedPtr<VulkanShaderProgram> shaderProgram, SharedPtr<VulkanInputAssembler> inputAssembler, SharedPtr<VulkanRasterizer> rasterizer, Array<SharedPtr<IViewport>> viewports, Array<SharedPtr<IScissor>> scissors) :
-		base(parent), m_renderPass(renderPass), m_alphaToCoverage(alphaToCoverage), m_layout(layout), m_program(shaderProgram), m_inputAssembler(inputAssembler), m_rasterizer(rasterizer), m_viewports(viewports), m_scissors(scissors)
+	VulkanRenderPipelineImpl(VulkanRenderPipeline* parent, const VulkanRenderPass& renderPass, const bool& alphaToCoverage, SharedPtr<VulkanPipelineLayout> layout, SharedPtr<VulkanShaderProgram> shaderProgram, SharedPtr<VulkanInputAssembler> inputAssembler, SharedPtr<VulkanRasterizer> rasterizer) :
+		base(parent), m_renderPass(renderPass), m_alphaToCoverage(alphaToCoverage), m_layout(layout), m_program(shaderProgram), m_inputAssembler(inputAssembler), m_rasterizer(rasterizer)
 	{
 	}
 
@@ -118,16 +114,10 @@ public:
 		inputState.vertexAttributeDescriptionCount = static_cast<UInt32>(vertexInputAttributes.size());
 		inputState.pVertexAttributeDescriptions = vertexInputAttributes.data();
 
-		// Setup viewport state.
-		VkPipelineViewportStateCreateInfo viewportState = {};
-		viewportState.sType = VK_STRUCTURE_TYPE_PIPELINE_VIEWPORT_STATE_CREATE_INFO;
-		viewportState.viewportCount = static_cast<UInt32>(m_viewports.size());
-		viewportState.scissorCount = static_cast<UInt32>(m_scissors.size());
-
 		// Setup dynamic state.
 		Array<VkDynamicState> dynamicStates { 
-			VkDynamicState::VK_DYNAMIC_STATE_VIEWPORT, 
-			VkDynamicState::VK_DYNAMIC_STATE_SCISSOR, 
+			VkDynamicState::VK_DYNAMIC_STATE_VIEWPORT_WITH_COUNT, 
+			VkDynamicState::VK_DYNAMIC_STATE_SCISSOR_WITH_COUNT, 
 			VkDynamicState::VK_DYNAMIC_STATE_LINE_WIDTH, 
 			VkDynamicState::VK_DYNAMIC_STATE_BLEND_CONSTANTS,
 			VkDynamicState::VK_DYNAMIC_STATE_STENCIL_REFERENCE
@@ -172,10 +162,6 @@ public:
 		colorBlending.logicOp = VK_LOGIC_OP_COPY;
 		colorBlending.attachmentCount = static_cast<UInt32>(colorBlendAttachments.size());
 		colorBlending.pAttachments = colorBlendAttachments.data();
-		colorBlending.blendConstants[0] = m_blendFactors.x();
-		colorBlending.blendConstants[1] = m_blendFactors.y();
-		colorBlending.blendConstants[2] = m_blendFactors.z();
-		colorBlending.blendConstants[3] = m_blendFactors.w();
 
 		// Setup depth/stencil state.
 		VkPipelineDepthStencilStateCreateInfo depthStencilState = {};
@@ -211,7 +197,7 @@ public:
 		pipelineInfo.sType = VK_STRUCTURE_TYPE_GRAPHICS_PIPELINE_CREATE_INFO;
 		pipelineInfo.pVertexInputState = &inputState;
 		pipelineInfo.pInputAssemblyState = &inputAssembly;
-		pipelineInfo.pViewportState = &viewportState;
+		pipelineInfo.pViewportState = nullptr;
 		pipelineInfo.pRasterizationState = &rasterizerState;
 		pipelineInfo.pMultisampleState = &multisampling;
 		pipelineInfo.pColorBlendState = &colorBlending;
@@ -241,8 +227,8 @@ public:
 // Interface.
 // ------------------------------------------------------------------------------------------------
 
-VulkanRenderPipeline::VulkanRenderPipeline(const VulkanRenderPass& renderPass, SharedPtr<VulkanShaderProgram> shaderProgram, SharedPtr<VulkanPipelineLayout> layout, SharedPtr<VulkanInputAssembler> inputAssembler, SharedPtr<VulkanRasterizer> rasterizer, Array<SharedPtr<IViewport>> viewports, Array<SharedPtr<IScissor>> scissors, const bool& enableAlphaToCoverage, const String& name) :
-	m_impl(makePimpl<VulkanRenderPipelineImpl>(this, renderPass, enableAlphaToCoverage, layout, shaderProgram, inputAssembler, rasterizer, viewports, scissors)), VulkanPipelineState(VK_NULL_HANDLE)
+VulkanRenderPipeline::VulkanRenderPipeline(const VulkanRenderPass& renderPass, SharedPtr<VulkanShaderProgram> shaderProgram, SharedPtr<VulkanPipelineLayout> layout, SharedPtr<VulkanInputAssembler> inputAssembler, SharedPtr<VulkanRasterizer> rasterizer, const bool& enableAlphaToCoverage, const String& name) :
+	m_impl(makePimpl<VulkanRenderPipelineImpl>(this, renderPass, enableAlphaToCoverage, layout, shaderProgram, inputAssembler, rasterizer)), VulkanPipelineState(VK_NULL_HANDLE)
 {
 	this->handle() = m_impl->initialize();
 
@@ -282,30 +268,6 @@ SharedPtr<VulkanRasterizer> VulkanRenderPipeline::rasterizer() const noexcept
 	return m_impl->m_rasterizer;
 }
 
-Array<const IViewport*> VulkanRenderPipeline::viewports() const noexcept 
-{
-	return m_impl->m_viewports |
-		std::views::transform([](const SharedPtr<IViewport>& viewport) { return viewport.get(); }) |
-		ranges::to<Array<const IViewport*>>();
-}
-
-Array<const IScissor*> VulkanRenderPipeline::scissors() const noexcept 
-{
-	return m_impl->m_scissors |
-		std::views::transform([](const SharedPtr<IScissor>& scissor) { return scissor.get(); }) |
-		ranges::to<Array<const IScissor*>>();
-}
-
-UInt32& VulkanRenderPipeline::stencilRef() const noexcept
-{
-	return m_impl->m_stencilRef;
-}
-
-Vector4f& VulkanRenderPipeline::blendFactors() const noexcept
-{
-	return m_impl->m_blendFactors;
-}
-
 const bool& VulkanRenderPipeline::alphaToCoverage() const noexcept
 {
 	return m_impl->m_alphaToCoverage;
@@ -313,23 +275,7 @@ const bool& VulkanRenderPipeline::alphaToCoverage() const noexcept
 
 void VulkanRenderPipeline::use(const VulkanCommandBuffer& commandBuffer) const noexcept
 {
-	auto viewports = m_impl->m_viewports |
-		std::views::transform([](const auto& viewport) { return VkViewport{.x = viewport->getRectangle().x(), .y = viewport->getRectangle().y(), .width = viewport->getRectangle().width(), .height = viewport->getRectangle().height(), .minDepth = viewport->getMinDepth(), .maxDepth = viewport->getMaxDepth()}; }) |
-		ranges::to<Array<VkViewport>>();
-	
-	auto scissors = m_impl->m_scissors |
-		std::views::transform([](const auto& scissor) { return VkRect2D{VkOffset2D{.x = static_cast<Int32>(scissor->getRectangle().x()), .y = static_cast<Int32>(scissor->getRectangle().y())}, VkExtent2D{.width = static_cast<UInt32>(scissor->getRectangle().width()), .height = static_cast<UInt32>(scissor->getRectangle().height())} };}) |
-		ranges::to<Array<VkRect2D>>();
-
-	Float blendFactor[4] = { m_impl->m_blendFactors.x(), m_impl->m_blendFactors.y(), m_impl->m_blendFactors.z(), m_impl->m_blendFactors.w() };
-
-	// Bind the pipeline and setup the dynamic state.
 	::vkCmdBindPipeline(commandBuffer.handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, this->handle());
-	::vkCmdSetViewport(commandBuffer.handle(), 0, static_cast<UInt32>(viewports.size()), viewports.data());
-	::vkCmdSetScissor(commandBuffer.handle(), 0, static_cast<UInt32>(scissors.size()), scissors.data());
-	::vkCmdSetLineWidth(commandBuffer.handle(), std::as_const(*m_impl->m_rasterizer).lineWidth());
-	::vkCmdSetBlendConstants(commandBuffer.handle(), blendFactor);
-	::vkCmdSetStencilReference(commandBuffer.handle(), VK_STENCIL_FACE_FRONT_AND_BACK, m_impl->m_stencilRef);
 }
 
 void VulkanRenderPipeline::bind(const VulkanCommandBuffer& commandBuffer, const VulkanDescriptorSet& descriptorSet) const noexcept
@@ -351,8 +297,6 @@ private:
 	SharedPtr<VulkanShaderProgram> m_program;
 	SharedPtr<VulkanInputAssembler> m_inputAssembler;
 	SharedPtr<VulkanRasterizer> m_rasterizer;
-	Array<SharedPtr<IViewport>> m_viewports;
-	Array<SharedPtr<IScissor>> m_scissors;
 	bool m_alphaToCoverage{ false };
 
 public:
@@ -381,8 +325,6 @@ void VulkanRenderPipelineBuilder::build()
 	instance->m_impl->m_layout = std::move(m_impl->m_layout);
 	instance->m_impl->m_inputAssembler = std::move(m_impl->m_inputAssembler);
 	instance->m_impl->m_rasterizer = std::move(m_impl->m_rasterizer);
-	instance->m_impl->m_viewports = std::move(m_impl->m_viewports);
-	instance->m_impl->m_scissors = std::move(m_impl->m_scissors);
 	instance->m_impl->m_alphaToCoverage = std::move(m_impl->m_alphaToCoverage);
 	instance->handle() = instance->m_impl->initialize();
 }
@@ -428,18 +370,6 @@ VulkanRenderPipelineBuilder& VulkanRenderPipelineBuilder::inputAssembler(SharedP
 #endif
 
 	m_impl->m_inputAssembler = inputAssembler;
-	return *this;
-}
-
-VulkanRenderPipelineBuilder& VulkanRenderPipelineBuilder::viewport(SharedPtr<IViewport> viewport)
-{
-	m_impl->m_viewports.push_back(viewport);
-	return *this;
-}
-
-VulkanRenderPipelineBuilder& VulkanRenderPipelineBuilder::scissor(SharedPtr<IScissor> scissor)
-{
-	m_impl->m_scissors.push_back(scissor);
 	return *this;
 }
 

--- a/src/Backends/Vulkan/src/render_pipeline.cpp
+++ b/src/Backends/Vulkan/src/render_pipeline.cpp
@@ -276,6 +276,9 @@ const bool& VulkanRenderPipeline::alphaToCoverage() const noexcept
 void VulkanRenderPipeline::use(const VulkanCommandBuffer& commandBuffer) const noexcept
 {
 	::vkCmdBindPipeline(commandBuffer.handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, this->handle());
+
+	// Set the line width (in case it has been changed). Currently we do not expose an command buffer interface for this, since this is mostly unsupported anyway and has no D3D12 counter-part.
+	::vkCmdSetLineWidth(commandBuffer.handle(), std::as_const(*m_impl->m_rasterizer).lineWidth());
 }
 
 void VulkanRenderPipeline::bind(const VulkanCommandBuffer& commandBuffer, const VulkanDescriptorSet& descriptorSet) const noexcept

--- a/src/Rendering/include/litefx/rendering_api.hpp
+++ b/src/Rendering/include/litefx/rendering_api.hpp
@@ -3984,10 +3984,22 @@ namespace LiteFX::Rendering {
         virtual void setViewports(Span<const IViewport*> viewports) const noexcept = 0;
 
         /// <summary>
+        /// Sets the viewport used for the subsequent draw calls.
+        /// </summary>
+        /// <param name="viewport">The viewport used for the subsequent draw calls.</param>
+        virtual void setViewports(const IViewport* viewport) const noexcept = 0;
+
+        /// <summary>
         /// Sets the scissor rectangles used for the subsequent draw calls.
         /// </summary>
         /// <param name="scissors">The scissor rectangles used for the subsequent draw calls.</param>
         virtual void setScissors(Span<const IScissor*> scissors) const noexcept = 0;
+
+        /// <summary>
+        /// Sets the scissor rectangle used for the subsequent draw calls.
+        /// </summary>
+        /// <param name="scissors">The scissor rectangle used for the subsequent draw calls.</param>
+        virtual void setScissors(const IScissor* scissor) const noexcept = 0;
 
         /// <summary>
         /// Sets the blend factors for the subsequent draw calls.

--- a/src/Rendering/include/litefx/rendering_api.hpp
+++ b/src/Rendering/include/litefx/rendering_api.hpp
@@ -3977,6 +3977,34 @@ namespace LiteFX::Rendering {
             this->cmdDrawIndexed(vertexBuffer, indexBuffer, instances, firstIndex, vertexOffset, firstInstance);
         }
 
+        /// <summary>
+        /// Sets the viewports used for the subsequent draw calls.
+        /// </summary>
+        /// <param name="viewports">The viewports used for the subsequent draw calls.</param>
+        virtual void setViewports(Span<const IViewport*> viewports) const noexcept = 0;
+
+        /// <summary>
+        /// Sets the scissor rectangles used for the subsequent draw calls.
+        /// </summary>
+        /// <param name="scissors">The scissor rectangles used for the subsequent draw calls.</param>
+        virtual void setScissors(Span<const IScissor*> scissors) const noexcept = 0;
+
+        /// <summary>
+        /// Sets the blend factors for the subsequent draw calls.
+        /// </summary>
+        /// <remarks>
+        /// Blend factors are set for all render targets that use the blend modes <c>BlendFactor::ConstantColor</c>, <c>BlendFactor::OneMinusConstantColor</c>, <c>BlendFactor::ConstantAlpha</c> or 
+        /// <c>BlendFactor::OneMinusConstantAlpha</c>.
+        /// </remarks>
+        /// <param name="blendFactors">The blend factors for the subsequent draw calls.</param>
+        virtual void setBlendFactors(const Vector4f& blendFactors) const noexcept = 0;
+
+        /// <summary>
+        /// Sets the stencil reference for the subsequent draw calls.
+        /// </summary>
+        /// <param name="stencilRef">The stencil reference for the subsequent draw calls.</param>
+        virtual void setStencilRef(const UInt32& stencilRef) const noexcept = 0;
+
     private:
         virtual void cmdBarrier(const IBarrier& barrier, const bool& invert) const noexcept = 0;
         virtual void cmdGenerateMipMaps(IImage& image) noexcept = 0;

--- a/src/Rendering/include/litefx/rendering_api.hpp
+++ b/src/Rendering/include/litefx/rendering_api.hpp
@@ -4019,38 +4019,6 @@ namespace LiteFX::Rendering {
         }
 
         /// <summary>
-        /// Returns the viewports, the render pipeline can draw to.
-        /// </summary>
-        /// <returns>The viewports, the render pipeline can draw to.</returns>
-        virtual Array<const IViewport*> viewports() const noexcept = 0;
-
-        /// <summary>
-        /// Returns the scissors of the render pipeline.
-        /// </summary>
-        /// <returns>The scissors of the render pipeline.</returns>
-        virtual Array<const IScissor*> scissors() const noexcept = 0;
-
-        /// <summary>
-        /// Returns a reference to the stencil reference value.
-        /// </summary>
-        /// <remarks>
-        /// The stencil reference value is used by the stencil test and is set with each call to <see cref="RenderPipeline::use" />.
-        /// </remarks>
-        /// <returns>A reference to the stencil reference value.</returns>
-        virtual UInt32& stencilRef() const noexcept = 0;
-
-        /// <summary>
-        /// Returns a reference of the constant blend factors for the pipeline.
-        /// </summary>
-        /// <remarks>
-        /// You can change the values inside this vector reference to influence the constant blend factors. Blend factors are set for all render targets that use the
-        /// blend factors <c>BlendFactor::ConstantColor</c>, <c>BlendFactor::OneMinusConstantColor</c>, <c>BlendFactor::ConstantAlpha</c> or 
-        /// <c>BlendFactor::OneMinusConstantAlpha</c>. They are set on each call to <see cref="RenderPipeline::use" />.
-        /// </remarks>
-        /// <returns>A reference of the constant blend factors for the pipeline.</returns>
-        virtual Vector4f& blendFactors() const noexcept = 0;
-
-        /// <summary>
         /// Returns <c>true</c>, if the pipeline uses <i>Alpha-to-Coverage</i> multi-sampling.
         /// </summary>
         /// <remarks>

--- a/src/Rendering/include/litefx/rendering_builders.hpp
+++ b/src/Rendering/include/litefx/rendering_builders.hpp
@@ -473,18 +473,6 @@ namespace LiteFX::Rendering {
         virtual TDerived& inputAssembler(SharedPtr<input_assembler_type> inputAssembler) = 0;
 
         /// <summary>
-        /// Uses the provided viewport to initialize the render pipeline. Can be invoked multiple times.
-        /// </summary>
-        /// <param name="viewport">A viewport to initialize the render pipeline with.</param>
-        virtual TDerived& viewport(SharedPtr<IViewport> viewport) = 0;
-
-        /// <summary>
-        /// Uses the provided scissor to initialize the render pipeline. Can be invoked multiple times.
-        /// </summary>
-        /// <param name="scissor">A scissor to initialize the render pipeline with.</param>
-        virtual TDerived& scissor(SharedPtr<IScissor> scissor) = 0;
-
-        /// <summary>
         /// Enables <i>Alpha-to-Coverage</i> multi-sampling on the pipeline.
         /// </summary>
         /// <remarks>

--- a/src/Samples/BasicRendering/src/sample.cpp
+++ b/src/Samples/BasicRendering/src/sample.cpp
@@ -40,7 +40,7 @@ const String FileExtensions<DirectX12Backend>::SHADER = "dxi";
 
 template<typename TRenderBackend> requires
     rtti::implements<TRenderBackend, IRenderBackend>
-void initRenderGraph(TRenderBackend* backend, SharedPtr<IViewport> viewport, SharedPtr<IScissor> scissor, SharedPtr<IInputAssembler>& inputAssemblerState)
+void initRenderGraph(TRenderBackend* backend, SharedPtr<IInputAssembler>& inputAssemblerState)
 {
     using RenderPass = TRenderBackend::render_pass_type;
     using RenderPipeline = TRenderBackend::render_pipeline_type;
@@ -75,8 +75,6 @@ void initRenderGraph(TRenderBackend* backend, SharedPtr<IViewport> viewport, Sha
 
     // Create a render pipeline.
     UniquePtr<RenderPipeline> renderPipeline = device->buildRenderPipeline(*renderPass, "Geometry")
-        .viewport(viewport)
-        .scissor(scissor)
         .inputAssembler(inputAssembler)
         .rasterizer(device->buildRasterizer()
             .polygonMode(PolygonMode::Solid)
@@ -186,7 +184,7 @@ void SampleApp::onStartup()
         m_device = backend->createDevice("Default", *adapter, std::move(surface), Format::B8G8R8A8_UNORM, m_viewport->getRectangle().extent(), 3);
 
         // Initialize resources.
-        ::initRenderGraph(backend, m_viewport, m_scissor, m_inputAssembler);
+        ::initRenderGraph(backend, m_inputAssembler);
         this->initBuffers(backend);
 
         return true;
@@ -384,6 +382,8 @@ void SampleApp::drawFrame()
     renderPass.begin(backBuffer);
     auto& commandBuffer = renderPass.activeFrameBuffer().commandBuffer(0);
     commandBuffer.use(geometryPipeline);
+    commandBuffer.setViewports(m_viewport.get());
+    commandBuffer.setScissors(m_scissor.get());
 
     // Get the amount of time that has passed since the first frame.
     auto now = std::chrono::high_resolution_clock::now();

--- a/src/Samples/Bindless/src/sample.cpp
+++ b/src/Samples/Bindless/src/sample.cpp
@@ -71,7 +71,7 @@ static void initInstanceData()
 
 template<typename TRenderBackend> requires
     rtti::implements<TRenderBackend, IRenderBackend>
-void initRenderGraph(TRenderBackend* backend, SharedPtr<IViewport> viewport, SharedPtr<IScissor> scissor, SharedPtr<IInputAssembler>& inputAssemblerState)
+void initRenderGraph(TRenderBackend* backend, SharedPtr<IInputAssembler>& inputAssemblerState)
 {
     using RenderPass = TRenderBackend::render_pass_type;
     using RenderPipeline = TRenderBackend::render_pipeline_type;
@@ -105,8 +105,6 @@ void initRenderGraph(TRenderBackend* backend, SharedPtr<IViewport> viewport, Sha
 
     // Create a render pipeline.
     UniquePtr<RenderPipeline> renderPipeline = device->buildRenderPipeline(*renderPass, "Geometry")
-        .viewport(viewport)
-        .scissor(scissor)
         .inputAssembler(inputAssembler)
         .rasterizer(device->buildRasterizer()
             .polygonMode(PolygonMode::Solid)
@@ -236,7 +234,7 @@ void SampleApp::onStartup()
         m_device = backend->createDevice("Default", *adapter, std::move(surface), Format::B8G8R8A8_UNORM, m_viewport->getRectangle().extent(), 3);
 
         // Initialize resources.
-        ::initRenderGraph(backend, m_viewport, m_scissor, m_inputAssembler);
+        ::initRenderGraph(backend, m_inputAssembler);
         this->initBuffers(backend);
 
         return true;
@@ -435,6 +433,8 @@ void SampleApp::drawFrame()
     renderPass.begin(backBuffer);
     auto& commandBuffer = renderPass.activeFrameBuffer().commandBuffer(0);
     commandBuffer.use(geometryPipeline);
+    commandBuffer.setViewports(m_viewport.get());
+    commandBuffer.setScissors(m_scissor.get());
 
     // Get the amount of time that has passed since the first frame.
     auto now = std::chrono::high_resolution_clock::now();

--- a/src/Samples/Multisampling/src/sample.cpp
+++ b/src/Samples/Multisampling/src/sample.cpp
@@ -40,7 +40,7 @@ const String FileExtensions<DirectX12Backend>::SHADER = "dxi";
 
 template<typename TRenderBackend> requires
     rtti::implements<TRenderBackend, IRenderBackend>
-void initRenderGraph(TRenderBackend* backend, SharedPtr<IViewport> viewport, SharedPtr<IScissor> scissor, SharedPtr<IInputAssembler>& inputAssemblerState)
+void initRenderGraph(TRenderBackend* backend, SharedPtr<IInputAssembler>& inputAssemblerState)
 {
     using RenderPass = TRenderBackend::render_pass_type;
     using RenderPipeline = TRenderBackend::render_pipeline_type;
@@ -75,8 +75,6 @@ void initRenderGraph(TRenderBackend* backend, SharedPtr<IViewport> viewport, Sha
 
     // Create a render pipeline.
     UniquePtr<RenderPipeline> renderPipeline = device->buildRenderPipeline(*renderPass, "Geometry")
-        .viewport(viewport)
-        .scissor(scissor)
         .inputAssembler(inputAssembler)
         .rasterizer(device->buildRasterizer()
             .polygonMode(PolygonMode::Solid)
@@ -186,7 +184,7 @@ void SampleApp::onStartup()
         m_device = backend->createDevice("Default", *adapter, std::move(surface), Format::B8G8R8A8_UNORM, m_viewport->getRectangle().extent(), 3);
 
         // Initialize resources.
-        ::initRenderGraph(backend, m_viewport, m_scissor, m_inputAssembler);
+        ::initRenderGraph(backend, m_inputAssembler);
         this->initBuffers(backend);
 
         return true;
@@ -384,6 +382,8 @@ void SampleApp::drawFrame()
     renderPass.begin(backBuffer);
     auto& commandBuffer = renderPass.activeFrameBuffer().commandBuffer(0);
     commandBuffer.use(geometryPipeline);
+    commandBuffer.setViewports(m_viewport.get());
+    commandBuffer.setScissors(m_scissor.get());
 
     // Get the amount of time that has passed since the first frame.
     auto now = std::chrono::high_resolution_clock::now();

--- a/src/Samples/Multithreading/src/sample.cpp
+++ b/src/Samples/Multithreading/src/sample.cpp
@@ -53,7 +53,7 @@ const String FileExtensions<DirectX12Backend>::SHADER = "dxi";
 
 template<typename TRenderBackend> requires
     rtti::implements<TRenderBackend, IRenderBackend>
-void initRenderGraph(TRenderBackend* backend, SharedPtr<IViewport> viewport, SharedPtr<IScissor> scissor, SharedPtr<IInputAssembler>& inputAssemblerState)
+void initRenderGraph(TRenderBackend* backend, SharedPtr<IInputAssembler>& inputAssemblerState)
 {
     using RenderPass = TRenderBackend::render_pass_type;
     using RenderPipeline = TRenderBackend::render_pipeline_type;
@@ -88,8 +88,6 @@ void initRenderGraph(TRenderBackend* backend, SharedPtr<IViewport> viewport, Sha
 
     // Create a render pipeline.
     UniquePtr<RenderPipeline> renderPipeline = device->buildRenderPipeline(*renderPass, "Geometry")
-        .viewport(viewport)
-        .scissor(scissor)
         .inputAssembler(inputAssembler)
         .rasterizer(device->buildRasterizer()
             .polygonMode(PolygonMode::Solid)
@@ -201,7 +199,7 @@ void SampleApp::onStartup()
         m_device = backend->createDevice("Default", *adapter, std::move(surface), Format::B8G8R8A8_UNORM, m_viewport->getRectangle().extent(), 3);
 
         // Initialize resources.
-        ::initRenderGraph(backend, m_viewport, m_scissor, m_inputAssembler);
+        ::initRenderGraph(backend, m_inputAssembler);
         this->initBuffers(backend);
 
         return true;
@@ -393,6 +391,8 @@ void SampleApp::drawObject(const IRenderPass* renderPass, int index, int backBuf
 
     // Set the pipeline on the command buffer.
     commandBuffer.use(geometryPipeline);
+    commandBuffer.setViewports(m_viewport.get());
+    commandBuffer.setScissors(m_scissor.get());
 
     // Compute world transform and update the transform buffer.
     transform[index].World = glm::translate(glm::rotate(glm::mat4(1.0f), time * glm::radians(42.0f), glm::vec3(0.0f, 0.0f, 1.0f)), translations[index]);

--- a/src/Samples/PushConstants/src/sample.cpp
+++ b/src/Samples/PushConstants/src/sample.cpp
@@ -67,7 +67,7 @@ const String FileExtensions<DirectX12Backend>::SHADER = "dxi";
 
 template<typename TRenderBackend> requires
     rtti::implements<TRenderBackend, IRenderBackend>
-void initRenderGraph(TRenderBackend* backend, SharedPtr<IViewport> viewport, SharedPtr<IScissor> scissor, SharedPtr<IInputAssembler>& inputAssemblerState)
+void initRenderGraph(TRenderBackend* backend, SharedPtr<IInputAssembler>& inputAssemblerState)
 {
     using RenderPass = TRenderBackend::render_pass_type;
     using RenderPipeline = TRenderBackend::render_pipeline_type;
@@ -102,8 +102,6 @@ void initRenderGraph(TRenderBackend* backend, SharedPtr<IViewport> viewport, Sha
 
     // Create a render pipeline.
     UniquePtr<RenderPipeline> renderPipeline = device->buildRenderPipeline(*renderPass, "Geometry")
-        .viewport(viewport)
-        .scissor(scissor)
         .inputAssembler(inputAssembler)
         .rasterizer(device->buildRasterizer()
             .polygonMode(PolygonMode::Solid)
@@ -202,7 +200,7 @@ void SampleApp::onStartup()
         m_device = backend->createDevice("Default", *adapter, std::move(surface), Format::B8G8R8A8_UNORM, m_viewport->getRectangle().extent(), 3);
 
         // Initialize resources.
-        ::initRenderGraph(backend, m_viewport, m_scissor, m_inputAssembler);
+        ::initRenderGraph(backend, m_inputAssembler);
         this->initBuffers(backend);
 
         return true;
@@ -395,6 +393,8 @@ void SampleApp::drawFrame()
     renderPass.begin(backBuffer);
     auto& commandBuffer = renderPass.activeFrameBuffer().commandBuffer(0);
     commandBuffer.use(geometryPipeline);
+    commandBuffer.setViewports(m_viewport.get());
+    commandBuffer.setScissors(m_scissor.get());
 
     // Get the amount of time that has passed since the first frame.
     auto now = std::chrono::high_resolution_clock::now();

--- a/src/Samples/Textures/src/sample.cpp
+++ b/src/Samples/Textures/src/sample.cpp
@@ -44,7 +44,7 @@ const String FileExtensions<DirectX12Backend>::SHADER = "dxi";
 
 template<typename TRenderBackend> requires
 rtti::implements<TRenderBackend, IRenderBackend>
-void initRenderGraph(TRenderBackend* backend, SharedPtr<IViewport> viewport, SharedPtr<IScissor> scissor, SharedPtr<IInputAssembler>& inputAssemblerState)
+void initRenderGraph(TRenderBackend* backend, SharedPtr<IInputAssembler>& inputAssemblerState)
 {
     using RenderPass = TRenderBackend::render_pass_type;
     using RenderPipeline = TRenderBackend::render_pipeline_type;
@@ -80,8 +80,6 @@ void initRenderGraph(TRenderBackend* backend, SharedPtr<IViewport> viewport, Sha
 
     // Create a render pipeline.
     UniquePtr<RenderPipeline> renderPipeline = device->buildRenderPipeline(*renderPass, "Geometry")
-        .viewport(viewport)
-        .scissor(scissor)
         .inputAssembler(inputAssembler)
         .rasterizer(device->buildRasterizer()
             .polygonMode(PolygonMode::Solid)
@@ -244,7 +242,7 @@ void SampleApp::onStartup()
         m_device = backend->createDevice("Default", *adapter, std::move(surface), Format::B8G8R8A8_UNORM, m_viewport->getRectangle().extent(), 3);
 
         // Initialize resources.
-        ::initRenderGraph(backend, m_viewport, m_scissor, m_inputAssembler);
+        ::initRenderGraph(backend, m_inputAssembler);
         this->initBuffers(backend);
 
         return true;
@@ -443,6 +441,8 @@ void SampleApp::drawFrame()
     renderPass.begin(backBuffer);
     auto& commandBuffer = renderPass.activeFrameBuffer().commandBuffer(0);
     commandBuffer.use(geometryPipeline);
+    commandBuffer.setViewports(m_viewport.get());
+    commandBuffer.setScissors(m_scissor.get());
 
     // Get the amount of time that has passed since the first frame.
     auto now = std::chrono::high_resolution_clock::now();

--- a/src/Samples/UniformArrays/src/sample.cpp
+++ b/src/Samples/UniformArrays/src/sample.cpp
@@ -76,7 +76,7 @@ const String FileExtensions<DirectX12Backend>::SHADER = "dxi";
 
 template<typename TRenderBackend> requires
     rtti::implements<TRenderBackend, IRenderBackend>
-void initRenderGraph(TRenderBackend* backend, SharedPtr<IViewport> viewport, SharedPtr<IScissor> scissor, SharedPtr<IInputAssembler>& inputAssemblerState)
+void initRenderGraph(TRenderBackend* backend, SharedPtr<IInputAssembler>& inputAssemblerState)
 {
     using RenderPass = TRenderBackend::render_pass_type;
     using RenderPipeline = TRenderBackend::render_pipeline_type;
@@ -112,8 +112,6 @@ void initRenderGraph(TRenderBackend* backend, SharedPtr<IViewport> viewport, Sha
 
     // Create a render pipeline.
     UniquePtr<RenderPipeline> renderPipeline = device->buildRenderPipeline(*renderPass, "Geometry")
-        .viewport(viewport)
-        .scissor(scissor)
         .inputAssembler(inputAssembler)
         .rasterizer(device->buildRasterizer()
             .polygonMode(PolygonMode::Solid)
@@ -248,7 +246,7 @@ void SampleApp::onStartup()
         m_device = backend->createDevice("Default", *adapter, std::move(surface), Format::B8G8R8A8_UNORM, m_viewport->getRectangle().extent(), 3);
 
         // Initialize resources.
-        ::initRenderGraph(backend, m_viewport, m_scissor, m_inputAssembler);
+        ::initRenderGraph(backend, m_inputAssembler);
         this->initBuffers(backend);
 
         return true;
@@ -446,6 +444,8 @@ void SampleApp::drawFrame()
     renderPass.begin(backBuffer);
     auto& commandBuffer = renderPass.activeFrameBuffer().commandBuffer(0);
     commandBuffer.use(geometryPipeline);
+    commandBuffer.setViewports(m_viewport.get());
+    commandBuffer.setScissors(m_scissor.get());
 
     // Get the amount of time that has passed since the first frame.
     auto now = std::chrono::high_resolution_clock::now();


### PR DESCRIPTION
**Describe the pull request**

This PR moves the viewport, scissor, blend factors and stencil reference states out of the render pipeline state. This allows for them to be altered without requiring a second pipeline instance. Instead, the command buffer now provides an interface to set the state accordingly.

For the Vulkan backend, this uses the `VK_EXT_extended_dynamic_state` extension, which has been promoted to core with Vulkan 1.3. This is a good excuse to raise the minimum required SDK version to 1.3.204.1.

Note, that it is now mandatory to set (at least) the viewport and scissor after binding a pipeline and not later than issuing a draw call, e.g.:

```cxx
renderPass.begin(backBuffer);
auto& commandBuffer = renderPass.activeFrameBuffer().commandBuffer(0);
commandBuffer.use(geometryPipeline);
commandBuffer.setViewports(m_viewport.get());
commandBuffer.setScissors(m_scissor.get());
```

All samples and the tutorial have been updated to reflect those changes.

**Known issues**

Note that calling `setViewports` or `setScissors` with validation layers enabled will crash the application. This is due to a bug in the validation layer implementation, which hopefully will be resolved soon.