### PR TITLE
Ensure valid image dimensions.

### DIFF
--- a/docs/release-logs/0.4.1.md
+++ b/docs/release-logs/0.4.1.md
@@ -11,3 +11,4 @@
 - Raise minimum Vulkan SDK version to 1.3.204.1. ([See PR #86](https://github.com/crud89/LiteFX/pull/86) and [See PR #88](https://github.com/crud89/LiteFX/pull/88))
 - Make most of the render pipeline state dynamic. ([See PR #86](https://github.com/crud89/LiteFX/pull/86))
 - Vector conversion to math types can now be done for constant vectors. ([See PR #87](https://github.com/crud89/LiteFX/pull/87))
+- Minor fix where it was previously possible to allocate images with a dimension of 0. ([See PR #90](https://github.com/crud89/LiteFX/pull/90))

--- a/src/Backends/Vulkan/src/swapchain.cpp
+++ b/src/Backends/Vulkan/src/swapchain.cpp
@@ -73,8 +73,8 @@ public:
 		createInfo.compositeAlpha = VK_COMPOSITE_ALPHA_OPAQUE_BIT_KHR;
 		createInfo.clipped = VK_TRUE;
 		createInfo.oldSwapchain = VK_NULL_HANDLE;
-		createInfo.imageExtent.height = std::clamp(static_cast<UInt32>(renderArea.height()), deviceCaps.minImageExtent.height, deviceCaps.maxImageExtent.height);
-		createInfo.imageExtent.width = std::clamp(static_cast<UInt32>(renderArea.width()), deviceCaps.minImageExtent.width, deviceCaps.maxImageExtent.width);
+		createInfo.imageExtent.height = std::max<UInt32>(1, std::clamp(static_cast<UInt32>(renderArea.height()), deviceCaps.minImageExtent.height, deviceCaps.maxImageExtent.height));
+		createInfo.imageExtent.width = std::max<UInt32>(1, std::clamp(static_cast<UInt32>(renderArea.width()), deviceCaps.minImageExtent.width, deviceCaps.maxImageExtent.width));
 
 		// Set the present mode to VK_PRESENT_MODE_MAILBOX_KHR, since it offers best performance without tearing. For VSync use VK_PRESENT_MODE_FIFO_KHR, which is also the only one guaranteed to be available.
 		createInfo.presentMode = VK_PRESENT_MODE_MAILBOX_KHR;
@@ -470,7 +470,7 @@ public:
 				.pNext = &wrapperInfo,
 				.imageType = VK_IMAGE_TYPE_2D,
 				.format = Vk::getFormat(format),
-				.extent = { static_cast<UInt32>(renderArea.width()), static_cast<UInt32>(renderArea.height()), 1 },
+				.extent = { std::max<UInt32>(1, renderArea.width()), std::max<UInt32>(1, renderArea.height()), 1 },
 				.mipLevels = 1,
 				.arrayLayers = 1,
 				.samples = VK_SAMPLE_COUNT_1_BIT,
@@ -531,7 +531,7 @@ public:
 			m_imageResources[image].handle = resourceHandle;
 			m_imageResources[image].image = std::move(resource);
 
-			return makeUnique<VulkanImage>(m_device, backBuffer, Size3d { renderArea.width(), renderArea.height(), 1 }, format, ImageDimensions::DIM_2, 1, 1, MultiSamplingLevel::x1, false, ResourceState::Present);
+			return makeUnique<VulkanImage>(m_device, backBuffer, Size3d { imageInfo.extent.width, imageInfo.extent.height, imageInfo.extent.depth }, format, ImageDimensions::DIM_2, 1, 1, MultiSamplingLevel::x1, false, ResourceState::Present);
 		});
 
 		// Destroy the image swap semaphores.


### PR DESCRIPTION
**Describe the pull request**

Currently, it is possible to allocate images with a dimension (width, height and/or depth) set to 0, which is not valid, since it would yield an empty memory block. Although this only produces warnings on most hardware, we should clamp image dimensions to 1 in any direction. This PR implements such clamping.