### PR TITLE
Expose contra-variant interface in sub-classes.

### DIFF
--- a/docs/release-logs/0.4.1.md
+++ b/docs/release-logs/0.4.1.md
@@ -11,3 +11,4 @@
 - Raise minimum Vulkan SDK version to 1.3.204.1. ([See PR #86](https://github.com/crud89/LiteFX/pull/86) and [See PR #88](https://github.com/crud89/LiteFX/pull/88))
 - Make most of the render pipeline state dynamic. ([See PR #86](https://github.com/crud89/LiteFX/pull/86))
 - Vector conversion to math types can now be done for constant vectors. ([See PR #87](https://github.com/crud89/LiteFX/pull/87))
+- Backend types now import contra-variant interface functions instead of hiding them. ([See PR #91](https://github.com/crud89/LiteFX/pull/91))

--- a/src/Backends/DirectX12/include/litefx/backends/dx12.hpp
+++ b/src/Backends/DirectX12/include/litefx/backends/dx12.hpp
@@ -155,6 +155,11 @@ namespace LiteFX::Rendering::Backends {
 		LITEFX_IMPLEMENTATION(DirectX12BarrierImpl);
 
 	public:
+		using base_type = Barrier<IDirectX12Buffer, IDirectX12Image>;
+		using base_type::transition;
+		using base_type::waitFor;
+
+	public:
 		explicit DirectX12Barrier() noexcept;
 		DirectX12Barrier(const DirectX12Barrier&) = delete;
 		DirectX12Barrier(DirectX12Barrier&&) = delete;
@@ -318,6 +323,11 @@ namespace LiteFX::Rendering::Backends {
 		LITEFX_IMPLEMENTATION(DirectX12DescriptorSetImpl);
 
 	public:
+		using base_type = DescriptorSet<IDirectX12Buffer, IDirectX12Image, IDirectX12Sampler>;
+		using base_type::update;
+		using base_type::attach;
+
+	public:
 		/// <summary>
 		/// Initializes a new descriptor set.
 		/// </summary>
@@ -441,6 +451,10 @@ namespace LiteFX::Rendering::Backends {
 		friend class DirectX12PipelineLayout;
 
 	public:
+		using base_type = DescriptorSetLayout<DirectX12DescriptorLayout, DirectX12DescriptorSet>;
+		using base_type::free;
+
+	public:
 		/// <summary>
 		/// Initializes a DirectX 12 descriptor set layout.
 		/// </summary>
@@ -534,10 +548,22 @@ namespace LiteFX::Rendering::Backends {
 
 	public:
 		/// <inheritdoc />
-		virtual UniquePtr<DirectX12DescriptorSet> allocate(const UInt32& descriptors = 0) const override;
+		virtual UniquePtr<DirectX12DescriptorSet> allocate(const Array<DescriptorBinding>& bindings = { }) const override;
 
 		/// <inheritdoc />
-		virtual Array<UniquePtr<DirectX12DescriptorSet>> allocateMultiple(const UInt32& descriptorSets, const UInt32& descriptors = 0) const override;
+		virtual UniquePtr<DirectX12DescriptorSet> allocate(const UInt32& descriptors, const Array<DescriptorBinding>& bindings = { }) const override;
+
+		/// <inheritdoc />
+		virtual Array<UniquePtr<DirectX12DescriptorSet>> allocateMultiple(const UInt32& descriptorSets, const Array<Array<DescriptorBinding>>& bindings = { }) const override;
+
+		/// <inheritdoc />
+		virtual Array<UniquePtr<DirectX12DescriptorSet>> allocateMultiple(const UInt32& descriptorSets, std::function<Array<DescriptorBinding>(const UInt32&)> bindingFactory) const override;
+
+		/// <inheritdoc />
+		virtual Array<UniquePtr<DirectX12DescriptorSet>> allocateMultiple(const UInt32& descriptorSets, const UInt32& descriptors, const Array<Array<DescriptorBinding>>& bindings = { }) const override;
+
+		/// <inheritdoc />
+		virtual Array<UniquePtr<DirectX12DescriptorSet>> allocateMultiple(const UInt32& descriptorSets, const UInt32& descriptors, std::function<Array<DescriptorBinding>(const UInt32&)> bindingFactory) const override;
 
 		/// <inheritdoc />
 		virtual void free(const DirectX12DescriptorSet& descriptorSet) const noexcept override;
@@ -788,6 +814,18 @@ namespace LiteFX::Rendering::Backends {
 	/// <seealso cref="DirectX12CommandQueue" />
 	class LITEFX_DIRECTX12_API DirectX12CommandBuffer : public CommandBuffer<IDirectX12Buffer, IDirectX12VertexBuffer, IDirectX12IndexBuffer, IDirectX12Image, DirectX12Barrier, DirectX12PipelineState>, public ComResource<ID3D12GraphicsCommandList4> {
 		LITEFX_IMPLEMENTATION(DirectX12CommandBufferImpl);
+
+	public:
+		using base_type = CommandBuffer<IDirectX12Buffer, IDirectX12VertexBuffer, IDirectX12IndexBuffer, IDirectX12Image, DirectX12Barrier, DirectX12PipelineState>;
+		using base_type::dispatch;
+		using base_type::draw;
+		using base_type::drawIndexed;
+		using base_type::barrier;
+		using base_type::transfer;
+		using base_type::generateMipMaps;
+		using base_type::bind;
+		using base_type::use;
+		using base_type::pushConstants;
 
 	public:
 		/// <summary>
@@ -1073,6 +1111,10 @@ namespace LiteFX::Rendering::Backends {
 		LITEFX_BUILDER(DirectX12RenderPassBuilder);
 
 	public:
+		using base_type = RenderPass<DirectX12RenderPipeline, DirectX12FrameBuffer, DirectX12InputAttachmentMapping>;
+		using base_type::updateAttachments;
+
+	public:
 		/// <summary>
 		/// Creates and initializes a new DirectX 12 render pass instance.
 		/// </summary>
@@ -1227,6 +1269,10 @@ namespace LiteFX::Rendering::Backends {
 		LITEFX_IMPLEMENTATION(DirectX12SwapChainImpl);
 
 	public:
+		using base_type = SwapChain<IDirectX12Image, DirectX12FrameBuffer>;
+		using base_type::present;
+
+	public:
 		/// <summary>
 		/// Initializes a DirectX 12 swap chain.
 		/// </summary>
@@ -1281,6 +1327,10 @@ namespace LiteFX::Rendering::Backends {
 	/// <seealso cref="DirectX12CommandBuffer" />
 	class LITEFX_DIRECTX12_API DirectX12Queue : public CommandQueue<DirectX12CommandBuffer>, public ComResource<ID3D12CommandQueue> {
 		LITEFX_IMPLEMENTATION(DirectX12QueueImpl);
+
+	public:
+		using base_type = CommandQueue<DirectX12CommandBuffer>;
+		using base_type::submit;
 
 	public:
 		/// <summary>
@@ -1356,6 +1406,17 @@ namespace LiteFX::Rendering::Backends {
 	/// </remarks>
 	class LITEFX_DIRECTX12_API DirectX12GraphicsFactory : public GraphicsFactory<DirectX12DescriptorLayout, IDirectX12Buffer, IDirectX12VertexBuffer, IDirectX12IndexBuffer, IDirectX12Image, IDirectX12Sampler> {
 		LITEFX_IMPLEMENTATION(DirectX12GraphicsFactoryImpl);
+
+	public:
+		using base_type = GraphicsFactory<DirectX12DescriptorLayout, IDirectX12Buffer, IDirectX12VertexBuffer, IDirectX12IndexBuffer, IDirectX12Image, IDirectX12Sampler>;
+		using base_type::createBuffer;
+		using base_type::createVertexBuffer;
+		using base_type::createIndexBuffer;
+		using base_type::createAttachment;
+		using base_type::createTexture;
+		using base_type::createTextures;
+		using base_type::createSampler;
+		using base_type::createSamplers;
 
 	public:
 		/// <summary>

--- a/src/Backends/DirectX12/src/descriptor_set_layout.cpp
+++ b/src/Backends/DirectX12/src/descriptor_set_layout.cpp
@@ -227,19 +227,52 @@ UInt32 DirectX12DescriptorSetLayout::inputAttachments() const noexcept
     return std::ranges::count_if(m_impl->m_layouts, [](const UniquePtr<DirectX12DescriptorLayout>& layout) { return layout->descriptorType() == DescriptorType::InputAttachment; });
 }
 
-UniquePtr<DirectX12DescriptorSet> DirectX12DescriptorSetLayout::allocate(const UInt32& descriptors) const
+UniquePtr<DirectX12DescriptorSet> DirectX12DescriptorSetLayout::allocate(const Array<DescriptorBinding>& bindings) const
 {
+    return this->allocate(0, bindings);
+}
+
+UniquePtr<DirectX12DescriptorSet> DirectX12DescriptorSetLayout::allocate(const UInt32& descriptors, const Array<DescriptorBinding>& bindings) const
+{
+    // Allocate the descriptor set.
     std::lock_guard<std::mutex> lock(m_impl->m_mutex);
     ComPtr<ID3D12DescriptorHeap> bufferHeap, samplerHeap;
     m_impl->tryAllocate(bufferHeap, samplerHeap, descriptors);
+    auto descriptorSet = makeUnique<DirectX12DescriptorSet>(*this, std::move(bufferHeap), std::move(samplerHeap));
 
-    return makeUnique<DirectX12DescriptorSet>(*this, std::move(bufferHeap), std::move(samplerHeap));
+    // Apply the default bindings.
+    for (auto& binding : bindings)
+        std::visit(type_switch{
+            [&descriptorSet, &binding](const ISampler& sampler) { descriptorSet->update(binding.binding, sampler, binding.firstDescriptor); },
+            [&descriptorSet, &binding](const IBuffer& buffer) { descriptorSet->update(binding.binding, buffer, binding.firstElement, binding.elements, binding.firstDescriptor); },
+            [&descriptorSet, &binding](const IImage& image) { descriptorSet->update(binding.binding, image, binding.firstDescriptor, binding.firstLevel, binding.levels, binding.firstElement, binding.elements); }
+        }, binding.resource);
+
+    // Return the descriptor set.
+    return descriptorSet;
 }
 
-Array<UniquePtr<DirectX12DescriptorSet>> DirectX12DescriptorSetLayout::allocateMultiple(const UInt32& count, const UInt32& descriptors) const
+Array<UniquePtr<DirectX12DescriptorSet>> DirectX12DescriptorSetLayout::allocateMultiple(const UInt32& descriptorSets, const Array<Array<DescriptorBinding>>& bindings) const
+{
+    return this->allocateMultiple(descriptorSets, 0, bindings);
+}
+
+Array<UniquePtr<DirectX12DescriptorSet>> DirectX12DescriptorSetLayout::allocateMultiple(const UInt32& descriptorSets, std::function<Array<DescriptorBinding>(const UInt32&)> bindingFactory) const
+{
+    return this->allocateMultiple(descriptorSets, 0, bindingFactory);
+}
+
+Array<UniquePtr<DirectX12DescriptorSet>> DirectX12DescriptorSetLayout::allocateMultiple(const UInt32& count, const UInt32& descriptors, const Array<Array<DescriptorBinding>>& bindings) const
 {
     Array<UniquePtr<DirectX12DescriptorSet>> descriptorSets(count);
-    std::ranges::generate(descriptorSets, [this, descriptors]() { return this->allocate(descriptors); });
+    std::ranges::generate(descriptorSets, [this, descriptors, bindings, i = 0]() mutable { return i < bindings.size() ? this->allocate(descriptors, bindings[i]) : this->allocate(descriptors, { }); });
+    return descriptorSets;
+}
+
+Array<UniquePtr<DirectX12DescriptorSet>> DirectX12DescriptorSetLayout::allocateMultiple(const UInt32& count, const UInt32& descriptors, std::function<Array<DescriptorBinding>(const UInt32&)> bindingFactory) const
+{
+    Array<UniquePtr<DirectX12DescriptorSet>> descriptorSets(count);
+    std::ranges::generate(descriptorSets, [this, descriptors, bindingFactory, i = 0]() mutable { return this->allocate(descriptors, bindingFactory(i)); });
     return descriptorSets;
 }
 

--- a/src/Backends/Vulkan/include/litefx/backends/vulkan.hpp
+++ b/src/Backends/Vulkan/include/litefx/backends/vulkan.hpp
@@ -180,6 +180,11 @@ namespace LiteFX::Rendering::Backends {
 		LITEFX_IMPLEMENTATION(VulkanBarrierImpl);
 
 	public:
+		using base_type = Barrier<IVulkanBuffer, IVulkanImage>;
+		using base_type::transition;
+		using base_type::waitFor;
+
+	public:
 		/// <summary>
 		/// Initializes a new Vulkan barrier.
 		/// </summary>
@@ -344,6 +349,11 @@ namespace LiteFX::Rendering::Backends {
 		LITEFX_IMPLEMENTATION(VulkanDescriptorSetImpl);
 
 	public:
+		using base_type = DescriptorSet<IVulkanBuffer, IVulkanImage, IVulkanSampler>;
+		using base_type::update;
+		using base_type::attach;
+
+	public:
 		/// <summary>
 		/// Initializes a new descriptor set.
 		/// </summary>
@@ -441,6 +451,10 @@ namespace LiteFX::Rendering::Backends {
 		LITEFX_BUILDER(VulkanDescriptorSetLayoutBuilder);
 
 	public:
+		using base_type = DescriptorSetLayout<VulkanDescriptorLayout, VulkanDescriptorSet>;
+		using base_type::free;
+
+	public:
 		/// <summary>
 		/// Initializes a Vulkan descriptor set layout.
 		/// </summary>
@@ -510,10 +524,22 @@ namespace LiteFX::Rendering::Backends {
 
 	public:
 		/// <inheritdoc />
-		virtual UniquePtr<VulkanDescriptorSet> allocate(const UInt32& descriptors = 0) const override;
+		virtual UniquePtr<VulkanDescriptorSet> allocate(const Array<DescriptorBinding>& bindings = { }) const override;
 
 		/// <inheritdoc />
-		virtual Array<UniquePtr<VulkanDescriptorSet>> allocateMultiple(const UInt32& descriptorSets, const UInt32& descriptors = 0) const override;
+		virtual UniquePtr<VulkanDescriptorSet> allocate(const UInt32& descriptors, const Array<DescriptorBinding>& bindings = { }) const override;
+
+		/// <inheritdoc />
+		virtual Array<UniquePtr<VulkanDescriptorSet>> allocateMultiple(const UInt32& descriptorSets, const Array<Array<DescriptorBinding>>& bindings = { }) const override;
+
+		/// <inheritdoc />
+		virtual Array<UniquePtr<VulkanDescriptorSet>> allocateMultiple(const UInt32& descriptorSets, std::function<Array<DescriptorBinding>(const UInt32&)> bindingFactory) const override;
+
+		/// <inheritdoc />
+		virtual Array<UniquePtr<VulkanDescriptorSet>> allocateMultiple(const UInt32& descriptorSets, const UInt32& descriptors, const Array<Array<DescriptorBinding>>& bindings = { }) const override;
+
+		/// <inheritdoc />
+		virtual Array<UniquePtr<VulkanDescriptorSet>> allocateMultiple(const UInt32& descriptorSets, const UInt32& descriptors, std::function<Array<DescriptorBinding>(const UInt32&)> bindingFactory) const override;
 
 		/// <inheritdoc />
 		virtual void free(const VulkanDescriptorSet& descriptorSet) const noexcept override;
@@ -803,6 +829,18 @@ namespace LiteFX::Rendering::Backends {
 		LITEFX_IMPLEMENTATION(VulkanCommandBufferImpl);
 
 	public:
+		using base_type = CommandBuffer<IVulkanBuffer, IVulkanVertexBuffer, IVulkanIndexBuffer, IVulkanImage, VulkanBarrier, VulkanPipelineState>;
+		using base_type::dispatch;
+		using base_type::draw;
+		using base_type::drawIndexed;
+		using base_type::barrier;
+		using base_type::transfer;
+		using base_type::generateMipMaps;
+		using base_type::bind;
+		using base_type::use;
+		using base_type::pushConstants;
+
+	public:
 		/// <summary>
 		/// Initializes a command buffer from a command queue.
 		/// </summary>
@@ -1075,6 +1113,10 @@ namespace LiteFX::Rendering::Backends {
 		LITEFX_BUILDER(VulkanRenderPassBuilder);
 
 	public:
+		using base_type = RenderPass<VulkanRenderPipeline, VulkanFrameBuffer, VulkanInputAttachmentMapping>;
+		using base_type::updateAttachments;
+
+	public:
 		/// <summary>
 		/// Creates and initializes a new Vulkan render pass instance.
 		/// </summary>
@@ -1229,6 +1271,10 @@ namespace LiteFX::Rendering::Backends {
 		LITEFX_IMPLEMENTATION(VulkanSwapChainImpl);
 
 	public:
+		using base_type = SwapChain<IVulkanImage, VulkanFrameBuffer>;
+		using base_type::present;
+
+	public:
 		/// <summary>
 		/// Initializes a Vulkan swap chain.
 		/// </summary>
@@ -1283,7 +1329,11 @@ namespace LiteFX::Rendering::Backends {
 	/// <seealso cref="VulkanCommandBuffer" />
 	class LITEFX_VULKAN_API VulkanQueue : public CommandQueue<VulkanCommandBuffer>, public Resource<VkQueue> {
 		LITEFX_IMPLEMENTATION(VulkanQueueImpl);
-	
+
+	public:
+		using base_type = CommandQueue<VulkanCommandBuffer>;
+		using base_type::submit;
+
 	public:
 		/// <summary>
 		/// Initializes the Vulkan command queue.
@@ -1426,6 +1476,17 @@ namespace LiteFX::Rendering::Backends {
 	/// </remarks>
 	class LITEFX_VULKAN_API VulkanGraphicsFactory : public GraphicsFactory<VulkanDescriptorLayout, IVulkanBuffer, IVulkanVertexBuffer, IVulkanIndexBuffer, IVulkanImage, IVulkanSampler> {
 		LITEFX_IMPLEMENTATION(VulkanGraphicsFactoryImpl);
+
+	public:
+		using base_type = GraphicsFactory<VulkanDescriptorLayout, IVulkanBuffer, IVulkanVertexBuffer, IVulkanIndexBuffer, IVulkanImage, IVulkanSampler>;
+		using base_type::createBuffer;
+		using base_type::createVertexBuffer;
+		using base_type::createIndexBuffer;
+		using base_type::createAttachment;
+		using base_type::createTexture;
+		using base_type::createTextures;
+		using base_type::createSampler;
+		using base_type::createSamplers;
 
 	public:
 		/// <summary>

--- a/src/Backends/Vulkan/src/descriptor_set_layout.cpp
+++ b/src/Backends/Vulkan/src/descriptor_set_layout.cpp
@@ -314,25 +314,60 @@ UInt32 VulkanDescriptorSetLayout::inputAttachments() const noexcept
     return m_impl->m_poolSizes[VK_DESCRIPTOR_TYPE_INPUT_ATTACHMENT].descriptorCount;
 }
 
-UniquePtr<VulkanDescriptorSet> VulkanDescriptorSetLayout::allocate(const UInt32& descriptors) const
+UniquePtr<VulkanDescriptorSet> VulkanDescriptorSetLayout::allocate(const Array<DescriptorBinding>& bindings) const
+{
+    return this->allocate(0, bindings);
+}
+
+UniquePtr<VulkanDescriptorSet> VulkanDescriptorSetLayout::allocate(const UInt32& descriptors, const Array<DescriptorBinding>& bindings) const
 {
     std::lock_guard<std::mutex> lock(m_impl->m_mutex);
 
     // If no descriptor sets are free, or the descriptor set contains an unbounded descriptor array, allocate a new descriptor set.
-    if (m_impl->m_usesDescriptorIndexing || m_impl->m_freeDescriptorSets.empty())
-        return makeUnique<VulkanDescriptorSet>(*this, m_impl->tryAllocate(descriptors));
-    
-    // Otherwise, pick and remove one from the list.
-    auto descriptorSet = makeUnique<VulkanDescriptorSet>(*this, m_impl->m_freeDescriptorSets.front());
-    m_impl->m_freeDescriptorSets.pop();
+    UniquePtr<VulkanDescriptorSet> descriptorSet;
 
+    if (m_impl->m_usesDescriptorIndexing || m_impl->m_freeDescriptorSets.empty())
+        descriptorSet = makeUnique<VulkanDescriptorSet>(*this, m_impl->tryAllocate(descriptors));
+    else
+    {
+        // Otherwise, pick and remove one from the list.
+        descriptorSet = makeUnique<VulkanDescriptorSet>(*this, m_impl->m_freeDescriptorSets.front());
+        m_impl->m_freeDescriptorSets.pop();
+    }
+
+    // Apply the default bindings.
+    for (auto& binding : bindings)
+        std::visit(type_switch{
+            [&descriptorSet, &binding](const ISampler& sampler) { descriptorSet->update(binding.binding, sampler, binding.firstDescriptor); },
+            [&descriptorSet, &binding](const IBuffer& buffer) { descriptorSet->update(binding.binding, buffer, binding.firstElement, binding.elements, binding.firstDescriptor); },
+            [&descriptorSet, &binding](const IImage& image) { descriptorSet->update(binding.binding, image, binding.firstDescriptor, binding.firstLevel, binding.levels, binding.firstElement, binding.elements); }
+        }, binding.resource);
+
+    // Return the descriptor set.
     return descriptorSet;
 }
 
-Array<UniquePtr<VulkanDescriptorSet>> VulkanDescriptorSetLayout::allocateMultiple(const UInt32& count, const UInt32& descriptors) const
+Array<UniquePtr<VulkanDescriptorSet>> VulkanDescriptorSetLayout::allocateMultiple(const UInt32& descriptorSets, const Array<Array<DescriptorBinding>>& bindings) const
+{
+    return this->allocateMultiple(descriptorSets, 0, bindings);
+}
+
+Array<UniquePtr<VulkanDescriptorSet>> VulkanDescriptorSetLayout::allocateMultiple(const UInt32& descriptorSets, std::function<Array<DescriptorBinding>(const UInt32&)> bindingFactory) const
+{
+    return this->allocateMultiple(descriptorSets, 0, bindingFactory);
+}
+
+Array<UniquePtr<VulkanDescriptorSet>> VulkanDescriptorSetLayout::allocateMultiple(const UInt32& count, const UInt32& descriptors, const Array<Array<DescriptorBinding>>& bindings) const
 {
     Array<UniquePtr<VulkanDescriptorSet>> descriptorSets(count);
-    std::ranges::generate(descriptorSets, [this, descriptors]() { return this->allocate(descriptors); });
+    std::ranges::generate(descriptorSets, [this, descriptors, bindings, i = 0]() mutable { return i < bindings.size() ? this->allocate(descriptors, bindings[i]) : this->allocate(descriptors, { }); });
+    return descriptorSets;
+}
+
+Array<UniquePtr<VulkanDescriptorSet>> VulkanDescriptorSetLayout::allocateMultiple(const UInt32& count, const UInt32& descriptors, std::function<Array<DescriptorBinding>(const UInt32&)> bindingFactory) const
+{
+    Array<UniquePtr<VulkanDescriptorSet>> descriptorSets(count);
+    std::ranges::generate(descriptorSets, [this, descriptors, bindingFactory, i = 0]() mutable { return this->allocate(descriptors, bindingFactory(i)); });
     return descriptorSets;
 }
 

--- a/src/Rendering/include/litefx/rendering.hpp
+++ b/src/Rendering/include/litefx/rendering.hpp
@@ -18,6 +18,9 @@ namespace LiteFX::Rendering {
         std::derived_from<TImage, IImage>
     class Barrier : public IBarrier {
     public:
+        using IBarrier::transition;
+        using IBarrier::waitFor;
+
         using buffer_type = TBuffer;
         using image_type = TImage;
 
@@ -168,6 +171,9 @@ namespace LiteFX::Rendering {
         std::derived_from<TImage, IImage>
     class DescriptorSet : public IDescriptorSet {
     public:
+        using IDescriptorSet::attach;
+        using IDescriptorSet::update;
+
         using buffer_type = TBuffer;
         using sampler_type = TSampler;
         using image_type = TImage;
@@ -223,6 +229,8 @@ namespace LiteFX::Rendering {
         rtti::implements<TDescriptorSet, DescriptorSet<typename TDescriptorSet::buffer_type, typename TDescriptorSet::image_type, typename TDescriptorSet::sampler_type>>
     class DescriptorSetLayout : public IDescriptorSetLayout {
     public:
+        using IDescriptorSetLayout::free;
+
         using descriptor_layout_type = TDescriptorLayout;
         using descriptor_set_type = TDescriptorSet;
 
@@ -237,10 +245,22 @@ namespace LiteFX::Rendering {
         virtual const descriptor_layout_type& descriptor(const UInt32& binding) const = 0;
 
         /// <inheritdoc />
-        virtual UniquePtr<descriptor_set_type> allocate(const UInt32& descriptors = 0) const = 0;
+        virtual UniquePtr<descriptor_set_type> allocate(const Array<DescriptorBinding>& bindings = { }) const = 0;
 
         /// <inheritdoc />
-        virtual Array<UniquePtr<descriptor_set_type>> allocateMultiple(const UInt32& descriptorSets, const UInt32& descriptors = 0) const = 0;
+        virtual UniquePtr<descriptor_set_type> allocate(const UInt32& descriptors, const Array<DescriptorBinding>& bindings = { }) const = 0;
+
+        /// <inheritdoc />
+        virtual Array<UniquePtr<descriptor_set_type>> allocateMultiple(const UInt32& descriptorSets, const Array<Array<DescriptorBinding>>& bindings = { }) const = 0;
+
+        /// <inheritdoc />
+        virtual Array<UniquePtr<descriptor_set_type>> allocateMultiple(const UInt32& descriptorSets, std::function<Array<DescriptorBinding>(const UInt32&)> bindingFactory) const = 0;
+
+        /// <inheritdoc />
+        virtual Array<UniquePtr<descriptor_set_type>> allocateMultiple(const UInt32& descriptorSets, const UInt32& descriptors, const Array<Array<DescriptorBinding>>& bindings = { }) const = 0;
+
+        /// <inheritdoc />
+        virtual Array<UniquePtr<descriptor_set_type>> allocateMultiple(const UInt32& descriptorSets, const UInt32& descriptors, std::function<Array<DescriptorBinding>(const UInt32&)> bindingFactory) const = 0;
 
         /// <inheritdoc />
         virtual void free(const descriptor_set_type& descriptorSet) const noexcept = 0;
@@ -251,12 +271,20 @@ namespace LiteFX::Rendering {
             return Array<const IDescriptorLayout*>(descriptors.begin(), descriptors.end());
         }
 
-        virtual UniquePtr<IDescriptorSet> getDescriptorSet(const UInt32& descriptors) const override {
-            return this->allocate(descriptors);
+        virtual UniquePtr<IDescriptorSet> getDescriptorSet(const UInt32& descriptors, const Array<DescriptorBinding>& bindings = { }) const override {
+            return this->allocate(descriptors, bindings);
         }
 
-        virtual Array<UniquePtr<IDescriptorSet>> getDescriptorSets(const UInt32& descriptorSets, const UInt32& descriptors) const override {
-            auto sets = this->allocateMultiple(descriptorSets, descriptors);
+        virtual Array<UniquePtr<IDescriptorSet>> getDescriptorSets(const UInt32& descriptorSets, const UInt32& descriptors, const Array<Array<DescriptorBinding>>& bindings = { }) const override {
+            auto sets = this->allocateMultiple(descriptorSets, descriptors, bindings);
+            Array<UniquePtr<IDescriptorSet>> results;
+            results.reserve(sets.size());
+            std::move(sets.begin(), sets.end(), std::inserter(results, results.end()));
+            return results;
+        }
+
+        virtual Array<UniquePtr<IDescriptorSet>> getDescriptorSets(const UInt32& descriptorSets, const UInt32& descriptors, std::function<Array<DescriptorBinding>(const UInt32&)> bindingFactory) const override {
+            auto sets = this->allocateMultiple(descriptorSets, descriptors, bindingFactory);
             Array<UniquePtr<IDescriptorSet>> results;
             results.reserve(sets.size());
             std::move(sets.begin(), sets.end(), std::inserter(results, results.end()));
@@ -486,11 +514,16 @@ namespace LiteFX::Rendering {
         rtti::implements<TBarrier, Barrier<TBuffer, TImage>> &&
         std::derived_from<TPipeline, Pipeline<typename TPipeline::pipeline_layout_type, typename TPipeline::shader_program_type>>
     class CommandBuffer : public ICommandBuffer {
-        using ICommandBuffer::begin;
-        using ICommandBuffer::end;
+    public:
         using ICommandBuffer::dispatch;
         using ICommandBuffer::draw;
         using ICommandBuffer::drawIndexed;
+        using ICommandBuffer::barrier;
+        using ICommandBuffer::transfer;
+        using ICommandBuffer::generateMipMaps;
+        using ICommandBuffer::bind;
+        using ICommandBuffer::use;
+        using ICommandBuffer::pushConstants;
 
     public:
         using buffer_type = TBuffer;
@@ -786,6 +819,8 @@ namespace LiteFX::Rendering {
         rtti::implements<TInputAttachmentMapping, IInputAttachmentMapping<TDerived>>*/
     class RenderPass : public virtual StateResource, public IRenderPass, public IInputAttachmentMappingSource<TFrameBuffer> {
     public:
+        using IRenderPass::updateAttachments;
+
         using frame_buffer_type = TFrameBuffer;
         using render_pipeline_type = TRenderPipeline;
         using input_attachment_mapping_type = TInputAttachmentMapping;
@@ -873,6 +908,8 @@ namespace LiteFX::Rendering {
         rtti::implements<TCommandBuffer, CommandBuffer<typename TCommandBuffer::buffer_type, typename TCommandBuffer::vertex_buffer_type, typename TCommandBuffer::index_buffer_type, typename TCommandBuffer::image_type, typename TCommandBuffer::barrier_type, typename TCommandBuffer::pipeline_type>>
     class CommandQueue : public ICommandQueue {
     public:
+        using ICommandQueue::submit;
+
         using command_buffer_type = TCommandBuffer;
 
     public:
@@ -929,6 +966,15 @@ namespace LiteFX::Rendering {
         std::derived_from<TSampler, ISampler>
     class GraphicsFactory : public IGraphicsFactory {
     public:
+        using IGraphicsFactory::createBuffer;
+        using IGraphicsFactory::createVertexBuffer;
+        using IGraphicsFactory::createIndexBuffer;
+        using IGraphicsFactory::createAttachment;
+        using IGraphicsFactory::createTexture;
+        using IGraphicsFactory::createTextures;
+        using IGraphicsFactory::createSampler;
+        using IGraphicsFactory::createSamplers;
+
         using descriptor_layout_type = TDescriptorLayout;
         using vertex_buffer_type = TVertexBuffer;
         using vertex_buffer_layout_type = vertex_buffer_type::vertex_buffer_layout_type;

--- a/src/Rendering/include/litefx/rendering_api.hpp
+++ b/src/Rendering/include/litefx/rendering_api.hpp
@@ -3327,19 +3327,7 @@ namespace LiteFX::Rendering {
         /// <returns>The instance of the descriptor set.</returns>
         /// <seealso cref="IDescriptorLayout" />
         UniquePtr<IDescriptorSet> allocate(const UInt32& descriptors, const Array<DescriptorBinding>& bindings = { }) const {
-            // Allocate a descriptor set.
-            auto descriptorSet = this->getDescriptorSet(descriptors);
-
-            // Automatically apply the bindings.
-            for (auto& binding : bindings)
-                std::visit(type_switch {
-                    [&descriptorSet, &binding](const ISampler& sampler) { descriptorSet->update(binding.binding, sampler, binding.firstDescriptor); },
-                    [&descriptorSet, &binding](const IBuffer& buffer) { descriptorSet->update(binding.binding, buffer, binding.firstElement, binding.elements, binding.firstDescriptor); },
-                    [&descriptorSet, &binding](const IImage& image) { descriptorSet->update(binding.binding, image, binding.firstDescriptor, binding.firstLevel, binding.levels, binding.firstElement, binding.elements); }
-                }, binding.resource);
-
-            // Return the descriptor set.
-            return descriptorSet;
+            return this->getDescriptorSet(descriptors, bindings);
         }
 
         /// <summary>
@@ -3373,23 +3361,7 @@ namespace LiteFX::Rendering {
         /// <returns>The array of descriptor set instances.</returns>
         /// <seealso cref="allocate" />
         Array<UniquePtr<IDescriptorSet>> allocateMultiple(const UInt32& descriptorSets, const UInt32& descriptors, const Array<Array<DescriptorBinding>>& bindings = { }) const {
-            // Allocate the descriptor sets.
-            auto sets = this->getDescriptorSets(descriptorSets, descriptors);
-
-            // Automatically apply the bindings.
-            for (size_t i(0); i < bindings.size() && i < descriptorSets; ++i) {
-                auto& descriptorSet = sets[i];
-
-                for (auto& binding : bindings[i])
-                    std::visit(type_switch {
-                        [&descriptorSet, &binding](const ISampler& sampler) { descriptorSet->update(binding.binding, sampler, binding.firstDescriptor); },
-                        [&descriptorSet, &binding](const IBuffer& buffer) { descriptorSet->update(binding.binding, buffer, binding.firstElement, binding.elements, binding.firstDescriptor); },
-                        [&descriptorSet, &binding](const IImage& image) { descriptorSet->update(binding.binding, image, binding.firstDescriptor, binding.firstLevel, binding.levels, binding.firstElement, binding.elements); }
-                    }, binding.resource);
-            }
-
-            // Return the descriptor sets.
-            return sets;
+            return this->getDescriptorSets(descriptorSets, descriptors, bindings);
         }
 
         /// <summary>
@@ -3401,24 +3373,7 @@ namespace LiteFX::Rendering {
         /// <returns>The array of descriptor set instances.</returns>
         /// <seealso cref="allocate" />
         Array<UniquePtr<IDescriptorSet>> allocateMultiple(const UInt32& descriptorSets, const UInt32& descriptors, std::function<Array<DescriptorBinding>(const UInt32&)> bindingFactory) const {
-            // Allocate the descriptor sets.
-            auto sets = this->getDescriptorSets(descriptorSets, descriptors);
-
-            // Automatically apply the bindings.
-            for (size_t i(0); i < descriptorSets; ++i) {
-                auto& descriptorSet = sets[i];
-                auto bindings = bindingFactory(i);
-
-                for (auto& binding : bindings)
-                    std::visit(type_switch {
-                        [&descriptorSet, &binding](const ISampler& sampler) { descriptorSet->update(binding.binding, sampler, binding.firstDescriptor); },
-                        [&descriptorSet, &binding](const IBuffer& buffer) { descriptorSet->update(binding.binding, buffer, binding.firstElement, binding.elements, binding.firstDescriptor); },
-                        [&descriptorSet, &binding](const IImage& image) { descriptorSet->update(binding.binding, image, binding.firstDescriptor, binding.firstLevel, binding.levels, binding.firstElement, binding.elements); }
-                    }, binding.resource);
-            }
-
-            // Return the descriptor sets.
-            return sets;
+            return this->getDescriptorSets(descriptorSets, descriptors, bindingFactory);
         }
 
         /// <summary>
@@ -3431,8 +3386,9 @@ namespace LiteFX::Rendering {
 
     private:
         virtual Array<const IDescriptorLayout*> getDescriptors() const noexcept = 0;
-        virtual UniquePtr<IDescriptorSet> getDescriptorSet(const UInt32& descriptors) const = 0;
-        virtual Array<UniquePtr<IDescriptorSet>> getDescriptorSets(const UInt32& descriptorSets, const UInt32& descriptors) const = 0;
+        virtual UniquePtr<IDescriptorSet> getDescriptorSet(const UInt32& descriptors, const Array<DescriptorBinding>& bindings = { }) const = 0;
+        virtual Array<UniquePtr<IDescriptorSet>> getDescriptorSets(const UInt32& descriptorSets, const UInt32& descriptors, const Array<Array<DescriptorBinding>>& bindings = { }) const = 0;
+        virtual Array<UniquePtr<IDescriptorSet>> getDescriptorSets(const UInt32& descriptorSets, const UInt32& descriptors, std::function<Array<DescriptorBinding>(const UInt32&)> bindingFactory) const = 0;
         virtual void releaseDescriptorSet(const IDescriptorSet& descriptorSet) const noexcept = 0;
     };
 


### PR DESCRIPTION
**Describe the pull request**

Currently, if a class holds an interface pointer or reference to any object, it cannot use it to call contra-variant methods in sub-classes. For example, a `ICommandBuffer` pointer cannot be submitted to a `VulkanCommandQueue`, even if the instance actually is a `VulkanCommandBuffer` and the `ICommandQueue` interface exposes a proper overload, that performs a dynamic up-cast. This PR addresses this issue by importing contra-variant overloads into sub-classes, which removes the manual casting involved.