### PR TITLE
Shared temporary ownership for command buffers and resources.

### DIFF
--- a/docs/release-logs/0.4.1.md
+++ b/docs/release-logs/0.4.1.md
@@ -8,6 +8,10 @@
 - Improved resource allocation and binding: ([See PR #83](https://github.com/crud89/LiteFX/pull/83))
   - Resources can now be created without querying the descriptor set layout or descriptor layout in advance.
   - When allocating descriptor sets, default bindings can be provided to make bind-once scenarios more straightforward.
+- Improved handling of temporary command buffers. ([See PR #89](https://github.com/crud89/LiteFX/pull/89))
+  - Command buffers can now be submitted with shared ownership to a command queue, which then stores them and releases the references, if the submit fence is passed (during `waitFor`).
+  - Command buffer transfers can now receive resources with shared ownership. Resource references are released in a similar fashion.
+  - To share ownership, the `asShared` function can be used.
 - Vulkan 🌋: Raise minimum Vulkan SDK version to 1.3.204.1. ([See PR #86](https://github.com/crud89/LiteFX/pull/86) and [See PR #88](https://github.com/crud89/LiteFX/pull/88))
 - Make most of the render pipeline state dynamic (viewports, scissors, ...). ([See PR #86](https://github.com/crud89/LiteFX/pull/86))
 - Vector conversion to math types can now be done for constant vectors. ([See PR #87](https://github.com/crud89/LiteFX/pull/87))

--- a/src/Backends/DirectX12/include/litefx/backends/dx12.hpp
+++ b/src/Backends/DirectX12/include/litefx/backends/dx12.hpp
@@ -1063,10 +1063,10 @@ namespace LiteFX::Rendering::Backends {
 		virtual size_t getHeight() const noexcept override;
 
 		/// <inheritdoc />
-		virtual Array<const DirectX12CommandBuffer*> commandBuffers() const noexcept override;
+		virtual Array<SharedPtr<const DirectX12CommandBuffer>> commandBuffers() const noexcept override;
 
 		/// <inheritdoc />
-		virtual const DirectX12CommandBuffer& commandBuffer(const UInt32& index) const override;
+		virtual SharedPtr<const DirectX12CommandBuffer> commandBuffer(const UInt32& index) const override;
 
 		/// <inheritdoc />
 		virtual Array<const IDirectX12Image*> images() const noexcept override;
@@ -1348,16 +1348,10 @@ namespace LiteFX::Rendering::Backends {
 		virtual void release() override;
 
 		/// <inheritdoc />
-		virtual UniquePtr<DirectX12CommandBuffer> createCommandBuffer(const bool& beginRecording = false) const override;
-
-		/// <inheritdoc />
-		virtual UInt64 submit(const DirectX12CommandBuffer& commandBuffer) const override;
+		virtual SharedPtr<DirectX12CommandBuffer> createCommandBuffer(const bool& beginRecording = false) const override;
 
 		/// <inheritdoc />
 		virtual UInt64 submit(SharedPtr<const DirectX12CommandBuffer> commandBuffer) const override;
-
-		/// <inheritdoc />
-		virtual UInt64 submit(const Array<const DirectX12CommandBuffer*>& commandBuffers) const override;
 
 		/// <inheritdoc />
 		virtual UInt64 submit(const Array<SharedPtr<const DirectX12CommandBuffer>>& commandBuffers) const override;

--- a/src/Backends/DirectX12/include/litefx/backends/dx12.hpp
+++ b/src/Backends/DirectX12/include/litefx/backends/dx12.hpp
@@ -845,6 +845,18 @@ namespace LiteFX::Rendering::Backends {
 		virtual void transfer(const IDirectX12Image& source, const IDirectX12Buffer& target, const UInt32& firstSubresource = 0, const UInt32& targetElement = 0, const UInt32& subresources = 1) const override;
 
 		/// <inheritdoc />
+		virtual void transfer(SharedPtr<const IDirectX12Buffer> source, const IDirectX12Buffer& target, const UInt32& sourceElement = 0, const UInt32& targetElement = 0, const UInt32& elements = 1) const override;
+
+		/// <inheritdoc />
+		virtual void transfer(SharedPtr<const IDirectX12Buffer> source, const IDirectX12Image& target, const UInt32& sourceElement = 0, const UInt32& firstSubresource = 0, const UInt32& elements = 1) const override;
+
+		/// <inheritdoc />
+		virtual void transfer(SharedPtr<const IDirectX12Image> source, const IDirectX12Image& target, const UInt32& sourceSubresource = 0, const UInt32& targetSubresource = 0, const UInt32& subresources = 1) const override;
+
+		/// <inheritdoc />
+		virtual void transfer(SharedPtr<const IDirectX12Image> source, const IDirectX12Buffer& target, const UInt32& firstSubresource = 0, const UInt32& targetElement = 0, const UInt32& subresources = 1) const override;
+
+		/// <inheritdoc />
 		virtual void use(const DirectX12PipelineState& pipeline) const noexcept override;
 
 		/// <inheritdoc />
@@ -867,6 +879,9 @@ namespace LiteFX::Rendering::Backends {
 		
 		/// <inheritdoc />
 		virtual void pushConstants(const DirectX12PushConstantsLayout& layout, const void* const memory) const noexcept override;
+
+	private:
+		virtual void releaseSharedState() const override;
 	};
 
 	/// <summary>
@@ -1339,7 +1354,13 @@ namespace LiteFX::Rendering::Backends {
 		virtual UInt64 submit(const DirectX12CommandBuffer& commandBuffer) const override;
 
 		/// <inheritdoc />
+		virtual UInt64 submit(SharedPtr<const DirectX12CommandBuffer> commandBuffer) const override;
+
+		/// <inheritdoc />
 		virtual UInt64 submit(const Array<const DirectX12CommandBuffer*>& commandBuffers) const override;
+
+		/// <inheritdoc />
+		virtual UInt64 submit(const Array<SharedPtr<const DirectX12CommandBuffer>>& commandBuffers) const override;
 
 		/// <inheritdoc />
 		virtual void waitFor(const UInt64& fence) const noexcept override;

--- a/src/Backends/DirectX12/src/descriptor_set_layout.cpp
+++ b/src/Backends/DirectX12/src/descriptor_set_layout.cpp
@@ -265,14 +265,14 @@ Array<UniquePtr<DirectX12DescriptorSet>> DirectX12DescriptorSetLayout::allocateM
 Array<UniquePtr<DirectX12DescriptorSet>> DirectX12DescriptorSetLayout::allocateMultiple(const UInt32& count, const UInt32& descriptors, const Array<Array<DescriptorBinding>>& bindings) const
 {
     Array<UniquePtr<DirectX12DescriptorSet>> descriptorSets(count);
-    std::ranges::generate(descriptorSets, [this, descriptors, bindings, i = 0]() mutable { return i < bindings.size() ? this->allocate(descriptors, bindings[i]) : this->allocate(descriptors, { }); });
+    std::ranges::generate(descriptorSets, [this, descriptors, bindings, i = 0]() mutable { return i < bindings.size() ? this->allocate(descriptors, bindings[i++]) : this->allocate(descriptors, { }); });
     return descriptorSets;
 }
 
 Array<UniquePtr<DirectX12DescriptorSet>> DirectX12DescriptorSetLayout::allocateMultiple(const UInt32& count, const UInt32& descriptors, std::function<Array<DescriptorBinding>(const UInt32&)> bindingFactory) const
 {
     Array<UniquePtr<DirectX12DescriptorSet>> descriptorSets(count);
-    std::ranges::generate(descriptorSets, [this, descriptors, bindingFactory, i = 0]() mutable { return this->allocate(descriptors, bindingFactory(i)); });
+    std::ranges::generate(descriptorSets, [this, descriptors, bindingFactory, i = 0]() mutable { return this->allocate(descriptors, bindingFactory(i++)); });
     return descriptorSets;
 }
 

--- a/src/Backends/DirectX12/src/frame_buffer.cpp
+++ b/src/Backends/DirectX12/src/frame_buffer.cpp
@@ -13,7 +13,7 @@ public:
 private:
     Array<UniquePtr<IDirectX12Image>> m_outputAttachments;
     Array<const IDirectX12Image*> m_renderTargetViews;
-    Array<UniquePtr<DirectX12CommandBuffer>> m_commandBuffers;
+    Array<SharedPtr<DirectX12CommandBuffer>> m_commandBuffers;
     ComPtr<ID3D12DescriptorHeap> m_renderTargetHeap, m_depthStencilHeap;
     UInt32 m_renderTargetDescriptorSize, m_depthStencilDescriptorSize;
     Size2d m_size;
@@ -175,19 +175,17 @@ size_t DirectX12FrameBuffer::getHeight() const noexcept
     return m_impl->m_size.height();
 }
 
-const DirectX12CommandBuffer& DirectX12FrameBuffer::commandBuffer(const UInt32& index) const
+SharedPtr<const DirectX12CommandBuffer> DirectX12FrameBuffer::commandBuffer(const UInt32& index) const
 {
     if (index >= static_cast<UInt32>(m_impl->m_commandBuffers.size())) [[unlikely]]
         throw ArgumentOutOfRangeException("No command buffer with index {1} is stored in the frame buffer. The frame buffer only contains {0} command buffers.", m_impl->m_commandBuffers.size(), index);
 
-    return *m_impl->m_commandBuffers[index];
+    return m_impl->m_commandBuffers[index];
 }
 
-Array<const DirectX12CommandBuffer*> DirectX12FrameBuffer::commandBuffers() const noexcept
+Array<SharedPtr<const DirectX12CommandBuffer>> DirectX12FrameBuffer::commandBuffers() const noexcept
 {
-    return m_impl->m_commandBuffers |
-        std::views::transform([](const UniquePtr<DirectX12CommandBuffer>& commandBuffer) { return commandBuffer.get(); }) |
-        ranges::to<Array<const DirectX12CommandBuffer*>>();
+    return m_impl->m_commandBuffers | ranges::to<Array<SharedPtr<const DirectX12CommandBuffer>>>();
 }
 
 Array<const IDirectX12Image*> DirectX12FrameBuffer::images() const noexcept

--- a/src/Backends/DirectX12/src/queue.cpp
+++ b/src/Backends/DirectX12/src/queue.cpp
@@ -19,7 +19,7 @@ private:
 	bool m_bound;
 	mutable std::mutex m_mutex;
 	const DirectX12Device& m_device;
-	Array<Tuple<UInt64, SharedPtr<const DirectX12CommandBuffer>>> m_sharedCommandBuffers;
+	Array<Tuple<UInt64, SharedPtr<const DirectX12CommandBuffer>>> m_submittedCommandBuffers;
 
 public:
 	DirectX12QueueImpl(DirectX12Queue* parent, const DirectX12Device& device, const QueueType& type, const QueuePriority& priority) :
@@ -68,6 +68,8 @@ public:
 	{
 		if (!m_bound)
 			return;
+
+		m_submittedCommandBuffers.clear();
 
 		// TODO: Destroy command pool, if bound.
 		m_bound = false;
@@ -145,50 +147,39 @@ void DirectX12Queue::release()
 	m_impl->release();
 }
 
-UniquePtr<DirectX12CommandBuffer> DirectX12Queue::createCommandBuffer(const bool& beginRecording) const
+SharedPtr<DirectX12CommandBuffer> DirectX12Queue::createCommandBuffer(const bool& beginRecording) const
 {
-	return makeUnique<DirectX12CommandBuffer>(*this, beginRecording);
+	return makeShared<DirectX12CommandBuffer>(*this, beginRecording);
 }
 
 UInt64 DirectX12Queue::submit(SharedPtr<const DirectX12CommandBuffer> commandBuffer) const
 {
-	auto fence = this->submit(*commandBuffer);
-	m_impl->m_sharedCommandBuffers.push_back({ fence, commandBuffer });
+	if (commandBuffer == nullptr)
+		throw InvalidArgumentException("The command buffer must be initialized.");
 
-	return fence;
-}
-
-UInt64 DirectX12Queue::submit(const DirectX12CommandBuffer& commandBuffer) const
-{
 	std::lock_guard<std::mutex> lock(m_impl->m_mutex);
 
 	// End the command buffer.
-	commandBuffer.end();
+	commandBuffer->end();
 	
 	// Submit the command buffer.
-	Array<ID3D12CommandList*> commandBuffers{ commandBuffer.handle().Get() };
+	Array<ID3D12CommandList*> commandBuffers{ commandBuffer->handle().Get() };
 	this->handle()->ExecuteCommandLists(1, commandBuffers.data());
 
 	// Insert a fence and return the value.
-	raiseIfFailed<RuntimeException>(this->handle()->Signal(m_impl->m_fence.Get(), ++m_impl->m_fenceValue), "Unable to add fence signal to command buffer.");
+	auto fence = ++m_impl->m_fenceValue;
+	raiseIfFailed<RuntimeException>(this->handle()->Signal(m_impl->m_fence.Get(), fence), "Unable to add fence signal to command buffer.");
 
-	return m_impl->m_fenceValue;
+	// Add the command buffer to the submitted command buffers list and return the fence.
+	m_impl->m_submittedCommandBuffers.push_back({ fence, commandBuffer });
+	return fence;
 }
 
 UInt64 DirectX12Queue::submit(const Array<SharedPtr<const DirectX12CommandBuffer>>& commandBuffers) const
 {
-	auto buffers = commandBuffers |
-		std::views::transform([](auto& buffer) { return buffer.get(); }) |
-		ranges::to<Array<const DirectX12CommandBuffer*>>();
+	if (!std::ranges::all_of(commandBuffers, [](const auto& buffer) { return buffer != nullptr; }))
+		throw InvalidArgumentException("At least one command buffer is not initialized.");
 
-	auto fence = this->submit(buffers);
-	std::ranges::for_each(commandBuffers, [this, &fence](auto& buffer) { m_impl->m_sharedCommandBuffers.push_back({ fence, buffer }); });
-
-	return fence;
-}
-
-UInt64 DirectX12Queue::submit(const Array<const DirectX12CommandBuffer*>& commandBuffers) const
-{
 	std::lock_guard<std::mutex> lock(m_impl->m_mutex);
 
 	// End and submit the command buffers.
@@ -202,9 +193,12 @@ UInt64 DirectX12Queue::submit(const Array<const DirectX12CommandBuffer*>& comman
 	this->handle()->ExecuteCommandLists(static_cast<UInt32>(handles.size()), handles.data());
 
 	// Insert a fence and return the value.
-	raiseIfFailed<RuntimeException>(this->handle()->Signal(m_impl->m_fence.Get(), ++m_impl->m_fenceValue), "Unable to add fence signal to command buffer.");
+	auto fence = ++m_impl->m_fenceValue;
+	raiseIfFailed<RuntimeException>(this->handle()->Signal(m_impl->m_fence.Get(), fence), "Unable to add fence signal to command buffer.");
 
-	return m_impl->m_fenceValue;
+	// Add the command buffers to the submitted command buffers list and return the fence.
+	std::ranges::for_each(commandBuffers, [this, &fence](auto& buffer) { m_impl->m_submittedCommandBuffers.push_back({ fence, buffer }); });
+	return fence;
 }
 
 void DirectX12Queue::waitFor(const UInt64& fence) const noexcept
@@ -224,14 +218,14 @@ void DirectX12Queue::waitFor(const UInt64& fence) const noexcept
 	}
 
 	// Release all shared command buffers until this point.
-	const auto [from, to] = std::ranges::remove_if(m_impl->m_sharedCommandBuffers, [this, &completedValue](auto& pair) {
+	const auto [from, to] = std::ranges::remove_if(m_impl->m_submittedCommandBuffers, [this, &completedValue](auto& pair) {
 		if (std::get<0>(pair) > completedValue)
 			return false;
 
 		this->releaseSharedState(*std::get<1>(pair));
 		return true;
 	});
-	m_impl->m_sharedCommandBuffers.erase(from, to);
+	m_impl->m_submittedCommandBuffers.erase(from, to);
 }
 
 UInt64 DirectX12Queue::currentFence() const noexcept

--- a/src/Backends/DirectX12/src/render_pass.cpp
+++ b/src/Backends/DirectX12/src/render_pass.cpp
@@ -19,7 +19,7 @@ private:
     Array<RenderTarget> m_renderTargets;
     Array<DirectX12InputAttachmentMapping> m_inputAttachments;
     Array<UniquePtr<DirectX12FrameBuffer>> m_frameBuffers;
-    Array<UniquePtr<DirectX12CommandBuffer>> m_beginCommandBuffers, m_endCommandBuffers;
+    Array<SharedPtr<DirectX12CommandBuffer>> m_beginCommandBuffers, m_endCommandBuffers;
     const DirectX12FrameBuffer* m_activeFrameBuffer = nullptr;
     UInt32 m_backBuffer{ 0 };
     const RenderTarget* m_presentTarget = nullptr;
@@ -305,7 +305,7 @@ void DirectX12RenderPass::begin(const UInt32& buffer)
     // Begin a suspending render pass for the transition and a suspend-the-resume render pass on each command buffer of the frame buffer.
     std::as_const(*beginCommandBuffer).handle()->BeginRenderPass(std::get<0>(context).size(), std::get<0>(context).data(), std::get<1>(context).has_value() ? &std::get<1>(context).value() : nullptr, D3D12_RENDER_PASS_FLAG_SUSPENDING_PASS);
     std::as_const(*beginCommandBuffer).handle()->EndRenderPass();
-    std::ranges::for_each(frameBuffer->commandBuffers(), [&context](const DirectX12CommandBuffer* commandBuffer) { 
+    std::ranges::for_each(frameBuffer->commandBuffers(), [&context](auto commandBuffer) { 
         commandBuffer->begin(); 
         commandBuffer->handle()->BeginRenderPass(std::get<0>(context).size(), std::get<0>(context).data(), std::get<1>(context).has_value() ? &std::get<1>(context).value() : nullptr, D3D12_RENDER_PASS_FLAG_SUSPENDING_PASS | D3D12_RENDER_PASS_FLAG_RESUMING_PASS);
     });
@@ -324,7 +324,7 @@ void DirectX12RenderPass::end() const
     const auto& buffer = m_impl->m_backBuffer;
     const auto& context = m_impl->m_contexts[buffer];
     auto& endCommandBuffer = m_impl->m_endCommandBuffers[buffer];
-    std::ranges::for_each(frameBuffer->commandBuffers(), [&context](const DirectX12CommandBuffer* commandBuffer) { commandBuffer->handle()->EndRenderPass(); });
+    std::ranges::for_each(frameBuffer->commandBuffers(), [&context](auto commandBuffer) { commandBuffer->handle()->EndRenderPass(); });
     endCommandBuffer->begin();
     std::as_const(*endCommandBuffer).handle()->BeginRenderPass(std::get<0>(context).size(), std::get<0>(context).data(), std::get<1>(context).has_value() ? &std::get<1>(context).value() : nullptr, D3D12_RENDER_PASS_FLAG_RESUMING_PASS);
     std::as_const(*endCommandBuffer).handle()->EndRenderPass();
@@ -367,9 +367,9 @@ void DirectX12RenderPass::end() const
     // End the command buffer recording and submit all command buffers.
     // NOTE: In order to suspend/resume render passes, we need to pass them to the queue in one `ExecuteCommandLists` (i.e. submit) call. The order we pass them to the call is 
     //       important, since the first command list also gets executed first.
-    Array<const DirectX12CommandBuffer*> commandBuffers = frameBuffer->commandBuffers();
-    commandBuffers.insert(commandBuffers.begin(), m_impl->m_beginCommandBuffers[buffer].get());
-    commandBuffers.push_back(endCommandBuffer.get());
+    auto commandBuffers = frameBuffer->commandBuffers();
+    commandBuffers.insert(commandBuffers.begin(), m_impl->m_beginCommandBuffers[buffer]);
+    commandBuffers.push_back(endCommandBuffer);
     m_impl->m_activeFrameBuffer->lastFence() = m_impl->m_device.graphicsQueue().submit(commandBuffers);
 
     if (!m_impl->m_name.empty())

--- a/src/Backends/Vulkan/include/litefx/backends/vulkan.hpp
+++ b/src/Backends/Vulkan/include/litefx/backends/vulkan.hpp
@@ -1065,10 +1065,10 @@ namespace LiteFX::Rendering::Backends {
 		virtual size_t getHeight() const noexcept override;
 
 		/// <inheritdoc />
-		virtual const VulkanCommandBuffer& commandBuffer(const UInt32& index) const override;
+		virtual SharedPtr<const VulkanCommandBuffer> commandBuffer(const UInt32& index) const override;
 
 		/// <inheritdoc />
-		virtual Array<const VulkanCommandBuffer*> commandBuffers() const noexcept override;
+		virtual Array<SharedPtr<const VulkanCommandBuffer>> commandBuffers() const noexcept override;
 
 		/// <inheritdoc />
 		virtual Array<const IVulkanImage*> images() const noexcept override;
@@ -1355,34 +1355,6 @@ namespace LiteFX::Rendering::Backends {
 		/// Submits a single command buffer and inserts a fence to wait for it.
 		/// </summary>
 		/// <remarks>
-		/// Note that submitting a command buffer that is currently recording will implicitly close the command buffer.
-		/// </remarks>
-		/// <param name="commandBuffer">The command buffer to submit to the command queue.</param>
-		/// <param name="waitForSemaphores">The semaphores to wait for on each pipeline stage. There must be a semaphore for each entry in the <see cref="waitForStages" /> array.</param>
-		/// <param name="waitForStages">The pipeline stages of the current render pass to wait for before submitting the command buffer.</param>
-		/// <param name="signalSemaphores">The semaphores to signal, when the command buffer is executed.</param>
-		/// <returns>The value of the fence, inserted after the command buffer.</returns>
-		/// <seealso cref="waitFor" />
-		virtual UInt64 submit(const VulkanCommandBuffer& commandBuffer, Span<VkSemaphore> waitForSemaphores, Span<VkPipelineStageFlags> waitForStages, Span<VkSemaphore> signalSemaphores = { }) const;
-
-		/// <summary>
-		/// Submits a set of command buffers and inserts a fence to wait for them.
-		/// </summary>
-		/// <remarks>
-		/// Note that submitting a command buffer that is currently recording will implicitly close the command buffer.
-		/// </remarks>
-		/// <param name="commandBuffers">The command buffers to submit to the command queue.</param>
-		/// <param name="waitForSemaphores">The semaphores to wait for on each pipeline stage. There must be a semaphore for each entry in the <see cref="waitForStages" /> array.</param>
-		/// <param name="waitForStages">The pipeline stages of the current render pass to wait for before submitting the command buffer.</param>
-		/// <param name="signalSemaphores">The semaphores to signal, when the command buffer is executed.</param>
-		/// <returns>The value of the fence, inserted after the command buffers.</returns>
-		/// <seealso cref="waitFor" />
-		virtual UInt64 submit(const Array<const VulkanCommandBuffer*>& commandBuffers, Span<VkSemaphore> waitForSemaphores, Span<VkPipelineStageFlags> waitForStages, Span<VkSemaphore> signalSemaphores = { }) const;
-		
-		/// <summary>
-		/// Submits a single command buffer and inserts a fence to wait for it.
-		/// </summary>
-		/// <remarks>
         /// By calling this method, the queue takes shared ownership over the <paramref name="commandBuffers" /> until the fence is passed. The reference will be released
         /// during a <see cref="waitFor" />, if the awaited fence is inserted after the associated one.
         /// 
@@ -1419,7 +1391,7 @@ namespace LiteFX::Rendering::Backends {
 		/// <param name="secondary">If set to <c>true</c>, the queue will create a secondary command buffer instance.</param>
 		/// <param name="beginRecording">If set to <c>true</c>, the command buffer will be initialized in recording state and can receive commands straight away.</param>
 		/// <returns>The instance of the command buffer.</returns>
-		virtual UniquePtr<VulkanCommandBuffer> createCommandBuffer(const bool& secondary, const bool& beginRecording) const;
+		virtual SharedPtr<VulkanCommandBuffer> createCommandBuffer(const bool& secondary, const bool& beginRecording) const;
 
 		// CommandQueue interface.
 	public:
@@ -1452,16 +1424,10 @@ namespace LiteFX::Rendering::Backends {
 		virtual void release() override;
 
 		/// <inheritdoc />
-		virtual UniquePtr<VulkanCommandBuffer> createCommandBuffer(const bool& beginRecording = false) const override;
-
-		/// <inheritdoc />
-		virtual UInt64 submit(const VulkanCommandBuffer& commandBuffer) const override;
+		virtual SharedPtr<VulkanCommandBuffer> createCommandBuffer(const bool& beginRecording = false) const override;
 
 		/// <inheritdoc />
 		virtual UInt64 submit(SharedPtr<const VulkanCommandBuffer> commandBuffer) const override;
-
-		/// <inheritdoc />
-		virtual UInt64 submit(const Array<const VulkanCommandBuffer*>& commandBuffers) const override;
 
 		/// <inheritdoc />
 		virtual UInt64 submit(const Array<SharedPtr<const VulkanCommandBuffer>>& commandBuffers) const override;

--- a/src/Backends/Vulkan/include/litefx/backends/vulkan.hpp
+++ b/src/Backends/Vulkan/include/litefx/backends/vulkan.hpp
@@ -867,6 +867,18 @@ namespace LiteFX::Rendering::Backends {
 		virtual void transfer(const IVulkanImage& source, const IVulkanBuffer& target, const UInt32& firstSubresource = 0, const UInt32& targetElement = 0, const UInt32& subresources = 1) const override;
 
 		/// <inheritdoc />
+		virtual void transfer(SharedPtr<const IVulkanBuffer> source, const IVulkanBuffer& target, const UInt32& sourceElement = 0, const UInt32& targetElement = 0, const UInt32& elements = 1) const override;
+
+		/// <inheritdoc />
+		virtual void transfer(SharedPtr<const IVulkanBuffer> source, const IVulkanImage& target, const UInt32& sourceElement = 0, const UInt32& firstSubresource = 0, const UInt32& elements = 1) const override;
+
+		/// <inheritdoc />
+		virtual void transfer(SharedPtr<const IVulkanImage> source, const IVulkanImage& target, const UInt32& sourceSubresource = 0, const UInt32& targetSubresource = 0, const UInt32& subresources = 1) const override;
+
+		/// <inheritdoc />
+		virtual void transfer(SharedPtr<const IVulkanImage> source, const IVulkanBuffer& target, const UInt32& firstSubresource = 0, const UInt32& targetElement = 0, const UInt32& subresources = 1) const override;
+
+		/// <inheritdoc />
 		virtual void use(const VulkanPipelineState& pipeline) const noexcept override;
 
 		/// <inheritdoc />
@@ -889,6 +901,9 @@ namespace LiteFX::Rendering::Backends {
 
 		/// <inheritdoc />
 		virtual void pushConstants(const VulkanPushConstantsLayout& layout, const void* const memory) const noexcept override;
+
+	private:
+		virtual void releaseSharedState() const override;
 	};
 
 	/// <summary>
@@ -1363,6 +1378,40 @@ namespace LiteFX::Rendering::Backends {
 		/// <returns>The value of the fence, inserted after the command buffers.</returns>
 		/// <seealso cref="waitFor" />
 		virtual UInt64 submit(const Array<const VulkanCommandBuffer*>& commandBuffers, Span<VkSemaphore> waitForSemaphores, Span<VkPipelineStageFlags> waitForStages, Span<VkSemaphore> signalSemaphores = { }) const;
+		
+		/// <summary>
+		/// Submits a single command buffer and inserts a fence to wait for it.
+		/// </summary>
+		/// <remarks>
+        /// By calling this method, the queue takes shared ownership over the <paramref name="commandBuffers" /> until the fence is passed. The reference will be released
+        /// during a <see cref="waitFor" />, if the awaited fence is inserted after the associated one.
+        /// 
+		/// Note that submitting a command buffer that is currently recording will implicitly close the command buffer.
+		/// </remarks>
+		/// <param name="commandBuffer">The command buffer to submit to the command queue.</param>
+		/// <param name="waitForSemaphores">The semaphores to wait for on each pipeline stage. There must be a semaphore for each entry in the <see cref="waitForStages" /> array.</param>
+		/// <param name="waitForStages">The pipeline stages of the current render pass to wait for before submitting the command buffer.</param>
+		/// <param name="signalSemaphores">The semaphores to signal, when the command buffer is executed.</param>
+		/// <returns>The value of the fence, inserted after the command buffer.</returns>
+		/// <seealso cref="waitFor" />
+		virtual UInt64 submit(SharedPtr<const VulkanCommandBuffer> commandBuffer, Span<VkSemaphore> waitForSemaphores, Span<VkPipelineStageFlags> waitForStages, Span<VkSemaphore> signalSemaphores = { }) const;
+
+		/// <summary>
+		/// Submits a set of command buffers and inserts a fence to wait for them.
+		/// </summary>
+		/// <remarks>
+        /// By calling this method, the queue takes shared ownership over the <paramref name="commandBuffers" /> until the fence is passed. The reference will be released
+        /// during a <see cref="waitFor" />, if the awaited fence is inserted after the associated one.
+        /// 
+		/// Note that submitting a command buffer that is currently recording will implicitly close the command buffer.
+		/// </remarks>
+		/// <param name="commandBuffers">The command buffers to submit to the command queue.</param>
+		/// <param name="waitForSemaphores">The semaphores to wait for on each pipeline stage. There must be a semaphore for each entry in the <see cref="waitForStages" /> array.</param>
+		/// <param name="waitForStages">The pipeline stages of the current render pass to wait for before submitting the command buffer.</param>
+		/// <param name="signalSemaphores">The semaphores to signal, when the command buffer is executed.</param>
+		/// <returns>The value of the fence, inserted after the command buffers.</returns>
+		/// <seealso cref="waitFor" />
+		virtual UInt64 submit(const Array<SharedPtr<const VulkanCommandBuffer>>& commandBuffers, Span<VkSemaphore> waitForSemaphores, Span<VkPipelineStageFlags> waitForStages, Span<VkSemaphore> signalSemaphores = { }) const;
 
 		/// <summary>
 		/// Creates a command buffer that can be used to allocate commands on the queue.
@@ -1409,7 +1458,13 @@ namespace LiteFX::Rendering::Backends {
 		virtual UInt64 submit(const VulkanCommandBuffer& commandBuffer) const override;
 
 		/// <inheritdoc />
+		virtual UInt64 submit(SharedPtr<const VulkanCommandBuffer> commandBuffer) const override;
+
+		/// <inheritdoc />
 		virtual UInt64 submit(const Array<const VulkanCommandBuffer*>& commandBuffers) const override;
+
+		/// <inheritdoc />
+		virtual UInt64 submit(const Array<SharedPtr<const VulkanCommandBuffer>>& commandBuffers) const override;
 
 		/// <inheritdoc />
 		virtual void waitFor(const UInt64& fence) const noexcept override;

--- a/src/Backends/Vulkan/src/descriptor_set_layout.cpp
+++ b/src/Backends/Vulkan/src/descriptor_set_layout.cpp
@@ -360,14 +360,14 @@ Array<UniquePtr<VulkanDescriptorSet>> VulkanDescriptorSetLayout::allocateMultipl
 Array<UniquePtr<VulkanDescriptorSet>> VulkanDescriptorSetLayout::allocateMultiple(const UInt32& count, const UInt32& descriptors, const Array<Array<DescriptorBinding>>& bindings) const
 {
     Array<UniquePtr<VulkanDescriptorSet>> descriptorSets(count);
-    std::ranges::generate(descriptorSets, [this, descriptors, bindings, i = 0]() mutable { return i < bindings.size() ? this->allocate(descriptors, bindings[i]) : this->allocate(descriptors, { }); });
+    std::ranges::generate(descriptorSets, [this, descriptors, bindings, i = 0]() mutable { return i < bindings.size() ? this->allocate(descriptors, bindings[i++]) : this->allocate(descriptors, { }); });
     return descriptorSets;
 }
 
 Array<UniquePtr<VulkanDescriptorSet>> VulkanDescriptorSetLayout::allocateMultiple(const UInt32& count, const UInt32& descriptors, std::function<Array<DescriptorBinding>(const UInt32&)> bindingFactory) const
 {
     Array<UniquePtr<VulkanDescriptorSet>> descriptorSets(count);
-    std::ranges::generate(descriptorSets, [this, descriptors, bindingFactory, i = 0]() mutable { return this->allocate(descriptors, bindingFactory(i)); });
+    std::ranges::generate(descriptorSets, [this, descriptors, bindingFactory, i = 0]() mutable { return this->allocate(descriptors, bindingFactory(i++)); });
     return descriptorSets;
 }
 

--- a/src/Backends/Vulkan/src/frame_buffer.cpp
+++ b/src/Backends/Vulkan/src/frame_buffer.cpp
@@ -14,7 +14,7 @@ private:
     const VulkanRenderPass& m_renderPass;
     Array<UniquePtr<IVulkanImage>> m_outputAttachments;
     Array<const IVulkanImage*> m_renderTargetViews;
-	Array<UniquePtr<VulkanCommandBuffer>> m_commandBuffers;
+	Array<SharedPtr<VulkanCommandBuffer>> m_commandBuffers;
 	Size2d m_size;
 	VkSemaphore m_semaphore;
     UInt32 m_bufferIndex;
@@ -164,19 +164,17 @@ size_t VulkanFrameBuffer::getHeight() const noexcept
 	return m_impl->m_size.height();
 }
 
-const VulkanCommandBuffer& VulkanFrameBuffer::commandBuffer(const UInt32& index) const
+SharedPtr<const VulkanCommandBuffer> VulkanFrameBuffer::commandBuffer(const UInt32& index) const
 {
     if (index >= static_cast<UInt32>(m_impl->m_commandBuffers.size())) [[unlikely]]
         throw ArgumentOutOfRangeException("No command buffer with index {1} is stored in the frame buffer. The frame buffer only contains {0} command buffers.", m_impl->m_commandBuffers.size(), index);
 
-	return *m_impl->m_commandBuffers[index];
+	return m_impl->m_commandBuffers[index];
 }
 
-Array<const VulkanCommandBuffer*> VulkanFrameBuffer::commandBuffers() const noexcept
+Array<SharedPtr<const VulkanCommandBuffer>> VulkanFrameBuffer::commandBuffers() const noexcept
 {
-    return m_impl->m_commandBuffers |
-        std::views::transform([](const UniquePtr<VulkanCommandBuffer>& commandBuffer) { return commandBuffer.get(); }) |
-        ranges::to<Array<const VulkanCommandBuffer*>>();
+    return m_impl->m_commandBuffers | ranges::to<Array<SharedPtr<const VulkanCommandBuffer>>>();
 }
 
 Array<const IVulkanImage*> VulkanFrameBuffer::images() const noexcept

--- a/src/Core/include/litefx/containers.hpp
+++ b/src/Core/include/litefx/containers.hpp
@@ -176,8 +176,8 @@ namespace LiteFX {
 	/// <param name="ptr">The unique pointer that should be turned into a shared pointer.</param>
 	/// <returns>A new shared pointer.</returns>
 	template <class T>
-	SharedPtr<T> makeShared(UniquePtr<T>&& ptr) {
-		return std::make_shared<T>(ptr.release());
+	SharedPtr<T> asShared(UniquePtr<T>&& ptr) {
+		return SharedPtr<T>(ptr.release());
 	}
 
 	/// <summary>

--- a/src/Rendering/include/litefx/rendering_api.hpp
+++ b/src/Rendering/include/litefx/rendering_api.hpp
@@ -4661,6 +4661,34 @@ namespace LiteFX::Rendering {
         };
 
         /// <summary>
+        /// Creates a buffer that can be bound to a specific descriptor.
+        /// </summary>
+        /// <param name="descriptorSet">The layout of the descriptors parent descriptor set.</param>
+        /// <param name="binding">The binding point of the descriptor within the parent descriptor set.</param>
+        /// <param name="usage">The buffer usage.</param>
+        /// <param name="elements">The number of elements in the buffer (in case the buffer is an array).</param>
+        /// <param name="allowWrite">Allows the resource to be bound to a read/write descriptor.</param>
+        /// <returns>The instance of the buffer.</returns>
+        UniquePtr<IBuffer> createBuffer(const IDescriptorSetLayout& descriptorSet, const UInt32& binding, const BufferUsage& usage, const UInt32& elementSize, const UInt32& elements, const bool& allowWrite = false) const {
+            auto& descriptor = descriptorSet.descriptor(binding);
+            return this->createBuffer(descriptor.type(), usage, elementSize, elements, allowWrite);
+        };
+
+        /// <summary>
+        /// Creates a buffer that can be bound to a descriptor of a specific descriptor set.
+        /// </summary>
+        /// <param name="pipeline">The pipeline that provides the descriptor set.</param>
+        /// <param name="space">The space, the descriptor set is bound to.</param>
+        /// <param name="binding">The binding point of the descriptor within the parent descriptor set.</param>
+        /// <param name="usage">The buffer usage.</param>
+        /// <param name="elements">The number of elements in the buffer (in case the buffer is an array).</param>
+        /// <param name="allowWrite">Allows the resource to be bound to a read/write descriptor.</param>
+        /// <returns>The instance of the buffer.</returns>
+        UniquePtr<IBuffer> createBuffer(const IPipeline& pipeline, const UInt32& space, const UInt32& binding, const BufferUsage& usage, const UInt32& elementSize, const UInt32& elements, const bool& allowWrite = false) const {
+            return this->createBuffer(pipeline.layout()->descriptorSet(space), binding, usage, elementSize, elements, allowWrite);
+        };
+
+        /// <summary>
         /// Creates a buffer that can be bound to a descriptor of a specific descriptor set.
         /// </summary>
         /// <param name="pipeline">The pipeline that provides the descriptor set.</param>

--- a/src/Rendering/include/litefx/rendering_api.hpp
+++ b/src/Rendering/include/litefx/rendering_api.hpp
@@ -4276,7 +4276,7 @@ namespace LiteFX::Rendering {
         /// </summary>
         /// <returns>All command buffers, the frame buffer stores.</returns>
         /// <seealso cref="commandBuffer" />
-        Array<const ICommandBuffer*> commandBuffers() const noexcept {
+        Array<SharedPtr<const ICommandBuffer>> commandBuffers() const noexcept {
             return this->getCommandBuffers();
         }
 
@@ -4287,7 +4287,9 @@ namespace LiteFX::Rendering {
         /// <returns>A command buffer that records draw commands for the frame buffer</returns>
         /// <exception cref="ArgumentOutOfRangeException">Thrown, if the frame buffer does not store a command buffer at <paramref name="index" />.</exception>
         /// <seealso cref="commandBuffers" />
-        virtual const ICommandBuffer& commandBuffer(const UInt32& index) const = 0;
+        SharedPtr<const ICommandBuffer> commandBuffer(const UInt32& index) const {
+            return this->getCommandBuffer(index);
+        }
 
         /// <summary>
         /// Returns the images that store the output attachments for the render targets of the <see cref="RenderPass" />.
@@ -4317,7 +4319,8 @@ namespace LiteFX::Rendering {
         virtual void resize(const Size2d& renderArea) = 0;
 
     private:
-        virtual Array<const ICommandBuffer*> getCommandBuffers() const noexcept = 0;
+        virtual SharedPtr<const ICommandBuffer> getCommandBuffer(const UInt32& index) const noexcept = 0;
+        virtual Array<SharedPtr<const ICommandBuffer>> getCommandBuffers() const noexcept = 0;
         virtual Array<const IImage*> getImages() const noexcept = 0;
     };
 
@@ -4595,21 +4598,8 @@ namespace LiteFX::Rendering {
         /// </summary>
         /// <param name="beginRecording">If set to <c>true</c>, the command buffer will be initialized in recording state and can receive commands straight away.</param>
         /// <returns>The instance of the command buffer.</returns>
-        UniquePtr<ICommandBuffer> createCommandBuffer(const bool& beginRecording = false) const {
+        SharedPtr<ICommandBuffer> createCommandBuffer(const bool& beginRecording = false) const {
             return this->getCommandBuffer(beginRecording);
-        }
-
-        /// <summary>
-        /// Submits a single command buffer and inserts a fence to wait for it.
-        /// </summary>
-        /// <remarks>
-        /// Note that submitting a command buffer that is currently recording will implicitly close the command buffer.
-        /// </remarks>
-        /// <param name="commandBuffer">The command buffer to submit to the command queue.</param>
-        /// <returns>The value of the fence, inserted after the command buffer.</returns>
-        /// <seealso cref="waitFor" />
-        UInt64 submit(const ICommandBuffer& commandBuffer) const {
-            return this->submitCommandBuffer(commandBuffer);
         }
 
         /// <summary>
@@ -4626,19 +4616,6 @@ namespace LiteFX::Rendering {
         /// <seealso cref="waitFor" />
         UInt64 submit(SharedPtr<const ICommandBuffer> commandBuffer) const {
             return this->submitCommandBuffer(commandBuffer);
-        }
-
-        /// <summary>
-        /// Submits a set of command buffers and inserts a fence to wait for them.
-        /// </summary>
-        /// <remarks>
-        /// Note that submitting a command buffer that is currently recording will implicitly close the command buffer.
-        /// </remarks>
-        /// <param name="commandBuffers">The command buffers to submit to the command queue.</param>
-        /// <returns>The value of the fence, inserted after the command buffers.</returns>
-        /// <seealso cref="waitFor" />
-        UInt64 submit(const Array<const ICommandBuffer*>& commandBuffers) const {
-            return this->submitCommandBuffers(commandBuffers);
         }
 
         /// <summary>
@@ -4682,10 +4659,8 @@ namespace LiteFX::Rendering {
         virtual UInt64 currentFence() const noexcept = 0;
 
     private:
-        virtual UniquePtr<ICommandBuffer> getCommandBuffer(const bool& beginRecording) const = 0;
-        virtual UInt64 submitCommandBuffer(const ICommandBuffer& commandBuffer) const = 0;
+        virtual SharedPtr<ICommandBuffer> getCommandBuffer(const bool& beginRecording) const = 0;
         virtual UInt64 submitCommandBuffer(SharedPtr<const ICommandBuffer> commandBuffer) const = 0;
-        virtual UInt64 submitCommandBuffers(const Array<const ICommandBuffer*>& commandBuffers) const = 0;
         virtual UInt64 submitCommandBuffers(const Array<SharedPtr<const ICommandBuffer>>& commandBuffers) const = 0;
         
     protected:

--- a/src/Samples/BasicRendering/src/sample.cpp
+++ b/src/Samples/BasicRendering/src/sample.cpp
@@ -102,7 +102,7 @@ void SampleApp::initBuffers(IRenderBackend* backend)
 
     // Create the actual vertex buffer and transfer the staging buffer into it.
     auto vertexBuffer = m_device->factory().createVertexBuffer("Vertex Buffer", m_inputAssembler->vertexBufferLayout(0), BufferUsage::Resource, vertices.size());
-    commandBuffer->transfer(*stagedVertices, *vertexBuffer, 0, 0, vertices.size());
+    commandBuffer->transfer(asShared(std::move(stagedVertices)), *vertexBuffer, 0, 0, vertices.size());
 
     // Create the staging buffer for the indices. For infos about the mapping see the note about the vertex buffer mapping above.
     auto stagedIndices = m_device->factory().createIndexBuffer(m_inputAssembler->indexBufferLayout(), BufferUsage::Staging, indices.size());
@@ -110,18 +110,17 @@ void SampleApp::initBuffers(IRenderBackend* backend)
 
     // Create the actual index buffer and transfer the staging buffer into it.
     auto indexBuffer = m_device->factory().createIndexBuffer("Index Buffer", m_inputAssembler->indexBufferLayout(), BufferUsage::Resource, indices.size());
-    commandBuffer->transfer(*stagedIndices, *indexBuffer, 0, 0, indices.size());
+    commandBuffer->transfer(asShared(std::move(stagedIndices)), *indexBuffer, 0, 0, indices.size());
 
     // Initialize the camera buffer. The camera buffer is constant, so we only need to create one buffer, that can be read from all frames. Since this is a 
     // write-once/read-multiple scenario, we also transfer the buffer to the more efficient memory heap on the GPU.
     auto& geometryPipeline = m_device->state().pipeline("Geometry");
     auto& cameraBindingLayout = geometryPipeline.layout()->descriptorSet(DescriptorSets::Constant);
-    auto cameraStagingBuffer = m_device->factory().createBuffer("Camera Staging", cameraBindingLayout, 0, BufferUsage::Staging);
     auto cameraBuffer = m_device->factory().createBuffer("Camera", cameraBindingLayout, 0, BufferUsage::Resource);
     auto cameraBindings = cameraBindingLayout.allocate({ { 0, *cameraBuffer } });
 
     // Update the camera. Since the descriptor set already points to the proper buffer, all changes are implicitly visible.
-    this->updateCamera(*commandBuffer, *cameraStagingBuffer, *cameraBuffer);
+    this->updateCamera(*commandBuffer, *cameraBuffer);
 
     // Next, we create the descriptor sets for the transform buffer. The transform changes with every frame. Since we have three frames in flight, we
     // create a buffer with three elements and bind the appropriate element to the descriptor set for every frame.
@@ -134,27 +133,29 @@ void SampleApp::initBuffers(IRenderBackend* backend)
     });
     
     // End and submit the command buffer.
-    m_loaderFence = m_device->bufferQueue().submit(asShared(std::move(commandBuffer)));
+    m_transferFence = m_device->bufferQueue().submit(commandBuffer);
     
     // Add everything to the state.
     m_device->state().add(std::move(vertexBuffer));
     m_device->state().add(std::move(indexBuffer));
-    m_device->state().add(std::move(cameraStagingBuffer));
     m_device->state().add(std::move(cameraBuffer));
     m_device->state().add(std::move(transformBuffer));
     m_device->state().add("Camera Bindings", std::move(cameraBindings));
     std::ranges::for_each(transformBindings, [this, i = 0](auto& binding) mutable { m_device->state().add(fmt::format("Transform Bindings {0}", i++), std::move(binding)); });
 }
 
-void SampleApp::updateCamera(const ICommandBuffer& commandBuffer, IBuffer& stagingBuffer, const IBuffer& buffer) const
+void SampleApp::updateCamera(const ICommandBuffer& commandBuffer, const IBuffer& buffer) const
 {
     // Calculate the camera view/projection matrix.
     auto aspectRatio = m_viewport->getRectangle().width() / m_viewport->getRectangle().height();
     glm::mat4 view = glm::lookAt(glm::vec3(1.5f, 1.5f, 1.5f), glm::vec3(0.0f, 0.0f, 0.0f), glm::vec3(0.0f, 0.0f, 1.0f));
     glm::mat4 projection = glm::perspective(glm::radians(60.0f), aspectRatio, 0.0001f, 1000.0f);
     camera.ViewProjection = projection * view;
-    stagingBuffer.map(reinterpret_cast<const void*>(&camera), sizeof(camera));
-    commandBuffer.transfer(stagingBuffer, buffer);
+
+    // Create a staging buffer and use to transfer the new uniform buffer to.
+    auto cameraStagingBuffer = m_device->factory().createBuffer(m_device->state().pipeline("Geometry"), DescriptorSets::Constant, 0, BufferUsage::Staging);
+    cameraStagingBuffer->map(reinterpret_cast<const void*>(&camera), sizeof(camera));
+    commandBuffer.transfer(asShared(std::move(cameraStagingBuffer)), buffer);
 }
 
 void SampleApp::onStartup()
@@ -264,12 +265,10 @@ void SampleApp::onResize(const void* sender, ResizeEventArgs e)
     m_scissor->setRectangle(RectF(0.f, 0.f, static_cast<Float>(e.width()), static_cast<Float>(e.height())));
 
     // Also update the camera.
-    auto& cameraStagingBuffer = m_device->state().buffer("Camera Staging");
     auto& cameraBuffer = m_device->state().buffer("Camera");
     auto commandBuffer = m_device->bufferQueue().createCommandBuffer(true);
-    this->updateCamera(*commandBuffer, cameraStagingBuffer, cameraBuffer);
-    auto fence = m_device->bufferQueue().submit(*commandBuffer);
-    m_device->bufferQueue().waitFor(fence);
+    this->updateCamera(*commandBuffer, cameraBuffer);
+    m_transferFence = m_device->bufferQueue().submit(commandBuffer);
 }
 
 void SampleApp::keyDown(int key, int scancode, int action, int mods)
@@ -377,15 +376,15 @@ void SampleApp::drawFrame()
     auto& vertexBuffer = m_device->state().vertexBuffer("Vertex Buffer");
     auto& indexBuffer = m_device->state().indexBuffer("Index Buffer");
 
-    // Wait for the initialization command buffer to finish.
-    m_device->bufferQueue().waitFor(m_loaderFence);
+    // Wait for all transfers to finish.
+    m_device->bufferQueue().waitFor(m_transferFence);
 
     // Begin rendering on the render pass and use the only pipeline we've created for it.
     renderPass.begin(backBuffer);
-    auto& commandBuffer = renderPass.activeFrameBuffer().commandBuffer(0);
-    commandBuffer.use(geometryPipeline);
-    commandBuffer.setViewports(m_viewport.get());
-    commandBuffer.setScissors(m_scissor.get());
+    auto commandBuffer = renderPass.activeFrameBuffer().commandBuffer(0);
+    commandBuffer->use(geometryPipeline);
+    commandBuffer->setViewports(m_viewport.get());
+    commandBuffer->setScissors(m_scissor.get());
 
     // Get the amount of time that has passed since the first frame.
     auto now = std::chrono::high_resolution_clock::now();
@@ -396,14 +395,14 @@ void SampleApp::drawFrame()
     transformBuffer.map(reinterpret_cast<const void*>(&transform), sizeof(transform), backBuffer);
 
     // Bind both descriptor sets to the pipeline.
-    commandBuffer.bind(cameraBindings, geometryPipeline);
-    commandBuffer.bind(transformBindings, geometryPipeline);
+    commandBuffer->bind(cameraBindings, geometryPipeline);
+    commandBuffer->bind(transformBindings, geometryPipeline);
 
     // Bind the vertex and index buffers.
-    commandBuffer.bind(vertexBuffer);
-    commandBuffer.bind(indexBuffer);
+    commandBuffer->bind(vertexBuffer);
+    commandBuffer->bind(indexBuffer);
 
     // Draw the object and present the frame by ending the render pass.
-    commandBuffer.drawIndexed(indexBuffer.elements());
+    commandBuffer->drawIndexed(indexBuffer.elements());
     renderPass.end();
 }

--- a/src/Samples/BasicRendering/src/sample.cpp
+++ b/src/Samples/BasicRendering/src/sample.cpp
@@ -134,9 +134,8 @@ void SampleApp::initBuffers(IRenderBackend* backend)
     });
     
     // End and submit the command buffer.
-    auto fence = m_device->bufferQueue().submit(*commandBuffer);
-    m_device->bufferQueue().waitFor(fence);
-
+    m_loaderFence = m_device->bufferQueue().submit(asShared(std::move(commandBuffer)));
+    
     // Add everything to the state.
     m_device->state().add(std::move(vertexBuffer));
     m_device->state().add(std::move(indexBuffer));
@@ -377,6 +376,9 @@ void SampleApp::drawFrame()
     auto& transformBindings = m_device->state().descriptorSet(fmt::format("Transform Bindings {0}", backBuffer));
     auto& vertexBuffer = m_device->state().vertexBuffer("Vertex Buffer");
     auto& indexBuffer = m_device->state().indexBuffer("Index Buffer");
+
+    // Wait for the initialization command buffer to finish.
+    m_device->bufferQueue().waitFor(m_loaderFence);
 
     // Begin rendering on the render pass and use the only pipeline we've created for it.
     renderPass.begin(backBuffer);

--- a/src/Samples/BasicRendering/src/sample.h
+++ b/src/Samples/BasicRendering/src/sample.h
@@ -84,7 +84,7 @@ private:
 	/// <summary>
 	/// Stores the fence created at application load time.
 	/// </summary>
-	UInt64 m_loaderFence;
+	UInt64 m_transferFence = 0;
 
 public:
 	SampleApp(GlfwWindowPtr&& window, Optional<UInt32> adapterId) : 
@@ -105,7 +105,7 @@ private:
 	/// <summary>
 	/// Updates the camera buffer. This needs to be done whenever the frame buffer changes, since we need to pass changes in the aspect ratio to the view/projection matrix.
 	/// </summary>
-	void updateCamera(const ICommandBuffer& commandBuffer, IBuffer& stagingBuffer, const IBuffer& buffer) const;
+	void updateCamera(const ICommandBuffer& commandBuffer, const IBuffer& buffer) const;
 
 private:
 	void onInit();

--- a/src/Samples/BasicRendering/src/sample.h
+++ b/src/Samples/BasicRendering/src/sample.h
@@ -81,6 +81,11 @@ private:
 	/// </summary>
 	IGraphicsDevice* m_device;
 
+	/// <summary>
+	/// Stores the fence created at application load time.
+	/// </summary>
+	UInt64 m_loaderFence;
+
 public:
 	SampleApp(GlfwWindowPtr&& window, Optional<UInt32> adapterId) : 
 		App(), m_window(std::move(window)), m_adapterId(adapterId), m_device(nullptr)

--- a/src/Samples/Bindless/src/sample.cpp
+++ b/src/Samples/Bindless/src/sample.cpp
@@ -179,8 +179,7 @@ void SampleApp::initBuffers(IRenderBackend* backend)
     commandBuffer->transfer(*instanceStagingBuffer, *instanceBuffer, 0, 0, NUM_INSTANCES);
 
     // End and submit the command buffer.
-    auto fence = m_device->bufferQueue().submit(*commandBuffer);
-    m_device->bufferQueue().waitFor(fence);
+    m_loaderFence = m_device->bufferQueue().submit(asShared(std::move(commandBuffer)));
 
     // Add everything to the state.
     m_device->state().add(std::move(vertexBuffer));
@@ -428,6 +427,9 @@ void SampleApp::drawFrame()
     auto& instanceBindings = m_device->state().descriptorSet("Instance Bindings");
     auto& vertexBuffer = m_device->state().vertexBuffer("Vertex Buffer");
     auto& indexBuffer = m_device->state().indexBuffer("Index Buffer");
+
+    // Wait for the initialization command buffer to finish.
+    m_device->bufferQueue().waitFor(m_loaderFence);
 
     // Begin rendering on the render pass and use the only pipeline we've created for it.
     renderPass.begin(backBuffer);

--- a/src/Samples/Bindless/src/sample.cpp
+++ b/src/Samples/Bindless/src/sample.cpp
@@ -133,7 +133,7 @@ void SampleApp::initBuffers(IRenderBackend* backend)
     
     // Create the actual vertex buffer and transfer the staging buffer into it.
     auto vertexBuffer = m_device->factory().createVertexBuffer("Vertex Buffer", m_inputAssembler->vertexBufferLayout(0), BufferUsage::Resource, vertices.size());
-    commandBuffer->transfer(*stagedVertices, *vertexBuffer, 0, 0, vertices.size());
+    commandBuffer->transfer(asShared(std::move(stagedVertices)), *vertexBuffer, 0, 0, vertices.size());
 
     // Create the staging buffer for the indices. For infos about the mapping see the note about the vertex buffer mapping above.
     auto stagedIndices = m_device->factory().createIndexBuffer(m_inputAssembler->indexBufferLayout(), BufferUsage::Staging, indices.size());
@@ -141,18 +141,17 @@ void SampleApp::initBuffers(IRenderBackend* backend)
 
     // Create the actual index buffer and transfer the staging buffer into it.
     auto indexBuffer = m_device->factory().createIndexBuffer("Index Buffer", m_inputAssembler->indexBufferLayout(), BufferUsage::Resource, indices.size());
-    commandBuffer->transfer(*stagedIndices, *indexBuffer, 0, 0, indices.size());
+    commandBuffer->transfer(asShared(std::move(stagedIndices)), *indexBuffer, 0, 0, indices.size());
 
     // Initialize the camera buffer. The camera buffer is constant, so we only need to create one buffer, that can be read from all frames. Since this is a 
     // write-once/read-multiple scenario, we also transfer the buffer to the more efficient memory heap on the GPU.
     auto& geometryPipeline = m_device->state().pipeline("Geometry");
     auto& cameraBindingLayout = geometryPipeline.layout()->descriptorSet(DescriptorSets::CameraData);
-    auto cameraStagingBuffer = m_device->factory().createBuffer("Camera Staging", cameraBindingLayout, 0, BufferUsage::Staging);
     auto cameraBuffer = m_device->factory().createBuffer("Camera", cameraBindingLayout, 0, BufferUsage::Resource);
     auto cameraBindings = cameraBindingLayout.allocate({ { 0, *cameraBuffer } });
 
     // Update the camera. Since the descriptor set already points to the proper buffer, all changes are implicitly visible.
-    this->updateCamera(*commandBuffer, *cameraStagingBuffer, *cameraBuffer);
+    this->updateCamera(*commandBuffer, *cameraBuffer);
 
     // Next, we create the descriptor sets for the draw-data buffer
     auto& drawDataBindingLayout = geometryPipeline.layout()->descriptorSet(DescriptorSets::DrawData);
@@ -172,19 +171,18 @@ void SampleApp::initBuffers(IRenderBackend* backend)
     auto& instanceBindingLayout = geometryPipeline.layout()->descriptorSet(DescriptorSets::InstanceData);
 
     // Since we are using an unstructured storage buffer, we need to specify the element size manually.
-    auto instanceStagingBuffer = m_device->factory().createBuffer("Instance Staging", instanceBindingLayout, 0, BufferUsage::Staging, sizeof(InstanceBuffer), NUM_INSTANCES);
+    auto instanceStagingBuffer = m_device->factory().createBuffer(instanceBindingLayout, 0, BufferUsage::Staging, sizeof(InstanceBuffer), NUM_INSTANCES, false);
     auto instanceBuffer = m_device->factory().createBuffer("Instance Buffer", instanceBindingLayout, 0, BufferUsage::Resource, sizeof(InstanceBuffer), NUM_INSTANCES);
     auto instanceBinding = instanceBindingLayout.allocate(NUM_INSTANCES, { { 0, *instanceBuffer } });
     instanceStagingBuffer->map(reinterpret_cast<const void*>(&instanceData), sizeof(instanceData));
-    commandBuffer->transfer(*instanceStagingBuffer, *instanceBuffer, 0, 0, NUM_INSTANCES);
+    commandBuffer->transfer(asShared(std::move(instanceStagingBuffer)), *instanceBuffer, 0, 0, NUM_INSTANCES);
 
     // End and submit the command buffer.
-    m_loaderFence = m_device->bufferQueue().submit(asShared(std::move(commandBuffer)));
+    m_transferFence = m_device->bufferQueue().submit(commandBuffer);
 
     // Add everything to the state.
     m_device->state().add(std::move(vertexBuffer));
     m_device->state().add(std::move(indexBuffer));
-    m_device->state().add(std::move(cameraStagingBuffer));
     m_device->state().add(std::move(cameraBuffer));
     m_device->state().add(std::move(drawDataBuffer));
     m_device->state().add(std::move(instanceBuffer));
@@ -193,15 +191,18 @@ void SampleApp::initBuffers(IRenderBackend* backend)
     m_device->state().add("Instance Bindings", std::move(instanceBinding));
 }
 
-void SampleApp::updateCamera(const ICommandBuffer& commandBuffer, IBuffer& stagingBuffer, const IBuffer& buffer) const
+void SampleApp::updateCamera(const ICommandBuffer& commandBuffer, const IBuffer& buffer) const
 {
     // Calculate the camera view/projection matrix.
     auto aspectRatio = m_viewport->getRectangle().width() / m_viewport->getRectangle().height();
     glm::mat4 view = glm::lookAt(glm::vec3(-155.f, -145.f, 42.0f), glm::vec3(0.0f, 0.0f, 0.0f), glm::vec3(0.0f, 0.0f, 1.0f));
     glm::mat4 projection = glm::perspective(glm::radians(60.0f), aspectRatio, 0.0001f, 1000.0f);
     camera.ViewProjection = projection * view;
-    stagingBuffer.map(reinterpret_cast<const void*>(&camera), sizeof(camera));
-    commandBuffer.transfer(stagingBuffer, buffer);
+
+    // Create a staging buffer and use to transfer the new uniform buffer to.
+    auto cameraStagingBuffer = m_device->factory().createBuffer(m_device->state().pipeline("Geometry"), DescriptorSets::CameraData, 0, BufferUsage::Staging);
+    cameraStagingBuffer->map(reinterpret_cast<const void*>(&camera), sizeof(camera));
+    commandBuffer.transfer(asShared(std::move(cameraStagingBuffer)), buffer);
 }
 
 void SampleApp::onStartup() 
@@ -314,12 +315,10 @@ void SampleApp::onResize(const void* sender, ResizeEventArgs e)
     m_scissor->setRectangle(RectF(0.f, 0.f, static_cast<Float>(e.width()), static_cast<Float>(e.height())));
 
     // Also update the camera.
-    auto& cameraStagingBuffer = m_device->state().buffer("Camera Staging");
     auto& cameraBuffer = m_device->state().buffer("Camera");
     auto commandBuffer = m_device->bufferQueue().createCommandBuffer(true);
-    this->updateCamera(*commandBuffer, cameraStagingBuffer, cameraBuffer);
-    auto fence = m_device->bufferQueue().submit(*commandBuffer);
-    m_device->bufferQueue().waitFor(fence);
+    this->updateCamera(*commandBuffer, cameraBuffer);
+    m_transferFence = m_device->bufferQueue().submit(commandBuffer);
 }
 
 void SampleApp::keyDown(int key, int scancode, int action, int mods)
@@ -428,15 +427,15 @@ void SampleApp::drawFrame()
     auto& vertexBuffer = m_device->state().vertexBuffer("Vertex Buffer");
     auto& indexBuffer = m_device->state().indexBuffer("Index Buffer");
 
-    // Wait for the initialization command buffer to finish.
-    m_device->bufferQueue().waitFor(m_loaderFence);
+    // Wait for all transfers to finish.
+    m_device->bufferQueue().waitFor(m_transferFence);
 
     // Begin rendering on the render pass and use the only pipeline we've created for it.
     renderPass.begin(backBuffer);
-    auto& commandBuffer = renderPass.activeFrameBuffer().commandBuffer(0);
-    commandBuffer.use(geometryPipeline);
-    commandBuffer.setViewports(m_viewport.get());
-    commandBuffer.setScissors(m_scissor.get());
+    auto commandBuffer = renderPass.activeFrameBuffer().commandBuffer(0);
+    commandBuffer->use(geometryPipeline);
+    commandBuffer->setViewports(m_viewport.get());
+    commandBuffer->setScissors(m_scissor.get());
 
     // Get the amount of time that has passed since the first frame.
     auto now = std::chrono::high_resolution_clock::now();
@@ -448,15 +447,15 @@ void SampleApp::drawFrame()
     drawDataBuffer.map(reinterpret_cast<const void*>(&drawData), sizeof(drawData), backBuffer);
 
     // Bind all descriptor sets to the pipeline.
-    commandBuffer.bind(cameraBindings, geometryPipeline);
-    commandBuffer.bind(drawDataBindings, geometryPipeline);
-    commandBuffer.bind(instanceBindings, geometryPipeline);
+    commandBuffer->bind(cameraBindings, geometryPipeline);
+    commandBuffer->bind(drawDataBindings, geometryPipeline);
+    commandBuffer->bind(instanceBindings, geometryPipeline);
 
     // Bind the vertex and index buffers.
-    commandBuffer.bind(vertexBuffer);
-    commandBuffer.bind(indexBuffer);
+    commandBuffer->bind(vertexBuffer);
+    commandBuffer->bind(indexBuffer);
 
     // Draw the object and present the frame by ending the render pass.
-    commandBuffer.drawIndexed(indexBuffer.elements(), NUM_INSTANCES);
+    commandBuffer->drawIndexed(indexBuffer.elements(), NUM_INSTANCES);
     renderPass.end();
 }

--- a/src/Samples/Bindless/src/sample.h
+++ b/src/Samples/Bindless/src/sample.h
@@ -84,7 +84,7 @@ private:
 	/// <summary>
 	/// Stores the fence created at application load time.
 	/// </summary>
-	UInt64 m_loaderFence;
+	UInt64 m_transferFence = 0;
 
 public:
 	SampleApp(GlfwWindowPtr&& window, Optional<UInt32> adapterId) : 
@@ -105,7 +105,7 @@ private:
 	/// <summary>
 	/// Updates the camera buffer. This needs to be done whenever the frame buffer changes, since we need to pass changes in the aspect ratio to the view/projection matrix.
 	/// </summary>
-	void updateCamera(const ICommandBuffer& commandBuffer, IBuffer& stagingBuffer, const IBuffer& buffer) const;
+	void updateCamera(const ICommandBuffer& commandBuffer, const IBuffer& buffer) const;
 
 private:
 	void onInit();

--- a/src/Samples/Bindless/src/sample.h
+++ b/src/Samples/Bindless/src/sample.h
@@ -81,6 +81,11 @@ private:
 	/// </summary>
 	IGraphicsDevice* m_device;
 
+	/// <summary>
+	/// Stores the fence created at application load time.
+	/// </summary>
+	UInt64 m_loaderFence;
+
 public:
 	SampleApp(GlfwWindowPtr&& window, Optional<UInt32> adapterId) : 
 		App(), m_window(std::move(window)), m_adapterId(adapterId), m_device(nullptr)

--- a/src/Samples/Multisampling/src/sample.h
+++ b/src/Samples/Multisampling/src/sample.h
@@ -81,6 +81,11 @@ private:
 	/// </summary>
 	IGraphicsDevice* m_device;
 
+	/// <summary>
+	/// Stores the fence created at application load time.
+	/// </summary>
+	UInt64 m_transferFence = 0;
+
 public:
 	SampleApp(GlfwWindowPtr&& window, Optional<UInt32> adapterId) : 
 		App(), m_window(std::move(window)), m_adapterId(adapterId), m_device(nullptr)
@@ -100,7 +105,7 @@ private:
 	/// <summary>
 	/// Updates the camera buffer. This needs to be done whenever the frame buffer changes, since we need to pass changes in the aspect ratio to the view/projection matrix.
 	/// </summary>
-	void updateCamera(const ICommandBuffer& commandBuffer, IBuffer& stagingBuffer, const IBuffer& buffer) const;
+	void updateCamera(const ICommandBuffer& commandBuffer, const IBuffer& buffer) const;
 
 private:
 	void onInit();

--- a/src/Samples/Multithreading/src/sample.cpp
+++ b/src/Samples/Multithreading/src/sample.cpp
@@ -116,7 +116,7 @@ void SampleApp::initBuffers(IRenderBackend* backend)
     
     // Create the actual vertex buffer and transfer the staging buffer into it.
     auto vertexBuffer = m_device->factory().createVertexBuffer("Vertex Buffer", m_inputAssembler->vertexBufferLayout(0), BufferUsage::Resource, vertices.size());
-    commandBuffer->transfer(*stagedVertices, *vertexBuffer, 0, 0, vertices.size());
+    commandBuffer->transfer(asShared(std::move(stagedVertices)), *vertexBuffer, 0, 0, vertices.size());
 
     // Create the staging buffer for the indices. For infos about the mapping see the note about the vertex buffer mapping above.
     auto stagedIndices = m_device->factory().createIndexBuffer(m_inputAssembler->indexBufferLayout(), BufferUsage::Staging, indices.size());
@@ -124,18 +124,17 @@ void SampleApp::initBuffers(IRenderBackend* backend)
 
     // Create the actual index buffer and transfer the staging buffer into it.
     auto indexBuffer = m_device->factory().createIndexBuffer("Index Buffer", m_inputAssembler->indexBufferLayout(), BufferUsage::Resource, indices.size());
-    commandBuffer->transfer(*stagedIndices, *indexBuffer, 0, 0, indices.size());
+    commandBuffer->transfer(asShared(std::move(stagedIndices)), *indexBuffer, 0, 0, indices.size());
 
     // Initialize the camera buffer. The camera buffer is constant, so we only need to create one buffer, that can be read from all frames. Since this is a 
     // write-once/read-multiple scenario, we also transfer the buffer to the more efficient memory heap on the GPU.
     auto& geometryPipeline = m_device->state().pipeline("Geometry");
     auto& cameraBindingLayout = geometryPipeline.layout()->descriptorSet(DescriptorSets::Constant);
-    auto cameraStagingBuffer = m_device->factory().createBuffer("Camera Staging", cameraBindingLayout, 0, BufferUsage::Staging);
     auto cameraBuffer = m_device->factory().createBuffer("Camera", cameraBindingLayout, 0, BufferUsage::Resource);
     auto cameraBindings = cameraBindingLayout.allocate({ { 0, *cameraBuffer } });
 
     // Update the camera. Since the descriptor set already points to the proper buffer, all changes are implicitly visible.
-    this->updateCamera(*commandBuffer, *cameraStagingBuffer, *cameraBuffer);
+    this->updateCamera(*commandBuffer, *cameraBuffer);
 
     // Next, we create the descriptor sets for the transform buffer. The transform changes with every frame. Since we have three frames in flight, we
     // create a buffer with three elements and bind the appropriate element to the descriptor set for every frame.
@@ -149,28 +148,29 @@ void SampleApp::initBuffers(IRenderBackend* backend)
     });
     
     // End and submit the command buffer.
-    auto fence = m_device->bufferQueue().submit(*commandBuffer);
-    m_device->bufferQueue().waitFor(fence);
+    m_transferFence = m_device->bufferQueue().submit(commandBuffer);
 
     // Add everything to the state.
     m_device->state().add(std::move(vertexBuffer));
     m_device->state().add(std::move(indexBuffer));
-    m_device->state().add(std::move(cameraStagingBuffer));
     m_device->state().add(std::move(cameraBuffer));
     m_device->state().add("Camera Bindings", std::move(cameraBindings));
     std::ranges::for_each(transformBuffers, [this](auto& buffer) { m_device->state().add(std::move(buffer)); });
     std::ranges::for_each(transformBindings, [this, i = 0](auto& binding) mutable { m_device->state().add(fmt::format("Transform Bindings {0}", i++), std::move(binding)); });
 }
 
-void SampleApp::updateCamera(const ICommandBuffer& commandBuffer, IBuffer& stagingBuffer, const IBuffer& buffer) const
+void SampleApp::updateCamera(const ICommandBuffer& commandBuffer, const IBuffer& buffer) const
 {
     // Calculate the camera view/projection matrix.
     auto aspectRatio = m_viewport->getRectangle().width() / m_viewport->getRectangle().height();
     glm::mat4 view = glm::lookAt(glm::vec3(5.f, 5.f, 2.5f), glm::vec3(0.0f, 0.0f, 0.0f), glm::vec3(0.0f, 0.0f, 1.0f));
     glm::mat4 projection = glm::perspective(glm::radians(60.0f), aspectRatio, 0.0001f, 1000.0f);
     camera.ViewProjection = projection * view;
-    stagingBuffer.map(reinterpret_cast<const void*>(&camera), sizeof(camera));
-    commandBuffer.transfer(stagingBuffer, buffer);
+
+    // Create a staging buffer and use to transfer the new uniform buffer to.
+    auto cameraStagingBuffer = m_device->factory().createBuffer(m_device->state().pipeline("Geometry"), DescriptorSets::Constant, 0, BufferUsage::Staging);
+    cameraStagingBuffer->map(reinterpret_cast<const void*>(&camera), sizeof(camera));
+    commandBuffer.transfer(asShared(std::move(cameraStagingBuffer)), buffer);
 }
 
 void SampleApp::onStartup() 
@@ -280,12 +280,10 @@ void SampleApp::onResize(const void* sender, ResizeEventArgs e)
     m_scissor->setRectangle(RectF(0.f, 0.f, static_cast<Float>(e.width()), static_cast<Float>(e.height())));
 
     // Also update the camera.
-    auto& cameraStagingBuffer = m_device->state().buffer("Camera Staging");
     auto& cameraBuffer = m_device->state().buffer("Camera");
     auto commandBuffer = m_device->bufferQueue().createCommandBuffer(true);
-    this->updateCamera(*commandBuffer, cameraStagingBuffer, cameraBuffer);
-    auto fence = m_device->bufferQueue().submit(*commandBuffer);
-    m_device->bufferQueue().waitFor(fence);
+    this->updateCamera(*commandBuffer, cameraBuffer);
+    m_transferFence = m_device->bufferQueue().submit(commandBuffer);
 }
 
 void SampleApp::keyDown(int key, int scancode, int action, int mods)
@@ -387,33 +385,36 @@ void SampleApp::drawObject(const IRenderPass* renderPass, int index, int backBuf
     auto& indexBuffer = m_device->state().indexBuffer("Index Buffer");
 
     // Acquire command buffer from index.
-    const auto& commandBuffer = renderPass->activeFrameBuffer().commandBuffer(index);
+    auto commandBuffer = renderPass->activeFrameBuffer().commandBuffer(index);
 
     // Set the pipeline on the command buffer.
-    commandBuffer.use(geometryPipeline);
-    commandBuffer.setViewports(m_viewport.get());
-    commandBuffer.setScissors(m_scissor.get());
+    commandBuffer->use(geometryPipeline);
+    commandBuffer->setViewports(m_viewport.get());
+    commandBuffer->setScissors(m_scissor.get());
 
     // Compute world transform and update the transform buffer.
     transform[index].World = glm::translate(glm::rotate(glm::mat4(1.0f), time * glm::radians(42.0f), glm::vec3(0.0f, 0.0f, 1.0f)), translations[index]);
     transformBuffer.map(reinterpret_cast<const void*>(&transform[index]), sizeof(TransformBuffer), backBuffer);
 
     // Bind both descriptor sets to the pipeline.
-    commandBuffer.bind(cameraBindings, geometryPipeline);
-    commandBuffer.bind(transformBindings, geometryPipeline);
+    commandBuffer->bind(cameraBindings, geometryPipeline);
+    commandBuffer->bind(transformBindings, geometryPipeline);
 
     // Bind the vertex and index buffers.
-    commandBuffer.bind(vertexBuffer);
-    commandBuffer.bind(indexBuffer);
+    commandBuffer->bind(vertexBuffer);
+    commandBuffer->bind(indexBuffer);
 
     // Record the draw call.
-    commandBuffer.drawIndexed(indexBuffer.elements());
+    commandBuffer->drawIndexed(indexBuffer.elements());
 }
 
 void SampleApp::drawFrame()
 {
     // Store the initial time this method has been called first.
     static auto start = std::chrono::high_resolution_clock::now();
+
+    // Wait for all transfers to finish.
+    m_device->bufferQueue().waitFor(m_transferFence);
 
     // Swap the back buffers for the next frame.
     auto backBuffer = m_device->swapChain().swapBackBuffer();

--- a/src/Samples/Multithreading/src/sample.h
+++ b/src/Samples/Multithreading/src/sample.h
@@ -89,6 +89,11 @@ private:
 	/// </summary>
 	Array<std::future<void>> m_workers = Array<std::future<void>>(NUM_WORKERS);
 
+	/// <summary>
+	/// Stores the fence created at application load time.
+	/// </summary>
+	UInt64 m_transferFence = 0;
+
 public:
 	SampleApp(GlfwWindowPtr&& window, Optional<UInt32> adapterId) : 
 		App(), m_window(std::move(window)), m_adapterId(adapterId), m_device(nullptr)
@@ -108,7 +113,7 @@ private:
 	/// <summary>
 	/// Updates the camera buffer. This needs to be done whenever the frame buffer changes, since we need to pass changes in the aspect ratio to the view/projection matrix.
 	/// </summary>
-	void updateCamera(const ICommandBuffer& commandBuffer, IBuffer& stagingBuffer, const IBuffer& buffer) const;
+	void updateCamera(const ICommandBuffer& commandBuffer, const IBuffer& buffer) const;
 
 private:
 	void onInit();

--- a/src/Samples/PushConstants/src/sample.cpp
+++ b/src/Samples/PushConstants/src/sample.cpp
@@ -130,7 +130,7 @@ void SampleApp::initBuffers(IRenderBackend* backend)
     
     // Create the actual vertex buffer and transfer the staging buffer into it.
     auto vertexBuffer = m_device->factory().createVertexBuffer("Vertex Buffer", m_inputAssembler->vertexBufferLayout(0), BufferUsage::Resource, vertices.size());
-    commandBuffer->transfer(*stagedVertices, *vertexBuffer, 0, 0, vertices.size());
+    commandBuffer->transfer(asShared(std::move(stagedVertices)), *vertexBuffer, 0, 0, vertices.size());
 
     // Create the staging buffer for the indices. For infos about the mapping see the note about the vertex buffer mapping above.
     auto stagedIndices = m_device->factory().createIndexBuffer(m_inputAssembler->indexBufferLayout(), BufferUsage::Staging, indices.size());
@@ -138,40 +138,40 @@ void SampleApp::initBuffers(IRenderBackend* backend)
 
     // Create the actual index buffer and transfer the staging buffer into it.
     auto indexBuffer = m_device->factory().createIndexBuffer("Index Buffer", m_inputAssembler->indexBufferLayout(), BufferUsage::Resource, indices.size());
-    commandBuffer->transfer(*stagedIndices, *indexBuffer, 0, 0, indices.size());
+    commandBuffer->transfer(asShared(std::move(stagedIndices)), *indexBuffer, 0, 0, indices.size());
 
     // Initialize the camera buffer. The camera buffer is constant, so we only need to create one buffer, that can be read from all frames. Since this is a 
     // write-once/read-multiple scenario, we also transfer the buffer to the more efficient memory heap on the GPU.
     auto& geometryPipeline = m_device->state().pipeline("Geometry");
     auto& cameraBindingLayout = geometryPipeline.layout()->descriptorSet(DescriptorSets::Constant);
-    auto cameraStagingBuffer = m_device->factory().createBuffer("Camera Staging", cameraBindingLayout, 0, BufferUsage::Staging);
     auto cameraBuffer = m_device->factory().createBuffer("Camera", cameraBindingLayout, 0, BufferUsage::Resource);
     auto cameraBindings = cameraBindingLayout.allocate({ { 0, *cameraBuffer } });
 
     // Update the camera. Since the descriptor set already points to the proper buffer, all changes are implicitly visible.
-    this->updateCamera(*commandBuffer, *cameraStagingBuffer, *cameraBuffer);
+    this->updateCamera(*commandBuffer, *cameraBuffer);
 
     // End and submit the command buffer.
-    auto fence = m_device->bufferQueue().submit(*commandBuffer);
-    m_device->bufferQueue().waitFor(fence);
+    m_transferFence = m_device->bufferQueue().submit(commandBuffer);
 
     // Add everything to the state.
     m_device->state().add(std::move(vertexBuffer));
     m_device->state().add(std::move(indexBuffer));
-    m_device->state().add(std::move(cameraStagingBuffer));
     m_device->state().add(std::move(cameraBuffer));
     m_device->state().add("Camera Bindings", std::move(cameraBindings));
 }
 
-void SampleApp::updateCamera(const ICommandBuffer& commandBuffer, IBuffer& stagingBuffer, const IBuffer& buffer) const
+void SampleApp::updateCamera(const ICommandBuffer& commandBuffer, const IBuffer& buffer) const
 {
     // Calculate the camera view/projection matrix.
     auto aspectRatio = m_viewport->getRectangle().width() / m_viewport->getRectangle().height();
     glm::mat4 view = glm::lookAt(glm::vec3(5.f, 5.f, 2.5f), glm::vec3(0.0f, 0.0f, 0.0f), glm::vec3(0.0f, 0.0f, 1.0f));
     glm::mat4 projection = glm::perspective(glm::radians(60.0f), aspectRatio, 0.0001f, 1000.0f);
     camera.ViewProjection = projection * view;
-    stagingBuffer.map(reinterpret_cast<const void*>(&camera), sizeof(camera));
-    commandBuffer.transfer(stagingBuffer, buffer);
+
+    // Create a staging buffer and use to transfer the new uniform buffer to.
+    auto cameraStagingBuffer = m_device->factory().createBuffer(m_device->state().pipeline("Geometry"), DescriptorSets::Constant, 0, BufferUsage::Staging);
+    cameraStagingBuffer->map(reinterpret_cast<const void*>(&camera), sizeof(camera));
+    commandBuffer.transfer(asShared(std::move(cameraStagingBuffer)), buffer);
 }
 
 void SampleApp::onStartup() 
@@ -278,12 +278,10 @@ void SampleApp::onResize(const void* sender, ResizeEventArgs e)
     m_scissor->setRectangle(RectF(0.f, 0.f, static_cast<Float>(e.width()), static_cast<Float>(e.height())));
 
     // Also update the camera.
-    auto& cameraStagingBuffer = m_device->state().buffer("Camera Staging");
     auto& cameraBuffer = m_device->state().buffer("Camera");
     auto commandBuffer = m_device->bufferQueue().createCommandBuffer(true);
-    this->updateCamera(*commandBuffer, cameraStagingBuffer, cameraBuffer);
-    auto fence = m_device->bufferQueue().submit(*commandBuffer);
-    m_device->bufferQueue().waitFor(fence);
+    this->updateCamera(*commandBuffer, cameraBuffer);
+    m_transferFence = m_device->bufferQueue().submit(commandBuffer);
 }
 
 void SampleApp::keyDown(int key, int scancode, int action, int mods)
@@ -379,6 +377,9 @@ void SampleApp::drawFrame()
     // Store the initial time this method has been called first.
     static auto start = std::chrono::high_resolution_clock::now();
 
+    // Wait for all transfers to finish.
+    m_device->bufferQueue().waitFor(m_transferFence);
+
     // Swap the back buffers for the next frame.
     auto backBuffer = m_device->swapChain().swapBackBuffer();
 
@@ -391,21 +392,21 @@ void SampleApp::drawFrame()
 
     // Begin rendering on the render pass and use the only pipeline we've created for it.
     renderPass.begin(backBuffer);
-    auto& commandBuffer = renderPass.activeFrameBuffer().commandBuffer(0);
-    commandBuffer.use(geometryPipeline);
-    commandBuffer.setViewports(m_viewport.get());
-    commandBuffer.setScissors(m_scissor.get());
+    auto commandBuffer = renderPass.activeFrameBuffer().commandBuffer(0);
+    commandBuffer->use(geometryPipeline);
+    commandBuffer->setViewports(m_viewport.get());
+    commandBuffer->setScissors(m_scissor.get());
 
     // Get the amount of time that has passed since the first frame.
     auto now = std::chrono::high_resolution_clock::now();
     auto time = std::chrono::duration<float, std::chrono::seconds::period>(now - start).count();
 
     // Bind both descriptor sets to the pipeline.
-    commandBuffer.bind(cameraBindings, geometryPipeline);
+    commandBuffer->bind(cameraBindings, geometryPipeline);
 
     // Bind the vertex and index buffers.
-    commandBuffer.bind(vertexBuffer);
-    commandBuffer.bind(indexBuffer);
+    commandBuffer->bind(vertexBuffer);
+    commandBuffer->bind(indexBuffer);
 
     // Draw 9 objects, each with a different color. The transform matrix and color is passed to the shader using push constants.
     for (int i(0); i < 9; ++i)
@@ -416,10 +417,10 @@ void SampleApp::drawFrame()
             .Color = colors[i]
         };
 
-        commandBuffer.pushConstants(*geometryPipeline.layout()->pushConstants(), &buffer);
+        commandBuffer->pushConstants(*geometryPipeline.layout()->pushConstants(), &buffer);
 
         // Record the draw call.
-        commandBuffer.drawIndexed(indexBuffer.elements());
+        commandBuffer->drawIndexed(indexBuffer.elements());
     }
 
     // If all commands are recorded, end the render pass to present the image.

--- a/src/Samples/PushConstants/src/sample.h
+++ b/src/Samples/PushConstants/src/sample.h
@@ -81,6 +81,11 @@ private:
 	/// </summary>
 	IGraphicsDevice* m_device;
 
+	/// <summary>
+	/// Stores the fence created at application load time.
+	/// </summary>
+	UInt64 m_transferFence = 0;
+
 public:
 	SampleApp(GlfwWindowPtr&& window, Optional<UInt32> adapterId) : 
 		App(), m_window(std::move(window)), m_adapterId(adapterId), m_device(nullptr)
@@ -100,7 +105,7 @@ private:
 	/// <summary>
 	/// Updates the camera buffer. This needs to be done whenever the frame buffer changes, since we need to pass changes in the aspect ratio to the view/projection matrix.
 	/// </summary>
-	void updateCamera(const ICommandBuffer& commandBuffer, IBuffer& stagingBuffer, const IBuffer& buffer) const;
+	void updateCamera(const ICommandBuffer& commandBuffer, const IBuffer& buffer) const;
 
 private:
 	void onInit();

--- a/src/Samples/RenderPasses/src/sample.cpp
+++ b/src/Samples/RenderPasses/src/sample.cpp
@@ -136,7 +136,7 @@ void SampleApp::initBuffers(IRenderBackend* backend)
     
     // Create the actual vertex buffer and transfer the staging buffer into it.
     auto vertexBuffer = m_device->factory().createVertexBuffer("Vertex Buffer", m_inputAssembler->vertexBufferLayout(0), BufferUsage::Resource, vertices.size());
-    commandBuffer->transfer(*stagedVertices, *vertexBuffer, 0, 0, vertices.size());
+    commandBuffer->transfer(asShared(std::move(stagedVertices)), *vertexBuffer, 0, 0, vertices.size());
 
     // Create the staging buffer for the indices. For infos about the mapping see the note about the vertex buffer mapping above.
     auto stagedIndices = m_device->factory().createIndexBuffer(m_inputAssembler->indexBufferLayout(), BufferUsage::Staging, indices.size());
@@ -144,18 +144,17 @@ void SampleApp::initBuffers(IRenderBackend* backend)
 
     // Create the actual index buffer and transfer the staging buffer into it.
     auto indexBuffer = m_device->factory().createIndexBuffer("Index Buffer", m_inputAssembler->indexBufferLayout(), BufferUsage::Resource, indices.size());
-    commandBuffer->transfer(*stagedIndices, *indexBuffer, 0, 0, indices.size());
+    commandBuffer->transfer(asShared(std::move(stagedIndices)), *indexBuffer, 0, 0, indices.size());
 
     // Initialize the camera buffer. The camera buffer is constant, so we only need to create one buffer, that can be read from all frames. Since this is a 
     // write-once/read-multiple scenario, we also transfer the buffer to the more efficient memory heap on the GPU.
     auto& geometryPipeline = m_device->state().pipeline("Geometry");
     auto& cameraBindingLayout = geometryPipeline.layout()->descriptorSet(DescriptorSets::Constant);
-    auto cameraStagingBuffer = m_device->factory().createBuffer("Camera Staging", cameraBindingLayout, 0, BufferUsage::Staging);
     auto cameraBuffer = m_device->factory().createBuffer("Camera", cameraBindingLayout, 0, BufferUsage::Resource);
     auto cameraBindings = cameraBindingLayout.allocate({ { 0, *cameraBuffer } });
 
     // Update the camera. Since the descriptor set already points to the proper buffer, all changes are implicitly visible.
-    this->updateCamera(*commandBuffer, *cameraStagingBuffer, *cameraBuffer);
+    this->updateCamera(*commandBuffer, *cameraBuffer);
 
     // Next, we create the descriptor sets for the transform buffer. The transform changes with every frame. Since we have three frames in flight, we
     // create a buffer with three elements and bind the appropriate element to the descriptor set for every frame.
@@ -171,27 +170,25 @@ void SampleApp::initBuffers(IRenderBackend* backend)
     auto stagedViewPlaneVertices = m_device->factory().createVertexBuffer(m_inputAssembler->vertexBufferLayout(0), BufferUsage::Staging, viewPlaneVertices.size());
     stagedViewPlaneVertices->map(viewPlaneVertices.data(), viewPlaneVertices.size() * sizeof(::Vertex), 0);
     auto viewPlaneVertexBuffer = m_device->factory().createVertexBuffer("View Plane Vertices", m_inputAssembler->vertexBufferLayout(0), BufferUsage::Resource, viewPlaneVertices.size());
-    commandBuffer->transfer(*stagedViewPlaneVertices, *viewPlaneVertexBuffer, 0, 0, viewPlaneVertices.size());
+    commandBuffer->transfer(asShared(std::move(stagedViewPlaneVertices)), *viewPlaneVertexBuffer, 0, 0, viewPlaneVertices.size());
 
     auto stagedViewPlaneIndices = m_device->factory().createIndexBuffer(m_inputAssembler->indexBufferLayout(), BufferUsage::Staging, viewPlaneIndices.size());
     stagedViewPlaneIndices->map(viewPlaneIndices.data(), viewPlaneIndices.size() * m_inputAssembler->indexBufferLayout().elementSize(), 0);
     auto viewPlaneIndexBuffer = m_device->factory().createIndexBuffer("View Plane Indices", m_inputAssembler->indexBufferLayout(), BufferUsage::Resource, viewPlaneIndices.size());
-    commandBuffer->transfer(*stagedViewPlaneIndices, *viewPlaneIndexBuffer, 0, 0, viewPlaneIndices.size());
+    commandBuffer->transfer(asShared(std::move(stagedViewPlaneIndices)), *viewPlaneIndexBuffer, 0, 0, viewPlaneIndices.size());
 
     // Create the G-Buffer bindings.
     auto& lightingPipeline = m_device->state().pipeline("Lighting");
     auto gBufferBindings = lightingPipeline.layout()->descriptorSet(0).allocateMultiple(3);
 
     // End and submit the command buffer.
-    auto fence = m_device->bufferQueue().submit(*commandBuffer);
-    m_device->bufferQueue().waitFor(fence);
+    m_transferFence = m_device->bufferQueue().submit(commandBuffer);
 
     // Add everything to the state.
     m_device->state().add(std::move(vertexBuffer));
     m_device->state().add(std::move(viewPlaneVertexBuffer));
     m_device->state().add(std::move(indexBuffer));
     m_device->state().add(std::move(viewPlaneIndexBuffer));
-    m_device->state().add(std::move(cameraStagingBuffer));
     m_device->state().add(std::move(cameraBuffer));
     m_device->state().add(std::move(transformBuffer));
     m_device->state().add("Camera Bindings", std::move(cameraBindings));
@@ -199,15 +196,18 @@ void SampleApp::initBuffers(IRenderBackend* backend)
     std::ranges::for_each(gBufferBindings, [this, i = 0](auto& binding) mutable { m_device->state().add(fmt::format("G-Buffer {0}", i++), std::move(binding)); });
 }
 
-void SampleApp::updateCamera(const ICommandBuffer& commandBuffer, IBuffer& stagingBuffer, const IBuffer& buffer) const
+void SampleApp::updateCamera(const ICommandBuffer& commandBuffer, const IBuffer& buffer) const
 {
     // Calculate the camera view/projection matrix.
     auto aspectRatio = m_viewport->getRectangle().width() / m_viewport->getRectangle().height();
     glm::mat4 view = glm::lookAt(glm::vec3(1.5f, 1.5f, 1.5f), glm::vec3(0.0f, 0.0f, 0.0f), glm::vec3(0.0f, 0.0f, 1.0f));
     glm::mat4 projection = glm::perspective(glm::radians(60.0f), aspectRatio, 0.0001f, 1000.0f);
     camera.ViewProjection = projection * view;
-    stagingBuffer.map(reinterpret_cast<const void*>(&camera), sizeof(camera));
-    commandBuffer.transfer(stagingBuffer, buffer);
+
+    // Create a staging buffer and use to transfer the new uniform buffer to.
+    auto cameraStagingBuffer = m_device->factory().createBuffer(m_device->state().pipeline("Geometry"), DescriptorSets::Constant, 0, BufferUsage::Staging);
+    cameraStagingBuffer->map(reinterpret_cast<const void*>(&camera), sizeof(camera));
+    commandBuffer.transfer(asShared(std::move(cameraStagingBuffer)), buffer);
 }
 
 void SampleApp::onStartup() 
@@ -315,12 +315,10 @@ void SampleApp::onResize(const void* sender, ResizeEventArgs e)
     m_scissor->setRectangle(RectF(0.f, 0.f, static_cast<Float>(e.width()), static_cast<Float>(e.height())));
 
     // Also update the camera.
-    auto& cameraStagingBuffer = m_device->state().buffer("Camera Staging");
     auto& cameraBuffer = m_device->state().buffer("Camera");
     auto commandBuffer = m_device->bufferQueue().createCommandBuffer(true);
-    this->updateCamera(*commandBuffer, cameraStagingBuffer, cameraBuffer);
-    auto fence = m_device->bufferQueue().submit(*commandBuffer);
-    m_device->bufferQueue().waitFor(fence);
+    this->updateCamera(*commandBuffer, cameraBuffer);
+    m_transferFence = m_device->bufferQueue().submit(commandBuffer);
 }
 
 void SampleApp::keyDown(int key, int scancode, int action, int mods)
@@ -416,6 +414,9 @@ void SampleApp::drawFrame()
     // Store the initial time this method has been called first.
     static auto start = std::chrono::high_resolution_clock::now();
 
+    // Wait for all transfers to finish.
+    m_device->bufferQueue().waitFor(m_transferFence);
+
     // Swap the back buffers for the next frame.
     auto backBuffer = m_device->swapChain().swapBackBuffer();
 
@@ -431,10 +432,10 @@ void SampleApp::drawFrame()
 
         // Begin rendering on the render pass and use the only pipeline we've created for it.
         geometryPass.begin(backBuffer);
-        auto& commandBuffer = geometryPass.activeFrameBuffer().commandBuffer(0);
-        commandBuffer.use(geometryPipeline);
-        commandBuffer.setViewports(m_viewport.get());
-        commandBuffer.setScissors(m_scissor.get());
+        auto commandBuffer = geometryPass.activeFrameBuffer().commandBuffer(0);
+        commandBuffer->use(geometryPipeline);
+        commandBuffer->setViewports(m_viewport.get());
+        commandBuffer->setScissors(m_scissor.get());
 
         // Get the amount of time that has passed since the first frame.
         auto now = std::chrono::high_resolution_clock::now();
@@ -445,15 +446,15 @@ void SampleApp::drawFrame()
         transformBuffer.map(reinterpret_cast<const void*>(&transform), sizeof(transform), backBuffer);
 
         // Bind both descriptor sets to the pipeline.
-        commandBuffer.bind(cameraBindings, geometryPipeline);
-        commandBuffer.bind(transformBindings, geometryPipeline);
+        commandBuffer->bind(cameraBindings, geometryPipeline);
+        commandBuffer->bind(transformBindings, geometryPipeline);
 
         // Bind the vertex and index buffers.
-        commandBuffer.bind(vertexBuffer);
-        commandBuffer.bind(indexBuffer);
+        commandBuffer->bind(vertexBuffer);
+        commandBuffer->bind(indexBuffer);
 
         // Draw the object and present the frame by ending the render pass.
-        commandBuffer.drawIndexed(indexBuffer.elements());
+        commandBuffer->drawIndexed(indexBuffer.elements());
         geometryPass.end();
     }
 
@@ -467,19 +468,19 @@ void SampleApp::drawFrame()
 
         // Start the lighting pass.
         lightingPass.begin(backBuffer);
-        auto& commandBuffer = lightingPass.activeFrameBuffer().commandBuffer(0);
-        commandBuffer.use(lightingPipeline);
-        commandBuffer.setViewports(m_viewport.get());
-        commandBuffer.setScissors(m_scissor.get());
+        auto commandBuffer = lightingPass.activeFrameBuffer().commandBuffer(0);
+        commandBuffer->use(lightingPipeline);
+        commandBuffer->setViewports(m_viewport.get());
+        commandBuffer->setScissors(m_scissor.get());
 
         // Bind the G-Buffer.
         lightingPass.updateAttachments(gBufferBinding);
 
         // Draw the view plane.
-        commandBuffer.bind(viewPlaneVertexBuffer);
-        commandBuffer.bind(viewPlaneIndexBuffer);
-        commandBuffer.bind(gBufferBinding, lightingPipeline);
-        commandBuffer.drawIndexed(viewPlaneIndexBuffer.elements());
+        commandBuffer->bind(viewPlaneVertexBuffer);
+        commandBuffer->bind(viewPlaneIndexBuffer);
+        commandBuffer->bind(gBufferBinding, lightingPipeline);
+        commandBuffer->drawIndexed(viewPlaneIndexBuffer.elements());
 
         // End the lighting pass.
         lightingPass.end();

--- a/src/Samples/RenderPasses/src/sample.h
+++ b/src/Samples/RenderPasses/src/sample.h
@@ -81,6 +81,11 @@ private:
 	/// </summary>
 	IGraphicsDevice* m_device;
 
+	/// <summary>
+	/// Stores the fence created at application load time.
+	/// </summary>
+	UInt64 m_transferFence = 0;
+
 public:
 	SampleApp(GlfwWindowPtr&& window, Optional<UInt32> adapterId) : 
 		App(), m_window(std::move(window)), m_adapterId(adapterId), m_device(nullptr)
@@ -100,7 +105,7 @@ private:
 	/// <summary>
 	/// Updates the camera buffer. This needs to be done whenever the frame buffer changes, since we need to pass changes in the aspect ratio to the view/projection matrix.
 	/// </summary>
-	void updateCamera(const ICommandBuffer& commandBuffer, IBuffer& stagingBuffer, const IBuffer& buffer) const;
+	void updateCamera(const ICommandBuffer& commandBuffer, const IBuffer& buffer) const;
 
 private:
 	void onInit();

--- a/src/Samples/Textures/src/sample.h
+++ b/src/Samples/Textures/src/sample.h
@@ -81,6 +81,11 @@ private:
 	/// </summary>
 	IGraphicsDevice* m_device;
 
+	/// <summary>
+	/// Stores the fence created at application load time.
+	/// </summary>
+	UInt64 m_transferFence = 0;
+
 public:
 	SampleApp(GlfwWindowPtr&& window, Optional<UInt32> adapterId) : 
 		App(), m_window(std::move(window)), m_adapterId(adapterId), m_device(nullptr)
@@ -105,7 +110,7 @@ private:
 	/// <summary>
 	/// Updates the camera buffer. This needs to be done whenever the frame buffer changes, since we need to pass changes in the aspect ratio to the view/projection matrix.
 	/// </summary>
-	void updateCamera(const ICommandBuffer& commandBuffer, IBuffer& stagingBuffer, const IBuffer& buffer) const;
+	void updateCamera(const ICommandBuffer& commandBuffer, const IBuffer& buffer) const;
 
 private:
 	void onInit();

--- a/src/Samples/UniformArrays/src/sample.h
+++ b/src/Samples/UniformArrays/src/sample.h
@@ -81,6 +81,11 @@ private:
 	/// </summary>
 	IGraphicsDevice* m_device;
 
+	/// <summary>
+	/// Stores the fence created at application load time.
+	/// </summary>
+	UInt64 m_transferFence = 0;
+
 public:
 	SampleApp(GlfwWindowPtr&& window, Optional<UInt32> adapterId) : 
 		App(), m_window(std::move(window)), m_adapterId(adapterId), m_device(nullptr)
@@ -105,7 +110,7 @@ private:
 	/// <summary>
 	/// Updates the camera buffer. This needs to be done whenever the frame buffer changes, since we need to pass changes in the aspect ratio to the view/projection matrix.
 	/// </summary>
-	void updateCamera(const ICommandBuffer& commandBuffer, IBuffer& stagingBuffer, const IBuffer& buffer) const;
+	void updateCamera(const ICommandBuffer& commandBuffer, const IBuffer& buffer) const;
 
 private:
 	void onInit();


### PR DESCRIPTION
**Describe the pull request**

This PR allows command queues to take temporary shared ownership over one or more command buffers during submit. Ownership is held until the submitted fence value has been surpassed. It is released during `waitFor`. This allows for temporary command buffers to stay alive, until they are executed. It is no longer necessary to manually manage and release such command buffers.

Similarly, transfer operations inside command buffers can take a temporary shared ownership over resources. If a command queue waits for a fence, all completed command buffers are asked to release the references shared this way. This is useful to implement "fire-and-forget" buffers, for example for staging purposes.

To make this possible, all command buffers are stored in shared pointers by default and the command queue only accepts shared command buffer pointers on submission. For resources, shared ownership can be enabled using `asShared`.