### PR TITLE
Change const-ness of vector conversion operators.

### DIFF
--- a/docs/release-logs/0.4.1.md
+++ b/docs/release-logs/0.4.1.md
@@ -10,3 +10,4 @@
   - When allocating descriptor sets, default bindings can be provided to make bind-once scenarios more straightforward.
 - Raise minimum Vulkan SDK version to 1.3.204.1. ([See PR #86](https://github.com/crud89/LiteFX/pull/86))
 - Make most of the render pipeline state dynamic. ([See PR #86](https://github.com/crud89/LiteFX/pull/86))
+- Vector conversion to math types can now be done for constant vectors. ([See PR #87](https://github.com/crud89/LiteFX/pull/87))

--- a/src/Math/include/litefx/math.hpp
+++ b/src/Math/include/litefx/math.hpp
@@ -101,14 +101,14 @@ namespace LiteFX::Math {
 	public:
 		Vector1f(const glm::f32vec1& v) noexcept;
 		Vector1f(glm::f32vec1&& v) noexcept;
-		inline operator glm::f32vec1() noexcept;
+		inline operator glm::f32vec1() const noexcept;
 #endif
 
 #if defined(BUILD_WITH_DIRECTX_MATH)
 	public:
 		Vector1f(const DirectX::XMVECTOR& v) noexcept;
 		Vector1f(DirectX::XMVECTOR&& v) noexcept;
-		inline operator DirectX::XMVECTOR() noexcept;
+		inline operator DirectX::XMVECTOR() const noexcept;
 #endif
 	};
 
@@ -137,14 +137,14 @@ namespace LiteFX::Math {
 	public:
 		Vector1u(const glm::u32vec1& v) noexcept;
 		Vector1u(glm::u32vec1&& v) noexcept;
-		inline operator glm::u32vec1() noexcept;
+		inline operator glm::u32vec1() const noexcept;
 #endif
 
 #if defined(BUILD_WITH_DIRECTX_MATH)
 	public:
 		Vector1u(const DirectX::XMVECTOR& v) noexcept;
 		Vector1u(DirectX::XMVECTOR&& v) noexcept;
-		inline operator DirectX::XMVECTOR() noexcept;
+		inline operator DirectX::XMVECTOR() const noexcept;
 #endif
 	};
 
@@ -173,7 +173,7 @@ namespace LiteFX::Math {
 	public:
 		Vector2f(const glm::f32vec2& v) noexcept;
 		Vector2f(glm::f32vec2&& v) noexcept;
-		inline operator glm::f32vec2() noexcept;
+		inline operator glm::f32vec2() const noexcept;
 #endif
 
 #if defined(BUILD_WITH_DIRECTX_MATH)
@@ -182,8 +182,8 @@ namespace LiteFX::Math {
 		Vector2f(DirectX::XMVECTOR&& v) noexcept;
 		Vector2f(const DirectX::XMFLOAT2& v) noexcept;
 		Vector2f(DirectX::XMFLOAT2&& v) noexcept;
-		inline operator DirectX::XMVECTOR() noexcept;
-		inline operator DirectX::XMFLOAT2() noexcept;
+		inline operator DirectX::XMVECTOR() const noexcept;
+		inline operator DirectX::XMFLOAT2() const noexcept;
 #endif
 	};
 
@@ -212,7 +212,7 @@ namespace LiteFX::Math {
 	public:
 		Vector2u(const glm::u32vec2& v) noexcept;
 		Vector2u(glm::u32vec2&& v) noexcept;
-		inline operator glm::u32vec2() noexcept;
+		inline operator glm::u32vec2() const noexcept;
 #endif
 
 #if defined(BUILD_WITH_DIRECTX_MATH)
@@ -221,8 +221,8 @@ namespace LiteFX::Math {
 		Vector2u(DirectX::XMVECTOR&& v) noexcept;
 		Vector2u(const DirectX::XMUINT2& v) noexcept;
 		Vector2u(DirectX::XMUINT2&& v) noexcept;
-		inline operator DirectX::XMVECTOR() noexcept;
-		inline operator DirectX::XMUINT2() noexcept;
+		inline operator DirectX::XMVECTOR() const noexcept;
+		inline operator DirectX::XMUINT2() const noexcept;
 #endif
 	};
 
@@ -251,7 +251,7 @@ namespace LiteFX::Math {
 	public:
 		Vector2i(const glm::i32vec2& v) noexcept;
 		Vector2i(glm::i32vec2&& v) noexcept;
-		inline operator glm::i32vec2() noexcept;
+		inline operator glm::i32vec2() const noexcept;
 #endif
 
 #if defined(BUILD_WITH_DIRECTX_MATH)
@@ -260,8 +260,8 @@ namespace LiteFX::Math {
 		Vector2i(DirectX::XMVECTOR&& v) noexcept;
 		Vector2i(const DirectX::XMINT2& v) noexcept;
 		Vector2i(DirectX::XMINT2&& v) noexcept;
-		inline operator DirectX::XMVECTOR() noexcept;
-		inline operator DirectX::XMINT2() noexcept;
+		inline operator DirectX::XMVECTOR() const noexcept;
+		inline operator DirectX::XMINT2() const noexcept;
 #endif
 	};
 
@@ -290,7 +290,7 @@ namespace LiteFX::Math {
 	public:
 		Vector3f(const glm::f32vec3& v) noexcept;
 		Vector3f(glm::f32vec3&& v) noexcept;
-		inline operator glm::f32vec3() noexcept;
+		inline operator glm::f32vec3() const noexcept;
 #endif
 
 #if defined(BUILD_WITH_DIRECTX_MATH)
@@ -299,8 +299,8 @@ namespace LiteFX::Math {
 		Vector3f(DirectX::XMVECTOR&& v) noexcept;
 		Vector3f(const DirectX::XMFLOAT3& v) noexcept;
 		Vector3f(DirectX::XMFLOAT3&& v) noexcept;
-		inline operator DirectX::XMVECTOR() noexcept;
-		inline operator DirectX::XMFLOAT3() noexcept;
+		inline operator DirectX::XMVECTOR() const noexcept;
+		inline operator DirectX::XMFLOAT3() const noexcept;
 #endif
 	};
 
@@ -329,7 +329,7 @@ namespace LiteFX::Math {
 	public:
 		Vector3u(const glm::u32vec3& v) noexcept;
 		Vector3u(glm::u32vec3&& v) noexcept;
-		inline operator glm::u32vec3() noexcept;
+		inline operator glm::u32vec3() const noexcept;
 #endif
 
 #if defined(BUILD_WITH_DIRECTX_MATH)
@@ -338,8 +338,8 @@ namespace LiteFX::Math {
 		Vector3u(DirectX::XMVECTOR&& v) noexcept;
 		Vector3u(const DirectX::XMUINT3& v) noexcept;
 		Vector3u(DirectX::XMUINT3&& v) noexcept;
-		inline operator DirectX::XMVECTOR() noexcept;
-		inline operator DirectX::XMUINT3() noexcept;
+		inline operator DirectX::XMVECTOR() const noexcept;
+		inline operator DirectX::XMUINT3() const noexcept;
 #endif
 	};
 
@@ -368,7 +368,7 @@ namespace LiteFX::Math {
 	public:
 		Vector3i(const glm::i32vec3& v) noexcept;
 		Vector3i(glm::i32vec3&& v) noexcept;
-		inline operator glm::i32vec3() noexcept;
+		inline operator glm::i32vec3() const noexcept;
 #endif
 
 #if defined(BUILD_WITH_DIRECTX_MATH)
@@ -377,8 +377,8 @@ namespace LiteFX::Math {
 		Vector3i(DirectX::XMVECTOR&& v) noexcept;
 		Vector3i(const DirectX::XMINT3& v) noexcept;
 		Vector3i(DirectX::XMINT3&& v) noexcept;
-		inline operator DirectX::XMVECTOR() noexcept;
-		inline operator DirectX::XMINT3() noexcept;
+		inline operator DirectX::XMVECTOR() const noexcept;
+		inline operator DirectX::XMINT3() const noexcept;
 #endif
 	};
 
@@ -407,7 +407,7 @@ namespace LiteFX::Math {
 	public:
 		Vector4f(const glm::f32vec4& v) noexcept;
 		Vector4f(glm::f32vec4&& v) noexcept;
-		inline operator glm::f32vec4() noexcept;
+		inline operator glm::f32vec4() const noexcept;
 #endif
 
 #if defined(BUILD_WITH_DIRECTX_MATH)
@@ -416,8 +416,8 @@ namespace LiteFX::Math {
 		Vector4f(DirectX::XMVECTOR&& v) noexcept;
 		Vector4f(const DirectX::XMFLOAT4& v) noexcept;
 		Vector4f(DirectX::XMFLOAT4&& v) noexcept;
-		inline operator DirectX::XMVECTOR() noexcept;
-		inline operator DirectX::XMFLOAT4() noexcept;
+		inline operator DirectX::XMVECTOR() const noexcept;
+		inline operator DirectX::XMFLOAT4() const noexcept;
 #endif
 	};
 
@@ -446,7 +446,7 @@ namespace LiteFX::Math {
 	public:
 		Vector4u(const glm::u32vec4& v) noexcept;
 		Vector4u(glm::u32vec4&& v) noexcept;
-		inline operator glm::u32vec4() noexcept;
+		inline operator glm::u32vec4() const noexcept;
 #endif
 
 #if defined(BUILD_WITH_DIRECTX_MATH)
@@ -455,8 +455,8 @@ namespace LiteFX::Math {
 		Vector4u(DirectX::XMVECTOR&& v) noexcept;
 		Vector4u(const DirectX::XMUINT4& v) noexcept;
 		Vector4u(DirectX::XMUINT4&& v) noexcept;
-		inline operator DirectX::XMVECTOR() noexcept;
-		inline operator DirectX::XMUINT4() noexcept;
+		inline operator DirectX::XMVECTOR() const noexcept;
+		inline operator DirectX::XMUINT4() const noexcept;
 #endif
 	};
 
@@ -485,7 +485,7 @@ namespace LiteFX::Math {
 	public:
 		Vector4i(const glm::i32vec4& v) noexcept;
 		Vector4i(glm::i32vec4&& v) noexcept;
-		inline operator glm::i32vec4() noexcept;
+		inline operator glm::i32vec4() const noexcept;
 #endif
 
 #if defined(BUILD_WITH_DIRECTX_MATH)
@@ -494,8 +494,8 @@ namespace LiteFX::Math {
 		Vector4i(DirectX::XMVECTOR&& v) noexcept;
 		Vector4i(const DirectX::XMINT4& v) noexcept;
 		Vector4i(DirectX::XMINT4&& v) noexcept;
-		inline operator DirectX::XMVECTOR() noexcept;
-		inline operator DirectX::XMINT4() noexcept;
+		inline operator DirectX::XMVECTOR() const noexcept;
+		inline operator DirectX::XMINT4() const noexcept;
 #endif
 	};
 

--- a/src/Math/src/vector.cpp
+++ b/src/Math/src/vector.cpp
@@ -68,7 +68,7 @@ Vector1f::Vector1f(glm::f32vec1&& v) noexcept {
     std::generate(std::begin(m_elements), std::end(m_elements), [&, i = 0]() mutable { return std::move(v[i++]); });
 }
 
-Vector1f::operator glm::f32vec1() noexcept {
+Vector1f::operator glm::f32vec1() const noexcept {
     return glm::f32vec1(m_elements[0]);
 }
 #endif
@@ -82,7 +82,7 @@ Vector1f::Vector1f(DirectX::XMVECTOR&& v) noexcept {
     DirectX::XMStoreFloat(m_elements, std::move(v));
 }
 
-Vector1f::operator DirectX::XMVECTOR() noexcept {
+Vector1f::operator DirectX::XMVECTOR() const noexcept {
     return DirectX::XMLoadFloat(m_elements);
 }
 #endif
@@ -153,7 +153,7 @@ Vector1u::Vector1u(glm::u32vec1&& v) noexcept {
     std::generate(std::begin(m_elements), std::end(m_elements), [&, i = 0]() mutable { return std::move(v[i++]); });
 }
 
-Vector1u::operator glm::u32vec1() noexcept {
+Vector1u::operator glm::u32vec1() const noexcept {
     return glm::u32vec1(m_elements[0]);
 }
 #endif
@@ -167,7 +167,7 @@ Vector1u::Vector1u(DirectX::XMVECTOR&& v) noexcept {
     DirectX::XMStoreInt(m_elements, std::move(v));
 }
 
-Vector1u::operator DirectX::XMVECTOR() noexcept {
+Vector1u::operator DirectX::XMVECTOR() const noexcept {
     return DirectX::XMLoadInt(m_elements);
 }
 #endif
@@ -243,7 +243,7 @@ Vector2f::Vector2f(glm::f32vec2&& v) noexcept {
     std::generate(std::begin(m_elements), std::end(m_elements), [&, i = 0]() mutable { return std::move(v[i++]); });
 }
 
-Vector2f::operator glm::f32vec2() noexcept {
+Vector2f::operator glm::f32vec2() const noexcept {
     return glm::f32vec2(m_elements[0], m_elements[1]);
 }
 #endif
@@ -275,12 +275,12 @@ Vector2f::Vector2f(DirectX::XMFLOAT2&& v) noexcept : Vector<Float, 2>() {
     this->y() = std::move(v.y);
 }
 
-Vector2f::operator DirectX::XMVECTOR() noexcept {
+Vector2f::operator DirectX::XMVECTOR() const noexcept {
     auto buffer = this->operator DirectX::XMFLOAT2();
     return DirectX::XMLoadFloat2(&buffer);
 }
 
-Vector2f::operator DirectX::XMFLOAT2() noexcept {
+Vector2f::operator DirectX::XMFLOAT2() const noexcept {
     return DirectX::XMFLOAT2(m_elements);
 }
 #endif
@@ -356,7 +356,7 @@ Vector2u::Vector2u(glm::u32vec2&& v) noexcept {
     std::generate(std::begin(m_elements), std::end(m_elements), [&, i = 0]() mutable { return std::move(v[i++]); });
 }
 
-Vector2u::operator glm::u32vec2() noexcept {
+Vector2u::operator glm::u32vec2() const noexcept {
     return glm::u32vec2(m_elements[0], m_elements[1]);
 }
 #endif
@@ -388,12 +388,12 @@ Vector2u::Vector2u(DirectX::XMUINT2&& v) noexcept : Vector<UInt32, 2>() {
     this->y() = std::move(v.y);
 }
 
-Vector2u::operator DirectX::XMVECTOR() noexcept {
+Vector2u::operator DirectX::XMVECTOR() const noexcept {
     auto buffer = this->operator DirectX::XMUINT2();
     return DirectX::XMLoadUInt2(&buffer);
 }
 
-Vector2u::operator DirectX::XMUINT2() noexcept {
+Vector2u::operator DirectX::XMUINT2() const noexcept {
     return DirectX::XMUINT2(m_elements);
 }
 #endif
@@ -469,7 +469,7 @@ Vector2i::Vector2i(glm::i32vec2&& v) noexcept {
     std::generate(std::begin(m_elements), std::end(m_elements), [&, i = 0]() mutable { return std::move(v[i++]); });
 }
 
-Vector2i::operator glm::i32vec2() noexcept {
+Vector2i::operator glm::i32vec2() const noexcept {
     return glm::i32vec2(m_elements[0], m_elements[1]);
 }
 #endif
@@ -501,12 +501,12 @@ Vector2i::Vector2i(DirectX::XMINT2&& v) noexcept : Vector<Int32, 2>() {
     this->y() = std::move(v.y);
 }
 
-Vector2i::operator DirectX::XMVECTOR() noexcept {
+Vector2i::operator DirectX::XMVECTOR() const noexcept {
     auto buffer = this->operator DirectX::XMINT2();
     return DirectX::XMLoadSInt2(&buffer);
 }
 
-Vector2i::operator DirectX::XMINT2() noexcept {
+Vector2i::operator DirectX::XMINT2() const noexcept {
     return DirectX::XMINT2(m_elements);
 }
 #endif
@@ -583,7 +583,7 @@ Vector3f::Vector3f(glm::f32vec3&& v) noexcept {
     std::generate(std::begin(m_elements), std::end(m_elements), [&, i = 0]() mutable { return std::move(v[i++]); });
 }
 
-Vector3f::operator glm::f32vec3() noexcept {
+Vector3f::operator glm::f32vec3() const noexcept {
     return glm::f32vec3(m_elements[0], m_elements[1], m_elements[2]);
 }
 #endif
@@ -619,12 +619,12 @@ Vector3f::Vector3f(DirectX::XMFLOAT3&& v) noexcept : Vector<Float, 3>() {
     this->z() = std::move(v.z);
 }
 
-Vector3f::operator DirectX::XMVECTOR() noexcept {
+Vector3f::operator DirectX::XMVECTOR() const noexcept {
     auto buffer = this->operator DirectX::XMFLOAT3();
     return DirectX::XMLoadFloat3(&buffer);
 }
 
-Vector3f::operator DirectX::XMFLOAT3() noexcept {
+Vector3f::operator DirectX::XMFLOAT3() const noexcept {
     return DirectX::XMFLOAT3(m_elements);
 }
 #endif
@@ -701,7 +701,7 @@ Vector3u::Vector3u(glm::u32vec3&& v) noexcept {
     std::generate(std::begin(m_elements), std::end(m_elements), [&, i = 0]() mutable { return std::move(v[i++]); });
 }
 
-Vector3u::operator glm::u32vec3() noexcept {
+Vector3u::operator glm::u32vec3() const noexcept {
     return glm::u32vec3(m_elements[0], m_elements[1], m_elements[2]);
 }
 #endif
@@ -737,12 +737,12 @@ Vector3u::Vector3u(DirectX::XMUINT3&& v) noexcept : Vector<UInt32, 3>() {
     this->z() = std::move(v.z);
 }
 
-Vector3u::operator DirectX::XMVECTOR() noexcept {
+Vector3u::operator DirectX::XMVECTOR() const noexcept {
     auto buffer = this->operator DirectX::XMUINT3();
     return DirectX::XMLoadUInt3(&buffer);
 }
 
-Vector3u::operator DirectX::XMUINT3() noexcept {
+Vector3u::operator DirectX::XMUINT3() const noexcept {
     return DirectX::XMUINT3(m_elements);
 }
 #endif
@@ -819,7 +819,7 @@ Vector3i::Vector3i(glm::i32vec3&& v) noexcept {
     std::generate(std::begin(m_elements), std::end(m_elements), [&, i = 0]() mutable { return std::move(v[i++]); });
 }
 
-Vector3i::operator glm::i32vec3() noexcept {
+Vector3i::operator glm::i32vec3() const noexcept {
     return glm::i32vec3(m_elements[0], m_elements[1], m_elements[2]);
 }
 #endif
@@ -855,12 +855,12 @@ Vector3i::Vector3i(DirectX::XMINT3&& v) noexcept : Vector<Int32, 3>() {
     this->z() = std::move(v.z);
 }
 
-Vector3i::operator DirectX::XMVECTOR() noexcept {
+Vector3i::operator DirectX::XMVECTOR() const noexcept {
     auto buffer = this->operator DirectX::XMINT3();
     return DirectX::XMLoadSInt3(&buffer);
 }
 
-Vector3i::operator DirectX::XMINT3() noexcept {
+Vector3i::operator DirectX::XMINT3() const noexcept {
     return DirectX::XMINT3(m_elements);
 }
 #endif
@@ -938,7 +938,7 @@ Vector4f::Vector4f(glm::f32vec4&& v) noexcept {
     std::generate(std::begin(m_elements), std::end(m_elements), [&, i = 0]() mutable { return std::move(v[i++]); });
 }
 
-Vector4f::operator glm::f32vec4() noexcept {
+Vector4f::operator glm::f32vec4() const noexcept {
     return glm::f32vec4(m_elements[0], m_elements[1], m_elements[2], m_elements[3]);
 }
 #endif
@@ -978,12 +978,12 @@ Vector4f::Vector4f(DirectX::XMFLOAT4&& v) noexcept : Vector<Float, 4>() {
     this->w() = std::move(v.w);
 }
 
-Vector4f::operator DirectX::XMVECTOR() noexcept {
+Vector4f::operator DirectX::XMVECTOR() const noexcept {
     auto buffer = this->operator DirectX::XMFLOAT4();
     return DirectX::XMLoadFloat4(&buffer);
 }
 
-Vector4f::operator DirectX::XMFLOAT4() noexcept {
+Vector4f::operator DirectX::XMFLOAT4() const noexcept {
     return DirectX::XMFLOAT4(m_elements);
 }
 #endif
@@ -1061,7 +1061,7 @@ Vector4u::Vector4u(glm::u32vec4&& v) noexcept {
     std::generate(std::begin(m_elements), std::end(m_elements), [&, i = 0]() mutable { return std::move(v[i++]); });
 }
 
-Vector4u::operator glm::u32vec4() noexcept {
+Vector4u::operator glm::u32vec4() const noexcept {
     return glm::u32vec4(m_elements[0], m_elements[1], m_elements[2], m_elements[3]);
 }
 #endif
@@ -1101,12 +1101,12 @@ Vector4u::Vector4u(DirectX::XMUINT4&& v) noexcept : Vector<UInt32, 4>() {
     this->w() = std::move(v.w);
 }
 
-Vector4u::operator DirectX::XMVECTOR() noexcept {
+Vector4u::operator DirectX::XMVECTOR() const noexcept {
     auto buffer = this->operator DirectX::XMUINT4();
     return DirectX::XMLoadUInt4(&buffer);
 }
 
-Vector4u::operator DirectX::XMUINT4() noexcept {
+Vector4u::operator DirectX::XMUINT4() const noexcept {
     return DirectX::XMUINT4(m_elements);
 }
 #endif
@@ -1184,7 +1184,7 @@ Vector4i::Vector4i(glm::i32vec4&& v) noexcept {
     std::generate(std::begin(m_elements), std::end(m_elements), [&, i = 0]() mutable { return std::move(v[i++]); });
 }
 
-Vector4i::operator glm::i32vec4() noexcept {
+Vector4i::operator glm::i32vec4() const noexcept {
     return glm::i32vec4(m_elements[0], m_elements[1], m_elements[2], m_elements[3]);
 }
 #endif
@@ -1224,12 +1224,12 @@ Vector4i::Vector4i(DirectX::XMINT4&& v) noexcept : Vector<Int32, 4>() {
     this->w() = std::move(v.w);
 }
 
-Vector4i::operator DirectX::XMVECTOR() noexcept {
+Vector4i::operator DirectX::XMVECTOR() const noexcept {
     auto buffer = this->operator DirectX::XMINT4();
     return DirectX::XMLoadSInt4(&buffer);
 }
 
-Vector4i::operator DirectX::XMINT4() noexcept {
+Vector4i::operator DirectX::XMINT4() const noexcept {
     return DirectX::XMINT4(m_elements);
 }
 #endif


### PR DESCRIPTION
**Describe the pull request**

Currently conversion from a vector type into a math library type (glm or DirectXMath) requires the vector instance to be non-const. Since a copy happens anyway, this constraint can be eased. This PR implements that change.