### PR TITLE
Fix crash during viewport/scissor updates when validation layers are enabled.

### DIFF
--- a/docs/release-logs/0.4.1.md
+++ b/docs/release-logs/0.4.1.md
@@ -8,5 +8,5 @@
 - Improved resource allocation and binding: ([See PR #83](https://github.com/crud89/LiteFX/pull/83))
   - Resources can now be created without querying the descriptor set layout or descriptor layout in advance.
   - When allocating descriptor sets, default bindings can be provided to make bind-once scenarios more straightforward.
-- Raise minimum Vulkan SDK version to 1.3.204.1. ([See PR #86](https://github.com/crud89/LiteFX/pull/86))
+- Raise minimum Vulkan SDK version to 1.3.204.1. ([See PR #86](https://github.com/crud89/LiteFX/pull/86) and [See PR #88](https://github.com/crud89/LiteFX/pull/88))
 - Make most of the render pipeline state dynamic. ([See PR #86](https://github.com/crud89/LiteFX/pull/86))

--- a/src/Backends/Vulkan/src/backend.cpp
+++ b/src/Backends/Vulkan/src/backend.cpp
@@ -113,7 +113,7 @@ public:
         appInfo.applicationVersion = VK_MAKE_VERSION(m_app.version().major(), m_app.version().minor(), m_app.version().patch());
         appInfo.pEngineName = LITEFX_ENGINE_ID;
         appInfo.engineVersion = VK_MAKE_VERSION(LITEFX_MAJOR, LITEFX_MINOR, LITEFX_REV);
-        appInfo.apiVersion = VK_API_VERSION_1_2;
+        appInfo.apiVersion = VK_API_VERSION_1_3;
 
         // Create Vulkan instance.
         VkInstanceCreateInfo createInfo = {};


### PR DESCRIPTION
**Describe the pull request**

This PR fixes an issue introduced in #86, where setting the viewport and/or scissor state with validation layers enabled could crash the application. This was due to a missing explicit version in the app creation info. Setting this to require API version 1.3, fixes the issue.
