### PR TITLE
Implement GPU time measurement.

### DIFF
--- a/docs/release-logs/0.4.1.md
+++ b/docs/release-logs/0.4.1.md
@@ -12,6 +12,7 @@
 - Make most of the render pipeline state dynamic (viewports, scissors, ...). ([See PR #86](https://github.com/crud89/LiteFX/pull/86))
 - Vector conversion to math types can now be done for constant vectors. ([See PR #87](https://github.com/crud89/LiteFX/pull/87))
 - Backend types now import contra-variant interface functions instead of hiding them. ([See PR #91](https://github.com/crud89/LiteFX/pull/91))
+- Add support for GPU time measurements (*Timing Events*). ([See PR #94](https://github.com/crud89/LiteFX/pull/94))
 
 **🌋 Vulkan:**
 

--- a/src/Backends/DirectX12/src/buffer.h
+++ b/src/Backends/DirectX12/src/buffer.h
@@ -67,6 +67,12 @@ namespace LiteFX::Rendering::Backends {
 		/// <inheritdoc />
 		virtual void map(Span<const void* const> data, const size_t& elementSize, const UInt32& firstElement = 0) override;
 
+		/// <inheritdoc />
+		virtual void map(void* data, const size_t& size, const UInt32& element = 0, bool write = true) override;
+
+		/// <inheritdoc />
+		virtual void map(Span<void*> data, const size_t& elementSize, const UInt32& firstElement = 0, bool write = true) override;
+
 		// DirectX 12 buffer.
 	protected:
 		virtual AllocatorPtr allocator() const noexcept;

--- a/src/Backends/DirectX12/src/command_buffer.cpp
+++ b/src/Backends/DirectX12/src/command_buffer.cpp
@@ -356,6 +356,14 @@ void DirectX12CommandBuffer::pushConstants(const DirectX12PushConstantsLayout& l
 	std::ranges::for_each(layout.ranges(), [this, &layout, &memory](const DirectX12PushConstantsRange* range) { this->handle()->SetGraphicsRoot32BitConstants(range->rootParameterIndex(), range->size() / 4, reinterpret_cast<const char* const>(memory) + range->offset(), 0); });
 }
 
+void DirectX12CommandBuffer::writeTimingEvent(SharedPtr<const TimingEvent> timingEvent) const
+{
+	if (timingEvent == nullptr) [[unlikely]]
+		throw ArgumentNotInitializedException("The timing event must be initialized.");
+
+	this->handle()->EndQuery(m_impl->m_queue.device().swapChain().timestampQueryHeap(), D3D12_QUERY_TYPE_TIMESTAMP, timingEvent->queryId());
+}
+
 void DirectX12CommandBuffer::releaseSharedState() const
 {
 	m_impl->m_sharedResources.clear();

--- a/src/Backends/DirectX12/src/device.cpp
+++ b/src/Backends/DirectX12/src/device.cpp
@@ -540,6 +540,13 @@ MultiSamplingLevel DirectX12Device::maximumMultiSamplingLevel(const Format& form
 	return MultiSamplingLevel::x1;
 }
 
+double DirectX12Device::ticksPerMillisecond() const noexcept
+{
+	UInt64 frequency = 1000000u;
+	std::as_const(*m_impl->m_graphicsQueue).handle()->GetTimestampFrequency(&frequency);
+	return static_cast<double>(frequency) / 1000.0;
+}
+
 void DirectX12Device::wait() const
 {
 	// NOTE: Currently we are only waiting for the graphics queue here - all other queues may continue their work.

--- a/src/Backends/DirectX12/src/render_pass.cpp
+++ b/src/Backends/DirectX12/src/render_pass.cpp
@@ -370,12 +370,18 @@ void DirectX12RenderPass::end() const
         endCommandBuffer->barrier(presentBarrier);
     }
 
+    // If there is a present target, allow the swap chain to resolve queries for the current heap.
+    if (m_impl->m_presentTarget != nullptr)
+        swapChain.resolveQueryHeaps(*endCommandBuffer);
+
     // End the command buffer recording and submit all command buffers.
     // NOTE: In order to suspend/resume render passes, we need to pass them to the queue in one `ExecuteCommandLists` (i.e. submit) call. The order we pass them to the call is 
     //       important, since the first command list also gets executed first.
     auto commandBuffers = frameBuffer->commandBuffers();
     commandBuffers.insert(commandBuffers.begin(), m_impl->m_beginCommandBuffers[buffer]);
     commandBuffers.push_back(endCommandBuffer);
+
+    // Submit and store the fence.
     m_impl->m_activeFrameBuffer->lastFence() = m_impl->m_device.graphicsQueue().submit(commandBuffers);
 
     if (!m_impl->m_name.empty())

--- a/src/Backends/Vulkan/include/litefx/backends/vulkan.hpp
+++ b/src/Backends/Vulkan/include/litefx/backends/vulkan.hpp
@@ -940,6 +940,9 @@ namespace LiteFX::Rendering::Backends {
 		/// <inheritdoc />
 		virtual void pushConstants(const VulkanPushConstantsLayout& layout, const void* const memory) const noexcept override;
 
+		/// <inheritdoc />
+		virtual void writeTimingEvent(SharedPtr<const TimingEvent> timingEvent) const override;
+
 	private:
 		virtual void releaseSharedState() const override;
 	};
@@ -1310,8 +1313,26 @@ namespace LiteFX::Rendering::Backends {
 		/// <returns>A reference of the current swap semaphore, a command queue can wait on for presenting.</returns>
 		virtual const VkSemaphore& semaphore() const noexcept;
 
+		/// <summary>
+		/// Returns the query pool for the current frame.
+		/// </summary>
+		/// <returns>A reference of the query pool for the current frame.</returns>
+		virtual const VkQueryPool& timestampQueryPool() const noexcept;
+
 		// SwapChain interface.
 	public:
+		/// <inheritdoc />
+		virtual Array<SharedPtr<TimingEvent>> timingEvents() const noexcept override;
+
+		/// <inheritdoc />
+		virtual SharedPtr<TimingEvent> timingEvent(const UInt32& queryId) const override;
+
+		/// <inheritdoc />
+		virtual UInt64 readTimingEvent(SharedPtr<const TimingEvent> timingEvent) const override;
+
+		/// <inheritdoc />
+		virtual UInt32 resolveQueryId(SharedPtr<const TimingEvent> timingEvent) const override;
+
 		/// <inheritdoc />
 		virtual const Format& surfaceFormat() const noexcept override;
 
@@ -1330,6 +1351,9 @@ namespace LiteFX::Rendering::Backends {
 	public:
 		/// <inheritdoc />
 		virtual Array<Format> getSurfaceFormats() const noexcept override;
+
+		/// <inheritdoc />
+		virtual void addTimingEvent(SharedPtr<TimingEvent> timingEvent) override;
 
 		/// <inheritdoc />
 		virtual void reset(const Format& surfaceFormat, const Size2d& renderArea, const UInt32& buffers) override;
@@ -1652,6 +1676,9 @@ namespace LiteFX::Rendering::Backends {
 
 		/// <inheritdoc />
 		virtual MultiSamplingLevel maximumMultiSamplingLevel(const Format& format) const noexcept override;
+
+		/// <inheritdoc />
+		virtual double ticksPerMillisecond() const noexcept override;
 
 		/// <inheritdoc />
 		virtual void wait() const override;

--- a/src/Backends/Vulkan/src/adaper.cpp
+++ b/src/Backends/Vulkan/src/adaper.cpp
@@ -95,7 +95,7 @@ GraphicsAdapterType VulkanGraphicsAdapter::type() const noexcept
     case VK_PHYSICAL_DEVICE_TYPE_VIRTUAL_GPU:
     case VK_PHYSICAL_DEVICE_TYPE_DISCRETE_GPU:
     case VK_PHYSICAL_DEVICE_TYPE_INTEGRATED_GPU:
-        return GraphicsAdapterType::CPU;
+        return GraphicsAdapterType::GPU;
     default:
         return GraphicsAdapterType::Other;
     }

--- a/src/Backends/Vulkan/src/buffer.cpp
+++ b/src/Backends/Vulkan/src/buffer.cpp
@@ -121,6 +121,34 @@ void VulkanBuffer::map(Span<const void* const> data, const size_t& elementSize, 
 	std::ranges::for_each(data, [this, &elementSize, i = firstElement](const void* const mem) mutable { this->map(mem, elementSize, i++); });
 }
 
+void VulkanBuffer::map(void* data, const size_t& size, const UInt32& element, bool write)
+{
+	if (element >= m_impl->m_elements)
+		throw ArgumentOutOfRangeException("The element {0} is out of range. The buffer only contains {1} elements.", element, m_impl->m_elements);
+
+	size_t alignedSize = size;
+	size_t alignment = this->elementAlignment();
+
+	if (alignment > 0)
+		alignedSize = (size + alignment - 1) & ~(alignment - 1);
+
+	char* buffer;		// A pointer to the whole (aligned) buffer memory.
+	raiseIfFailed<RuntimeException>(::vmaMapMemory(m_impl->m_allocator, m_impl->m_allocation, reinterpret_cast<void**>(&buffer)), "Unable to map buffer memory.");
+	auto result = write ?
+		::memcpy_s(reinterpret_cast<void*>(buffer + (element * alignedSize)), alignedSize, data, size) :
+		::memcpy_s(data, size, reinterpret_cast<void*>(buffer + (element * alignedSize)), alignedSize);
+
+	::vmaUnmapMemory(m_impl->m_allocator, m_impl->m_allocation);
+
+	if (result != 0)
+		throw RuntimeException("Error mapping buffer to device memory: {#X}.", result);
+}
+
+void VulkanBuffer::map(Span<void*> data, const size_t& elementSize, const UInt32& firstElement, bool write)
+{
+	std::ranges::for_each(data, [this, &elementSize, &write, i = firstElement](void* mem) mutable { this->map(mem, elementSize, i++, write); });
+}
+
 UniquePtr<IVulkanBuffer> VulkanBuffer::allocate(const BufferType& type, const UInt32& elements, const size_t& elementSize, const size_t& alignment, const bool& writable, const ResourceState& initialState, const VmaAllocator& allocator, const VkBufferCreateInfo& createInfo, const VmaAllocationCreateInfo& allocationInfo, VmaAllocationInfo* allocationResult)
 {
 	return VulkanBuffer::allocate("", type, elements, elementSize, alignment, writable, initialState, allocator, createInfo, allocationInfo, allocationResult);

--- a/src/Backends/Vulkan/src/buffer.h
+++ b/src/Backends/Vulkan/src/buffer.h
@@ -58,6 +58,12 @@ namespace LiteFX::Rendering::Backends {
 		/// <inheritdoc />
 		virtual void map(Span<const void* const> data, const size_t& elementSize, const UInt32& firstElement = 0) override;
 
+		/// <inheritdoc />
+		virtual void map(void* data, const size_t& size, const UInt32& element = 0, bool write = true) override;
+
+		/// <inheritdoc />
+		virtual void map(Span<void*> data, const size_t& elementSize, const UInt32& firstElement = 0, bool write = true) override;
+
 		// VulkanBuffer.
 	public:
 		static UniquePtr<IVulkanBuffer> allocate(const BufferType& type, const UInt32& elements, const size_t& elementSize, const size_t& alignment, const bool& writable, const ResourceState& initialState, const VmaAllocator& allocator, const VkBufferCreateInfo& createInfo, const VmaAllocationCreateInfo& allocationInfo, VmaAllocationInfo* allocationResult = nullptr);

--- a/src/Backends/Vulkan/src/command_buffer.cpp
+++ b/src/Backends/Vulkan/src/command_buffer.cpp
@@ -488,6 +488,14 @@ void VulkanCommandBuffer::pushConstants(const VulkanPushConstantsLayout& layout,
 	std::ranges::for_each(layout.ranges(), [this, &layout, &memory](const VulkanPushConstantsRange* range) { ::vkCmdPushConstants(this->handle(), layout.pipelineLayout().handle(), static_cast<VkShaderStageFlags>(Vk::getShaderStage(range->stage())), range->offset(), range->size(), memory); });
 }
 
+void VulkanCommandBuffer::writeTimingEvent(SharedPtr<const TimingEvent> timingEvent) const
+{
+	if (timingEvent == nullptr) [[unlikely]]
+		throw ArgumentNotInitializedException("The timing event must be initialized.");
+
+	::vkCmdWriteTimestamp(this->handle(), VK_PIPELINE_STAGE_BOTTOM_OF_PIPE_BIT, m_impl->m_queue.device().swapChain().timestampQueryPool(), timingEvent->queryId());
+}
+
 void VulkanCommandBuffer::releaseSharedState() const
 {
 	m_impl->m_sharedResources.clear();

--- a/src/Backends/Vulkan/src/device.cpp
+++ b/src/Backends/Vulkan/src/device.cpp
@@ -236,6 +236,7 @@ public:
 			.descriptorBindingPartiallyBound = true,
 			.descriptorBindingVariableDescriptorCount = true,
 			.runtimeDescriptorArray = true,
+			.hostQueryReset = true,
 			.timelineSemaphore = true
 		};
 
@@ -502,6 +503,11 @@ MultiSamplingLevel VulkanDevice::maximumMultiSamplingLevel(const Format& format)
 		return MultiSamplingLevel::x2;
 	else
 		return MultiSamplingLevel::x1;
+}
+
+double VulkanDevice::ticksPerMillisecond() const noexcept
+{
+	return 1000000.0 / static_cast<double>(this->adapter().limits().timestampPeriod);
 }
 
 void VulkanDevice::wait() const

--- a/src/Rendering/CMakeLists.txt
+++ b/src/Rendering/CMakeLists.txt
@@ -25,6 +25,7 @@ SET(RENDERING_SOURCES
     "src/render_target.cpp"
     "src/state_resource.cpp"
     "src/device_state.cpp"
+    "src/timing_event.cpp"
 )
 
 # Add shared library project.

--- a/src/Rendering/src/timing_event.cpp
+++ b/src/Rendering/src/timing_event.cpp
@@ -1,0 +1,48 @@
+#include <litefx/rendering.hpp>
+
+using namespace LiteFX::Rendering;
+
+// ------------------------------------------------------------------------------------------------
+// Implementation.
+// ------------------------------------------------------------------------------------------------
+
+class TimingEvent::TimingEventImpl : public Implement<TimingEvent> {
+public:
+	friend class TimingEvent;
+
+private:
+	String m_name;
+	const ISwapChain& m_swapChain;
+
+public:
+	TimingEventImpl(TimingEvent* parent, const ISwapChain& swapChain, StringView name) :
+		base(parent), m_swapChain(swapChain), m_name(name)
+	{
+	}
+};
+
+// ------------------------------------------------------------------------------------------------
+// Shared interface.
+// ------------------------------------------------------------------------------------------------
+
+TimingEvent::TimingEvent(const ISwapChain& swapChain, StringView name) noexcept :
+	m_impl(makePimpl<TimingEventImpl>(this, swapChain, name))
+{
+}
+
+TimingEvent::~TimingEvent() noexcept = default;
+
+String TimingEvent::name() const noexcept
+{
+	return m_impl->m_name;
+}
+
+UInt64 TimingEvent::readTimestamp() const noexcept
+{
+	return m_impl->m_swapChain.readTimingEvent(this->shared_from_this());
+}
+
+UInt32 TimingEvent::queryId() const
+{
+	return m_impl->m_swapChain.resolveQueryId(this->shared_from_this());
+}


### PR DESCRIPTION
**Describe the pull request**

This PR implements support for GPU-based time measurements. This works by defining one or more *Timing Events*, that are written to a command buffer during frame drawing. If the frame has finished drawing (i.e., the next time the swap chain swaps back to the frame's back buffer), the results of the measurements are read and can be requested from the event.

**Usage**

During initialization (usually in the startup-callback for a backend), all timing events need to be registered:

```cxx
m_beginEvent = m_device->swapChain().registerTimingEvent("Begin Frame");
// ...
m_endEvent = m_device->swapChain().registerTimingEvent("End Frame");
```

Note that it is possible to insert more events during runtime, but this results in re-creation of query pools/heaps, which may be inefficient.

When drawing a frame, the events can be set on a command buffer:

```cxx
auto commandBuffer = renderPass.activeFrameBuffer().commandBuffer(0);
commandBuffer->writeTimingEvent(m_beginEvent);
// ...
commandBuffer->writeTimingEvent(m_endEvent);
```

Finally, the events themselves can be used to acquire the current readings. In this example, the duration is converted into milliseconds and then written into a string.

```cxx
auto begin = m_beginEvent->readTimestamp();
auto end = m_endEvent->readTimestamp();
auto ticks = end - begin;
double time = ticks / m_device->ticksPerMillisecond();

std::stringstream drawTime;
drawTime << "Draw time: " << std::fixed << std::setprecision(4) << time << "ms";
```

Note that timestamp queries are asynchronous, so the readings are not representing the last frame drawn by the app, but the last presented frame. Also note that the timestamps are expressed as 64 bit *ticks*, which need to be converted into milliseconds by querying the `ticksPerSecond` property of the current device.

**Known issues**

When using the native Vulkan swap chain, the validation layers in some rare occasions complain about a query pool not being reset properly. Usually, this only means that the readings are not valid in those instances, but since the behavior is undefined, it is best not to rely on this feature when using this swap chain. This does not happen when using the D3D interop swap chain.