### PR TITLE
Improve core guideline conformance.

### DIFF
--- a/docs/release-logs/0.4.1.md
+++ b/docs/release-logs/0.4.1.md
@@ -6,6 +6,7 @@
   - A novel `Enumerable` container is introduced to pass around immutable collections.
   - Some places that previously used `std::ranges::generate` or `std::generate` now use `std::generator`.
   - Builders are now `constexpr` where possible and are implemented using `deducing this` in place of CRTP, which makes them more lightweight.
+- Improvements to C++ core guideline conformance ([See PR #103](https://github.com/crud89/LiteFX/pull/103)).
 - New event infrastructure. ([See PR #81](https://github.com/crud89/LiteFX/pull/81))
 - Add support for user-defined debug markers. ([See PR #82](https://github.com/crud89/LiteFX/pull/82))
 - Improved resource allocation and binding: ([See PR #83](https://github.com/crud89/LiteFX/pull/83))

--- a/src/AppModel/include/litefx/app.hpp
+++ b/src/AppModel/include/litefx/app.hpp
@@ -330,7 +330,7 @@ namespace LiteFX {
 		/// Returns the new window width.
 		/// </summary>
 		/// <returns>The new window width.</returns>
-		const int& width() const noexcept {
+		inline int width() const noexcept {
 			return m_width;
 		}
 
@@ -338,7 +338,7 @@ namespace LiteFX {
 		/// Returns the new window height.
 		/// </summary>
 		/// <returns>The new window height.</returns>
-		const int& height() const noexcept {
+		inline int height() const noexcept {
 			return m_height;
 		}
 	};
@@ -449,21 +449,21 @@ namespace LiteFX {
 		/// </summary>
 		/// <param name="type">The backend type for which the active backend should be stopped.</param>
 		/// <seealso cref="stopBackend" />
-		virtual void stopActiveBackends(const BackendType& type) const;
+		virtual void stopActiveBackends(BackendType type) const;
 
 		/// <summary>
 		/// Returns the active backend of the provided backend <paramref name="type" />.
 		/// </summary>
 		/// <param name="type">The type of the backend.</param>
 		/// <returns>The active backend of the provided backend type, or <c>std::nullptr</c>, if no backend is active.</returns>
-		virtual IBackend* activeBackend(const BackendType& type) const;
+		virtual IBackend* activeBackend(BackendType type) const;
 
 		/// <summary>
 		/// Returns the type index of the active backend of the provided backend <paramref name="type" />.
 		/// </summary>
 		/// <param name="type">The type of the backend.</param>
 		/// <returns>Type index of the active backend of the provided backend type, or the type index of <c>std::nullptr_t</c>, if no backend is active.</returns>
-		virtual std::type_index activeBackendType(const BackendType& type) const;
+		virtual std::type_index activeBackendType(BackendType type) const;
 
 	private:
 		/// <summary>
@@ -619,12 +619,9 @@ namespace LiteFX {
 		/// <summary>
 		/// Called, if the application window resizes.
 		/// </summary>
-		/// <remarks>
-		/// Calling this method ensures, that the <paramref name="width" /> and <paramref name="height" /> parameters are valid.
-		/// </remarks>
 		/// <param name="width">The new width of the application window.</param>
 		/// <param name="height">The new height of the application window.</param>
-		void resize(int& width, int& height);
+		void resize(int width, int height);
 
 	public:
 		/// <summary>

--- a/src/AppModel/src/app.cpp
+++ b/src/AppModel/src/app.cpp
@@ -111,13 +111,13 @@ void App::stopBackend(std::type_index type) const
 	}
 }
 
-void App::stopActiveBackends(const BackendType& type) const
+void App::stopActiveBackends(BackendType type) const
 {
 	for (auto& backend : m_impl->m_backends | std::views::filter([type](const auto& b) { return b.second->type() == type && b.second->state() == BackendState::Active; }))
 		this->stopBackend(backend.first);
 }
 
-IBackend* App::activeBackend(const BackendType& type) const
+IBackend* App::activeBackend(BackendType type) const
 {
 	for (auto& backend : m_impl->m_backends | std::views::filter([type](const auto& b) { return b.second->type() == type && b.second->state() == BackendState::Active; }))
 		return backend.second.get();
@@ -125,7 +125,7 @@ IBackend* App::activeBackend(const BackendType& type) const
 	return nullptr;
 }
 
-std::type_index App::activeBackendType(const BackendType& type) const
+std::type_index App::activeBackendType(BackendType type) const
 {
 	for (auto& backend : m_impl->m_backends | std::views::filter([type](const auto& b) { return b.second->type() == type && b.second->state() == BackendState::Active; }))
 		return backend.first;
@@ -193,7 +193,7 @@ void App::run()
 	this->shutdown(this, { });
 }
 
-void App::resize(int& width, int& height)
+void App::resize(int width, int height)
 {
 	// Ensure the area is at least 1 pixel into each direction.
 	width = std::max(width, 1);

--- a/src/Backends/DirectX12/include/litefx/backends/dx12.hpp
+++ b/src/Backends/DirectX12/include/litefx/backends/dx12.hpp
@@ -25,7 +25,7 @@ namespace LiteFX::Rendering::Backends {
 		/// </summary>
 		/// <param name="vertexSize">The size of a single vertex.</param>
 		/// <param name="binding">The binding point of the vertex buffers using this layout.</param>
-		explicit DirectX12VertexBufferLayout(const size_t& vertexSize, const UInt32& binding = 0);
+		explicit DirectX12VertexBufferLayout(size_t vertexSize, UInt32 binding = 0);
 		DirectX12VertexBufferLayout(DirectX12VertexBufferLayout&&) = delete;
 		DirectX12VertexBufferLayout(const DirectX12VertexBufferLayout&) = delete;
 		virtual ~DirectX12VertexBufferLayout() noexcept;
@@ -41,7 +41,7 @@ namespace LiteFX::Rendering::Backends {
 		virtual size_t elementSize() const noexcept override;
 
 		/// <inheritdoc />
-		virtual const UInt32& binding() const noexcept override;
+		virtual UInt32 binding() const noexcept override;
 
 		/// <inheritdoc />
 		virtual BufferType type() const noexcept override;
@@ -76,7 +76,7 @@ namespace LiteFX::Rendering::Backends {
 		virtual size_t elementSize() const noexcept override;
 
 		/// <inheritdoc />
-		virtual const UInt32& binding() const noexcept override;
+		virtual UInt32 binding() const noexcept override;
 
 		/// <inheritdoc />
 		virtual BufferType type() const noexcept override;
@@ -135,7 +135,7 @@ namespace LiteFX::Rendering::Backends {
 		virtual ~IDirectX12Image() noexcept = default;
 
 	private:
-		virtual ImageLayout& layout(const UInt32& subresource) = 0;
+		virtual ImageLayout& layout(UInt32 subresource) = 0;
 	};
 
 	/// <summary>
@@ -196,7 +196,7 @@ namespace LiteFX::Rendering::Backends {
 		constexpr inline void transition(IDirectX12Buffer& buffer, ResourceAccess accessBefore, ResourceAccess accessAfter) override;
 
 		/// <inheritdoc />
-		constexpr inline void transition(IDirectX12Buffer& buffer, const UInt32& element, ResourceAccess accessBefore, ResourceAccess accessAfter) override;
+		constexpr inline void transition(IDirectX12Buffer& buffer, UInt32 element, ResourceAccess accessBefore, ResourceAccess accessAfter) override;
 
 		/// <inheritdoc />
 		constexpr inline void transition(IDirectX12Image& image, ResourceAccess accessBefore, ResourceAccess accessAfter, ImageLayout layout) override;
@@ -205,10 +205,10 @@ namespace LiteFX::Rendering::Backends {
 		constexpr inline void transition(IDirectX12Image& image, ResourceAccess accessBefore, ResourceAccess accessAfter, ImageLayout fromLayout, ImageLayout toLayout) override;
 
 		/// <inheritdoc />
-		constexpr inline void transition(IDirectX12Image& image, const UInt32& level, const UInt32& levels, const UInt32& layer, const UInt32& layers, const UInt32& plane, ResourceAccess accessBefore, ResourceAccess accessAfter, ImageLayout layout) override;
+		constexpr inline void transition(IDirectX12Image& image, UInt32 level, UInt32 levels, UInt32 layer, UInt32 layers, UInt32 plane, ResourceAccess accessBefore, ResourceAccess accessAfter, ImageLayout layout) override;
 
 		/// <inheritdoc />
-		constexpr inline void transition(IDirectX12Image& image, const UInt32& level, const UInt32& levels, const UInt32& layer, const UInt32& layers, const UInt32& plane, ResourceAccess accessBefore, ResourceAccess accessAfter, ImageLayout fromLayout, ImageLayout toLayout) override;
+		constexpr inline void transition(IDirectX12Image& image, UInt32 level, UInt32 levels, UInt32 layer, UInt32 layers, UInt32 plane, ResourceAccess accessBefore, ResourceAccess accessAfter, ImageLayout fromLayout, ImageLayout toLayout) override;
 
 	public:
 		/// <summary>
@@ -350,16 +350,16 @@ namespace LiteFX::Rendering::Backends {
 
 	public:
 		/// <inheritdoc />
-		virtual void update(const UInt32& binding, const IDirectX12Buffer& buffer, const UInt32& bufferElement = 0, const UInt32& elements = 0, const UInt32& firstDescriptor = 0) const override;
+		virtual void update(UInt32 binding, const IDirectX12Buffer& buffer, UInt32 bufferElement = 0, UInt32 elements = 0, UInt32 firstDescriptor = 0) const override;
 
 		/// <inheritdoc />
-		virtual void update(const UInt32& binding, const IDirectX12Image& texture, const UInt32& descriptor = 0, const UInt32& firstLevel = 0, const UInt32& levels = 0, const UInt32& firstLayer = 0, const UInt32& layers = 0) const override;
+		virtual void update(UInt32 binding, const IDirectX12Image& texture, UInt32 descriptor = 0, UInt32 firstLevel = 0, UInt32 levels = 0, UInt32 firstLayer = 0, UInt32 layers = 0) const override;
 
 		/// <inheritdoc />
-		virtual void update(const UInt32& binding, const IDirectX12Sampler& sampler, const UInt32& descriptor = 0) const override;
+		virtual void update(UInt32 binding, const IDirectX12Sampler& sampler, UInt32 descriptor = 0) const override;
 
 		/// <inheritdoc />
-		virtual void attach(const UInt32& binding, const IDirectX12Image& image) const override;
+		virtual void attach(UInt32 binding, const IDirectX12Image& image) const override;
 
 	public:
 		/// <summary>
@@ -372,7 +372,7 @@ namespace LiteFX::Rendering::Backends {
 		/// Returns the offset of the buffer descriptors in the global descriptor heap.
 		/// </summary>
 		/// <returns>The offset of the buffer descriptors in the global descriptor heap.</returns>
-		virtual const UInt32& bufferOffset() const noexcept;
+		virtual UInt32 bufferOffset() const noexcept;
 
 		/// <summary>
 		/// Returns the local (CPU-visible) heap that contains the sampler descriptors.
@@ -384,7 +384,7 @@ namespace LiteFX::Rendering::Backends {
 		/// Returns the offset of the sampler descriptors in the global descriptor heap.
 		/// </summary>
 		/// <returns>The offset of the sampler descriptors in the global descriptor heap.</returns>
-		virtual const UInt32& samplerOffset() const noexcept;
+		virtual UInt32 samplerOffset() const noexcept;
 	};
 
 	/// <summary>
@@ -406,14 +406,14 @@ namespace LiteFX::Rendering::Backends {
 		/// <param name="binding">The binding point for the descriptor.</param>
 		/// <param name="elementSize">The size of the descriptor.</param>
 		/// <param name="elementSize">The number of descriptors in the descriptor array.</param>
-		explicit DirectX12DescriptorLayout(DescriptorType type, const UInt32& binding, const size_t& elementSize, const UInt32& descriptors = 1);
+		explicit DirectX12DescriptorLayout(DescriptorType type, UInt32 binding, size_t elementSize, UInt32 descriptors = 1);
 
 		/// <summary>
 		/// Initializes a new DirectX 12 descriptor layout for a static sampler.
 		/// </summary>
 		/// <param name="staticSampler">The static sampler to initialize the state with.</param>
 		/// <param name="binding">The binding point for the descriptor.</param>
-		explicit DirectX12DescriptorLayout(UniquePtr<IDirectX12Sampler>&& staticSampler, const UInt32& binding);
+		explicit DirectX12DescriptorLayout(UniquePtr<IDirectX12Sampler>&& staticSampler, UInt32 binding);
 
 		DirectX12DescriptorLayout(DirectX12DescriptorLayout&&) = delete;
 		DirectX12DescriptorLayout(const DirectX12DescriptorLayout&) = delete;
@@ -425,7 +425,7 @@ namespace LiteFX::Rendering::Backends {
 		virtual DescriptorType descriptorType() const noexcept override;
 
 		/// <inheritdoc />
-		virtual const UInt32& descriptors() const noexcept override;
+		virtual UInt32 descriptors() const noexcept override;
 
 		/// <inheritdoc />
 		virtual const IDirectX12Sampler* staticSampler() const noexcept override;
@@ -436,7 +436,7 @@ namespace LiteFX::Rendering::Backends {
 		virtual size_t elementSize() const noexcept override;
 
 		/// <inheritdoc />
-		virtual const UInt32& binding() const noexcept override;
+		virtual UInt32 binding() const noexcept override;
 
 		/// <inheritdoc />
 		virtual BufferType type() const noexcept override;
@@ -464,7 +464,7 @@ namespace LiteFX::Rendering::Backends {
 		/// <param name="descriptorLayouts">The descriptor layouts of the descriptors within the descriptor set.</param>
 		/// <param name="space">The space or set id of the descriptor set.</param>
 		/// <param name="stages">The shader stages, the descriptor sets are bound to.</param>
-		explicit DirectX12DescriptorSetLayout(const DirectX12Device& device, Enumerable<UniquePtr<DirectX12DescriptorLayout>>&& descriptorLayouts, const UInt32& space, ShaderStage stages);
+		explicit DirectX12DescriptorSetLayout(const DirectX12Device& device, Enumerable<UniquePtr<DirectX12DescriptorLayout>>&& descriptorLayouts, UInt32 space, ShaderStage stages);
 		DirectX12DescriptorSetLayout(DirectX12DescriptorSetLayout&&) = delete;
 		DirectX12DescriptorSetLayout(const DirectX12DescriptorSetLayout&) = delete;
 		virtual ~DirectX12DescriptorSetLayout() noexcept;
@@ -481,7 +481,7 @@ namespace LiteFX::Rendering::Backends {
 		/// Returns the index of the descriptor set root parameter.
 		/// </summary>
 		/// <returns>The index of the descriptor set root parameter.</returns>
-		virtual const UInt32& rootParameterIndex() const noexcept;
+		virtual UInt32 rootParameterIndex() const noexcept;
 
 		/// <summary>
 		/// Returns the index of the first descriptor for a certain binding. The offset is relative to the heap for the descriptor (i.e. sampler for sampler descriptors and
@@ -490,7 +490,7 @@ namespace LiteFX::Rendering::Backends {
 		/// <param name="binding">The binding of the descriptor.</param>
 		/// <returns>The index of the first descriptor for the binding.</returns>
 		/// <exception cref="ArgumentOutOfRangeException">Thrown, if the descriptor set does not contain a descriptor bound to the binding point specified by <paramref name="binding"/>.</exception>
-		virtual UInt32 descriptorOffsetForBinding(const UInt32& binding) const;
+		virtual UInt32 descriptorOffsetForBinding(UInt32 binding) const;
 
 		/// <summary>
 		/// Returns the parent device.
@@ -519,10 +519,10 @@ namespace LiteFX::Rendering::Backends {
 		virtual Enumerable<const DirectX12DescriptorLayout*> descriptors() const noexcept override;
 
 		/// <inheritdoc />
-		virtual const DirectX12DescriptorLayout& descriptor(const UInt32& binding) const override;
+		virtual const DirectX12DescriptorLayout& descriptor(UInt32 binding) const override;
 
 		/// <inheritdoc />
-		virtual const UInt32& space() const noexcept override;
+		virtual UInt32 space() const noexcept override;
 
 		/// <inheritdoc />
 		virtual ShaderStage shaderStages() const noexcept override;
@@ -553,19 +553,19 @@ namespace LiteFX::Rendering::Backends {
 		virtual UniquePtr<DirectX12DescriptorSet> allocate(const Enumerable<DescriptorBinding>& bindings = { }) const override;
 
 		/// <inheritdoc />
-		virtual UniquePtr<DirectX12DescriptorSet> allocate(const UInt32& descriptors, const Enumerable<DescriptorBinding>& bindings = { }) const override;
+		virtual UniquePtr<DirectX12DescriptorSet> allocate(UInt32 descriptors, const Enumerable<DescriptorBinding>& bindings = { }) const override;
 
 		/// <inheritdoc />
-		virtual Enumerable<UniquePtr<DirectX12DescriptorSet>> allocateMultiple(const UInt32& descriptorSets, const Enumerable<Enumerable<DescriptorBinding>>& bindings = { }) const override;
+		virtual Enumerable<UniquePtr<DirectX12DescriptorSet>> allocateMultiple(UInt32 descriptorSets, const Enumerable<Enumerable<DescriptorBinding>>& bindings = { }) const override;
 
 		/// <inheritdoc />
-		virtual Enumerable<UniquePtr<DirectX12DescriptorSet>> allocateMultiple(const UInt32& descriptorSets, std::function<Enumerable<DescriptorBinding>(const UInt32&)> bindingFactory) const override;
+		virtual Enumerable<UniquePtr<DirectX12DescriptorSet>> allocateMultiple(UInt32 descriptorSets, std::function<Enumerable<DescriptorBinding>(UInt32)> bindingFactory) const override;
 
 		/// <inheritdoc />
-		virtual Enumerable<UniquePtr<DirectX12DescriptorSet>> allocateMultiple(const UInt32& descriptorSets, const UInt32& descriptors, const Enumerable<Enumerable<DescriptorBinding>>& bindings = { }) const override;
+		virtual Enumerable<UniquePtr<DirectX12DescriptorSet>> allocateMultiple(UInt32 descriptorSets, UInt32 descriptors, const Enumerable<Enumerable<DescriptorBinding>>& bindings = { }) const override;
 
 		/// <inheritdoc />
-		virtual Enumerable<UniquePtr<DirectX12DescriptorSet>> allocateMultiple(const UInt32& descriptorSets, const UInt32& descriptors, std::function<Enumerable<DescriptorBinding>(const UInt32&)> bindingFactory) const override;
+		virtual Enumerable<UniquePtr<DirectX12DescriptorSet>> allocateMultiple(UInt32 descriptorSets, UInt32 descriptors, std::function<Enumerable<DescriptorBinding>(UInt32)> bindingFactory) const override;
 
 		/// <inheritdoc />
 		virtual void free(const DirectX12DescriptorSet& descriptorSet) const noexcept override;
@@ -588,23 +588,23 @@ namespace LiteFX::Rendering::Backends {
 		/// <param name="size">The size of the push constants range.</param>
 		/// <param name="space">The space from which the push constants of the range will be accessible in the shader.</param>
 		/// <param name="binding">The register from which the push constants of the range will be accessible in the shader.</param>
-		explicit DirectX12PushConstantsRange(ShaderStage shaderStages, const UInt32& offset, const UInt32& size, const UInt32& space, const UInt32& binding);
+		explicit DirectX12PushConstantsRange(ShaderStage shaderStages, UInt32 offset, UInt32 size, UInt32 space, UInt32 binding);
 		DirectX12PushConstantsRange(const DirectX12PushConstantsRange&) = delete;
 		DirectX12PushConstantsRange(DirectX12PushConstantsRange&&) = delete;
 		virtual ~DirectX12PushConstantsRange() noexcept;
 
 	public:
 		/// <inheritdoc />
-		virtual const UInt32& space() const noexcept override;
+		virtual UInt32 space() const noexcept override;
 
 		/// <inheritdoc />
-		virtual const UInt32& binding() const noexcept override;
+		virtual UInt32 binding() const noexcept override;
 
 		/// <inheritdoc />
-		virtual const UInt32& offset() const noexcept override;
+		virtual UInt32 offset() const noexcept override;
 
 		/// <inheritdoc />
-		virtual const UInt32& size() const noexcept override;
+		virtual UInt32 size() const noexcept override;
 
 		/// <inheritdoc />
 		virtual ShaderStage stage() const noexcept override;
@@ -614,7 +614,7 @@ namespace LiteFX::Rendering::Backends {
 		/// Returns the index of the root parameter, the range is bound to.
 		/// </summary>
 		/// <returns>The index of the root parameter, the range is bound to.</returns>
-		virtual const UInt32& rootParameterIndex() const noexcept;
+		virtual UInt32 rootParameterIndex() const noexcept;
 
 	protected:
 		/// <summary>
@@ -646,7 +646,7 @@ namespace LiteFX::Rendering::Backends {
 		/// </summary>
 		/// <param name="ranges">The ranges contained by the layout.</param>
 		/// <param name="size">The overall size (in bytes) of the push constants backing memory.</param>
-		explicit DirectX12PushConstantsLayout(Enumerable<UniquePtr<DirectX12PushConstantsRange>>&& ranges, const UInt32& size);
+		explicit DirectX12PushConstantsLayout(Enumerable<UniquePtr<DirectX12PushConstantsRange>>&& ranges, UInt32 size);
 		DirectX12PushConstantsLayout(const DirectX12PushConstantsLayout&) = delete;
 		DirectX12PushConstantsLayout(DirectX12PushConstantsLayout&&) = delete;
 		virtual ~DirectX12PushConstantsLayout() noexcept;
@@ -656,11 +656,11 @@ namespace LiteFX::Rendering::Backends {
 		/// Initializes a new push constants layout.
 		/// </summary>
 		/// <param name="size">The overall size (in bytes) of the push constants backing memory.</param>
-		explicit DirectX12PushConstantsLayout(const UInt32& size);
+		explicit DirectX12PushConstantsLayout(UInt32 size);
 
 	public:
 		/// <inheritdoc />
-		virtual const UInt32& size() const noexcept override;
+		virtual UInt32 size() const noexcept override;
 
 		/// <inheritdoc />
 		virtual const DirectX12PushConstantsRange& range(ShaderStage stage) const override;
@@ -713,7 +713,7 @@ namespace LiteFX::Rendering::Backends {
 		// PipelineLayout interface.
 	public:
 		/// <inheritdoc />
-		virtual const DirectX12DescriptorSetLayout& descriptorSet(const UInt32& space) const override;
+		virtual const DirectX12DescriptorSetLayout& descriptorSet(UInt32 space) const override;
 
 		/// <inheritdoc />
 		virtual Enumerable<const DirectX12DescriptorSetLayout*> descriptorSets() const noexcept override;
@@ -753,7 +753,7 @@ namespace LiteFX::Rendering::Backends {
 		virtual Enumerable<const DirectX12VertexBufferLayout*> vertexBufferLayouts() const noexcept override;
 
 		/// <inheritdoc />
-		virtual const DirectX12VertexBufferLayout& vertexBufferLayout(const UInt32& binding) const override;
+		virtual const DirectX12VertexBufferLayout& vertexBufferLayout(UInt32 binding) const override;
 
 		/// <inheritdoc />
 		virtual const DirectX12IndexBufferLayout& indexBufferLayout() const override;
@@ -778,7 +778,7 @@ namespace LiteFX::Rendering::Backends {
 		/// <param name="cullOrder">The cull order used by the pipeline.</param>
 		/// <param name="lineWidth">The line width used by the pipeline.</param>
 		/// <param name="depthStencilState">The rasterizer depth/stencil state.</param>
-		explicit DirectX12Rasterizer(PolygonMode polygonMode, CullMode cullMode, CullOrder cullOrder, const Float& lineWidth = 1.f, const DepthStencilState& depthStencilState = {}) noexcept;
+		explicit DirectX12Rasterizer(PolygonMode polygonMode, CullMode cullMode, CullOrder cullOrder, Float lineWidth = 1.f, const DepthStencilState& depthStencilState = {}) noexcept;
 		DirectX12Rasterizer(DirectX12Rasterizer&&) noexcept = delete;
 		DirectX12Rasterizer(const DirectX12Rasterizer&) noexcept = delete;
 		virtual ~DirectX12Rasterizer() noexcept;
@@ -834,7 +834,7 @@ namespace LiteFX::Rendering::Backends {
 		/// <param name="queue">The parent command queue, the buffer gets submitted to.</param>
 		/// <param name="begin">If set to <c>true</c>, the command buffer automatically starts recording by calling <see cref="begin" />.</param>
 		/// <param name="primary"><c>true</c>, if the command buffer is a primary command buffer.</param>
-		explicit DirectX12CommandBuffer(const DirectX12Queue& queue, const bool& begin = false, const bool& primary = true);
+		explicit DirectX12CommandBuffer(const DirectX12Queue& queue, bool begin = false, bool primary = true);
 		DirectX12CommandBuffer(const DirectX12CommandBuffer&) = delete;
 		DirectX12CommandBuffer(DirectX12CommandBuffer&&) = delete;
 		virtual ~DirectX12CommandBuffer() noexcept;
@@ -848,7 +848,7 @@ namespace LiteFX::Rendering::Backends {
 		virtual void end() const override;
 
 		/// <inheritdoc />
-		virtual const bool& isSecondary() const noexcept override;
+		virtual bool isSecondary() const noexcept override;
 
 		/// <inheritdoc />
 		virtual void setViewports(Span<const IViewport*> viewports) const noexcept override;
@@ -866,7 +866,7 @@ namespace LiteFX::Rendering::Backends {
 		virtual void setBlendFactors(const Vector4f& blendFactors) const noexcept override;
 
 		/// <inheritdoc />
-		virtual void setStencilRef(const UInt32& stencilRef) const noexcept override;
+		virtual void setStencilRef(UInt32 stencilRef) const noexcept override;
 
 		/// <inheritdoc />
 		virtual void generateMipMaps(IDirectX12Image& image) noexcept override;
@@ -875,28 +875,28 @@ namespace LiteFX::Rendering::Backends {
 		virtual void barrier(const DirectX12Barrier& barrier) const noexcept override;
 
 		/// <inheritdoc />
-		virtual void transfer(IDirectX12Buffer& source, IDirectX12Buffer& target, const UInt32& sourceElement = 0, const UInt32& targetElement = 0, const UInt32& elements = 1) const override;
+		virtual void transfer(IDirectX12Buffer& source, IDirectX12Buffer& target, UInt32 sourceElement = 0, UInt32 targetElement = 0, UInt32 elements = 1) const override;
 
 		/// <inheritdoc />
-		virtual void transfer(IDirectX12Buffer& source, IDirectX12Image& target, const UInt32& sourceElement = 0, const UInt32& firstSubresource = 0, const UInt32& elements = 1) const override;
+		virtual void transfer(IDirectX12Buffer& source, IDirectX12Image& target, UInt32 sourceElement = 0, UInt32 firstSubresource = 0, UInt32 elements = 1) const override;
 
 		/// <inheritdoc />
-		virtual void transfer(IDirectX12Image& source, IDirectX12Image& target, const UInt32& sourceSubresource = 0, const UInt32& targetSubresource = 0, const UInt32& subresources = 1) const override;
+		virtual void transfer(IDirectX12Image& source, IDirectX12Image& target, UInt32 sourceSubresource = 0, UInt32 targetSubresource = 0, UInt32 subresources = 1) const override;
 
 		/// <inheritdoc />
-		virtual void transfer(IDirectX12Image& source, IDirectX12Buffer& target, const UInt32& firstSubresource = 0, const UInt32& targetElement = 0, const UInt32& subresources = 1) const override;
+		virtual void transfer(IDirectX12Image& source, IDirectX12Buffer& target, UInt32 firstSubresource = 0, UInt32 targetElement = 0, UInt32 subresources = 1) const override;
 
 		/// <inheritdoc />
-		virtual void transfer(SharedPtr<IDirectX12Buffer> source, IDirectX12Buffer& target, const UInt32& sourceElement = 0, const UInt32& targetElement = 0, const UInt32& elements = 1) const override;
+		virtual void transfer(SharedPtr<IDirectX12Buffer> source, IDirectX12Buffer& target, UInt32 sourceElement = 0, UInt32 targetElement = 0, UInt32 elements = 1) const override;
 
 		/// <inheritdoc />
-		virtual void transfer(SharedPtr<IDirectX12Buffer> source, IDirectX12Image& target, const UInt32& sourceElement = 0, const UInt32& firstSubresource = 0, const UInt32& elements = 1) const override;
+		virtual void transfer(SharedPtr<IDirectX12Buffer> source, IDirectX12Image& target, UInt32 sourceElement = 0, UInt32 firstSubresource = 0, UInt32 elements = 1) const override;
 
 		/// <inheritdoc />
-		virtual void transfer(SharedPtr<IDirectX12Image> source, IDirectX12Image& target, const UInt32& sourceSubresource = 0, const UInt32& targetSubresource = 0, const UInt32& subresources = 1) const override;
+		virtual void transfer(SharedPtr<IDirectX12Image> source, IDirectX12Image& target, UInt32 sourceSubresource = 0, UInt32 targetSubresource = 0, UInt32 subresources = 1) const override;
 
 		/// <inheritdoc />
-		virtual void transfer(SharedPtr<IDirectX12Image> source, IDirectX12Buffer& target, const UInt32& firstSubresource = 0, const UInt32& targetElement = 0, const UInt32& subresources = 1) const override;
+		virtual void transfer(SharedPtr<IDirectX12Image> source, IDirectX12Buffer& target, UInt32 firstSubresource = 0, UInt32 targetElement = 0, UInt32 subresources = 1) const override;
 
 		/// <inheritdoc />
 		virtual void use(const DirectX12PipelineState& pipeline) const noexcept override;
@@ -914,10 +914,10 @@ namespace LiteFX::Rendering::Backends {
 		virtual void dispatch(const Vector3u& threadCount) const noexcept override;
 
 		/// <inheritdoc />
-		virtual void draw(const UInt32& vertices, const UInt32& instances = 1, const UInt32& firstVertex = 0, const UInt32& firstInstance = 0) const noexcept override;
+		virtual void draw(UInt32 vertices, UInt32 instances = 1, UInt32 firstVertex = 0, UInt32 firstInstance = 0) const noexcept override;
 
 		/// <inheritdoc />
-		virtual void drawIndexed(const UInt32& indices, const UInt32& instances = 1, const UInt32& firstIndex = 0, const Int32& vertexOffset = 0, const UInt32& firstInstance = 0) const noexcept override;
+		virtual void drawIndexed(UInt32 indices, UInt32 instances = 1, UInt32 firstIndex = 0, Int32 vertexOffset = 0, UInt32 firstInstance = 0) const noexcept override;
 		
 		/// <inheritdoc />
 		virtual void pushConstants(const DirectX12PushConstantsLayout& layout, const void* const memory) const noexcept override;
@@ -985,7 +985,7 @@ namespace LiteFX::Rendering::Backends {
 		virtual SharedPtr<DirectX12Rasterizer> rasterizer() const noexcept override;
 
 		/// <inheritdoc />
-		virtual const bool& alphaToCoverage() const noexcept override;
+		virtual bool alphaToCoverage() const noexcept override;
 
 		// DirectX12PipelineState interface.
 	public:
@@ -1050,7 +1050,7 @@ namespace LiteFX::Rendering::Backends {
 		/// <param name="bufferIndex">The index of the frame buffer within the parent render pass.</param>
 		/// <param name="renderArea">The initial size of the render area.</param>
 		/// <param name="commandBuffers">The number of command buffers, the frame buffer stores.</param>
-		DirectX12FrameBuffer(const DirectX12RenderPass& renderPass, const UInt32& bufferIndex, const Size2d& renderArea, const UInt32& commandBuffers = 1);
+		DirectX12FrameBuffer(const DirectX12RenderPass& renderPass, UInt32 bufferIndex, const Size2d& renderArea, UInt32 commandBuffers = 1);
 		DirectX12FrameBuffer(const DirectX12FrameBuffer&) noexcept = delete;
 		DirectX12FrameBuffer(DirectX12FrameBuffer&&) noexcept = delete;
 		virtual ~DirectX12FrameBuffer() noexcept;
@@ -1081,14 +1081,14 @@ namespace LiteFX::Rendering::Backends {
 		/// </summary>
 		/// <returns>The size of a descriptor for a render target within the frame buffer.</returns>
 		/// <seealso cref="renderTargetHeap" />
-		virtual const UInt32& renderTargetDescriptorSize() const noexcept;
+		virtual UInt32 renderTargetDescriptorSize() const noexcept;
 
 		/// <summary>
 		/// Returns the size of a descriptor for a depth/stencil view within the frame buffer.
 		/// </summary>
 		/// <returns>The size of a descriptor for a depth/stencil view within the frame buffer.</returns>
 		/// <seealso cref="depthStencilTargetHeap" />
-		virtual const UInt32& depthStencilTargetDescriptorSize() const noexcept;
+		virtual UInt32 depthStencilTargetDescriptorSize() const noexcept;
 
 		/// <summary>
 		/// Returns a reference of the last fence value for the frame buffer.
@@ -1102,7 +1102,7 @@ namespace LiteFX::Rendering::Backends {
 		// FrameBuffer interface.
 	public:
 		/// <inheritdoc />
-		virtual const UInt32& bufferIndex() const noexcept override;
+		virtual UInt32 bufferIndex() const noexcept override;
 
 		/// <inheritdoc />
 		virtual const Size2d& size() const noexcept override;
@@ -1117,13 +1117,13 @@ namespace LiteFX::Rendering::Backends {
 		virtual Enumerable<SharedPtr<const DirectX12CommandBuffer>> commandBuffers() const noexcept override;
 
 		/// <inheritdoc />
-		virtual SharedPtr<const DirectX12CommandBuffer> commandBuffer(const UInt32& index) const override;
+		virtual SharedPtr<const DirectX12CommandBuffer> commandBuffer(UInt32 index) const override;
 
 		/// <inheritdoc />
 		virtual Enumerable<const IDirectX12Image*> images() const noexcept override;
 
 		/// <inheritdoc />
-		virtual const IDirectX12Image& image(const UInt32& location) const override;
+		virtual const IDirectX12Image& image(UInt32 location) const override;
 
 	public:
 		/// <inheritdoc />
@@ -1151,7 +1151,7 @@ namespace LiteFX::Rendering::Backends {
 		/// <param name="renderTargets">The render targets that are output by the render pass.</param>
 		/// <param name="samples">The number of samples for the render targets in this render pass.</param>
 		/// <param name="inputAttachments">The input attachments that are read by the render pass.</param>
-		explicit DirectX12RenderPass(const DirectX12Device& device, Span<RenderTarget> renderTargets, const UInt32& commandBuffers = 1, MultiSamplingLevel samples = MultiSamplingLevel::x1, Span<DirectX12InputAttachmentMapping> inputAttachments = { });
+		explicit DirectX12RenderPass(const DirectX12Device& device, Span<RenderTarget> renderTargets, UInt32 commandBuffers = 1, MultiSamplingLevel samples = MultiSamplingLevel::x1, Span<DirectX12InputAttachmentMapping> inputAttachments = { });
 
 		/// <summary>
 		/// Creates and initializes a new DirectX 12 render pass instance.
@@ -1162,7 +1162,7 @@ namespace LiteFX::Rendering::Backends {
 		/// <param name="renderTargets">The render targets that are output by the render pass.</param>
 		/// <param name="samples">The number of samples for the render targets in this render pass.</param>
 		/// <param name="inputAttachments">The input attachments that are read by the render pass.</param>
-		explicit DirectX12RenderPass(const DirectX12Device& device, const String& name, Span<RenderTarget> renderTargets, const UInt32& commandBuffers = 1, MultiSamplingLevel samples = MultiSamplingLevel::x1, Span<DirectX12InputAttachmentMapping> inputAttachments = { });
+		explicit DirectX12RenderPass(const DirectX12Device& device, const String& name, Span<RenderTarget> renderTargets, UInt32 commandBuffers = 1, MultiSamplingLevel samples = MultiSamplingLevel::x1, Span<DirectX12InputAttachmentMapping> inputAttachments = { });
 
 		DirectX12RenderPass(const DirectX12RenderPass&) = delete;
 		DirectX12RenderPass(DirectX12RenderPass&&) = delete;
@@ -1183,7 +1183,7 @@ namespace LiteFX::Rendering::Backends {
 		// IInputAttachmentMappingSource interface.
 	public:
 		/// <inheritdoc />
-		virtual const DirectX12FrameBuffer& frameBuffer(const UInt32& buffer) const override;
+		virtual const DirectX12FrameBuffer& frameBuffer(UInt32 buffer) const override;
 
 		// RenderPass interface.
 	public:
@@ -1203,7 +1203,7 @@ namespace LiteFX::Rendering::Backends {
 		virtual Enumerable<const DirectX12RenderPipeline*> pipelines() const noexcept override;
 
 		/// <inheritdoc />
-		virtual const RenderTarget& renderTarget(const UInt32& location) const override;
+		virtual const RenderTarget& renderTarget(UInt32 location) const override;
 
 		/// <inheritdoc />
 		virtual Span<const RenderTarget> renderTargets() const noexcept override;
@@ -1219,7 +1219,7 @@ namespace LiteFX::Rendering::Backends {
 
 	public:
 		/// <inheritdoc />
-		virtual void begin(const UInt32& buffer) override;
+		virtual void begin(UInt32 buffer) override;
 
 		/// <inheritdoc />
 		virtual void end() const override;
@@ -1254,7 +1254,7 @@ namespace LiteFX::Rendering::Backends {
 		/// <param name="renderPass">The render pass to fetch the input attachment from.</param>
 		/// <param name="renderTarget">The render target of the <paramref name="renderPass"/> that is used for the input attachment.</param>
 		/// <param name="location">The location to bind the input attachment to.</param>
-		DirectX12InputAttachmentMapping(const DirectX12RenderPass& renderPass, const RenderTarget& renderTarget, const UInt32& location);
+		DirectX12InputAttachmentMapping(const DirectX12RenderPass& renderPass, const RenderTarget& renderTarget, UInt32 location);
 
 		/// <summary>
 		/// Copies another input attachment mapping.
@@ -1287,7 +1287,7 @@ namespace LiteFX::Rendering::Backends {
 		const RenderTarget& renderTarget() const noexcept override;
 
 		/// <inheritdoc />
-		const UInt32& location() const noexcept override;
+		UInt32 location() const noexcept override;
 	};
 
 	/// <summary>
@@ -1309,7 +1309,7 @@ namespace LiteFX::Rendering::Backends {
 		/// <param name="format">The initial surface format.</param>
 		/// <param name="renderArea">The initial size of the render area.</param>
 		/// <param name="buffers">The initial number of buffers.</param>
-		explicit DirectX12SwapChain(const DirectX12Device& device, Format surfaceFormat = Format::B8G8R8A8_SRGB, const Size2d& renderArea = { 800, 600 }, const UInt32& buffers = 3);
+		explicit DirectX12SwapChain(const DirectX12Device& device, Format surfaceFormat = Format::B8G8R8A8_SRGB, const Size2d& renderArea = { 800, 600 }, UInt32 buffers = 3);
 		DirectX12SwapChain(const DirectX12SwapChain&) = delete;
 		DirectX12SwapChain(DirectX12SwapChain&&) = delete;
 		virtual ~DirectX12SwapChain() noexcept;
@@ -1320,7 +1320,7 @@ namespace LiteFX::Rendering::Backends {
 		/// Returns <c>true</c>, if the adapter supports variable refresh rates (i.e. tearing is allowed).
 		/// </summary>
 		/// <returns><c>true</c>, if the adapter supports variable refresh rates (i.e. tearing is allowed).</returns>
-		virtual const bool& supportsVariableRefreshRate() const noexcept;
+		virtual bool supportsVariableRefreshRate() const noexcept;
 
 		/// <summary>
 		/// Returns the query heap for the current frame.
@@ -1334,7 +1334,7 @@ namespace LiteFX::Rendering::Backends {
 		virtual Enumerable<SharedPtr<TimingEvent>> timingEvents() const noexcept override;
 
 		/// <inheritdoc />
-		virtual SharedPtr<TimingEvent> timingEvent(const UInt32& queryId) const override;
+		virtual SharedPtr<TimingEvent> timingEvent(UInt32 queryId) const override;
 
 		/// <inheritdoc />
 		virtual UInt64 readTimingEvent(SharedPtr<const TimingEvent> timingEvent) const override;
@@ -1346,13 +1346,13 @@ namespace LiteFX::Rendering::Backends {
 		virtual Format surfaceFormat() const noexcept override;
 
 		/// <inheritdoc />
-		virtual const UInt32& buffers() const noexcept override;
+		virtual UInt32 buffers() const noexcept override;
 
 		/// <inheritdoc />
 		virtual const Size2d& renderArea() const noexcept override;
 
 		/// <inheritdoc />
-		virtual const IDirectX12Image* image(const UInt32& backBuffer) const override;
+		virtual const IDirectX12Image* image(UInt32 backBuffer) const override;
 
 		/// <inheritdoc />
 		virtual Enumerable<const IDirectX12Image*> images() const noexcept override;
@@ -1368,7 +1368,7 @@ namespace LiteFX::Rendering::Backends {
 		virtual void addTimingEvent(SharedPtr<TimingEvent> timingEvent) override;
 
 		/// <inheritdoc />
-		virtual void reset(Format surfaceFormat, const Size2d& renderArea, const UInt32& buffers) override;
+		virtual void reset(Format surfaceFormat, const Size2d& renderArea, UInt32 buffers) override;
 
 		/// <inheritdoc />
 		[[nodiscard]] virtual UInt32 swapBackBuffer() const override;
@@ -1439,7 +1439,7 @@ namespace LiteFX::Rendering::Backends {
 		virtual void release() override;
 
 		/// <inheritdoc />
-		virtual SharedPtr<DirectX12CommandBuffer> createCommandBuffer(const bool& beginRecording = false, const bool& secondary = false) const override;
+		virtual SharedPtr<DirectX12CommandBuffer> createCommandBuffer(bool beginRecording = false, bool secondary = false) const override;
 
 		/// <inheritdoc />
 		virtual UInt64 submit(SharedPtr<const DirectX12CommandBuffer> commandBuffer) const override;
@@ -1448,7 +1448,7 @@ namespace LiteFX::Rendering::Backends {
 		virtual UInt64 submit(const Enumerable<SharedPtr<const DirectX12CommandBuffer>>& commandBuffers) const override;
 
 		/// <inheritdoc />
-		virtual void waitFor(const UInt64& fence) const noexcept override;
+		virtual void waitFor(UInt64 fence) const noexcept override;
 
 		/// <inheritdoc />
 		virtual UInt64 currentFence() const noexcept override;
@@ -1486,22 +1486,22 @@ namespace LiteFX::Rendering::Backends {
 
 	public:
 		/// <inheritdoc />
-		virtual UniquePtr<IDirectX12Buffer> createBuffer(BufferType type, BufferUsage usage, const size_t& elementSize, const UInt32& elements = 1, const bool& allowWrite = false) const override;
+		virtual UniquePtr<IDirectX12Buffer> createBuffer(BufferType type, BufferUsage usage, size_t elementSize, UInt32 elements = 1, bool allowWrite = false) const override;
 
 		/// <inheritdoc />
-		virtual UniquePtr<IDirectX12Buffer> createBuffer(const String& name, BufferType type, BufferUsage usage, const size_t& elementSize, const UInt32& elements = 1, const bool& allowWrite = false) const override;
+		virtual UniquePtr<IDirectX12Buffer> createBuffer(const String& name, BufferType type, BufferUsage usage, size_t elementSize, UInt32 elements = 1, bool allowWrite = false) const override;
 
 		/// <inheritdoc />
-		virtual UniquePtr<IDirectX12VertexBuffer> createVertexBuffer(const DirectX12VertexBufferLayout& layout, BufferUsage usage, const UInt32& elements = 1) const override;
+		virtual UniquePtr<IDirectX12VertexBuffer> createVertexBuffer(const DirectX12VertexBufferLayout& layout, BufferUsage usage, UInt32 elements = 1) const override;
 
 		/// <inheritdoc />
-		virtual UniquePtr<IDirectX12VertexBuffer> createVertexBuffer(const String& name, const DirectX12VertexBufferLayout& layout, BufferUsage usage, const UInt32& elements = 1) const override;
+		virtual UniquePtr<IDirectX12VertexBuffer> createVertexBuffer(const String& name, const DirectX12VertexBufferLayout& layout, BufferUsage usage, UInt32 elements = 1) const override;
 
 		/// <inheritdoc />
-		virtual UniquePtr<IDirectX12IndexBuffer> createIndexBuffer(const DirectX12IndexBufferLayout& layout, BufferUsage usage, const UInt32& elements) const override;
+		virtual UniquePtr<IDirectX12IndexBuffer> createIndexBuffer(const DirectX12IndexBufferLayout& layout, BufferUsage usage, UInt32 elements) const override;
 
 		/// <inheritdoc />
-		virtual UniquePtr<IDirectX12IndexBuffer> createIndexBuffer(const String& name, const DirectX12IndexBufferLayout& layout, BufferUsage usage, const UInt32& elements) const override;
+		virtual UniquePtr<IDirectX12IndexBuffer> createIndexBuffer(const String& name, const DirectX12IndexBufferLayout& layout, BufferUsage usage, UInt32 elements) const override;
 
 		/// <inheritdoc />
 		virtual UniquePtr<IDirectX12Image> createAttachment(Format format, const Size2d& size, MultiSamplingLevel samples = MultiSamplingLevel::x1) const override;
@@ -1510,22 +1510,22 @@ namespace LiteFX::Rendering::Backends {
 		virtual UniquePtr<IDirectX12Image> createAttachment(const String& name, Format format, const Size2d& size, MultiSamplingLevel samples = MultiSamplingLevel::x1) const override;
 
 		/// <inheritdoc />
-		virtual UniquePtr<IDirectX12Image> createTexture(Format format, const Size3d& size, ImageDimensions dimension = ImageDimensions::DIM_2, const UInt32& levels = 1, const UInt32& layers = 1, MultiSamplingLevel samples = MultiSamplingLevel::x1, const bool& allowWrite = false) const override;
+		virtual UniquePtr<IDirectX12Image> createTexture(Format format, const Size3d& size, ImageDimensions dimension = ImageDimensions::DIM_2, UInt32 levels = 1, UInt32 layers = 1, MultiSamplingLevel samples = MultiSamplingLevel::x1, bool allowWrite = false) const override;
 
 		/// <inheritdoc />
-		virtual UniquePtr<IDirectX12Image> createTexture(const String& name, Format format, const Size3d& size, ImageDimensions dimension = ImageDimensions::DIM_2, const UInt32& levels = 1, const UInt32& layers = 1, MultiSamplingLevel samples = MultiSamplingLevel::x1, const bool& allowWrite = false) const override;
+		virtual UniquePtr<IDirectX12Image> createTexture(const String& name, Format format, const Size3d& size, ImageDimensions dimension = ImageDimensions::DIM_2, UInt32 levels = 1, UInt32 layers = 1, MultiSamplingLevel samples = MultiSamplingLevel::x1, bool allowWrite = false) const override;
 
 		/// <inheritdoc />
-		virtual Enumerable<UniquePtr<IDirectX12Image>> createTextures(const UInt32& elements, Format format, const Size3d& size, ImageDimensions dimension = ImageDimensions::DIM_2, const UInt32& levels = 1, const UInt32& layers = 1, MultiSamplingLevel samples = MultiSamplingLevel::x1, const bool& allowWrite = false) const override;
+		virtual Enumerable<UniquePtr<IDirectX12Image>> createTextures(UInt32 elements, Format format, const Size3d& size, ImageDimensions dimension = ImageDimensions::DIM_2, UInt32 levels = 1, UInt32 layers = 1, MultiSamplingLevel samples = MultiSamplingLevel::x1, bool allowWrite = false) const override;
 
 		/// <inheritdoc />
-		virtual UniquePtr<IDirectX12Sampler> createSampler(FilterMode magFilter = FilterMode::Nearest, FilterMode minFilter = FilterMode::Nearest, BorderMode borderU = BorderMode::Repeat, BorderMode borderV = BorderMode::Repeat, BorderMode borderW = BorderMode::Repeat, MipMapMode mipMapMode = MipMapMode::Nearest, const Float& mipMapBias = 0.f, const Float& maxLod = std::numeric_limits<Float>::max(), const Float& minLod = 0.f, const Float& anisotropy = 0.f) const override;
+		virtual UniquePtr<IDirectX12Sampler> createSampler(FilterMode magFilter = FilterMode::Nearest, FilterMode minFilter = FilterMode::Nearest, BorderMode borderU = BorderMode::Repeat, BorderMode borderV = BorderMode::Repeat, BorderMode borderW = BorderMode::Repeat, MipMapMode mipMapMode = MipMapMode::Nearest, Float mipMapBias = 0.f, Float maxLod = std::numeric_limits<Float>::max(), Float minLod = 0.f, Float anisotropy = 0.f) const override;
 
 		/// <inheritdoc />
-		virtual UniquePtr<IDirectX12Sampler> createSampler(const String& name, FilterMode magFilter = FilterMode::Nearest, FilterMode minFilter = FilterMode::Nearest, BorderMode borderU = BorderMode::Repeat, BorderMode borderV = BorderMode::Repeat, BorderMode borderW = BorderMode::Repeat, MipMapMode mipMapMode = MipMapMode::Nearest, const Float& mipMapBias = 0.f, const Float& maxLod = std::numeric_limits<Float>::max(), const Float& minLod = 0.f, const Float& anisotropy = 0.f) const override;
+		virtual UniquePtr<IDirectX12Sampler> createSampler(const String& name, FilterMode magFilter = FilterMode::Nearest, FilterMode minFilter = FilterMode::Nearest, BorderMode borderU = BorderMode::Repeat, BorderMode borderV = BorderMode::Repeat, BorderMode borderW = BorderMode::Repeat, MipMapMode mipMapMode = MipMapMode::Nearest, Float mipMapBias = 0.f, Float maxLod = std::numeric_limits<Float>::max(), Float minLod = 0.f, Float anisotropy = 0.f) const override;
 
 		/// <inheritdoc />
-		virtual Enumerable<UniquePtr<IDirectX12Sampler>> createSamplers(const UInt32& elements, FilterMode magFilter = FilterMode::Nearest, FilterMode minFilter = FilterMode::Nearest, BorderMode borderU = BorderMode::Repeat, BorderMode borderV = BorderMode::Repeat, BorderMode borderW = BorderMode::Repeat, MipMapMode mipMapMode = MipMapMode::Nearest, const Float& mipMapBias = 0.f, const Float& maxLod = std::numeric_limits<Float>::max(), const Float& minLod = 0.f, const Float& anisotropy = 0.f) const override;
+		virtual Enumerable<UniquePtr<IDirectX12Sampler>> createSamplers(UInt32 elements, FilterMode magFilter = FilterMode::Nearest, FilterMode minFilter = FilterMode::Nearest, BorderMode borderU = BorderMode::Repeat, BorderMode borderV = BorderMode::Repeat, BorderMode borderW = BorderMode::Repeat, MipMapMode mipMapMode = MipMapMode::Nearest, Float mipMapBias = 0.f, Float maxLod = std::numeric_limits<Float>::max(), Float minLod = 0.f, Float anisotropy = 0.f) const override;
 	};
 
 	/// <summary>
@@ -1554,7 +1554,7 @@ namespace LiteFX::Rendering::Backends {
 		/// <param name="frameBuffers">The initial number of frame buffers.</param>
 		/// <param name="globalBufferHeapSize">The size of the global heap for constant buffers, shader resources and images.</param>
 		/// <param name="globalSamplerHeapSize">The size of the global heap for samplers.</param>
-		explicit DirectX12Device(const DirectX12Backend& backend, const DirectX12GraphicsAdapter& adapter, UniquePtr<DirectX12Surface>&& surface, Format format, const Size2d& frameBufferSize, const UInt32& frameBuffers, const UInt32& globalBufferHeapSize = 524287, const UInt32& globalSamplerHeapSize = 2048);
+		explicit DirectX12Device(const DirectX12Backend& backend, const DirectX12GraphicsAdapter& adapter, UniquePtr<DirectX12Surface>&& surface, Format format, const Size2d& frameBufferSize, UInt32 frameBuffers, UInt32 globalBufferHeapSize = 524287, UInt32 globalSamplerHeapSize = 2048);
 
 		DirectX12Device(const DirectX12Device&) = delete;
 		DirectX12Device(DirectX12Device&&) = delete;
@@ -1609,7 +1609,7 @@ namespace LiteFX::Rendering::Backends {
 		/// <param name="descriptorSet">The descriptor set to copy the descriptors from.</param>
 		/// <param name="firstDescriptor">The index of the first descriptor to copy.</param>
 		/// <param name="descriptors">The number of descriptors to copy.</param>
-		virtual void updateBufferDescriptors(const DirectX12DescriptorSet& descriptorSet, const UInt32& firstDescriptor, const UInt32& descriptors) const noexcept;
+		virtual void updateBufferDescriptors(const DirectX12DescriptorSet& descriptorSet, UInt32 firstDescriptor, UInt32 descriptors) const noexcept;
 
 		/// <summary>
 		/// Updates a sampler descriptors in the global buffer descriptor heap with a descriptor from <paramref name="descriptorSet" />.
@@ -1617,7 +1617,7 @@ namespace LiteFX::Rendering::Backends {
 		/// <param name="descriptorSet">The descriptor set to copy the descriptors from.</param>
 		/// <param name="firstDescriptor">The index of the first descriptor to copy.</param>
 		/// <param name="descriptors">The number of descriptors to copy.</param>
-		virtual void updateSamplerDescriptors(const DirectX12DescriptorSet& descriptorSet, const UInt32& firstDescriptor, const UInt32& descriptors) const noexcept;
+		virtual void updateSamplerDescriptors(const DirectX12DescriptorSet& descriptorSet, UInt32 firstDescriptor, UInt32 descriptors) const noexcept;
 
 		/// <summary>
 		/// Binds the descriptors of the descriptor set to the global descriptor heaps.
@@ -1696,10 +1696,10 @@ namespace LiteFX::Rendering::Backends {
 #if defined(BUILD_DEFINE_BUILDERS)
 	public:
 		/// <inheritdoc />
-		[[nodiscard]] virtual DirectX12RenderPassBuilder buildRenderPass(MultiSamplingLevel samples = MultiSamplingLevel::x1, const UInt32& commandBuffers = 1) const override;
+		[[nodiscard]] virtual DirectX12RenderPassBuilder buildRenderPass(MultiSamplingLevel samples = MultiSamplingLevel::x1, UInt32 commandBuffers = 1) const override;
 
 		/// <inheritdoc />
-		[[nodiscard]] virtual DirectX12RenderPassBuilder buildRenderPass(const String& name, MultiSamplingLevel samples = MultiSamplingLevel::x1, const UInt32& commandBuffers = 1) const override;
+		[[nodiscard]] virtual DirectX12RenderPassBuilder buildRenderPass(const String& name, MultiSamplingLevel samples = MultiSamplingLevel::x1, UInt32 commandBuffers = 1) const override;
 
 		/// <inheritdoc />
 		//[[nodiscard]] virtual DirectX12RenderPipelineBuilder buildRenderPipeline(const String& name) const override;
@@ -1734,7 +1734,7 @@ namespace LiteFX::Rendering::Backends {
 		LITEFX_IMPLEMENTATION(DirectX12BackendImpl);
 
 	public:
-		explicit DirectX12Backend(const App& app, const bool& advancedSoftwareRasterizer = false);
+		explicit DirectX12Backend(const App& app, bool advancedSoftwareRasterizer = false);
 		DirectX12Backend(const DirectX12Backend&) noexcept = delete;
 		DirectX12Backend(DirectX12Backend&&) noexcept = delete;
 		virtual ~DirectX12Backend();
@@ -1790,6 +1790,6 @@ namespace LiteFX::Rendering::Backends {
 		/// will only return WARP-compatible adapters.
 		/// </remarks>
 		/// <param name="enable"><c>true</c>, if advanced software rasterization should be used.</param>
-		virtual void enableAdvancedSoftwareRasterizer(const bool& enable = false);
+		virtual void enableAdvancedSoftwareRasterizer(bool enable = false);
 	};
 }

--- a/src/Backends/DirectX12/include/litefx/backends/dx12.hpp
+++ b/src/Backends/DirectX12/include/litefx/backends/dx12.hpp
@@ -15,7 +15,7 @@ namespace LiteFX::Rendering::Backends {
 	/// <seealso cref="DirectX12VertexBuffer" />
 	/// <seealso cref="DirectX12IndexBuffer" />
 	/// <seealso cref="DirectX12VertexBufferLayoutBuilder" />
-	class LITEFX_DIRECTX12_API DirectX12VertexBufferLayout : public IVertexBufferLayout {
+	class LITEFX_DIRECTX12_API DirectX12VertexBufferLayout final : public IVertexBufferLayout {
 		LITEFX_IMPLEMENTATION(DirectX12VertexBufferLayoutImpl);
 		LITEFX_BUILDER(DirectX12VertexBufferLayoutBuilder);
 
@@ -52,7 +52,7 @@ namespace LiteFX::Rendering::Backends {
 	/// </summary>
 	/// <seealso cref="DirectX12IndexBuffer" />
 	/// <seealso cref="DirectX12VertexBufferLayout" />
-	class LITEFX_DIRECTX12_API DirectX12IndexBufferLayout : public IIndexBufferLayout {
+	class LITEFX_DIRECTX12_API DirectX12IndexBufferLayout final : public IIndexBufferLayout {
 		LITEFX_IMPLEMENTATION(DirectX12IndexBufferLayoutImpl);
 
 	public:
@@ -157,7 +157,7 @@ namespace LiteFX::Rendering::Backends {
 	/// <seealso cref="IDirectX12Buffer" />
 	/// <seealso cref="IDirectX12Image" />
 	/// <seealso cref="Barrier" />
-	class LITEFX_DIRECTX12_API DirectX12Barrier : public Barrier<IDirectX12Buffer, IDirectX12Image> {
+	class LITEFX_DIRECTX12_API DirectX12Barrier final : public Barrier<IDirectX12Buffer, IDirectX12Image> {
 		LITEFX_IMPLEMENTATION(DirectX12BarrierImpl);
 		LITEFX_BUILDER(DirectX12BarrierBuilder);
 
@@ -224,7 +224,7 @@ namespace LiteFX::Rendering::Backends {
 	/// </summary>
 	/// <seealso cref="DirectX12ShaderProgram" />
 	/// <seealso href="https://github.com/crud89/LiteFX/wiki/Shader-Development" />
-	class LITEFX_DIRECTX12_API DirectX12ShaderModule : public IShaderModule, public ComResource<IDxcBlob> {
+	class LITEFX_DIRECTX12_API DirectX12ShaderModule final : public IShaderModule, public ComResource<IDxcBlob> {
 		LITEFX_IMPLEMENTATION(DirectX12ShaderModuleImpl);
 
 	public:
@@ -267,7 +267,7 @@ namespace LiteFX::Rendering::Backends {
 	/// </summary>
 	/// <seealso cref="DirectX12ShaderProgramBuilder" />
 	/// <seealso href="https://github.com/crud89/LiteFX/wiki/Shader-Development" />
-	class LITEFX_DIRECTX12_API DirectX12ShaderProgram : public ShaderProgram<DirectX12ShaderModule> {
+	class LITEFX_DIRECTX12_API DirectX12ShaderProgram final : public ShaderProgram<DirectX12ShaderModule> {
 		LITEFX_IMPLEMENTATION(DirectX12ShaderProgramImpl);
 		LITEFX_BUILDER(DirectX12ShaderProgramBuilder);
 
@@ -321,7 +321,7 @@ namespace LiteFX::Rendering::Backends {
 	/// Implements a DirectX 12 <see cref="DescriptorSet" />.
 	/// </summary>
 	/// <seealso cref="DirectX12DescriptorSetLayout" />
-	class LITEFX_DIRECTX12_API DirectX12DescriptorSet : public DescriptorSet<IDirectX12Buffer, IDirectX12Image, IDirectX12Sampler> {
+	class LITEFX_DIRECTX12_API DirectX12DescriptorSet final : public DescriptorSet<IDirectX12Buffer, IDirectX12Image, IDirectX12Sampler> {
 		LITEFX_IMPLEMENTATION(DirectX12DescriptorSetImpl);
 
 	public:
@@ -395,7 +395,7 @@ namespace LiteFX::Rendering::Backends {
 	/// <seealso cref="IDirectX12Sampler" />
 	/// <seealso cref="DirectX12DescriptorSet" />
 	/// <seealso cref="DirectX12DescriptorSetLayout" />
-	class LITEFX_DIRECTX12_API DirectX12DescriptorLayout : public IDescriptorLayout {
+	class LITEFX_DIRECTX12_API DirectX12DescriptorLayout final : public IDescriptorLayout {
 		LITEFX_IMPLEMENTATION(DirectX12DescriptorLayoutImpl);
 
 	public:
@@ -447,7 +447,7 @@ namespace LiteFX::Rendering::Backends {
 	/// </summary>
 	/// <seealso cref="DirectX12DescriptorSet" />
 	/// <seealso cref="DirectX12PipelineDescriptorSetLayoutBuilder" />
-	class LITEFX_DIRECTX12_API DirectX12DescriptorSetLayout : public DescriptorSetLayout<DirectX12DescriptorLayout, DirectX12DescriptorSet> {
+	class LITEFX_DIRECTX12_API DirectX12DescriptorSetLayout final : public DescriptorSetLayout<DirectX12DescriptorLayout, DirectX12DescriptorSet> {
 		LITEFX_IMPLEMENTATION(DirectX12DescriptorSetLayoutImpl);
 		LITEFX_BUILDER(DirectX12DescriptorSetLayoutBuilder);
 		friend class DirectX12PipelineLayout;
@@ -575,7 +575,7 @@ namespace LiteFX::Rendering::Backends {
 	/// Implements the DirectX 12 <see cref="IPushConstantsRange" />.
 	/// </summary>
 	/// <seealso cref="DirectX12PushConstantsLayout" />
-	class LITEFX_DIRECTX12_API DirectX12PushConstantsRange : public IPushConstantsRange {
+	class LITEFX_DIRECTX12_API DirectX12PushConstantsRange final : public IPushConstantsRange {
 		LITEFX_IMPLEMENTATION(DirectX12PushConstantsRangeImpl);
 		friend class DirectX12PipelineLayout;
 
@@ -635,7 +635,7 @@ namespace LiteFX::Rendering::Backends {
 	/// </remarks>
 	/// <seealso cref="DirectX12PushConstantsRange" />
 	/// <seealso cref="DirectX12PipelinePushConstantsLayoutBuilder" />
-	class LITEFX_DIRECTX12_API DirectX12PushConstantsLayout : public PushConstantsLayout<DirectX12PushConstantsRange> {
+	class LITEFX_DIRECTX12_API DirectX12PushConstantsLayout final : public PushConstantsLayout<DirectX12PushConstantsRange> {
 		LITEFX_IMPLEMENTATION(DirectX12PushConstantsLayoutImpl);
 		LITEFX_BUILDER(DirectX12PushConstantsLayoutBuilder);
 		friend class DirectX12PipelineLayout;
@@ -680,7 +680,7 @@ namespace LiteFX::Rendering::Backends {
 	/// Implements a DirectX 12 <see cref="PipelineLayout" />.
 	/// </summary>
 	/// <seealso cref="DirectX12PipelineLayoutBuilder" />
-	class LITEFX_DIRECTX12_API DirectX12PipelineLayout : public PipelineLayout<DirectX12DescriptorSetLayout, DirectX12PushConstantsLayout>, public ComResource<ID3D12RootSignature> {
+	class LITEFX_DIRECTX12_API DirectX12PipelineLayout final : public PipelineLayout<DirectX12DescriptorSetLayout, DirectX12PushConstantsLayout>, public ComResource<ID3D12RootSignature> {
 		LITEFX_IMPLEMENTATION(DirectX12PipelineLayoutImpl);
 		LITEFX_BUILDER(DirectX12PipelineLayoutBuilder);
 
@@ -726,7 +726,7 @@ namespace LiteFX::Rendering::Backends {
 	/// Implements the DirectX 12 input assembler state.
 	/// </summary>
 	/// <seealso cref="DirectX12InputAssemblerBuilder" />
-	class LITEFX_DIRECTX12_API DirectX12InputAssembler : public InputAssembler<DirectX12VertexBufferLayout, DirectX12IndexBufferLayout> {
+	class LITEFX_DIRECTX12_API DirectX12InputAssembler final : public InputAssembler<DirectX12VertexBufferLayout, DirectX12IndexBufferLayout> {
 		LITEFX_IMPLEMENTATION(DirectX12InputAssemblerImpl);
 		LITEFX_BUILDER(DirectX12InputAssemblerBuilder);
 
@@ -766,7 +766,7 @@ namespace LiteFX::Rendering::Backends {
 	/// Implements a DirectX 12 <see cref="IRasterizer" />.
 	/// </summary>
 	/// <seealso cref="DirectX12RasterizerBuilder" />
-	class LITEFX_DIRECTX12_API DirectX12Rasterizer : public Rasterizer {
+	class LITEFX_DIRECTX12_API DirectX12Rasterizer final : public Rasterizer {
 		LITEFX_BUILDER(DirectX12RasterizerBuilder);
 
 	public:
@@ -812,7 +812,7 @@ namespace LiteFX::Rendering::Backends {
 	/// Records commands for a <see cref="DirectX12CommandQueue" />
 	/// </summary>
 	/// <seealso cref="DirectX12CommandQueue" />
-	class LITEFX_DIRECTX12_API DirectX12CommandBuffer : public CommandBuffer<DirectX12CommandBuffer, IDirectX12Buffer, IDirectX12VertexBuffer, IDirectX12IndexBuffer, IDirectX12Image, DirectX12Barrier, DirectX12PipelineState>, public ComResource<ID3D12GraphicsCommandList7> {
+	class LITEFX_DIRECTX12_API DirectX12CommandBuffer final : public CommandBuffer<DirectX12CommandBuffer, IDirectX12Buffer, IDirectX12VertexBuffer, IDirectX12IndexBuffer, IDirectX12Image, DirectX12Barrier, DirectX12PipelineState>, public ComResource<ID3D12GraphicsCommandList7> {
 		LITEFX_IMPLEMENTATION(DirectX12CommandBufferImpl);
 
 	public:
@@ -940,7 +940,7 @@ namespace LiteFX::Rendering::Backends {
 	/// </summary>
 	/// <seealso cref="DirectX12ComputePipeline" />
 	/// <seealso cref="DirectX12RenderPipelineBuilder" />
-	class LITEFX_DIRECTX12_API DirectX12RenderPipeline : public virtual DirectX12PipelineState, public RenderPipeline<DirectX12PipelineLayout, DirectX12ShaderProgram, DirectX12InputAssembler, DirectX12Rasterizer> {
+	class LITEFX_DIRECTX12_API DirectX12RenderPipeline final : public virtual DirectX12PipelineState, public RenderPipeline<DirectX12PipelineLayout, DirectX12ShaderProgram, DirectX12InputAssembler, DirectX12Rasterizer> {
 		LITEFX_IMPLEMENTATION(DirectX12RenderPipelineImpl);
 		LITEFX_BUILDER(DirectX12RenderPipelineBuilder);
 
@@ -998,7 +998,7 @@ namespace LiteFX::Rendering::Backends {
 	/// </summary>
 	/// <seealso cref="DirectX12RenderPipeline" />
 	/// <seealso cref="DirectX12ComputePipelineBuilder" />
-	class LITEFX_DIRECTX12_API DirectX12ComputePipeline : public virtual DirectX12PipelineState, public ComputePipeline<DirectX12PipelineLayout, DirectX12ShaderProgram> {
+	class LITEFX_DIRECTX12_API DirectX12ComputePipeline final : public virtual DirectX12PipelineState, public ComputePipeline<DirectX12PipelineLayout, DirectX12ShaderProgram> {
 		LITEFX_IMPLEMENTATION(DirectX12ComputePipelineImpl);
 		LITEFX_BUILDER(DirectX12ComputePipelineBuilder);
 
@@ -1039,7 +1039,7 @@ namespace LiteFX::Rendering::Backends {
 	/// Implements a DirectX 12 frame buffer.
 	/// </summary>
 	/// <seealso cref="DirectX12RenderPass" />
-	class LITEFX_DIRECTX12_API DirectX12FrameBuffer : public FrameBuffer<DirectX12CommandBuffer> {
+	class LITEFX_DIRECTX12_API DirectX12FrameBuffer final : public FrameBuffer<DirectX12CommandBuffer> {
 		LITEFX_IMPLEMENTATION(DirectX12FrameBufferImpl);
 
 	public:
@@ -1134,7 +1134,7 @@ namespace LiteFX::Rendering::Backends {
 	/// Implements a DirectX 12 render pass.
 	/// </summary>
 	/// <seealso cref="DirectX12RenderPassBuilder" />
-	class LITEFX_DIRECTX12_API DirectX12RenderPass : public RenderPass<DirectX12RenderPipeline, DirectX12FrameBuffer, DirectX12InputAttachmentMapping> {
+	class LITEFX_DIRECTX12_API DirectX12RenderPass final : public RenderPass<DirectX12RenderPipeline, DirectX12FrameBuffer, DirectX12InputAttachmentMapping> {
 		LITEFX_IMPLEMENTATION(DirectX12RenderPassImpl);
 		LITEFX_BUILDER(DirectX12RenderPassBuilder);
 
@@ -1239,7 +1239,7 @@ namespace LiteFX::Rendering::Backends {
 	/// </summary>
 	/// <seealso cref="DirectX12RenderPass" />
 	/// <seealso cref="DirectX12RenderPassBuilder" />
-	class LITEFX_DIRECTX12_API DirectX12InputAttachmentMapping : public IInputAttachmentMapping<DirectX12RenderPass> {
+	class LITEFX_DIRECTX12_API DirectX12InputAttachmentMapping final : public IInputAttachmentMapping<DirectX12RenderPass> {
 		LITEFX_IMPLEMENTATION(DirectX12InputAttachmentMappingImpl);
 
 	public:
@@ -1293,7 +1293,7 @@ namespace LiteFX::Rendering::Backends {
 	/// <summary>
 	/// Implements a DirectX 12 swap chain.
 	/// </summary>
-	class LITEFX_DIRECTX12_API DirectX12SwapChain : public SwapChain<IDirectX12Image, DirectX12FrameBuffer>, public ComResource<IDXGISwapChain4> {
+	class LITEFX_DIRECTX12_API DirectX12SwapChain final : public SwapChain<IDirectX12Image, DirectX12FrameBuffer>, public ComResource<IDXGISwapChain4> {
 		LITEFX_IMPLEMENTATION(DirectX12SwapChainImpl);
 		friend class DirectX12RenderPass;
 
@@ -1381,7 +1381,7 @@ namespace LiteFX::Rendering::Backends {
 	/// Implements a DirectX 12 command queue.
 	/// </summary>
 	/// <seealso cref="DirectX12CommandBuffer" />
-	class LITEFX_DIRECTX12_API DirectX12Queue : public CommandQueue<DirectX12CommandBuffer>, public ComResource<ID3D12CommandQueue> {
+	class LITEFX_DIRECTX12_API DirectX12Queue final : public CommandQueue<DirectX12CommandBuffer>, public ComResource<ID3D12CommandQueue> {
 		LITEFX_IMPLEMENTATION(DirectX12QueueImpl);
 
 	public:
@@ -1460,7 +1460,7 @@ namespace LiteFX::Rendering::Backends {
 	/// <remarks>
 	/// The DX12 graphics factory is implemented using <a href="https://gpuopen.com/d3d12-memory-allocator/" target="_blank">D3D12 Memory Allocator</a>.
 	/// </remarks>
-	class LITEFX_DIRECTX12_API DirectX12GraphicsFactory : public GraphicsFactory<DirectX12DescriptorLayout, IDirectX12Buffer, IDirectX12VertexBuffer, IDirectX12IndexBuffer, IDirectX12Image, IDirectX12Sampler> {
+	class LITEFX_DIRECTX12_API DirectX12GraphicsFactory final : public GraphicsFactory<DirectX12DescriptorLayout, IDirectX12Buffer, IDirectX12VertexBuffer, IDirectX12IndexBuffer, IDirectX12Image, IDirectX12Sampler> {
 		LITEFX_IMPLEMENTATION(DirectX12GraphicsFactoryImpl);
 
 	public:
@@ -1531,7 +1531,7 @@ namespace LiteFX::Rendering::Backends {
 	/// <summary>
 	/// Implements a DirectX 12 graphics device.
 	/// </summary>
-	class LITEFX_DIRECTX12_API DirectX12Device : public GraphicsDevice<DirectX12GraphicsFactory, DirectX12Surface, DirectX12GraphicsAdapter, DirectX12SwapChain, DirectX12Queue, DirectX12RenderPass, DirectX12ComputePipeline, DirectX12Barrier>, public ComResource<ID3D12Device10> {
+	class LITEFX_DIRECTX12_API DirectX12Device final : public GraphicsDevice<DirectX12GraphicsFactory, DirectX12Surface, DirectX12GraphicsAdapter, DirectX12SwapChain, DirectX12Queue, DirectX12RenderPass, DirectX12ComputePipeline, DirectX12Barrier>, public ComResource<ID3D12Device10> {
 		LITEFX_IMPLEMENTATION(DirectX12DeviceImpl);
 
 	public:
@@ -1730,7 +1730,7 @@ namespace LiteFX::Rendering::Backends {
 	/// <summary>
 	/// Implements the DirectX 12 <see cref="RenderBackend" />.
 	/// </summary>
-	class LITEFX_DIRECTX12_API DirectX12Backend : public RenderBackend<DirectX12Device>, public ComResource<IDXGIFactory7> {
+	class LITEFX_DIRECTX12_API DirectX12Backend final : public RenderBackend<DirectX12Device>, public ComResource<IDXGIFactory7> {
 		LITEFX_IMPLEMENTATION(DirectX12BackendImpl);
 
 	public:
@@ -1792,4 +1792,5 @@ namespace LiteFX::Rendering::Backends {
 		/// <param name="enable"><c>true</c>, if advanced software rasterization should be used.</param>
 		virtual void enableAdvancedSoftwareRasterizer(bool enable = false);
 	};
+
 }

--- a/src/Backends/DirectX12/include/litefx/backends/dx12.hpp
+++ b/src/Backends/DirectX12/include/litefx/backends/dx12.hpp
@@ -33,18 +33,18 @@ namespace LiteFX::Rendering::Backends {
 		// IVertexBufferLayout interface.
 	public:
 		/// <inheritdoc />
-		virtual Enumerable<const BufferAttribute*> attributes() const noexcept override;
+		Enumerable<const BufferAttribute*> attributes() const noexcept override;
 
 		// IBufferLayout interface.
 	public:
 		/// <inheritdoc />
-		virtual size_t elementSize() const noexcept override;
+		size_t elementSize() const noexcept override;
 
 		/// <inheritdoc />
-		virtual UInt32 binding() const noexcept override;
+		UInt32 binding() const noexcept override;
 
 		/// <inheritdoc />
-		virtual BufferType type() const noexcept override;
+		BufferType type() const noexcept override;
 	};
 
 	/// <summary>
@@ -68,18 +68,18 @@ namespace LiteFX::Rendering::Backends {
 		// IIndexBufferLayout interface.
 	public:
 		/// <inheritdoc />
-		virtual IndexType indexType() const noexcept override;
+		IndexType indexType() const noexcept override;
 
 		// IBufferLayout interface.
 	public:
 		/// <inheritdoc />
-		virtual size_t elementSize() const noexcept override;
+		size_t elementSize() const noexcept override;
 
 		/// <inheritdoc />
-		virtual UInt32 binding() const noexcept override;
+		UInt32 binding() const noexcept override;
 
 		/// <inheritdoc />
-		virtual BufferType type() const noexcept override;
+		BufferType type() const noexcept override;
 	};
 
 	/// <summary>
@@ -253,13 +253,13 @@ namespace LiteFX::Rendering::Backends {
 		// IShaderModule interface.
 	public:
 		/// <inheritdoc />
-		virtual const String& fileName() const noexcept override;
+		const String& fileName() const noexcept override;
 
 		/// <inheritdoc />
-		virtual const String& entryPoint() const noexcept override;
+		const String& entryPoint() const noexcept override;
 
 		/// <inheritdoc />
-		virtual ShaderStage type() const noexcept override;
+		ShaderStage type() const noexcept override;
 	};
 
 	/// <summary>
@@ -291,13 +291,13 @@ namespace LiteFX::Rendering::Backends {
 
 	public:
 		/// <inheritdoc />
-		virtual Enumerable<const DirectX12ShaderModule*> modules() const noexcept override;
+		Enumerable<const DirectX12ShaderModule*> modules() const noexcept override;
 
 		/// <inheritdoc />
 		virtual SharedPtr<DirectX12PipelineLayout> reflectPipelineLayout() const;
 
 	private:
-		virtual SharedPtr<IPipelineLayout> parsePipelineLayout() const override {
+		SharedPtr<IPipelineLayout> parsePipelineLayout() const override {
 			return std::static_pointer_cast<IPipelineLayout>(this->reflectPipelineLayout());
 		}
 
@@ -350,16 +350,16 @@ namespace LiteFX::Rendering::Backends {
 
 	public:
 		/// <inheritdoc />
-		virtual void update(UInt32 binding, const IDirectX12Buffer& buffer, UInt32 bufferElement = 0, UInt32 elements = 0, UInt32 firstDescriptor = 0) const override;
+		void update(UInt32 binding, const IDirectX12Buffer& buffer, UInt32 bufferElement = 0, UInt32 elements = 0, UInt32 firstDescriptor = 0) const override;
 
 		/// <inheritdoc />
-		virtual void update(UInt32 binding, const IDirectX12Image& texture, UInt32 descriptor = 0, UInt32 firstLevel = 0, UInt32 levels = 0, UInt32 firstLayer = 0, UInt32 layers = 0) const override;
+		void update(UInt32 binding, const IDirectX12Image& texture, UInt32 descriptor = 0, UInt32 firstLevel = 0, UInt32 levels = 0, UInt32 firstLayer = 0, UInt32 layers = 0) const override;
 
 		/// <inheritdoc />
-		virtual void update(UInt32 binding, const IDirectX12Sampler& sampler, UInt32 descriptor = 0) const override;
+		void update(UInt32 binding, const IDirectX12Sampler& sampler, UInt32 descriptor = 0) const override;
 
 		/// <inheritdoc />
-		virtual void attach(UInt32 binding, const IDirectX12Image& image) const override;
+		void attach(UInt32 binding, const IDirectX12Image& image) const override;
 
 	public:
 		/// <summary>
@@ -422,24 +422,24 @@ namespace LiteFX::Rendering::Backends {
 		// IDescriptorLayout interface.
 	public:
 		/// <inheritdoc />
-		virtual DescriptorType descriptorType() const noexcept override;
+		DescriptorType descriptorType() const noexcept override;
 
 		/// <inheritdoc />
-		virtual UInt32 descriptors() const noexcept override;
+		UInt32 descriptors() const noexcept override;
 
 		/// <inheritdoc />
-		virtual const IDirectX12Sampler* staticSampler() const noexcept override;
+		const IDirectX12Sampler* staticSampler() const noexcept override;
 
 		// IBufferLayout interface.
 	public:
 		/// <inheritdoc />
-		virtual size_t elementSize() const noexcept override;
+		size_t elementSize() const noexcept override;
 
 		/// <inheritdoc />
-		virtual UInt32 binding() const noexcept override;
+		UInt32 binding() const noexcept override;
 
 		/// <inheritdoc />
-		virtual BufferType type() const noexcept override;
+		BufferType type() const noexcept override;
 	};
 
 	/// <summary>
@@ -516,59 +516,59 @@ namespace LiteFX::Rendering::Backends {
 
 	public:
 		/// <inheritdoc />
-		virtual Enumerable<const DirectX12DescriptorLayout*> descriptors() const noexcept override;
+		Enumerable<const DirectX12DescriptorLayout*> descriptors() const noexcept override;
 
 		/// <inheritdoc />
-		virtual const DirectX12DescriptorLayout& descriptor(UInt32 binding) const override;
+		const DirectX12DescriptorLayout& descriptor(UInt32 binding) const override;
 
 		/// <inheritdoc />
-		virtual UInt32 space() const noexcept override;
+		UInt32 space() const noexcept override;
 
 		/// <inheritdoc />
-		virtual ShaderStage shaderStages() const noexcept override;
+		ShaderStage shaderStages() const noexcept override;
 
 		/// <inheritdoc />
-		virtual UInt32 uniforms() const noexcept override;
+		UInt32 uniforms() const noexcept override;
 
 		/// <inheritdoc />
-		virtual UInt32 storages() const noexcept override;
+		UInt32 storages() const noexcept override;
 
 		/// <inheritdoc />
-		virtual UInt32 images() const noexcept override;
+		UInt32 images() const noexcept override;
 
 		/// <inheritdoc />
-		virtual UInt32 buffers() const noexcept override;
+		UInt32 buffers() const noexcept override;
 
 		/// <inheritdoc />
-		virtual UInt32 samplers() const noexcept override;
+		UInt32 samplers() const noexcept override;
 
 		/// <inheritdoc />
-		virtual UInt32 staticSamplers() const noexcept override;
+		UInt32 staticSamplers() const noexcept override;
 
 		/// <inheritdoc />
-		virtual UInt32 inputAttachments() const noexcept override;
+		UInt32 inputAttachments() const noexcept override;
 
 	public:
 		/// <inheritdoc />
-		virtual UniquePtr<DirectX12DescriptorSet> allocate(const Enumerable<DescriptorBinding>& bindings = { }) const override;
+		UniquePtr<DirectX12DescriptorSet> allocate(const Enumerable<DescriptorBinding>& bindings = { }) const override;
 
 		/// <inheritdoc />
-		virtual UniquePtr<DirectX12DescriptorSet> allocate(UInt32 descriptors, const Enumerable<DescriptorBinding>& bindings = { }) const override;
+		UniquePtr<DirectX12DescriptorSet> allocate(UInt32 descriptors, const Enumerable<DescriptorBinding>& bindings = { }) const override;
 
 		/// <inheritdoc />
-		virtual Enumerable<UniquePtr<DirectX12DescriptorSet>> allocateMultiple(UInt32 descriptorSets, const Enumerable<Enumerable<DescriptorBinding>>& bindings = { }) const override;
+		Enumerable<UniquePtr<DirectX12DescriptorSet>> allocateMultiple(UInt32 descriptorSets, const Enumerable<Enumerable<DescriptorBinding>>& bindings = { }) const override;
 
 		/// <inheritdoc />
-		virtual Enumerable<UniquePtr<DirectX12DescriptorSet>> allocateMultiple(UInt32 descriptorSets, std::function<Enumerable<DescriptorBinding>(UInt32)> bindingFactory) const override;
+		Enumerable<UniquePtr<DirectX12DescriptorSet>> allocateMultiple(UInt32 descriptorSets, std::function<Enumerable<DescriptorBinding>(UInt32)> bindingFactory) const override;
 
 		/// <inheritdoc />
-		virtual Enumerable<UniquePtr<DirectX12DescriptorSet>> allocateMultiple(UInt32 descriptorSets, UInt32 descriptors, const Enumerable<Enumerable<DescriptorBinding>>& bindings = { }) const override;
+		Enumerable<UniquePtr<DirectX12DescriptorSet>> allocateMultiple(UInt32 descriptorSets, UInt32 descriptors, const Enumerable<Enumerable<DescriptorBinding>>& bindings = { }) const override;
 
 		/// <inheritdoc />
-		virtual Enumerable<UniquePtr<DirectX12DescriptorSet>> allocateMultiple(UInt32 descriptorSets, UInt32 descriptors, std::function<Enumerable<DescriptorBinding>(UInt32)> bindingFactory) const override;
+		Enumerable<UniquePtr<DirectX12DescriptorSet>> allocateMultiple(UInt32 descriptorSets, UInt32 descriptors, std::function<Enumerable<DescriptorBinding>(UInt32)> bindingFactory) const override;
 
 		/// <inheritdoc />
-		virtual void free(const DirectX12DescriptorSet& descriptorSet) const noexcept override;
+		void free(const DirectX12DescriptorSet& descriptorSet) const noexcept override;
 	};
 
 	/// <summary>
@@ -595,19 +595,19 @@ namespace LiteFX::Rendering::Backends {
 
 	public:
 		/// <inheritdoc />
-		virtual UInt32 space() const noexcept override;
+		UInt32 space() const noexcept override;
 
 		/// <inheritdoc />
-		virtual UInt32 binding() const noexcept override;
+		UInt32 binding() const noexcept override;
 
 		/// <inheritdoc />
-		virtual UInt32 offset() const noexcept override;
+		UInt32 offset() const noexcept override;
 
 		/// <inheritdoc />
-		virtual UInt32 size() const noexcept override;
+		UInt32 size() const noexcept override;
 
 		/// <inheritdoc />
-		virtual ShaderStage stage() const noexcept override;
+		ShaderStage stage() const noexcept override;
 
 	public:
 		/// <summary>
@@ -660,13 +660,13 @@ namespace LiteFX::Rendering::Backends {
 
 	public:
 		/// <inheritdoc />
-		virtual UInt32 size() const noexcept override;
+		UInt32 size() const noexcept override;
 
 		/// <inheritdoc />
-		virtual const DirectX12PushConstantsRange& range(ShaderStage stage) const override;
+		const DirectX12PushConstantsRange& range(ShaderStage stage) const override;
 
 		/// <inheritdoc />
-		virtual Enumerable<const DirectX12PushConstantsRange*> ranges() const noexcept override;
+		Enumerable<const DirectX12PushConstantsRange*> ranges() const noexcept override;
 
 	protected:
 		/// <summary>
@@ -713,13 +713,13 @@ namespace LiteFX::Rendering::Backends {
 		// PipelineLayout interface.
 	public:
 		/// <inheritdoc />
-		virtual const DirectX12DescriptorSetLayout& descriptorSet(UInt32 space) const override;
+		const DirectX12DescriptorSetLayout& descriptorSet(UInt32 space) const override;
 
 		/// <inheritdoc />
-		virtual Enumerable<const DirectX12DescriptorSetLayout*> descriptorSets() const noexcept override;
+		Enumerable<const DirectX12DescriptorSetLayout*> descriptorSets() const noexcept override;
 
 		/// <inheritdoc />
-		virtual const DirectX12PushConstantsLayout* pushConstants() const noexcept override;
+		const DirectX12PushConstantsLayout* pushConstants() const noexcept override;
 	};
 
 	/// <summary>
@@ -750,16 +750,16 @@ namespace LiteFX::Rendering::Backends {
 
 	public:
 		/// <inheritdoc />
-		virtual Enumerable<const DirectX12VertexBufferLayout*> vertexBufferLayouts() const noexcept override;
+		Enumerable<const DirectX12VertexBufferLayout*> vertexBufferLayouts() const noexcept override;
 
 		/// <inheritdoc />
-		virtual const DirectX12VertexBufferLayout& vertexBufferLayout(UInt32 binding) const override;
+		const DirectX12VertexBufferLayout& vertexBufferLayout(UInt32 binding) const override;
 
 		/// <inheritdoc />
-		virtual const DirectX12IndexBufferLayout& indexBufferLayout() const override;
+		const DirectX12IndexBufferLayout& indexBufferLayout() const override;
 
 		/// <inheritdoc />
-		virtual PrimitiveTopology topology() const noexcept override;
+		PrimitiveTopology topology() const noexcept override;
 	};
 
 	/// <summary>
@@ -842,97 +842,97 @@ namespace LiteFX::Rendering::Backends {
 		// CommandBuffer interface.
 	public:
 		/// <inheritdoc />
-		virtual void begin() const override;
+		void begin() const override;
 
 		/// <inheritdoc />
-		virtual void end() const override;
+		void end() const override;
 
 		/// <inheritdoc />
-		virtual bool isSecondary() const noexcept override;
+		bool isSecondary() const noexcept override;
 
 		/// <inheritdoc />
-		virtual void setViewports(Span<const IViewport*> viewports) const noexcept override;
+		void setViewports(Span<const IViewport*> viewports) const noexcept override;
 
 		/// <inheritdoc />
-		virtual void setViewports(const IViewport* viewport) const noexcept override;
+		void setViewports(const IViewport* viewport) const noexcept override;
 
 		/// <inheritdoc />
-		virtual void setScissors(Span<const IScissor*> scissors) const noexcept override;
+		void setScissors(Span<const IScissor*> scissors) const noexcept override;
 
 		/// <inheritdoc />
-		virtual void setScissors(const IScissor* scissor) const noexcept override;
+		void setScissors(const IScissor* scissor) const noexcept override;
 
 		/// <inheritdoc />
-		virtual void setBlendFactors(const Vector4f& blendFactors) const noexcept override;
+		void setBlendFactors(const Vector4f& blendFactors) const noexcept override;
 
 		/// <inheritdoc />
-		virtual void setStencilRef(UInt32 stencilRef) const noexcept override;
+		void setStencilRef(UInt32 stencilRef) const noexcept override;
 
 		/// <inheritdoc />
-		virtual void generateMipMaps(IDirectX12Image& image) noexcept override;
+		void generateMipMaps(IDirectX12Image& image) noexcept override;
 
 		/// <inheritdoc />
-		virtual void barrier(const DirectX12Barrier& barrier) const noexcept override;
+		void barrier(const DirectX12Barrier& barrier) const noexcept override;
 
 		/// <inheritdoc />
-		virtual void transfer(IDirectX12Buffer& source, IDirectX12Buffer& target, UInt32 sourceElement = 0, UInt32 targetElement = 0, UInt32 elements = 1) const override;
+		void transfer(IDirectX12Buffer& source, IDirectX12Buffer& target, UInt32 sourceElement = 0, UInt32 targetElement = 0, UInt32 elements = 1) const override;
 
 		/// <inheritdoc />
-		virtual void transfer(IDirectX12Buffer& source, IDirectX12Image& target, UInt32 sourceElement = 0, UInt32 firstSubresource = 0, UInt32 elements = 1) const override;
+		void transfer(IDirectX12Buffer& source, IDirectX12Image& target, UInt32 sourceElement = 0, UInt32 firstSubresource = 0, UInt32 elements = 1) const override;
 
 		/// <inheritdoc />
-		virtual void transfer(IDirectX12Image& source, IDirectX12Image& target, UInt32 sourceSubresource = 0, UInt32 targetSubresource = 0, UInt32 subresources = 1) const override;
+		void transfer(IDirectX12Image& source, IDirectX12Image& target, UInt32 sourceSubresource = 0, UInt32 targetSubresource = 0, UInt32 subresources = 1) const override;
 
 		/// <inheritdoc />
-		virtual void transfer(IDirectX12Image& source, IDirectX12Buffer& target, UInt32 firstSubresource = 0, UInt32 targetElement = 0, UInt32 subresources = 1) const override;
+		void transfer(IDirectX12Image& source, IDirectX12Buffer& target, UInt32 firstSubresource = 0, UInt32 targetElement = 0, UInt32 subresources = 1) const override;
 
 		/// <inheritdoc />
-		virtual void transfer(SharedPtr<IDirectX12Buffer> source, IDirectX12Buffer& target, UInt32 sourceElement = 0, UInt32 targetElement = 0, UInt32 elements = 1) const override;
+		void transfer(SharedPtr<IDirectX12Buffer> source, IDirectX12Buffer& target, UInt32 sourceElement = 0, UInt32 targetElement = 0, UInt32 elements = 1) const override;
 
 		/// <inheritdoc />
-		virtual void transfer(SharedPtr<IDirectX12Buffer> source, IDirectX12Image& target, UInt32 sourceElement = 0, UInt32 firstSubresource = 0, UInt32 elements = 1) const override;
+		void transfer(SharedPtr<IDirectX12Buffer> source, IDirectX12Image& target, UInt32 sourceElement = 0, UInt32 firstSubresource = 0, UInt32 elements = 1) const override;
 
 		/// <inheritdoc />
-		virtual void transfer(SharedPtr<IDirectX12Image> source, IDirectX12Image& target, UInt32 sourceSubresource = 0, UInt32 targetSubresource = 0, UInt32 subresources = 1) const override;
+		void transfer(SharedPtr<IDirectX12Image> source, IDirectX12Image& target, UInt32 sourceSubresource = 0, UInt32 targetSubresource = 0, UInt32 subresources = 1) const override;
 
 		/// <inheritdoc />
-		virtual void transfer(SharedPtr<IDirectX12Image> source, IDirectX12Buffer& target, UInt32 firstSubresource = 0, UInt32 targetElement = 0, UInt32 subresources = 1) const override;
+		void transfer(SharedPtr<IDirectX12Image> source, IDirectX12Buffer& target, UInt32 firstSubresource = 0, UInt32 targetElement = 0, UInt32 subresources = 1) const override;
 
 		/// <inheritdoc />
-		virtual void use(const DirectX12PipelineState& pipeline) const noexcept override;
+		void use(const DirectX12PipelineState& pipeline) const noexcept override;
 
 		/// <inheritdoc />
-		virtual void bind(const DirectX12DescriptorSet& descriptorSet, const DirectX12PipelineState& pipeline) const noexcept override;
+		void bind(const DirectX12DescriptorSet& descriptorSet, const DirectX12PipelineState& pipeline) const noexcept override;
 
 		/// <inheritdoc />
-		virtual void bind(const IDirectX12VertexBuffer& buffer) const noexcept override;
+		void bind(const IDirectX12VertexBuffer& buffer) const noexcept override;
 
 		/// <inheritdoc />
-		virtual void bind(const IDirectX12IndexBuffer& buffer) const noexcept override;
+		void bind(const IDirectX12IndexBuffer& buffer) const noexcept override;
 
 		/// <inheritdoc />
-		virtual void dispatch(const Vector3u& threadCount) const noexcept override;
+		void dispatch(const Vector3u& threadCount) const noexcept override;
 
 		/// <inheritdoc />
-		virtual void draw(UInt32 vertices, UInt32 instances = 1, UInt32 firstVertex = 0, UInt32 firstInstance = 0) const noexcept override;
+		void draw(UInt32 vertices, UInt32 instances = 1, UInt32 firstVertex = 0, UInt32 firstInstance = 0) const noexcept override;
 
 		/// <inheritdoc />
-		virtual void drawIndexed(UInt32 indices, UInt32 instances = 1, UInt32 firstIndex = 0, Int32 vertexOffset = 0, UInt32 firstInstance = 0) const noexcept override;
+		void drawIndexed(UInt32 indices, UInt32 instances = 1, UInt32 firstIndex = 0, Int32 vertexOffset = 0, UInt32 firstInstance = 0) const noexcept override;
 		
 		/// <inheritdoc />
-		virtual void pushConstants(const DirectX12PushConstantsLayout& layout, const void* const memory) const noexcept override;
+		void pushConstants(const DirectX12PushConstantsLayout& layout, const void* const memory) const noexcept override;
 
 		/// <inheritdoc />
-		virtual void writeTimingEvent(SharedPtr<const TimingEvent> timingEvent) const override;
+		void writeTimingEvent(SharedPtr<const TimingEvent> timingEvent) const override;
 
 		/// <inheritdoc />
-		virtual void execute(SharedPtr<const DirectX12CommandBuffer> commandBuffer) const override;
+		void execute(SharedPtr<const DirectX12CommandBuffer> commandBuffer) const override;
 
 		/// <inheritdoc />
-		virtual void execute(Enumerable<SharedPtr<const DirectX12CommandBuffer>> commandBuffers) const override;
+		void execute(Enumerable<SharedPtr<const DirectX12CommandBuffer>> commandBuffers) const override;
 
 	private:
-		virtual void releaseSharedState() const override;
+		void releaseSharedState() const override;
 	};
 
 	/// <summary>
@@ -971,26 +971,26 @@ namespace LiteFX::Rendering::Backends {
 		// Pipeline interface.
 	public:
 		/// <inheritdoc />
-		virtual SharedPtr<const DirectX12ShaderProgram> program() const noexcept override;
+		SharedPtr<const DirectX12ShaderProgram> program() const noexcept override;
 
 		/// <inheritdoc />
-		virtual SharedPtr<const DirectX12PipelineLayout> layout() const noexcept override;
+		SharedPtr<const DirectX12PipelineLayout> layout() const noexcept override;
 
 		// RenderPipeline interface.
 	public:
 		/// <inheritdoc />
-		virtual SharedPtr<DirectX12InputAssembler> inputAssembler() const noexcept override;
+		SharedPtr<DirectX12InputAssembler> inputAssembler() const noexcept override;
 
 		/// <inheritdoc />
-		virtual SharedPtr<DirectX12Rasterizer> rasterizer() const noexcept override;
+		SharedPtr<DirectX12Rasterizer> rasterizer() const noexcept override;
 
 		/// <inheritdoc />
-		virtual bool alphaToCoverage() const noexcept override;
+		bool alphaToCoverage() const noexcept override;
 
 		// DirectX12PipelineState interface.
 	public:
 		/// <inheritdoc />
-		virtual void use(const DirectX12CommandBuffer& commandBuffer) const noexcept override;
+		void use(const DirectX12CommandBuffer& commandBuffer) const noexcept override;
 	};
 
 	/// <summary>
@@ -1025,14 +1025,14 @@ namespace LiteFX::Rendering::Backends {
 		// Pipeline interface.
 	public:
 		/// <inheritdoc />
-		virtual SharedPtr<const DirectX12ShaderProgram> program() const noexcept override;
+		SharedPtr<const DirectX12ShaderProgram> program() const noexcept override;
 
 		/// <inheritdoc />
-		virtual SharedPtr<const DirectX12PipelineLayout> layout() const noexcept override;
+		SharedPtr<const DirectX12PipelineLayout> layout() const noexcept override;
 
 		// DirectX12PipelineState interface.
 	public:
-		virtual void use(const DirectX12CommandBuffer& commandBuffer) const noexcept override;
+		void use(const DirectX12CommandBuffer& commandBuffer) const noexcept override;
 	};
 
 	/// <summary>
@@ -1102,32 +1102,32 @@ namespace LiteFX::Rendering::Backends {
 		// FrameBuffer interface.
 	public:
 		/// <inheritdoc />
-		virtual UInt32 bufferIndex() const noexcept override;
+		UInt32 bufferIndex() const noexcept override;
 
 		/// <inheritdoc />
-		virtual const Size2d& size() const noexcept override;
+		const Size2d& size() const noexcept override;
 
 		/// <inheritdoc />
-		virtual size_t getWidth() const noexcept override;
+		size_t getWidth() const noexcept override;
 
 		/// <inheritdoc />
-		virtual size_t getHeight() const noexcept override;
+		size_t getHeight() const noexcept override;
 
 		/// <inheritdoc />
-		virtual Enumerable<SharedPtr<const DirectX12CommandBuffer>> commandBuffers() const noexcept override;
+		Enumerable<SharedPtr<const DirectX12CommandBuffer>> commandBuffers() const noexcept override;
 
 		/// <inheritdoc />
-		virtual SharedPtr<const DirectX12CommandBuffer> commandBuffer(UInt32 index) const override;
+		SharedPtr<const DirectX12CommandBuffer> commandBuffer(UInt32 index) const override;
 
 		/// <inheritdoc />
-		virtual Enumerable<const IDirectX12Image*> images() const noexcept override;
+		Enumerable<const IDirectX12Image*> images() const noexcept override;
 
 		/// <inheritdoc />
-		virtual const IDirectX12Image& image(UInt32 location) const override;
+		const IDirectX12Image& image(UInt32 location) const override;
 
 	public:
 		/// <inheritdoc />
-		virtual void resize(const Size2d& renderArea) override;
+		void resize(const Size2d& renderArea) override;
 	};
 
 	/// <summary>
@@ -1183,7 +1183,7 @@ namespace LiteFX::Rendering::Backends {
 		// IInputAttachmentMappingSource interface.
 	public:
 		/// <inheritdoc />
-		virtual const DirectX12FrameBuffer& frameBuffer(UInt32 buffer) const override;
+		const DirectX12FrameBuffer& frameBuffer(UInt32 buffer) const override;
 
 		// RenderPass interface.
 	public:
@@ -1194,44 +1194,44 @@ namespace LiteFX::Rendering::Backends {
 		virtual const DirectX12Device& device() const noexcept;
 
 		/// <inheritdoc />
-		virtual const DirectX12FrameBuffer& activeFrameBuffer() const override;
+		const DirectX12FrameBuffer& activeFrameBuffer() const override;
 
 		/// <inheritdoc />
-		virtual Enumerable<const DirectX12FrameBuffer*> frameBuffers() const noexcept override;
+		Enumerable<const DirectX12FrameBuffer*> frameBuffers() const noexcept override;
 
 		/// <inheritdoc />
-		virtual Enumerable<const DirectX12RenderPipeline*> pipelines() const noexcept override;
+		Enumerable<const DirectX12RenderPipeline*> pipelines() const noexcept override;
 
 		/// <inheritdoc />
-		virtual const RenderTarget& renderTarget(UInt32 location) const override;
+		const RenderTarget& renderTarget(UInt32 location) const override;
 
 		/// <inheritdoc />
-		virtual Span<const RenderTarget> renderTargets() const noexcept override;
+		Span<const RenderTarget> renderTargets() const noexcept override;
 
 		/// <inheritdoc />
-		virtual bool hasPresentTarget() const noexcept override;
+		bool hasPresentTarget() const noexcept override;
 
 		/// <inheritdoc />
-		virtual Span<const DirectX12InputAttachmentMapping> inputAttachments() const noexcept override;
+		Span<const DirectX12InputAttachmentMapping> inputAttachments() const noexcept override;
 
 		/// <inheritdoc />
-		virtual MultiSamplingLevel multiSamplingLevel() const noexcept override;
+		MultiSamplingLevel multiSamplingLevel() const noexcept override;
 
 	public:
 		/// <inheritdoc />
-		virtual void begin(UInt32 buffer) override;
+		void begin(UInt32 buffer) override;
 
 		/// <inheritdoc />
-		virtual void end() const override;
+		void end() const override;
 
 		/// <inheritdoc />
-		virtual void resizeFrameBuffers(const Size2d& renderArea) override;
+		void resizeFrameBuffers(const Size2d& renderArea) override;
 
 		/// <inheritdoc />
-		virtual void changeMultiSamplingLevel(MultiSamplingLevel samples) override;
+		void changeMultiSamplingLevel(MultiSamplingLevel samples) override;
 
 		/// <inheritdoc />
-		virtual void updateAttachments(const DirectX12DescriptorSet& descriptorSet) const override;
+		void updateAttachments(const DirectX12DescriptorSet& descriptorSet) const override;
 	};
 
 	/// <summary>
@@ -1331,47 +1331,47 @@ namespace LiteFX::Rendering::Backends {
 		// SwapChain interface.
 	public:
 		/// <inheritdoc />
-		virtual Enumerable<SharedPtr<TimingEvent>> timingEvents() const noexcept override;
+		Enumerable<SharedPtr<TimingEvent>> timingEvents() const noexcept override;
 
 		/// <inheritdoc />
-		virtual SharedPtr<TimingEvent> timingEvent(UInt32 queryId) const override;
+		SharedPtr<TimingEvent> timingEvent(UInt32 queryId) const override;
 
 		/// <inheritdoc />
-		virtual UInt64 readTimingEvent(SharedPtr<const TimingEvent> timingEvent) const override;
+		UInt64 readTimingEvent(SharedPtr<const TimingEvent> timingEvent) const override;
 
 		/// <inheritdoc />
-		virtual UInt32 resolveQueryId(SharedPtr<const TimingEvent> timingEvent) const override;
+		UInt32 resolveQueryId(SharedPtr<const TimingEvent> timingEvent) const override;
 
 		/// <inheritdoc />
-		virtual Format surfaceFormat() const noexcept override;
+		Format surfaceFormat() const noexcept override;
 
 		/// <inheritdoc />
-		virtual UInt32 buffers() const noexcept override;
+		UInt32 buffers() const noexcept override;
 
 		/// <inheritdoc />
-		virtual const Size2d& renderArea() const noexcept override;
+		const Size2d& renderArea() const noexcept override;
 
 		/// <inheritdoc />
-		virtual const IDirectX12Image* image(UInt32 backBuffer) const override;
+		const IDirectX12Image* image(UInt32 backBuffer) const override;
 
 		/// <inheritdoc />
-		virtual Enumerable<const IDirectX12Image*> images() const noexcept override;
+		Enumerable<const IDirectX12Image*> images() const noexcept override;
 
 		/// <inheritdoc />
-		virtual void present(const DirectX12FrameBuffer& frameBuffer) const override;
+		void present(const DirectX12FrameBuffer& frameBuffer) const override;
 
 	public:
 		/// <inheritdoc />
-		virtual Enumerable<Format> getSurfaceFormats() const noexcept override;
+		Enumerable<Format> getSurfaceFormats() const noexcept override;
 
 		/// <inheritdoc />
-		virtual void addTimingEvent(SharedPtr<TimingEvent> timingEvent) override;
+		void addTimingEvent(SharedPtr<TimingEvent> timingEvent) override;
 
 		/// <inheritdoc />
-		virtual void reset(Format surfaceFormat, const Size2d& renderArea, UInt32 buffers) override;
+		void reset(Format surfaceFormat, const Size2d& renderArea, UInt32 buffers) override;
 
 		/// <inheritdoc />
-		[[nodiscard]] virtual UInt32 swapBackBuffer() const override;
+		[[nodiscard]] UInt32 swapBackBuffer() const override;
 
 	private:
 		void resolveQueryHeaps(const DirectX12CommandBuffer& commandBuffer) const noexcept;
@@ -1411,47 +1411,47 @@ namespace LiteFX::Rendering::Backends {
 		// CommandQueue interface.
 	public:
 		/// <inheritdoc />
-		virtual bool isBound() const noexcept override;
+		bool isBound() const noexcept override;
 
 		/// <inheritdoc />
-		virtual QueuePriority priority() const noexcept override;
+		QueuePriority priority() const noexcept override;
 
 		/// <inheritdoc />
-		virtual QueueType type() const noexcept override;
+		QueueType type() const noexcept override;
 
 #if !defined(NDEBUG) && defined(_WIN64)
 	public:
 		/// <inheritdoc />
-		virtual void BeginDebugRegion(const String& label, const Vectors::ByteVector3& color = { 128_b, 128_b, 128_b }) const noexcept override;
+		void BeginDebugRegion(const String& label, const Vectors::ByteVector3& color = { 128_b, 128_b, 128_b }) const noexcept override;
 
 		/// <inheritdoc />
-		virtual void EndDebugRegion() const noexcept override;
+		void EndDebugRegion() const noexcept override;
 
 		/// <inheritdoc />
-		virtual void SetDebugMarker(const String& label, const Vectors::ByteVector3& color = { 128_b, 128_b, 128_b }) const noexcept override;
+		void SetDebugMarker(const String& label, const Vectors::ByteVector3& color = { 128_b, 128_b, 128_b }) const noexcept override;
 #endif // !defined(NDEBUG) && defined(_WIN64)
 
 	public:
 		/// <inheritdoc />
-		virtual void bind() override;
+		void bind() override;
 
 		/// <inheritdoc />
-		virtual void release() override;
+		void release() override;
 
 		/// <inheritdoc />
-		virtual SharedPtr<DirectX12CommandBuffer> createCommandBuffer(bool beginRecording = false, bool secondary = false) const override;
+		SharedPtr<DirectX12CommandBuffer> createCommandBuffer(bool beginRecording = false, bool secondary = false) const override;
 
 		/// <inheritdoc />
-		virtual UInt64 submit(SharedPtr<const DirectX12CommandBuffer> commandBuffer) const override;
+		UInt64 submit(SharedPtr<const DirectX12CommandBuffer> commandBuffer) const override;
 
 		/// <inheritdoc />
-		virtual UInt64 submit(const Enumerable<SharedPtr<const DirectX12CommandBuffer>>& commandBuffers) const override;
+		UInt64 submit(const Enumerable<SharedPtr<const DirectX12CommandBuffer>>& commandBuffers) const override;
 
 		/// <inheritdoc />
-		virtual void waitFor(UInt64 fence) const noexcept override;
+		void waitFor(UInt64 fence) const noexcept override;
 
 		/// <inheritdoc />
-		virtual UInt64 currentFence() const noexcept override;
+		UInt64 currentFence() const noexcept override;
 	};
 
 	/// <summary>
@@ -1486,46 +1486,46 @@ namespace LiteFX::Rendering::Backends {
 
 	public:
 		/// <inheritdoc />
-		virtual UniquePtr<IDirectX12Buffer> createBuffer(BufferType type, BufferUsage usage, size_t elementSize, UInt32 elements = 1, bool allowWrite = false) const override;
+		UniquePtr<IDirectX12Buffer> createBuffer(BufferType type, BufferUsage usage, size_t elementSize, UInt32 elements = 1, bool allowWrite = false) const override;
 
 		/// <inheritdoc />
-		virtual UniquePtr<IDirectX12Buffer> createBuffer(const String& name, BufferType type, BufferUsage usage, size_t elementSize, UInt32 elements = 1, bool allowWrite = false) const override;
+		UniquePtr<IDirectX12Buffer> createBuffer(const String& name, BufferType type, BufferUsage usage, size_t elementSize, UInt32 elements = 1, bool allowWrite = false) const override;
 
 		/// <inheritdoc />
-		virtual UniquePtr<IDirectX12VertexBuffer> createVertexBuffer(const DirectX12VertexBufferLayout& layout, BufferUsage usage, UInt32 elements = 1) const override;
+		UniquePtr<IDirectX12VertexBuffer> createVertexBuffer(const DirectX12VertexBufferLayout& layout, BufferUsage usage, UInt32 elements = 1) const override;
 
 		/// <inheritdoc />
-		virtual UniquePtr<IDirectX12VertexBuffer> createVertexBuffer(const String& name, const DirectX12VertexBufferLayout& layout, BufferUsage usage, UInt32 elements = 1) const override;
+		UniquePtr<IDirectX12VertexBuffer> createVertexBuffer(const String& name, const DirectX12VertexBufferLayout& layout, BufferUsage usage, UInt32 elements = 1) const override;
 
 		/// <inheritdoc />
-		virtual UniquePtr<IDirectX12IndexBuffer> createIndexBuffer(const DirectX12IndexBufferLayout& layout, BufferUsage usage, UInt32 elements) const override;
+		UniquePtr<IDirectX12IndexBuffer> createIndexBuffer(const DirectX12IndexBufferLayout& layout, BufferUsage usage, UInt32 elements) const override;
 
 		/// <inheritdoc />
-		virtual UniquePtr<IDirectX12IndexBuffer> createIndexBuffer(const String& name, const DirectX12IndexBufferLayout& layout, BufferUsage usage, UInt32 elements) const override;
+		UniquePtr<IDirectX12IndexBuffer> createIndexBuffer(const String& name, const DirectX12IndexBufferLayout& layout, BufferUsage usage, UInt32 elements) const override;
 
 		/// <inheritdoc />
-		virtual UniquePtr<IDirectX12Image> createAttachment(Format format, const Size2d& size, MultiSamplingLevel samples = MultiSamplingLevel::x1) const override;
+		UniquePtr<IDirectX12Image> createAttachment(Format format, const Size2d& size, MultiSamplingLevel samples = MultiSamplingLevel::x1) const override;
 
 		/// <inheritdoc />
-		virtual UniquePtr<IDirectX12Image> createAttachment(const String& name, Format format, const Size2d& size, MultiSamplingLevel samples = MultiSamplingLevel::x1) const override;
+		UniquePtr<IDirectX12Image> createAttachment(const String& name, Format format, const Size2d& size, MultiSamplingLevel samples = MultiSamplingLevel::x1) const override;
 
 		/// <inheritdoc />
-		virtual UniquePtr<IDirectX12Image> createTexture(Format format, const Size3d& size, ImageDimensions dimension = ImageDimensions::DIM_2, UInt32 levels = 1, UInt32 layers = 1, MultiSamplingLevel samples = MultiSamplingLevel::x1, bool allowWrite = false) const override;
+		UniquePtr<IDirectX12Image> createTexture(Format format, const Size3d& size, ImageDimensions dimension = ImageDimensions::DIM_2, UInt32 levels = 1, UInt32 layers = 1, MultiSamplingLevel samples = MultiSamplingLevel::x1, bool allowWrite = false) const override;
 
 		/// <inheritdoc />
-		virtual UniquePtr<IDirectX12Image> createTexture(const String& name, Format format, const Size3d& size, ImageDimensions dimension = ImageDimensions::DIM_2, UInt32 levels = 1, UInt32 layers = 1, MultiSamplingLevel samples = MultiSamplingLevel::x1, bool allowWrite = false) const override;
+		UniquePtr<IDirectX12Image> createTexture(const String& name, Format format, const Size3d& size, ImageDimensions dimension = ImageDimensions::DIM_2, UInt32 levels = 1, UInt32 layers = 1, MultiSamplingLevel samples = MultiSamplingLevel::x1, bool allowWrite = false) const override;
 
 		/// <inheritdoc />
-		virtual Enumerable<UniquePtr<IDirectX12Image>> createTextures(UInt32 elements, Format format, const Size3d& size, ImageDimensions dimension = ImageDimensions::DIM_2, UInt32 levels = 1, UInt32 layers = 1, MultiSamplingLevel samples = MultiSamplingLevel::x1, bool allowWrite = false) const override;
+		Enumerable<UniquePtr<IDirectX12Image>> createTextures(UInt32 elements, Format format, const Size3d& size, ImageDimensions dimension = ImageDimensions::DIM_2, UInt32 levels = 1, UInt32 layers = 1, MultiSamplingLevel samples = MultiSamplingLevel::x1, bool allowWrite = false) const override;
 
 		/// <inheritdoc />
-		virtual UniquePtr<IDirectX12Sampler> createSampler(FilterMode magFilter = FilterMode::Nearest, FilterMode minFilter = FilterMode::Nearest, BorderMode borderU = BorderMode::Repeat, BorderMode borderV = BorderMode::Repeat, BorderMode borderW = BorderMode::Repeat, MipMapMode mipMapMode = MipMapMode::Nearest, Float mipMapBias = 0.f, Float maxLod = std::numeric_limits<Float>::max(), Float minLod = 0.f, Float anisotropy = 0.f) const override;
+		UniquePtr<IDirectX12Sampler> createSampler(FilterMode magFilter = FilterMode::Nearest, FilterMode minFilter = FilterMode::Nearest, BorderMode borderU = BorderMode::Repeat, BorderMode borderV = BorderMode::Repeat, BorderMode borderW = BorderMode::Repeat, MipMapMode mipMapMode = MipMapMode::Nearest, Float mipMapBias = 0.f, Float maxLod = std::numeric_limits<Float>::max(), Float minLod = 0.f, Float anisotropy = 0.f) const override;
 
 		/// <inheritdoc />
-		virtual UniquePtr<IDirectX12Sampler> createSampler(const String& name, FilterMode magFilter = FilterMode::Nearest, FilterMode minFilter = FilterMode::Nearest, BorderMode borderU = BorderMode::Repeat, BorderMode borderV = BorderMode::Repeat, BorderMode borderW = BorderMode::Repeat, MipMapMode mipMapMode = MipMapMode::Nearest, Float mipMapBias = 0.f, Float maxLod = std::numeric_limits<Float>::max(), Float minLod = 0.f, Float anisotropy = 0.f) const override;
+		UniquePtr<IDirectX12Sampler> createSampler(const String& name, FilterMode magFilter = FilterMode::Nearest, FilterMode minFilter = FilterMode::Nearest, BorderMode borderU = BorderMode::Repeat, BorderMode borderV = BorderMode::Repeat, BorderMode borderW = BorderMode::Repeat, MipMapMode mipMapMode = MipMapMode::Nearest, Float mipMapBias = 0.f, Float maxLod = std::numeric_limits<Float>::max(), Float minLod = 0.f, Float anisotropy = 0.f) const override;
 
 		/// <inheritdoc />
-		virtual Enumerable<UniquePtr<IDirectX12Sampler>> createSamplers(UInt32 elements, FilterMode magFilter = FilterMode::Nearest, FilterMode minFilter = FilterMode::Nearest, BorderMode borderU = BorderMode::Repeat, BorderMode borderV = BorderMode::Repeat, BorderMode borderW = BorderMode::Repeat, MipMapMode mipMapMode = MipMapMode::Nearest, Float mipMapBias = 0.f, Float maxLod = std::numeric_limits<Float>::max(), Float minLod = 0.f, Float anisotropy = 0.f) const override;
+		Enumerable<UniquePtr<IDirectX12Sampler>> createSamplers(UInt32 elements, FilterMode magFilter = FilterMode::Nearest, FilterMode minFilter = FilterMode::Nearest, BorderMode borderU = BorderMode::Repeat, BorderMode borderV = BorderMode::Repeat, BorderMode borderW = BorderMode::Repeat, MipMapMode mipMapMode = MipMapMode::Nearest, Float mipMapBias = 0.f, Float maxLod = std::numeric_limits<Float>::max(), Float minLod = 0.f, Float anisotropy = 0.f) const override;
 	};
 
 	/// <summary>
@@ -1650,80 +1650,80 @@ namespace LiteFX::Rendering::Backends {
 		// GraphicsDevice interface.
 	public:
 		/// <inheritdoc />
-		virtual DeviceState& state() const noexcept override;
+		DeviceState& state() const noexcept override;
 
 		/// <inheritdoc />
-		virtual const DirectX12SwapChain& swapChain() const noexcept override;
+		const DirectX12SwapChain& swapChain() const noexcept override;
 
 		/// <inheritdoc />
-		virtual DirectX12SwapChain& swapChain() noexcept override;
+		DirectX12SwapChain& swapChain() noexcept override;
 
 		/// <inheritdoc />
-		virtual const DirectX12Surface& surface() const noexcept override;
+		const DirectX12Surface& surface() const noexcept override;
 
 		/// <inheritdoc />
-		virtual const DirectX12GraphicsAdapter& adapter() const noexcept override;
+		const DirectX12GraphicsAdapter& adapter() const noexcept override;
 
 		/// <inheritdoc />
-		virtual const DirectX12GraphicsFactory& factory() const noexcept override;
+		const DirectX12GraphicsFactory& factory() const noexcept override;
 
 		/// <inheritdoc />
-		virtual const DirectX12Queue& graphicsQueue() const noexcept override;
+		const DirectX12Queue& graphicsQueue() const noexcept override;
 
 		/// <inheritdoc />
-		virtual const DirectX12Queue& transferQueue() const noexcept override;
+		const DirectX12Queue& transferQueue() const noexcept override;
 
 		/// <inheritdoc />
-		virtual const DirectX12Queue& bufferQueue() const noexcept override;
+		const DirectX12Queue& bufferQueue() const noexcept override;
 
 		/// <inheritdoc />
-		virtual const DirectX12Queue& computeQueue() const noexcept override;
+		const DirectX12Queue& computeQueue() const noexcept override;
 
 		/// <inheritdoc />
-		[[nodiscard]] virtual UniquePtr<DirectX12Barrier> makeBarrier(PipelineStage syncBefore, PipelineStage syncAfter) const noexcept override;
+		[[nodiscard]] UniquePtr<DirectX12Barrier> makeBarrier(PipelineStage syncBefore, PipelineStage syncAfter) const noexcept override;
 
 		/// <inheritdoc />
 		/// <seealso href="https://docs.microsoft.com/en-us/windows/win32/api/d3d11/ne-d3d11-d3d11_standard_multisample_quality_levels" />
-		virtual MultiSamplingLevel maximumMultiSamplingLevel(Format format) const noexcept override;
+		MultiSamplingLevel maximumMultiSamplingLevel(Format format) const noexcept override;
 
 		/// <inheritdoc />
-		virtual double ticksPerMillisecond() const noexcept override;
+		double ticksPerMillisecond() const noexcept override;
 
 	public:
 		/// <inheritdoc />
-		virtual void wait() const override;
+		void wait() const override;
 
 #if defined(BUILD_DEFINE_BUILDERS)
 	public:
 		/// <inheritdoc />
-		[[nodiscard]] virtual DirectX12RenderPassBuilder buildRenderPass(MultiSamplingLevel samples = MultiSamplingLevel::x1, UInt32 commandBuffers = 1) const override;
+		[[nodiscard]] DirectX12RenderPassBuilder buildRenderPass(MultiSamplingLevel samples = MultiSamplingLevel::x1, UInt32 commandBuffers = 1) const override;
 
 		/// <inheritdoc />
-		[[nodiscard]] virtual DirectX12RenderPassBuilder buildRenderPass(const String& name, MultiSamplingLevel samples = MultiSamplingLevel::x1, UInt32 commandBuffers = 1) const override;
+		[[nodiscard]] DirectX12RenderPassBuilder buildRenderPass(const String& name, MultiSamplingLevel samples = MultiSamplingLevel::x1, UInt32 commandBuffers = 1) const override;
 
 		/// <inheritdoc />
-		//[[nodiscard]] virtual DirectX12RenderPipelineBuilder buildRenderPipeline(const String& name) const override;
+		//[[nodiscard]] DirectX12RenderPipelineBuilder buildRenderPipeline(const String& name) const override;
 
 		/// <inheritdoc />
-		[[nodiscard]] virtual DirectX12RenderPipelineBuilder buildRenderPipeline(const DirectX12RenderPass& renderPass, const String& name) const override;
+		[[nodiscard]] DirectX12RenderPipelineBuilder buildRenderPipeline(const DirectX12RenderPass& renderPass, const String& name) const override;
 
 		/// <inheritdoc />
-		[[nodiscard]] virtual DirectX12ComputePipelineBuilder buildComputePipeline(const String& name) const override;
+		[[nodiscard]] DirectX12ComputePipelineBuilder buildComputePipeline(const String& name) const override;
 		
 		/// <inheritdoc />
-		[[nodiscard]] virtual DirectX12PipelineLayoutBuilder buildPipelineLayout() const override;
+		[[nodiscard]] DirectX12PipelineLayoutBuilder buildPipelineLayout() const override;
 
 		/// <inheritdoc />
-		[[nodiscard]] virtual DirectX12InputAssemblerBuilder buildInputAssembler() const override;
+		[[nodiscard]] DirectX12InputAssemblerBuilder buildInputAssembler() const override;
 
 		/// <inheritdoc />
-		[[nodiscard]] virtual DirectX12RasterizerBuilder buildRasterizer() const override;
+		[[nodiscard]] DirectX12RasterizerBuilder buildRasterizer() const override;
 
 		/// <inheritdoc />
-		[[nodiscard]] virtual DirectX12ShaderProgramBuilder buildShaderProgram() const override;
+		[[nodiscard]] DirectX12ShaderProgramBuilder buildShaderProgram() const override;
 
 		/// <inheritdoc />
-		[[nodiscard]] virtual DirectX12BarrierBuilder buildBarrier() const override;
+		[[nodiscard]] DirectX12BarrierBuilder buildBarrier() const override;
 #endif // defined(BUILD_DEFINE_BUILDERS)
 	};
 	
@@ -1742,37 +1742,37 @@ namespace LiteFX::Rendering::Backends {
 		// IBackend interface.
 	public:
 		/// <inheritdoc />
-		virtual BackendType type() const noexcept override;
+		BackendType type() const noexcept override;
 
 		/// <inheritdoc />
-		virtual String name() const noexcept override;
+		String name() const noexcept override;
 
 	protected:
 		/// <inheritdoc />
-		virtual void activate() override;
+		void activate() override;
 
 		/// <inheritdoc />
-		virtual void deactivate() override;
+		void deactivate() override;
 
 		// RenderBackend interface.
 	public:
 		/// <inheritdoc />
-		virtual Enumerable<const DirectX12GraphicsAdapter*> listAdapters() const override;
+		Enumerable<const DirectX12GraphicsAdapter*> listAdapters() const override;
 
 		/// <inheritdoc />
-		virtual const DirectX12GraphicsAdapter* findAdapter(const Optional<UInt64>& adapterId = std::nullopt) const override;
+		const DirectX12GraphicsAdapter* findAdapter(const Optional<UInt64>& adapterId = std::nullopt) const override;
 
 		/// <inheritdoc />
-		virtual void registerDevice(String name, UniquePtr<DirectX12Device>&& device) override;
+		void registerDevice(String name, UniquePtr<DirectX12Device>&& device) override;
 
 		/// <inheritdoc />
-		virtual void releaseDevice(const String& name) override;
+		void releaseDevice(const String& name) override;
 
 		/// <inheritdoc />
-		virtual DirectX12Device* device(const String& name) noexcept override;
+		DirectX12Device* device(const String& name) noexcept override;
 
 		/// <inheritdoc />
-		virtual const DirectX12Device* device(const String& name) const noexcept override;
+		const DirectX12Device* device(const String& name) const noexcept override;
 
 	public:
 		/// <summary>

--- a/src/Backends/DirectX12/include/litefx/backends/dx12.hpp
+++ b/src/Backends/DirectX12/include/litefx/backends/dx12.hpp
@@ -44,7 +44,7 @@ namespace LiteFX::Rendering::Backends {
 		virtual const UInt32& binding() const noexcept override;
 
 		/// <inheritdoc />
-		virtual const BufferType& type() const noexcept override;
+		virtual BufferType type() const noexcept override;
 	};
 
 	/// <summary>
@@ -60,7 +60,7 @@ namespace LiteFX::Rendering::Backends {
 		/// Initializes a new index buffer layout
 		/// </summary>
 		/// <param name="type">The type of the indices within the index buffer.</param>
-		explicit DirectX12IndexBufferLayout(const IndexType& type);
+		explicit DirectX12IndexBufferLayout(IndexType type);
 		DirectX12IndexBufferLayout(DirectX12IndexBufferLayout&&) = delete;
 		DirectX12IndexBufferLayout(const DirectX12IndexBufferLayout&) = delete;
 		virtual ~DirectX12IndexBufferLayout() noexcept;
@@ -68,7 +68,7 @@ namespace LiteFX::Rendering::Backends {
 		// IIndexBufferLayout interface.
 	public:
 		/// <inheritdoc />
-		virtual const IndexType& indexType() const noexcept override;
+		virtual IndexType indexType() const noexcept override;
 
 		// IBufferLayout interface.
 	public:
@@ -79,7 +79,7 @@ namespace LiteFX::Rendering::Backends {
 		virtual const UInt32& binding() const noexcept override;
 
 		/// <inheritdoc />
-		virtual const BufferType& type() const noexcept override;
+		virtual BufferType type() const noexcept override;
 	};
 
 	/// <summary>
@@ -171,7 +171,7 @@ namespace LiteFX::Rendering::Backends {
 		/// </summary>
 		/// <param name="syncBefore">The pipeline stage(s) all previous commands have to finish before the barrier is executed.</param>
 		/// <param name="syncAfter">The pipeline stage(s) all subsequent commands are blocked at until the barrier is executed.</param>
-		constexpr inline explicit DirectX12Barrier(const PipelineStage& syncBefore, const PipelineStage& syncAfter) noexcept;
+		constexpr inline explicit DirectX12Barrier(PipelineStage syncBefore, PipelineStage syncAfter) noexcept;
 		DirectX12Barrier(const DirectX12Barrier&) = delete;
 		DirectX12Barrier(DirectX12Barrier&&) = delete;
 		constexpr inline virtual ~DirectX12Barrier() noexcept;
@@ -184,31 +184,31 @@ namespace LiteFX::Rendering::Backends {
 		// Barrier interface.
 	public:
 		/// <inheritdoc />
-		constexpr inline const PipelineStage& syncBefore() const noexcept override;
+		constexpr inline PipelineStage syncBefore() const noexcept override;
 
 		/// <inheritdoc />
-		constexpr inline const PipelineStage& syncAfter() const noexcept override;
+		constexpr inline PipelineStage syncAfter() const noexcept override;
 
 		/// <inheritdoc />
-		constexpr inline void wait(const ResourceAccess& accessBefore, const ResourceAccess& accessAfter) noexcept override;
+		constexpr inline void wait(ResourceAccess accessBefore, ResourceAccess accessAfter) noexcept override;
 
 		/// <inheritdoc />
-		constexpr inline void transition(IDirectX12Buffer& buffer, const ResourceAccess& accessBefore, const ResourceAccess& accessAfter) override;
+		constexpr inline void transition(IDirectX12Buffer& buffer, ResourceAccess accessBefore, ResourceAccess accessAfter) override;
 
 		/// <inheritdoc />
-		constexpr inline void transition(IDirectX12Buffer& buffer, const UInt32& element, const ResourceAccess& accessBefore, const ResourceAccess& accessAfter) override;
+		constexpr inline void transition(IDirectX12Buffer& buffer, const UInt32& element, ResourceAccess accessBefore, ResourceAccess accessAfter) override;
 
 		/// <inheritdoc />
-		constexpr inline void transition(IDirectX12Image& image, const ResourceAccess& accessBefore, const ResourceAccess& accessAfter, const ImageLayout& layout) override;
+		constexpr inline void transition(IDirectX12Image& image, ResourceAccess accessBefore, ResourceAccess accessAfter, ImageLayout layout) override;
 
 		/// <inheritdoc />
-		constexpr inline void transition(IDirectX12Image& image, const ResourceAccess& accessBefore, const ResourceAccess& accessAfter, const ImageLayout& fromLayout, const ImageLayout& toLayout) override;
+		constexpr inline void transition(IDirectX12Image& image, ResourceAccess accessBefore, ResourceAccess accessAfter, ImageLayout fromLayout, ImageLayout toLayout) override;
 
 		/// <inheritdoc />
-		constexpr inline void transition(IDirectX12Image& image, const UInt32& level, const UInt32& levels, const UInt32& layer, const UInt32& layers, const UInt32& plane, const ResourceAccess& accessBefore, const ResourceAccess& accessAfter, const ImageLayout& layout) override;
+		constexpr inline void transition(IDirectX12Image& image, const UInt32& level, const UInt32& levels, const UInt32& layer, const UInt32& layers, const UInt32& plane, ResourceAccess accessBefore, ResourceAccess accessAfter, ImageLayout layout) override;
 
 		/// <inheritdoc />
-		constexpr inline void transition(IDirectX12Image& image, const UInt32& level, const UInt32& levels, const UInt32& layer, const UInt32& layers, const UInt32& plane, const ResourceAccess& accessBefore, const ResourceAccess& accessAfter, const ImageLayout& fromLayout, const ImageLayout& toLayout) override;
+		constexpr inline void transition(IDirectX12Image& image, const UInt32& level, const UInt32& levels, const UInt32& layer, const UInt32& layers, const UInt32& plane, ResourceAccess accessBefore, ResourceAccess accessAfter, ImageLayout fromLayout, ImageLayout toLayout) override;
 
 	public:
 		/// <summary>
@@ -235,7 +235,7 @@ namespace LiteFX::Rendering::Backends {
 		/// <param name="type">The shader stage, this module is used in.</param>
 		/// <param name="fileName">The file name of the module source.</param>
 		/// <param name="entryPoint">The name of the module entry point.</param>
-		explicit DirectX12ShaderModule(const DirectX12Device& device, const ShaderStage& type, const String& fileName, const String& entryPoint = "main");
+		explicit DirectX12ShaderModule(const DirectX12Device& device, ShaderStage type, const String& fileName, const String& entryPoint = "main");
 
 		/// <summary>
 		/// Initializes a new DirectX 12 shader module.
@@ -245,7 +245,7 @@ namespace LiteFX::Rendering::Backends {
 		/// <param name="stream">The file stream to read the shader module from.</param>
 		/// <param name="name">The file name of the module source.</param>
 		/// <param name="entryPoint">The name of the module entry point.</param>
-		explicit DirectX12ShaderModule(const DirectX12Device& device, const ShaderStage& type, std::istream& stream, const String& name, const String& entryPoint = "main");
+		explicit DirectX12ShaderModule(const DirectX12Device& device, ShaderStage type, std::istream& stream, const String& name, const String& entryPoint = "main");
 		DirectX12ShaderModule(const DirectX12ShaderModule&) noexcept = delete;
 		DirectX12ShaderModule(DirectX12ShaderModule&&) noexcept = delete;
 		virtual ~DirectX12ShaderModule() noexcept;
@@ -259,7 +259,7 @@ namespace LiteFX::Rendering::Backends {
 		virtual const String& entryPoint() const noexcept override;
 
 		/// <inheritdoc />
-		virtual const ShaderStage& type() const noexcept override;
+		virtual ShaderStage type() const noexcept override;
 	};
 
 	/// <summary>
@@ -406,7 +406,7 @@ namespace LiteFX::Rendering::Backends {
 		/// <param name="binding">The binding point for the descriptor.</param>
 		/// <param name="elementSize">The size of the descriptor.</param>
 		/// <param name="elementSize">The number of descriptors in the descriptor array.</param>
-		explicit DirectX12DescriptorLayout(const DescriptorType& type, const UInt32& binding, const size_t& elementSize, const UInt32& descriptors = 1);
+		explicit DirectX12DescriptorLayout(DescriptorType type, const UInt32& binding, const size_t& elementSize, const UInt32& descriptors = 1);
 
 		/// <summary>
 		/// Initializes a new DirectX 12 descriptor layout for a static sampler.
@@ -422,7 +422,7 @@ namespace LiteFX::Rendering::Backends {
 		// IDescriptorLayout interface.
 	public:
 		/// <inheritdoc />
-		virtual const DescriptorType& descriptorType() const noexcept override;
+		virtual DescriptorType descriptorType() const noexcept override;
 
 		/// <inheritdoc />
 		virtual const UInt32& descriptors() const noexcept override;
@@ -439,7 +439,7 @@ namespace LiteFX::Rendering::Backends {
 		virtual const UInt32& binding() const noexcept override;
 
 		/// <inheritdoc />
-		virtual const BufferType& type() const noexcept override;
+		virtual BufferType type() const noexcept override;
 	};
 
 	/// <summary>
@@ -464,7 +464,7 @@ namespace LiteFX::Rendering::Backends {
 		/// <param name="descriptorLayouts">The descriptor layouts of the descriptors within the descriptor set.</param>
 		/// <param name="space">The space or set id of the descriptor set.</param>
 		/// <param name="stages">The shader stages, the descriptor sets are bound to.</param>
-		explicit DirectX12DescriptorSetLayout(const DirectX12Device& device, Enumerable<UniquePtr<DirectX12DescriptorLayout>>&& descriptorLayouts, const UInt32& space, const ShaderStage& stages);
+		explicit DirectX12DescriptorSetLayout(const DirectX12Device& device, Enumerable<UniquePtr<DirectX12DescriptorLayout>>&& descriptorLayouts, const UInt32& space, ShaderStage stages);
 		DirectX12DescriptorSetLayout(DirectX12DescriptorSetLayout&&) = delete;
 		DirectX12DescriptorSetLayout(const DirectX12DescriptorSetLayout&) = delete;
 		virtual ~DirectX12DescriptorSetLayout() noexcept;
@@ -525,7 +525,7 @@ namespace LiteFX::Rendering::Backends {
 		virtual const UInt32& space() const noexcept override;
 
 		/// <inheritdoc />
-		virtual const ShaderStage& shaderStages() const noexcept override;
+		virtual ShaderStage shaderStages() const noexcept override;
 
 		/// <inheritdoc />
 		virtual UInt32 uniforms() const noexcept override;
@@ -588,7 +588,7 @@ namespace LiteFX::Rendering::Backends {
 		/// <param name="size">The size of the push constants range.</param>
 		/// <param name="space">The space from which the push constants of the range will be accessible in the shader.</param>
 		/// <param name="binding">The register from which the push constants of the range will be accessible in the shader.</param>
-		explicit DirectX12PushConstantsRange(const ShaderStage& shaderStages, const UInt32& offset, const UInt32& size, const UInt32& space, const UInt32& binding);
+		explicit DirectX12PushConstantsRange(ShaderStage shaderStages, const UInt32& offset, const UInt32& size, const UInt32& space, const UInt32& binding);
 		DirectX12PushConstantsRange(const DirectX12PushConstantsRange&) = delete;
 		DirectX12PushConstantsRange(DirectX12PushConstantsRange&&) = delete;
 		virtual ~DirectX12PushConstantsRange() noexcept;
@@ -607,7 +607,7 @@ namespace LiteFX::Rendering::Backends {
 		virtual const UInt32& size() const noexcept override;
 
 		/// <inheritdoc />
-		virtual const ShaderStage& stage() const noexcept override;
+		virtual ShaderStage stage() const noexcept override;
 
 	public:
 		/// <summary>
@@ -663,7 +663,7 @@ namespace LiteFX::Rendering::Backends {
 		virtual const UInt32& size() const noexcept override;
 
 		/// <inheritdoc />
-		virtual const DirectX12PushConstantsRange& range(const ShaderStage& stage) const override;
+		virtual const DirectX12PushConstantsRange& range(ShaderStage stage) const override;
 
 		/// <inheritdoc />
 		virtual Enumerable<const DirectX12PushConstantsRange*> ranges() const noexcept override;
@@ -778,7 +778,7 @@ namespace LiteFX::Rendering::Backends {
 		/// <param name="cullOrder">The cull order used by the pipeline.</param>
 		/// <param name="lineWidth">The line width used by the pipeline.</param>
 		/// <param name="depthStencilState">The rasterizer depth/stencil state.</param>
-		explicit DirectX12Rasterizer(const PolygonMode& polygonMode, const CullMode& cullMode, const CullOrder& cullOrder, const Float& lineWidth = 1.f, const DepthStencilState& depthStencilState = {}) noexcept;
+		explicit DirectX12Rasterizer(PolygonMode polygonMode, CullMode cullMode, CullOrder cullOrder, const Float& lineWidth = 1.f, const DepthStencilState& depthStencilState = {}) noexcept;
 		DirectX12Rasterizer(DirectX12Rasterizer&&) noexcept = delete;
 		DirectX12Rasterizer(const DirectX12Rasterizer&) noexcept = delete;
 		virtual ~DirectX12Rasterizer() noexcept;
@@ -1151,7 +1151,7 @@ namespace LiteFX::Rendering::Backends {
 		/// <param name="renderTargets">The render targets that are output by the render pass.</param>
 		/// <param name="samples">The number of samples for the render targets in this render pass.</param>
 		/// <param name="inputAttachments">The input attachments that are read by the render pass.</param>
-		explicit DirectX12RenderPass(const DirectX12Device& device, Span<RenderTarget> renderTargets, const UInt32& commandBuffers = 1, const MultiSamplingLevel& samples = MultiSamplingLevel::x1, Span<DirectX12InputAttachmentMapping> inputAttachments = { });
+		explicit DirectX12RenderPass(const DirectX12Device& device, Span<RenderTarget> renderTargets, const UInt32& commandBuffers = 1, MultiSamplingLevel samples = MultiSamplingLevel::x1, Span<DirectX12InputAttachmentMapping> inputAttachments = { });
 
 		/// <summary>
 		/// Creates and initializes a new DirectX 12 render pass instance.
@@ -1162,7 +1162,7 @@ namespace LiteFX::Rendering::Backends {
 		/// <param name="renderTargets">The render targets that are output by the render pass.</param>
 		/// <param name="samples">The number of samples for the render targets in this render pass.</param>
 		/// <param name="inputAttachments">The input attachments that are read by the render pass.</param>
-		explicit DirectX12RenderPass(const DirectX12Device& device, const String& name, Span<RenderTarget> renderTargets, const UInt32& commandBuffers = 1, const MultiSamplingLevel& samples = MultiSamplingLevel::x1, Span<DirectX12InputAttachmentMapping> inputAttachments = { });
+		explicit DirectX12RenderPass(const DirectX12Device& device, const String& name, Span<RenderTarget> renderTargets, const UInt32& commandBuffers = 1, MultiSamplingLevel samples = MultiSamplingLevel::x1, Span<DirectX12InputAttachmentMapping> inputAttachments = { });
 
 		DirectX12RenderPass(const DirectX12RenderPass&) = delete;
 		DirectX12RenderPass(DirectX12RenderPass&&) = delete;
@@ -1215,7 +1215,7 @@ namespace LiteFX::Rendering::Backends {
 		virtual Span<const DirectX12InputAttachmentMapping> inputAttachments() const noexcept override;
 
 		/// <inheritdoc />
-		virtual const MultiSamplingLevel& multiSamplingLevel() const noexcept override;
+		virtual MultiSamplingLevel multiSamplingLevel() const noexcept override;
 
 	public:
 		/// <inheritdoc />
@@ -1228,7 +1228,7 @@ namespace LiteFX::Rendering::Backends {
 		virtual void resizeFrameBuffers(const Size2d& renderArea) override;
 
 		/// <inheritdoc />
-		virtual void changeMultiSamplingLevel(const MultiSamplingLevel& samples) override;
+		virtual void changeMultiSamplingLevel(MultiSamplingLevel samples) override;
 
 		/// <inheritdoc />
 		virtual void updateAttachments(const DirectX12DescriptorSet& descriptorSet) const override;
@@ -1309,7 +1309,7 @@ namespace LiteFX::Rendering::Backends {
 		/// <param name="format">The initial surface format.</param>
 		/// <param name="renderArea">The initial size of the render area.</param>
 		/// <param name="buffers">The initial number of buffers.</param>
-		explicit DirectX12SwapChain(const DirectX12Device& device, const Format& surfaceFormat = Format::B8G8R8A8_SRGB, const Size2d& renderArea = { 800, 600 }, const UInt32& buffers = 3);
+		explicit DirectX12SwapChain(const DirectX12Device& device, Format surfaceFormat = Format::B8G8R8A8_SRGB, const Size2d& renderArea = { 800, 600 }, const UInt32& buffers = 3);
 		DirectX12SwapChain(const DirectX12SwapChain&) = delete;
 		DirectX12SwapChain(DirectX12SwapChain&&) = delete;
 		virtual ~DirectX12SwapChain() noexcept;
@@ -1343,7 +1343,7 @@ namespace LiteFX::Rendering::Backends {
 		virtual UInt32 resolveQueryId(SharedPtr<const TimingEvent> timingEvent) const override;
 
 		/// <inheritdoc />
-		virtual const Format& surfaceFormat() const noexcept override;
+		virtual Format surfaceFormat() const noexcept override;
 
 		/// <inheritdoc />
 		virtual const UInt32& buffers() const noexcept override;
@@ -1368,7 +1368,7 @@ namespace LiteFX::Rendering::Backends {
 		virtual void addTimingEvent(SharedPtr<TimingEvent> timingEvent) override;
 
 		/// <inheritdoc />
-		virtual void reset(const Format& surfaceFormat, const Size2d& renderArea, const UInt32& buffers) override;
+		virtual void reset(Format surfaceFormat, const Size2d& renderArea, const UInt32& buffers) override;
 
 		/// <inheritdoc />
 		[[nodiscard]] virtual UInt32 swapBackBuffer() const override;
@@ -1395,7 +1395,7 @@ namespace LiteFX::Rendering::Backends {
 		/// <param name="device">The device, commands get send to.</param>
 		/// <param name="type">The type of the command queue.</param>
 		/// <param name="priority">The priority, of which commands are issued on the device.</param>
-		explicit DirectX12Queue(const DirectX12Device& device, const QueueType& type, const QueuePriority& priority);
+		explicit DirectX12Queue(const DirectX12Device& device, QueueType type, QueuePriority priority);
 		DirectX12Queue(const DirectX12Queue&) = delete;
 		DirectX12Queue(DirectX12Queue&&) = delete;
 		virtual ~DirectX12Queue() noexcept;
@@ -1414,10 +1414,10 @@ namespace LiteFX::Rendering::Backends {
 		virtual bool isBound() const noexcept override;
 
 		/// <inheritdoc />
-		virtual const QueuePriority& priority() const noexcept override;
+		virtual QueuePriority priority() const noexcept override;
 
 		/// <inheritdoc />
-		virtual const QueueType& type() const noexcept override;
+		virtual QueueType type() const noexcept override;
 
 #if !defined(NDEBUG) && defined(_WIN64)
 	public:
@@ -1486,46 +1486,46 @@ namespace LiteFX::Rendering::Backends {
 
 	public:
 		/// <inheritdoc />
-		virtual UniquePtr<IDirectX12Buffer> createBuffer(const BufferType& type, const BufferUsage& usage, const size_t& elementSize, const UInt32& elements = 1, const bool& allowWrite = false) const override;
+		virtual UniquePtr<IDirectX12Buffer> createBuffer(BufferType type, BufferUsage usage, const size_t& elementSize, const UInt32& elements = 1, const bool& allowWrite = false) const override;
 
 		/// <inheritdoc />
-		virtual UniquePtr<IDirectX12Buffer> createBuffer(const String& name, const BufferType& type, const BufferUsage& usage, const size_t& elementSize, const UInt32& elements = 1, const bool& allowWrite = false) const override;
+		virtual UniquePtr<IDirectX12Buffer> createBuffer(const String& name, BufferType type, BufferUsage usage, const size_t& elementSize, const UInt32& elements = 1, const bool& allowWrite = false) const override;
 
 		/// <inheritdoc />
-		virtual UniquePtr<IDirectX12VertexBuffer> createVertexBuffer(const DirectX12VertexBufferLayout& layout, const BufferUsage& usage, const UInt32& elements = 1) const override;
+		virtual UniquePtr<IDirectX12VertexBuffer> createVertexBuffer(const DirectX12VertexBufferLayout& layout, BufferUsage usage, const UInt32& elements = 1) const override;
 
 		/// <inheritdoc />
-		virtual UniquePtr<IDirectX12VertexBuffer> createVertexBuffer(const String& name, const DirectX12VertexBufferLayout& layout, const BufferUsage& usage, const UInt32& elements = 1) const override;
+		virtual UniquePtr<IDirectX12VertexBuffer> createVertexBuffer(const String& name, const DirectX12VertexBufferLayout& layout, BufferUsage usage, const UInt32& elements = 1) const override;
 
 		/// <inheritdoc />
-		virtual UniquePtr<IDirectX12IndexBuffer> createIndexBuffer(const DirectX12IndexBufferLayout& layout, const BufferUsage& usage, const UInt32& elements) const override;
+		virtual UniquePtr<IDirectX12IndexBuffer> createIndexBuffer(const DirectX12IndexBufferLayout& layout, BufferUsage usage, const UInt32& elements) const override;
 
 		/// <inheritdoc />
-		virtual UniquePtr<IDirectX12IndexBuffer> createIndexBuffer(const String& name, const DirectX12IndexBufferLayout& layout, const BufferUsage& usage, const UInt32& elements) const override;
+		virtual UniquePtr<IDirectX12IndexBuffer> createIndexBuffer(const String& name, const DirectX12IndexBufferLayout& layout, BufferUsage usage, const UInt32& elements) const override;
 
 		/// <inheritdoc />
-		virtual UniquePtr<IDirectX12Image> createAttachment(const Format& format, const Size2d& size, const MultiSamplingLevel& samples = MultiSamplingLevel::x1) const override;
+		virtual UniquePtr<IDirectX12Image> createAttachment(Format format, const Size2d& size, MultiSamplingLevel samples = MultiSamplingLevel::x1) const override;
 
 		/// <inheritdoc />
-		virtual UniquePtr<IDirectX12Image> createAttachment(const String& name, const Format& format, const Size2d& size, const MultiSamplingLevel& samples = MultiSamplingLevel::x1) const override;
+		virtual UniquePtr<IDirectX12Image> createAttachment(const String& name, Format format, const Size2d& size, MultiSamplingLevel samples = MultiSamplingLevel::x1) const override;
 
 		/// <inheritdoc />
-		virtual UniquePtr<IDirectX12Image> createTexture(const Format& format, const Size3d& size, const ImageDimensions& dimension = ImageDimensions::DIM_2, const UInt32& levels = 1, const UInt32& layers = 1, const MultiSamplingLevel& samples = MultiSamplingLevel::x1, const bool& allowWrite = false) const override;
+		virtual UniquePtr<IDirectX12Image> createTexture(Format format, const Size3d& size, ImageDimensions dimension = ImageDimensions::DIM_2, const UInt32& levels = 1, const UInt32& layers = 1, MultiSamplingLevel samples = MultiSamplingLevel::x1, const bool& allowWrite = false) const override;
 
 		/// <inheritdoc />
-		virtual UniquePtr<IDirectX12Image> createTexture(const String& name, const Format& format, const Size3d& size, const ImageDimensions& dimension = ImageDimensions::DIM_2, const UInt32& levels = 1, const UInt32& layers = 1, const MultiSamplingLevel& samples = MultiSamplingLevel::x1, const bool& allowWrite = false) const override;
+		virtual UniquePtr<IDirectX12Image> createTexture(const String& name, Format format, const Size3d& size, ImageDimensions dimension = ImageDimensions::DIM_2, const UInt32& levels = 1, const UInt32& layers = 1, MultiSamplingLevel samples = MultiSamplingLevel::x1, const bool& allowWrite = false) const override;
 
 		/// <inheritdoc />
-		virtual Enumerable<UniquePtr<IDirectX12Image>> createTextures(const UInt32& elements, const Format& format, const Size3d& size, const ImageDimensions& dimension = ImageDimensions::DIM_2, const UInt32& levels = 1, const UInt32& layers = 1, const MultiSamplingLevel& samples = MultiSamplingLevel::x1, const bool& allowWrite = false) const override;
+		virtual Enumerable<UniquePtr<IDirectX12Image>> createTextures(const UInt32& elements, Format format, const Size3d& size, ImageDimensions dimension = ImageDimensions::DIM_2, const UInt32& levels = 1, const UInt32& layers = 1, MultiSamplingLevel samples = MultiSamplingLevel::x1, const bool& allowWrite = false) const override;
 
 		/// <inheritdoc />
-		virtual UniquePtr<IDirectX12Sampler> createSampler(const FilterMode& magFilter = FilterMode::Nearest, const FilterMode& minFilter = FilterMode::Nearest, const BorderMode& borderU = BorderMode::Repeat, const BorderMode& borderV = BorderMode::Repeat, const BorderMode& borderW = BorderMode::Repeat, const MipMapMode& mipMapMode = MipMapMode::Nearest, const Float& mipMapBias = 0.f, const Float& maxLod = std::numeric_limits<Float>::max(), const Float& minLod = 0.f, const Float& anisotropy = 0.f) const override;
+		virtual UniquePtr<IDirectX12Sampler> createSampler(FilterMode magFilter = FilterMode::Nearest, FilterMode minFilter = FilterMode::Nearest, BorderMode borderU = BorderMode::Repeat, BorderMode borderV = BorderMode::Repeat, BorderMode borderW = BorderMode::Repeat, MipMapMode mipMapMode = MipMapMode::Nearest, const Float& mipMapBias = 0.f, const Float& maxLod = std::numeric_limits<Float>::max(), const Float& minLod = 0.f, const Float& anisotropy = 0.f) const override;
 
 		/// <inheritdoc />
-		virtual UniquePtr<IDirectX12Sampler> createSampler(const String& name, const FilterMode& magFilter = FilterMode::Nearest, const FilterMode& minFilter = FilterMode::Nearest, const BorderMode& borderU = BorderMode::Repeat, const BorderMode& borderV = BorderMode::Repeat, const BorderMode& borderW = BorderMode::Repeat, const MipMapMode& mipMapMode = MipMapMode::Nearest, const Float& mipMapBias = 0.f, const Float& maxLod = std::numeric_limits<Float>::max(), const Float& minLod = 0.f, const Float& anisotropy = 0.f) const override;
+		virtual UniquePtr<IDirectX12Sampler> createSampler(const String& name, FilterMode magFilter = FilterMode::Nearest, FilterMode minFilter = FilterMode::Nearest, BorderMode borderU = BorderMode::Repeat, BorderMode borderV = BorderMode::Repeat, BorderMode borderW = BorderMode::Repeat, MipMapMode mipMapMode = MipMapMode::Nearest, const Float& mipMapBias = 0.f, const Float& maxLod = std::numeric_limits<Float>::max(), const Float& minLod = 0.f, const Float& anisotropy = 0.f) const override;
 
 		/// <inheritdoc />
-		virtual Enumerable<UniquePtr<IDirectX12Sampler>> createSamplers(const UInt32& elements, const FilterMode& magFilter = FilterMode::Nearest, const FilterMode& minFilter = FilterMode::Nearest, const BorderMode& borderU = BorderMode::Repeat, const BorderMode& borderV = BorderMode::Repeat, const BorderMode& borderW = BorderMode::Repeat, const MipMapMode& mipMapMode = MipMapMode::Nearest, const Float& mipMapBias = 0.f, const Float& maxLod = std::numeric_limits<Float>::max(), const Float& minLod = 0.f, const Float& anisotropy = 0.f) const override;
+		virtual Enumerable<UniquePtr<IDirectX12Sampler>> createSamplers(const UInt32& elements, FilterMode magFilter = FilterMode::Nearest, FilterMode minFilter = FilterMode::Nearest, BorderMode borderU = BorderMode::Repeat, BorderMode borderV = BorderMode::Repeat, BorderMode borderW = BorderMode::Repeat, MipMapMode mipMapMode = MipMapMode::Nearest, const Float& mipMapBias = 0.f, const Float& maxLod = std::numeric_limits<Float>::max(), const Float& minLod = 0.f, const Float& anisotropy = 0.f) const override;
 	};
 
 	/// <summary>
@@ -1554,7 +1554,7 @@ namespace LiteFX::Rendering::Backends {
 		/// <param name="frameBuffers">The initial number of frame buffers.</param>
 		/// <param name="globalBufferHeapSize">The size of the global heap for constant buffers, shader resources and images.</param>
 		/// <param name="globalSamplerHeapSize">The size of the global heap for samplers.</param>
-		explicit DirectX12Device(const DirectX12Backend& backend, const DirectX12GraphicsAdapter& adapter, UniquePtr<DirectX12Surface>&& surface, const Format& format, const Size2d& frameBufferSize, const UInt32& frameBuffers, const UInt32& globalBufferHeapSize = 524287, const UInt32& globalSamplerHeapSize = 2048);
+		explicit DirectX12Device(const DirectX12Backend& backend, const DirectX12GraphicsAdapter& adapter, UniquePtr<DirectX12Surface>&& surface, Format format, const Size2d& frameBufferSize, const UInt32& frameBuffers, const UInt32& globalBufferHeapSize = 524287, const UInt32& globalSamplerHeapSize = 2048);
 
 		DirectX12Device(const DirectX12Device&) = delete;
 		DirectX12Device(DirectX12Device&&) = delete;
@@ -1680,11 +1680,11 @@ namespace LiteFX::Rendering::Backends {
 		virtual const DirectX12Queue& computeQueue() const noexcept override;
 
 		/// <inheritdoc />
-		[[nodiscard]] virtual UniquePtr<DirectX12Barrier> makeBarrier(const PipelineStage& syncBefore, const PipelineStage& syncAfter) const noexcept override;
+		[[nodiscard]] virtual UniquePtr<DirectX12Barrier> makeBarrier(PipelineStage syncBefore, PipelineStage syncAfter) const noexcept override;
 
 		/// <inheritdoc />
 		/// <seealso href="https://docs.microsoft.com/en-us/windows/win32/api/d3d11/ne-d3d11-d3d11_standard_multisample_quality_levels" />
-		virtual MultiSamplingLevel maximumMultiSamplingLevel(const Format& format) const noexcept override;
+		virtual MultiSamplingLevel maximumMultiSamplingLevel(Format format) const noexcept override;
 
 		/// <inheritdoc />
 		virtual double ticksPerMillisecond() const noexcept override;
@@ -1696,10 +1696,10 @@ namespace LiteFX::Rendering::Backends {
 #if defined(BUILD_DEFINE_BUILDERS)
 	public:
 		/// <inheritdoc />
-		[[nodiscard]] virtual DirectX12RenderPassBuilder buildRenderPass(const MultiSamplingLevel& samples = MultiSamplingLevel::x1, const UInt32& commandBuffers = 1) const override;
+		[[nodiscard]] virtual DirectX12RenderPassBuilder buildRenderPass(MultiSamplingLevel samples = MultiSamplingLevel::x1, const UInt32& commandBuffers = 1) const override;
 
 		/// <inheritdoc />
-		[[nodiscard]] virtual DirectX12RenderPassBuilder buildRenderPass(const String& name, const MultiSamplingLevel& samples = MultiSamplingLevel::x1, const UInt32& commandBuffers = 1) const override;
+		[[nodiscard]] virtual DirectX12RenderPassBuilder buildRenderPass(const String& name, MultiSamplingLevel samples = MultiSamplingLevel::x1, const UInt32& commandBuffers = 1) const override;
 
 		/// <inheritdoc />
 		//[[nodiscard]] virtual DirectX12RenderPipelineBuilder buildRenderPipeline(const String& name) const override;

--- a/src/Backends/DirectX12/include/litefx/backends/dx12.hpp
+++ b/src/Backends/DirectX12/include/litefx/backends/dx12.hpp
@@ -737,7 +737,7 @@ namespace LiteFX::Rendering::Backends {
 		/// <param name="vertexBufferLayouts">The vertex buffer layouts supported by the input assembler state. Each layout must have a unique binding.</param>
 		/// <param name="indexBufferLayout">The index buffer layout.</param>
 		/// <param name="primitiveTopology">The primitive topology.</param>
-		explicit DirectX12InputAssembler(Enumerable<UniquePtr<DirectX12VertexBufferLayout>>&& vertexBufferLayouts, UniquePtr<DirectX12IndexBufferLayout>&& indexBufferLayout, const PrimitiveTopology& primitiveTopology = PrimitiveTopology::TriangleList);
+		explicit DirectX12InputAssembler(Enumerable<UniquePtr<DirectX12VertexBufferLayout>>&& vertexBufferLayouts, UniquePtr<DirectX12IndexBufferLayout>&& indexBufferLayout, PrimitiveTopology primitiveTopology = PrimitiveTopology::TriangleList);
 		DirectX12InputAssembler(DirectX12InputAssembler&&) noexcept = delete;
 		DirectX12InputAssembler(const DirectX12InputAssembler&) noexcept = delete;
 		virtual ~DirectX12InputAssembler() noexcept;
@@ -759,7 +759,7 @@ namespace LiteFX::Rendering::Backends {
 		virtual const DirectX12IndexBufferLayout& indexBufferLayout() const override;
 
 		/// <inheritdoc />
-		virtual const PrimitiveTopology& topology() const noexcept override;
+		virtual PrimitiveTopology topology() const noexcept override;
 	};
 
 	/// <summary>

--- a/src/Backends/DirectX12/include/litefx/backends/dx12_api.hpp
+++ b/src/Backends/DirectX12/include/litefx/backends/dx12_api.hpp
@@ -215,7 +215,7 @@ namespace LiteFX::Rendering::Backends {
     /// <summary>
     /// Implements a DirectX12 <see cref="IGraphicsAdapter" />.
     /// </summary>
-    class LITEFX_DIRECTX12_API DirectX12GraphicsAdapter : public IGraphicsAdapter, public ComResource<IDXGIAdapter4> {
+    class LITEFX_DIRECTX12_API DirectX12GraphicsAdapter final : public IGraphicsAdapter, public ComResource<IDXGIAdapter4> {
         LITEFX_IMPLEMENTATION(DirectX12GraphicsAdapterImpl);
 
     public:
@@ -263,7 +263,7 @@ namespace LiteFX::Rendering::Backends {
     /// <summary>
     /// Implements a DirectX12 <see cref="ISurface" />.
     /// </summary>
-    class LITEFX_DIRECTX12_API DirectX12Surface : public ISurface, public Resource<HWND> {
+    class LITEFX_DIRECTX12_API DirectX12Surface final : public ISurface, public Resource<HWND> {
     public:
         /// <summary>
         /// Initializes a new DirectX 12 surface.

--- a/src/Backends/DirectX12/include/litefx/backends/dx12_api.hpp
+++ b/src/Backends/DirectX12/include/litefx/backends/dx12_api.hpp
@@ -230,34 +230,34 @@ namespace LiteFX::Rendering::Backends {
 
     public:
         /// <inheritdoc />
-        virtual String name() const noexcept override;
+        String name() const noexcept override;
 
         /// <inheritdoc />
-        virtual UInt64 uniqueId() const noexcept override;
+        UInt64 uniqueId() const noexcept override;
 
         /// <inheritdoc />
-        virtual UInt32 vendorId() const noexcept override;
+        UInt32 vendorId() const noexcept override;
 
         /// <inheritdoc />
-        virtual UInt32 deviceId() const noexcept override;
+        UInt32 deviceId() const noexcept override;
 
         /// <inheritdoc />
-        virtual GraphicsAdapterType type() const noexcept override;
-
-        /// <inheritdoc />
-        /// <remarks>
-        /// This property is not supported by DirectX 12. The method always returns `0`.
-        /// </remarks>
-        virtual UInt32 driverVersion() const noexcept override;
+        GraphicsAdapterType type() const noexcept override;
 
         /// <inheritdoc />
         /// <remarks>
         /// This property is not supported by DirectX 12. The method always returns `0`.
         /// </remarks>
-        virtual UInt32 apiVersion() const noexcept override;
+        UInt32 driverVersion() const noexcept override;
 
         /// <inheritdoc />
-        virtual UInt64 dedicatedMemory() const noexcept override;
+        /// <remarks>
+        /// This property is not supported by DirectX 12. The method always returns `0`.
+        /// </remarks>
+        UInt32 apiVersion() const noexcept override;
+
+        /// <inheritdoc />
+        UInt64 dedicatedMemory() const noexcept override;
     };
 
     /// <summary>

--- a/src/Backends/DirectX12/include/litefx/backends/dx12_api.hpp
+++ b/src/Backends/DirectX12/include/litefx/backends/dx12_api.hpp
@@ -112,22 +112,22 @@ namespace LiteFX::Rendering::Backends {
         /// <summary>
         /// 
         /// </summary>
-        constexpr inline DXGI_FORMAT LITEFX_DIRECTX12_API getFormat(const Format& format);
+        constexpr inline DXGI_FORMAT LITEFX_DIRECTX12_API getFormat(Format format);
 
         /// <summary>
         /// 
         /// </summary>
-        constexpr inline DXGI_FORMAT LITEFX_DIRECTX12_API getFormat(const BufferFormat& format);
+        constexpr inline DXGI_FORMAT LITEFX_DIRECTX12_API getFormat(BufferFormat format);
 
         /// <summary>
         /// 
         /// </summary>
-        constexpr inline bool LITEFX_DIRECTX12_API isSRGB(const Format& format);
+        constexpr inline bool LITEFX_DIRECTX12_API isSRGB(Format format);
 
         /// <summary>
         /// 
         /// </summary>
-        constexpr inline D3D12_RESOURCE_DIMENSION LITEFX_DIRECTX12_API getImageType(const ImageDimensions& dimensions);
+        constexpr inline D3D12_RESOURCE_DIMENSION LITEFX_DIRECTX12_API getImageType(ImageDimensions dimensions);
 
         /// <summary>
         /// 
@@ -137,7 +137,7 @@ namespace LiteFX::Rendering::Backends {
         /// <summary>
         /// 
         /// </summary>
-        constexpr inline D3D12_FILL_MODE LITEFX_DIRECTX12_API getPolygonMode(const PolygonMode& mode);
+        constexpr inline D3D12_FILL_MODE LITEFX_DIRECTX12_API getPolygonMode(PolygonMode mode);
 
         /// <summary>
         /// 
@@ -147,7 +147,7 @@ namespace LiteFX::Rendering::Backends {
         /// <summary>
         /// 
         /// </summary>
-        constexpr inline D3D12_CULL_MODE LITEFX_DIRECTX12_API getCullMode(const CullMode& mode);
+        constexpr inline D3D12_CULL_MODE LITEFX_DIRECTX12_API getCullMode(CullMode mode);
 
         /// <summary>
         /// 
@@ -167,7 +167,7 @@ namespace LiteFX::Rendering::Backends {
         /// <summary>
         /// 
         /// </summary>
-        constexpr inline LPCTSTR LITEFX_DIRECTX12_API getSemanticName(const AttributeSemantic& semantic);
+        constexpr inline LPCTSTR LITEFX_DIRECTX12_API getSemanticName(AttributeSemantic semantic);
 
         /// <summary>
         /// 
@@ -179,37 +179,37 @@ namespace LiteFX::Rendering::Backends {
         /// <summary>
         /// 
         /// </summary>
-        constexpr inline D3D12_COMPARISON_FUNC LITEFX_DIRECTX12_API getCompareOp(const CompareOperation& compareOp);
+        constexpr inline D3D12_COMPARISON_FUNC LITEFX_DIRECTX12_API getCompareOp(CompareOperation compareOp);
 
         /// <summary>
         /// 
         /// </summary>
-        constexpr inline D3D12_STENCIL_OP LITEFX_DIRECTX12_API getStencilOp(const StencilOperation& stencilOp);
+        constexpr inline D3D12_STENCIL_OP LITEFX_DIRECTX12_API getStencilOp(StencilOperation stencilOp);
 
         /// <summary>
         /// 
         /// </summary>
-        constexpr inline D3D12_BLEND LITEFX_DIRECTX12_API getBlendFactor(const BlendFactor& blendFactor);
+        constexpr inline D3D12_BLEND LITEFX_DIRECTX12_API getBlendFactor(BlendFactor blendFactor);
 
         /// <summary>
         /// 
         /// </summary>
-        constexpr inline D3D12_BLEND_OP LITEFX_DIRECTX12_API getBlendOperation(const BlendOperation& blendOperation);
+        constexpr inline D3D12_BLEND_OP LITEFX_DIRECTX12_API getBlendOperation(BlendOperation blendOperation);
 
         /// <summary>
         /// 
         /// </summary>
-        constexpr inline D3D12_BARRIER_SYNC LITEFX_DIRECTX12_API getPipelineStage(const PipelineStage& pipelineStage);
+        constexpr inline D3D12_BARRIER_SYNC LITEFX_DIRECTX12_API getPipelineStage(PipelineStage pipelineStage);
 
         /// <summary>
         /// 
         /// </summary>
-        constexpr inline D3D12_BARRIER_ACCESS LITEFX_DIRECTX12_API getResourceAccess(const ResourceAccess& resourceAccess);
+        constexpr inline D3D12_BARRIER_ACCESS LITEFX_DIRECTX12_API getResourceAccess(ResourceAccess resourceAccess);
 
         /// <summary>
         /// 
         /// </summary>
-        constexpr inline D3D12_BARRIER_LAYOUT LITEFX_DIRECTX12_API getImageLayout(const ImageLayout& imageLayout);
+        constexpr inline D3D12_BARRIER_LAYOUT LITEFX_DIRECTX12_API getImageLayout(ImageLayout imageLayout);
     }
 
     /// <summary>

--- a/src/Backends/DirectX12/include/litefx/backends/dx12_api.hpp
+++ b/src/Backends/DirectX12/include/litefx/backends/dx12_api.hpp
@@ -107,109 +107,109 @@ namespace LiteFX::Rendering::Backends {
         /// <summary>
         /// 
         /// </summary>
-        Format LITEFX_DIRECTX12_API getFormat(const DXGI_FORMAT& format);
+        constexpr inline Format LITEFX_DIRECTX12_API getFormat(const DXGI_FORMAT& format);
 
         /// <summary>
         /// 
         /// </summary>
-        DXGI_FORMAT LITEFX_DIRECTX12_API getFormat(const Format& format);
+        constexpr inline DXGI_FORMAT LITEFX_DIRECTX12_API getFormat(const Format& format);
 
         /// <summary>
         /// 
         /// </summary>
-        DXGI_FORMAT LITEFX_DIRECTX12_API getFormat(const BufferFormat& format);
+        constexpr inline DXGI_FORMAT LITEFX_DIRECTX12_API getFormat(const BufferFormat& format);
 
         /// <summary>
         /// 
         /// </summary>
-        bool LITEFX_DIRECTX12_API isSRGB(const Format& format);
+        constexpr inline bool LITEFX_DIRECTX12_API isSRGB(const Format& format);
 
         /// <summary>
         /// 
         /// </summary>
-        D3D12_RESOURCE_DIMENSION LITEFX_DIRECTX12_API getImageType(const ImageDimensions& dimensions);
+        constexpr inline D3D12_RESOURCE_DIMENSION LITEFX_DIRECTX12_API getImageType(const ImageDimensions& dimensions);
 
         /// <summary>
         /// 
         /// </summary>
-        PolygonMode LITEFX_DIRECTX12_API getPolygonMode(const D3D12_FILL_MODE& mode);
+        constexpr inline PolygonMode LITEFX_DIRECTX12_API getPolygonMode(const D3D12_FILL_MODE& mode);
 
         /// <summary>
         /// 
         /// </summary>
-        D3D12_FILL_MODE LITEFX_DIRECTX12_API getPolygonMode(const PolygonMode& mode);
+        constexpr inline D3D12_FILL_MODE LITEFX_DIRECTX12_API getPolygonMode(const PolygonMode& mode);
 
         /// <summary>
         /// 
         /// </summary>
-        CullMode LITEFX_DIRECTX12_API getCullMode(const D3D12_CULL_MODE& mode);
+        constexpr inline CullMode LITEFX_DIRECTX12_API getCullMode(const D3D12_CULL_MODE& mode);
 
         /// <summary>
         /// 
         /// </summary>
-        D3D12_CULL_MODE LITEFX_DIRECTX12_API getCullMode(const CullMode& mode);
+        constexpr inline D3D12_CULL_MODE LITEFX_DIRECTX12_API getCullMode(const CullMode& mode);
 
         /// <summary>
         /// 
         /// </summary>
-        PrimitiveTopology LITEFX_DIRECTX12_API getPrimitiveTopology(const D3D12_PRIMITIVE_TOPOLOGY& topology);
+        constexpr inline PrimitiveTopology LITEFX_DIRECTX12_API getPrimitiveTopology(const D3D12_PRIMITIVE_TOPOLOGY& topology);
 
         /// <summary>
         /// 
         /// </summary>
-        D3D12_PRIMITIVE_TOPOLOGY LITEFX_DIRECTX12_API getPrimitiveTopology(const PrimitiveTopology& topology);
+        constexpr inline D3D12_PRIMITIVE_TOPOLOGY LITEFX_DIRECTX12_API getPrimitiveTopology(const PrimitiveTopology& topology);
 
         /// <summary>
         /// 
         /// </summary>
-        D3D12_PRIMITIVE_TOPOLOGY_TYPE LITEFX_DIRECTX12_API getPrimitiveTopologyType(const PrimitiveTopology& topology);
+        constexpr inline D3D12_PRIMITIVE_TOPOLOGY_TYPE LITEFX_DIRECTX12_API getPrimitiveTopologyType(const PrimitiveTopology& topology);
 
         /// <summary>
         /// 
         /// </summary>
-        LPCTSTR LITEFX_DIRECTX12_API getSemanticName(const AttributeSemantic& semantic);
+        constexpr inline LPCTSTR LITEFX_DIRECTX12_API getSemanticName(const AttributeSemantic& semantic);
 
         /// <summary>
         /// 
         /// </summary>
         /// <param name="vendorId"></param>
         /// <returns></returns>
-        String LITEFX_DIRECTX12_API getVendorName(const UInt32& vendorId);
+        constexpr inline String LITEFX_DIRECTX12_API getVendorName(const UInt32& vendorId);
 
         /// <summary>
         /// 
         /// </summary>
-        D3D12_COMPARISON_FUNC LITEFX_DIRECTX12_API getCompareOp(const CompareOperation& compareOp);
+        constexpr inline D3D12_COMPARISON_FUNC LITEFX_DIRECTX12_API getCompareOp(const CompareOperation& compareOp);
 
         /// <summary>
         /// 
         /// </summary>
-        D3D12_STENCIL_OP LITEFX_DIRECTX12_API getStencilOp(const StencilOperation& stencilOp);
+        constexpr inline D3D12_STENCIL_OP LITEFX_DIRECTX12_API getStencilOp(const StencilOperation& stencilOp);
 
         /// <summary>
         /// 
         /// </summary>
-        D3D12_BLEND LITEFX_DIRECTX12_API getBlendFactor(const BlendFactor& blendFactor);
+        constexpr inline D3D12_BLEND LITEFX_DIRECTX12_API getBlendFactor(const BlendFactor& blendFactor);
 
         /// <summary>
         /// 
         /// </summary>
-        D3D12_BLEND_OP LITEFX_DIRECTX12_API getBlendOperation(const BlendOperation& blendOperation);
+        constexpr inline D3D12_BLEND_OP LITEFX_DIRECTX12_API getBlendOperation(const BlendOperation& blendOperation);
 
         /// <summary>
         /// 
         /// </summary>
-        D3D12_BARRIER_SYNC LITEFX_DIRECTX12_API getPipelineStage(const PipelineStage& pipelineStage);
+        constexpr inline D3D12_BARRIER_SYNC LITEFX_DIRECTX12_API getPipelineStage(const PipelineStage& pipelineStage);
 
         /// <summary>
         /// 
         /// </summary>
-        D3D12_BARRIER_ACCESS LITEFX_DIRECTX12_API getResourceAccess(const ResourceAccess& resourceAccess);
+        constexpr inline D3D12_BARRIER_ACCESS LITEFX_DIRECTX12_API getResourceAccess(const ResourceAccess& resourceAccess);
 
         /// <summary>
         /// 
         /// </summary>
-        D3D12_BARRIER_LAYOUT LITEFX_DIRECTX12_API getImageLayout(const ImageLayout& imageLayout);
+        constexpr inline D3D12_BARRIER_LAYOUT LITEFX_DIRECTX12_API getImageLayout(const ImageLayout& imageLayout);
     }
 
     /// <summary>

--- a/src/Backends/DirectX12/include/litefx/backends/dx12_api.hpp
+++ b/src/Backends/DirectX12/include/litefx/backends/dx12_api.hpp
@@ -157,12 +157,12 @@ namespace LiteFX::Rendering::Backends {
         /// <summary>
         /// 
         /// </summary>
-        constexpr inline D3D12_PRIMITIVE_TOPOLOGY LITEFX_DIRECTX12_API getPrimitiveTopology(const PrimitiveTopology& topology);
+        constexpr inline D3D12_PRIMITIVE_TOPOLOGY LITEFX_DIRECTX12_API getPrimitiveTopology(PrimitiveTopology topology);
 
         /// <summary>
         /// 
         /// </summary>
-        constexpr inline D3D12_PRIMITIVE_TOPOLOGY_TYPE LITEFX_DIRECTX12_API getPrimitiveTopologyType(const PrimitiveTopology& topology);
+        constexpr inline D3D12_PRIMITIVE_TOPOLOGY_TYPE LITEFX_DIRECTX12_API getPrimitiveTopologyType(PrimitiveTopology topology);
 
         /// <summary>
         /// 

--- a/src/Backends/DirectX12/include/litefx/backends/dx12_api.hpp
+++ b/src/Backends/DirectX12/include/litefx/backends/dx12_api.hpp
@@ -174,7 +174,7 @@ namespace LiteFX::Rendering::Backends {
         /// </summary>
         /// <param name="vendorId"></param>
         /// <returns></returns>
-        constexpr inline String LITEFX_DIRECTX12_API getVendorName(const UInt32& vendorId);
+        constexpr inline String LITEFX_DIRECTX12_API getVendorName(UInt32 vendorId);
 
         /// <summary>
         /// 

--- a/src/Backends/DirectX12/src/backend.cpp
+++ b/src/Backends/DirectX12/src/backend.cpp
@@ -40,7 +40,7 @@ public:
         return factory;
     }
 
-    void loadAdapters(const bool& enableWarp = false)
+    void loadAdapters(bool enableWarp = false)
     {
         ComPtr<IDXGIAdapter1> adapterInterface;
         ComPtr<IDXGIAdapter4> adapterInstance;
@@ -76,7 +76,7 @@ public:
 // Shared interface.
 // ------------------------------------------------------------------------------------------------
 
-DirectX12Backend::DirectX12Backend(const App& app, const bool& useAdvancedSoftwareRasterizer) :
+DirectX12Backend::DirectX12Backend(const App& app, bool useAdvancedSoftwareRasterizer) :
     m_impl(makePimpl<DirectX12BackendImpl>(this, app)), ComResource<IDXGIFactory7>(nullptr)
 {
     this->handle() = m_impl->initialize();
@@ -162,7 +162,7 @@ UniquePtr<DirectX12Surface> DirectX12Backend::createSurface(const HWND& hwnd) co
     return makeUnique<DirectX12Surface>(hwnd);
 }
 
-void DirectX12Backend::enableAdvancedSoftwareRasterizer(const bool& enable)
+void DirectX12Backend::enableAdvancedSoftwareRasterizer(bool enable)
 {
     m_impl->loadAdapters(enable);
 }

--- a/src/Backends/DirectX12/src/barrier.cpp
+++ b/src/Backends/DirectX12/src/barrier.cpp
@@ -74,7 +74,7 @@ constexpr void DirectX12Barrier::transition(IDirectX12Buffer& buffer, ResourceAc
 	m_impl->m_bufferBarriers.push_back({ accessBefore, accessAfter, buffer, D3D12_RESOURCE_BARRIER_ALL_SUBRESOURCES });
 }
 
-constexpr void DirectX12Barrier::transition(IDirectX12Buffer& buffer, const UInt32& element, ResourceAccess accessBefore, ResourceAccess accessAfter)
+constexpr void DirectX12Barrier::transition(IDirectX12Buffer& buffer, UInt32 element, ResourceAccess accessBefore, ResourceAccess accessAfter)
 {
 	m_impl->m_bufferBarriers.push_back({ accessBefore, accessAfter, buffer, element });
 }
@@ -89,12 +89,12 @@ constexpr void DirectX12Barrier::transition(IDirectX12Image& image, ResourceAcce
 	m_impl->m_imageBarriers.push_back({ accessBefore, accessAfter, image, fromLayout, toLayout, 0, image.levels(), 0, image.layers(), 0 });
 }
 
-constexpr void DirectX12Barrier::transition(IDirectX12Image& image, const UInt32& level, const UInt32& levels, const UInt32& layer, const UInt32& layers, const UInt32& plane, ResourceAccess accessBefore, ResourceAccess accessAfter, ImageLayout layout)
+constexpr void DirectX12Barrier::transition(IDirectX12Image& image, UInt32 level, UInt32 levels, UInt32 layer, UInt32 layers, UInt32 plane, ResourceAccess accessBefore, ResourceAccess accessAfter, ImageLayout layout)
 {
 	m_impl->m_imageBarriers.push_back({ accessBefore, accessAfter, image, std::nullopt, layout, level, levels, layer, layers, plane });
 }
 
-constexpr void DirectX12Barrier::transition(IDirectX12Image& image, const UInt32& level, const UInt32& levels, const UInt32& layer, const UInt32& layers, const UInt32& plane, ResourceAccess accessBefore, ResourceAccess accessAfter, ImageLayout fromLayout, ImageLayout toLayout)
+constexpr void DirectX12Barrier::transition(IDirectX12Image& image, UInt32 level, UInt32 levels, UInt32 layer, UInt32 layers, UInt32 plane, ResourceAccess accessBefore, ResourceAccess accessAfter, ImageLayout fromLayout, ImageLayout toLayout)
 {
 	m_impl->m_imageBarriers.push_back({ accessBefore, accessAfter, image, fromLayout, toLayout, level, levels, layer, layers, plane });
 }

--- a/src/Backends/DirectX12/src/barrier.cpp
+++ b/src/Backends/DirectX12/src/barrier.cpp
@@ -22,7 +22,7 @@ private:
 	Array<ImageBarrier> m_imageBarriers;
 
 public:
-	DirectX12BarrierImpl(DirectX12Barrier* parent, const PipelineStage& syncBefore, const PipelineStage& syncAfter) :
+	DirectX12BarrierImpl(DirectX12Barrier* parent, PipelineStage syncBefore, PipelineStage syncAfter) :
 		base(parent), m_syncBefore(syncBefore), m_syncAfter(syncAfter)
 	{
 	}
@@ -32,7 +32,7 @@ public:
 // Shared interface.
 // ------------------------------------------------------------------------------------------------
 
-constexpr DirectX12Barrier::DirectX12Barrier(const PipelineStage& syncBefore, const PipelineStage& syncAfter) noexcept :
+constexpr DirectX12Barrier::DirectX12Barrier(PipelineStage syncBefore, PipelineStage syncAfter) noexcept :
 	m_impl(makePimpl<DirectX12BarrierImpl>(this, syncBefore, syncAfter))
 {
 }
@@ -44,7 +44,7 @@ constexpr DirectX12Barrier::DirectX12Barrier() noexcept :
 
 constexpr DirectX12Barrier::~DirectX12Barrier() noexcept = default;
 
-constexpr const PipelineStage& DirectX12Barrier::syncBefore() const noexcept
+constexpr PipelineStage DirectX12Barrier::syncBefore() const noexcept
 {
 	return m_impl->m_syncBefore;
 }
@@ -54,7 +54,7 @@ constexpr PipelineStage& DirectX12Barrier::syncBefore() noexcept
 	return m_impl->m_syncBefore;
 }
 
-constexpr const PipelineStage& DirectX12Barrier::syncAfter() const noexcept
+constexpr PipelineStage DirectX12Barrier::syncAfter() const noexcept
 {
 	return m_impl->m_syncAfter;
 }
@@ -64,37 +64,37 @@ constexpr PipelineStage& DirectX12Barrier::syncAfter() noexcept
 	return m_impl->m_syncAfter;
 }
 
-constexpr void DirectX12Barrier::wait(const ResourceAccess& accessBefore, const ResourceAccess& accessAfter) noexcept
+constexpr void DirectX12Barrier::wait(ResourceAccess accessBefore, ResourceAccess accessAfter) noexcept
 {
 	m_impl->m_globalBarriers.push_back({ accessBefore, accessAfter });
 }
 
-constexpr void DirectX12Barrier::transition(IDirectX12Buffer& buffer, const ResourceAccess& accessBefore, const ResourceAccess& accessAfter)
+constexpr void DirectX12Barrier::transition(IDirectX12Buffer& buffer, ResourceAccess accessBefore, ResourceAccess accessAfter)
 {
 	m_impl->m_bufferBarriers.push_back({ accessBefore, accessAfter, buffer, D3D12_RESOURCE_BARRIER_ALL_SUBRESOURCES });
 }
 
-constexpr void DirectX12Barrier::transition(IDirectX12Buffer& buffer, const UInt32& element, const ResourceAccess& accessBefore, const ResourceAccess& accessAfter)
+constexpr void DirectX12Barrier::transition(IDirectX12Buffer& buffer, const UInt32& element, ResourceAccess accessBefore, ResourceAccess accessAfter)
 {
 	m_impl->m_bufferBarriers.push_back({ accessBefore, accessAfter, buffer, element });
 }
 
-constexpr void DirectX12Barrier::transition(IDirectX12Image& image, const ResourceAccess& accessBefore, const ResourceAccess& accessAfter, const ImageLayout& layout)
+constexpr void DirectX12Barrier::transition(IDirectX12Image& image, ResourceAccess accessBefore, ResourceAccess accessAfter, ImageLayout layout)
 {
 	m_impl->m_imageBarriers.push_back({ accessBefore, accessAfter, image, std::nullopt, layout, 0, image.levels(), 0, image.layers(), 0 });
 }
 
-constexpr void DirectX12Barrier::transition(IDirectX12Image& image, const ResourceAccess& accessBefore, const ResourceAccess& accessAfter, const ImageLayout& fromLayout, const ImageLayout& toLayout)
+constexpr void DirectX12Barrier::transition(IDirectX12Image& image, ResourceAccess accessBefore, ResourceAccess accessAfter, ImageLayout fromLayout, ImageLayout toLayout)
 {
 	m_impl->m_imageBarriers.push_back({ accessBefore, accessAfter, image, fromLayout, toLayout, 0, image.levels(), 0, image.layers(), 0 });
 }
 
-constexpr void DirectX12Barrier::transition(IDirectX12Image& image, const UInt32& level, const UInt32& levels, const UInt32& layer, const UInt32& layers, const UInt32& plane, const ResourceAccess& accessBefore, const ResourceAccess& accessAfter, const ImageLayout& layout)
+constexpr void DirectX12Barrier::transition(IDirectX12Image& image, const UInt32& level, const UInt32& levels, const UInt32& layer, const UInt32& layers, const UInt32& plane, ResourceAccess accessBefore, ResourceAccess accessAfter, ImageLayout layout)
 {
 	m_impl->m_imageBarriers.push_back({ accessBefore, accessAfter, image, std::nullopt, layout, level, levels, layer, layers, plane });
 }
 
-constexpr void DirectX12Barrier::transition(IDirectX12Image& image, const UInt32& level, const UInt32& levels, const UInt32& layer, const UInt32& layers, const UInt32& plane, const ResourceAccess& accessBefore, const ResourceAccess& accessAfter, const ImageLayout& fromLayout, const ImageLayout& toLayout)
+constexpr void DirectX12Barrier::transition(IDirectX12Image& image, const UInt32& level, const UInt32& levels, const UInt32& layer, const UInt32& layers, const UInt32& plane, ResourceAccess accessBefore, ResourceAccess accessAfter, ImageLayout fromLayout, ImageLayout toLayout)
 {
 	m_impl->m_imageBarriers.push_back({ accessBefore, accessAfter, image, fromLayout, toLayout, level, levels, layer, layers, plane });
 }

--- a/src/Backends/DirectX12/src/buffer.cpp
+++ b/src/Backends/DirectX12/src/buffer.cpp
@@ -19,7 +19,7 @@ private:
 	bool m_writable;
 
 public:
-	DirectX12BufferImpl(DirectX12Buffer* parent, BufferType type, const UInt32& elements, const size_t& elementSize, const size_t& alignment, const bool& writable, AllocatorPtr allocator, AllocationPtr&& allocation) :
+	DirectX12BufferImpl(DirectX12Buffer* parent, BufferType type, UInt32 elements, size_t elementSize, size_t alignment, bool writable, AllocatorPtr allocator, AllocationPtr&& allocation) :
 		base(parent), m_type(type), m_elements(elements), m_elementSize(elementSize), m_alignment(alignment), m_writable(writable), m_allocator(allocator), m_allocation(std::move(allocation))
 	{
 	}
@@ -29,7 +29,7 @@ public:
 // Buffer shared interface.
 // ------------------------------------------------------------------------------------------------
 
-DirectX12Buffer::DirectX12Buffer(ComPtr<ID3D12Resource>&& buffer, BufferType type, const UInt32& elements, const size_t& elementSize, const size_t& alignment, const bool& writable, AllocatorPtr allocator, AllocationPtr&& allocation, const String& name) :
+DirectX12Buffer::DirectX12Buffer(ComPtr<ID3D12Resource>&& buffer, BufferType type, UInt32 elements, size_t elementSize, size_t alignment, bool writable, AllocatorPtr allocator, AllocationPtr&& allocation, const String& name) :
 	m_impl(makePimpl<DirectX12BufferImpl>(this, type, elements, elementSize, alignment, writable, allocator, std::move(allocation))), ComResource<ID3D12Resource>(nullptr)
 {
 	this->handle() = std::move(buffer);
@@ -51,7 +51,7 @@ BufferType DirectX12Buffer::type() const noexcept
 	return m_impl->m_type;
 }
 
-const UInt32& DirectX12Buffer::elements() const noexcept
+UInt32 DirectX12Buffer::elements() const noexcept
 {
 	return m_impl->m_elements;
 }
@@ -76,12 +76,12 @@ size_t DirectX12Buffer::alignedElementSize() const noexcept
 	return m_impl->m_alignment == 0 ? m_impl->m_elementSize : (m_impl->m_elementSize + m_impl->m_alignment - 1) & ~(m_impl->m_alignment - 1);
 }
 
-const bool& DirectX12Buffer::writable() const noexcept
+bool DirectX12Buffer::writable() const noexcept
 {
 	return m_impl->m_writable;
 }
 
-void DirectX12Buffer::map(const void* const data, const size_t& size, const UInt32& element)
+void DirectX12Buffer::map(const void* const data, size_t size, UInt32 element)
 {
 	if (element >= m_impl->m_elements) [[unlikely]]
 		throw ArgumentOutOfRangeException("The element {0} is out of range. The buffer only contains {1} elements.", element, m_impl->m_elements);
@@ -102,12 +102,12 @@ void DirectX12Buffer::map(const void* const data, const size_t& size, const UInt
 		throw RuntimeException("Error mapping buffer to device memory: {#X}.", result);
 }
 
-void DirectX12Buffer::map(Span<const void* const> data, const size_t& elementSize, const UInt32& firstElement)
+void DirectX12Buffer::map(Span<const void* const> data, size_t elementSize, UInt32 firstElement)
 {
 	std::ranges::for_each(data, [this, &elementSize, i = firstElement](const void* const mem) mutable { this->map(mem, elementSize, i++); });
 }
 
-void DirectX12Buffer::map(void* data, const size_t& size, const UInt32& element, bool write)
+void DirectX12Buffer::map(void* data, size_t size, UInt32 element, bool write)
 {
 	if (element >= m_impl->m_elements) [[unlikely]]
 		throw ArgumentOutOfRangeException("The element {0} is out of range. The buffer only contains {1} elements.", element, m_impl->m_elements);
@@ -131,7 +131,7 @@ void DirectX12Buffer::map(void* data, const size_t& size, const UInt32& element,
 		throw RuntimeException("Error mapping buffer to device memory: {#X}.", result);
 }
 
-void DirectX12Buffer::map(Span<void*> data, const size_t& elementSize, const UInt32& firstElement, bool write)
+void DirectX12Buffer::map(Span<void*> data, size_t elementSize, UInt32 firstElement, bool write)
 {
 	std::ranges::for_each(data, [this, &elementSize, &write, i = firstElement](void* mem) mutable { this->map(mem, elementSize, i++, write); });
 }
@@ -146,12 +146,12 @@ const D3D12MA::Allocation* DirectX12Buffer::allocationInfo() const noexcept
 	return m_impl->m_allocation.get();
 }
 
-UniquePtr<IDirectX12Buffer> DirectX12Buffer::allocate(AllocatorPtr allocator, BufferType type, const UInt32& elements, const size_t& elementSize, const size_t& alignment, const bool& writable, const D3D12_RESOURCE_DESC1& resourceDesc, const D3D12MA::ALLOCATION_DESC& allocationDesc)
+UniquePtr<IDirectX12Buffer> DirectX12Buffer::allocate(AllocatorPtr allocator, BufferType type, UInt32 elements, size_t elementSize, size_t alignment, bool writable, const D3D12_RESOURCE_DESC1& resourceDesc, const D3D12MA::ALLOCATION_DESC& allocationDesc)
 {
 	return DirectX12Buffer::allocate("", allocator, type, elements, elementSize, alignment, writable, resourceDesc, allocationDesc);
 }
 
-UniquePtr<IDirectX12Buffer> DirectX12Buffer::allocate(const String& name, AllocatorPtr allocator, BufferType type, const UInt32& elements, const size_t& elementSize, const size_t& alignment, const bool& writable, const D3D12_RESOURCE_DESC1& resourceDesc, const D3D12MA::ALLOCATION_DESC& allocationDesc)
+UniquePtr<IDirectX12Buffer> DirectX12Buffer::allocate(const String& name, AllocatorPtr allocator, BufferType type, UInt32 elements, size_t elementSize, size_t alignment, bool writable, const D3D12_RESOURCE_DESC1& resourceDesc, const D3D12MA::ALLOCATION_DESC& allocationDesc)
 {
 	if (allocator == nullptr) [[unlikely]]
 		throw ArgumentNotInitializedException("The allocator must be initialized.");
@@ -198,7 +198,7 @@ public:
 // Vertex buffer shared interface.
 // ------------------------------------------------------------------------------------------------
 
-DirectX12VertexBuffer::DirectX12VertexBuffer(ComPtr<ID3D12Resource>&& buffer, const DirectX12VertexBufferLayout& layout, const UInt32& elements, AllocatorPtr allocator, AllocationPtr&& allocation, const String& name) :
+DirectX12VertexBuffer::DirectX12VertexBuffer(ComPtr<ID3D12Resource>&& buffer, const DirectX12VertexBufferLayout& layout, UInt32 elements, AllocatorPtr allocator, AllocationPtr&& allocation, const String& name) :
 	m_impl(makePimpl<DirectX12VertexBufferImpl>(this, layout)), DirectX12Buffer(std::move(buffer), BufferType::Vertex, elements, layout.elementSize(), 0, false, allocator, std::move(allocation), name)
 {
 	m_impl->initialize();
@@ -216,12 +216,12 @@ const D3D12_VERTEX_BUFFER_VIEW& DirectX12VertexBuffer::view() const noexcept
 	return m_impl->m_view;
 }
 
-UniquePtr<IDirectX12VertexBuffer> DirectX12VertexBuffer::allocate(const DirectX12VertexBufferLayout& layout, AllocatorPtr allocator, const UInt32& elements, const D3D12_RESOURCE_DESC1& resourceDesc, const D3D12MA::ALLOCATION_DESC& allocationDesc)
+UniquePtr<IDirectX12VertexBuffer> DirectX12VertexBuffer::allocate(const DirectX12VertexBufferLayout& layout, AllocatorPtr allocator, UInt32 elements, const D3D12_RESOURCE_DESC1& resourceDesc, const D3D12MA::ALLOCATION_DESC& allocationDesc)
 {
 	return DirectX12VertexBuffer::allocate("", layout, allocator, elements, resourceDesc, allocationDesc);
 }
 
-UniquePtr<IDirectX12VertexBuffer> DirectX12VertexBuffer::allocate(const String& name, const DirectX12VertexBufferLayout& layout, AllocatorPtr allocator, const UInt32& elements, const D3D12_RESOURCE_DESC1& resourceDesc, const D3D12MA::ALLOCATION_DESC& allocationDesc)
+UniquePtr<IDirectX12VertexBuffer> DirectX12VertexBuffer::allocate(const String& name, const DirectX12VertexBufferLayout& layout, AllocatorPtr allocator, UInt32 elements, const D3D12_RESOURCE_DESC1& resourceDesc, const D3D12MA::ALLOCATION_DESC& allocationDesc)
 {
 	if (allocator == nullptr) [[unlikely]]
 		throw ArgumentNotInitializedException("The allocator must be initialized.");
@@ -268,7 +268,7 @@ public:
 // Index buffer shared interface.
 // ------------------------------------------------------------------------------------------------
 
-DirectX12IndexBuffer::DirectX12IndexBuffer(ComPtr<ID3D12Resource>&& buffer, const DirectX12IndexBufferLayout& layout, const UInt32& elements, AllocatorPtr allocator, AllocationPtr&& allocation, const String& name) :
+DirectX12IndexBuffer::DirectX12IndexBuffer(ComPtr<ID3D12Resource>&& buffer, const DirectX12IndexBufferLayout& layout, UInt32 elements, AllocatorPtr allocator, AllocationPtr&& allocation, const String& name) :
 	m_impl(makePimpl<DirectX12IndexBufferImpl>(this, layout)), DirectX12Buffer(std::move(buffer), BufferType::Index, elements, layout.elementSize(), 0, false, allocator, std::move(allocation), name)
 {
 	m_impl->initialize();
@@ -286,12 +286,12 @@ const D3D12_INDEX_BUFFER_VIEW& DirectX12IndexBuffer::view() const noexcept
 	return m_impl->m_view;
 }
 
-UniquePtr<IDirectX12IndexBuffer> DirectX12IndexBuffer::allocate(const DirectX12IndexBufferLayout& layout, AllocatorPtr allocator, const UInt32& elements, const D3D12_RESOURCE_DESC1& resourceDesc, const D3D12MA::ALLOCATION_DESC& allocationDesc)
+UniquePtr<IDirectX12IndexBuffer> DirectX12IndexBuffer::allocate(const DirectX12IndexBufferLayout& layout, AllocatorPtr allocator, UInt32 elements, const D3D12_RESOURCE_DESC1& resourceDesc, const D3D12MA::ALLOCATION_DESC& allocationDesc)
 {
 	return DirectX12IndexBuffer::allocate("", layout, allocator, elements, resourceDesc, allocationDesc);
 }
 
-UniquePtr<IDirectX12IndexBuffer> DirectX12IndexBuffer::allocate(const String& name, const DirectX12IndexBufferLayout& layout, AllocatorPtr allocator, const UInt32& elements, const D3D12_RESOURCE_DESC1& resourceDesc, const D3D12MA::ALLOCATION_DESC& allocationDesc)
+UniquePtr<IDirectX12IndexBuffer> DirectX12IndexBuffer::allocate(const String& name, const DirectX12IndexBufferLayout& layout, AllocatorPtr allocator, UInt32 elements, const D3D12_RESOURCE_DESC1& resourceDesc, const D3D12MA::ALLOCATION_DESC& allocationDesc)
 {
 	if (allocator == nullptr) [[unlikely]]
 		throw ArgumentNotInitializedException("The allocator must be initialized.");

--- a/src/Backends/DirectX12/src/buffer.cpp
+++ b/src/Backends/DirectX12/src/buffer.cpp
@@ -19,7 +19,7 @@ private:
 	bool m_writable;
 
 public:
-	DirectX12BufferImpl(DirectX12Buffer* parent, const BufferType& type, const UInt32& elements, const size_t& elementSize, const size_t& alignment, const bool& writable, AllocatorPtr allocator, AllocationPtr&& allocation) :
+	DirectX12BufferImpl(DirectX12Buffer* parent, BufferType type, const UInt32& elements, const size_t& elementSize, const size_t& alignment, const bool& writable, AllocatorPtr allocator, AllocationPtr&& allocation) :
 		base(parent), m_type(type), m_elements(elements), m_elementSize(elementSize), m_alignment(alignment), m_writable(writable), m_allocator(allocator), m_allocation(std::move(allocation))
 	{
 	}
@@ -29,7 +29,7 @@ public:
 // Buffer shared interface.
 // ------------------------------------------------------------------------------------------------
 
-DirectX12Buffer::DirectX12Buffer(ComPtr<ID3D12Resource>&& buffer, const BufferType& type, const UInt32& elements, const size_t& elementSize, const size_t& alignment, const bool& writable, AllocatorPtr allocator, AllocationPtr&& allocation, const String& name) :
+DirectX12Buffer::DirectX12Buffer(ComPtr<ID3D12Resource>&& buffer, BufferType type, const UInt32& elements, const size_t& elementSize, const size_t& alignment, const bool& writable, AllocatorPtr allocator, AllocationPtr&& allocation, const String& name) :
 	m_impl(makePimpl<DirectX12BufferImpl>(this, type, elements, elementSize, alignment, writable, allocator, std::move(allocation))), ComResource<ID3D12Resource>(nullptr)
 {
 	this->handle() = std::move(buffer);
@@ -46,7 +46,7 @@ DirectX12Buffer::DirectX12Buffer(ComPtr<ID3D12Resource>&& buffer, const BufferTy
 
 DirectX12Buffer::~DirectX12Buffer() noexcept = default;
 
-const BufferType& DirectX12Buffer::type() const noexcept
+BufferType DirectX12Buffer::type() const noexcept
 {
 	return m_impl->m_type;
 }
@@ -146,12 +146,12 @@ const D3D12MA::Allocation* DirectX12Buffer::allocationInfo() const noexcept
 	return m_impl->m_allocation.get();
 }
 
-UniquePtr<IDirectX12Buffer> DirectX12Buffer::allocate(AllocatorPtr allocator, const BufferType& type, const UInt32& elements, const size_t& elementSize, const size_t& alignment, const bool& writable, const D3D12_RESOURCE_DESC1& resourceDesc, const D3D12MA::ALLOCATION_DESC& allocationDesc)
+UniquePtr<IDirectX12Buffer> DirectX12Buffer::allocate(AllocatorPtr allocator, BufferType type, const UInt32& elements, const size_t& elementSize, const size_t& alignment, const bool& writable, const D3D12_RESOURCE_DESC1& resourceDesc, const D3D12MA::ALLOCATION_DESC& allocationDesc)
 {
 	return DirectX12Buffer::allocate("", allocator, type, elements, elementSize, alignment, writable, resourceDesc, allocationDesc);
 }
 
-UniquePtr<IDirectX12Buffer> DirectX12Buffer::allocate(const String& name, AllocatorPtr allocator, const BufferType& type, const UInt32& elements, const size_t& elementSize, const size_t& alignment, const bool& writable, const D3D12_RESOURCE_DESC1& resourceDesc, const D3D12MA::ALLOCATION_DESC& allocationDesc)
+UniquePtr<IDirectX12Buffer> DirectX12Buffer::allocate(const String& name, AllocatorPtr allocator, BufferType type, const UInt32& elements, const size_t& elementSize, const size_t& alignment, const bool& writable, const D3D12_RESOURCE_DESC1& resourceDesc, const D3D12MA::ALLOCATION_DESC& allocationDesc)
 {
 	if (allocator == nullptr) [[unlikely]]
 		throw ArgumentNotInitializedException("The allocator must be initialized.");

--- a/src/Backends/DirectX12/src/buffer.h
+++ b/src/Backends/DirectX12/src/buffer.h
@@ -23,7 +23,7 @@ namespace LiteFX::Rendering::Backends {
 		LITEFX_IMPLEMENTATION(DirectX12BufferImpl);
 
 	public:
-		explicit DirectX12Buffer(ComPtr<ID3D12Resource>&& buffer, BufferType type, const UInt32& elements, const size_t& elementSize, const size_t& alignment, const bool& writable, AllocatorPtr allocator = nullptr, AllocationPtr&& allocation = nullptr, const String& name = "");
+		explicit DirectX12Buffer(ComPtr<ID3D12Resource>&& buffer, BufferType type, UInt32 elements, size_t elementSize, size_t alignment, bool writable, AllocatorPtr allocator = nullptr, AllocationPtr&& allocation = nullptr, const String& name = "");
 		DirectX12Buffer(DirectX12Buffer&&) = delete;
 		DirectX12Buffer(const DirectX12Buffer&) = delete;
 		virtual ~DirectX12Buffer() noexcept;
@@ -36,7 +36,7 @@ namespace LiteFX::Rendering::Backends {
 		// IDeviceMemory interface.
 	public:
 		/// <inheritdoc />
-		virtual const UInt32& elements() const noexcept override;
+		virtual UInt32 elements() const noexcept override;
 
 		/// <inheritdoc />
 		virtual size_t size() const noexcept override;
@@ -51,21 +51,21 @@ namespace LiteFX::Rendering::Backends {
 		virtual size_t alignedElementSize() const noexcept override;
 
 		/// <inheritdoc />
-		virtual const bool& writable() const noexcept override;
+		virtual bool writable() const noexcept override;
 
 		// IMappable interface.
 	public:
 		/// <inheritdoc />
-		virtual void map(const void* const data, const size_t& size, const UInt32& element = 0) override;
+		virtual void map(const void* const data, size_t size, UInt32 element = 0) override;
 
 		/// <inheritdoc />
-		virtual void map(Span<const void* const> data, const size_t& elementSize, const UInt32& firstElement = 0) override;
+		virtual void map(Span<const void* const> data, size_t elementSize, UInt32 firstElement = 0) override;
 
 		/// <inheritdoc />
-		virtual void map(void* data, const size_t& size, const UInt32& element = 0, bool write = true) override;
+		virtual void map(void* data, size_t size, UInt32 element = 0, bool write = true) override;
 
 		/// <inheritdoc />
-		virtual void map(Span<void*> data, const size_t& elementSize, const UInt32& firstElement = 0, bool write = true) override;
+		virtual void map(Span<void*> data, size_t elementSize, UInt32 firstElement = 0, bool write = true) override;
 
 		// DirectX 12 buffer.
 	protected:
@@ -73,8 +73,8 @@ namespace LiteFX::Rendering::Backends {
 		virtual const D3D12MA::Allocation* allocationInfo() const noexcept;
 
 	public:
-		static UniquePtr<IDirectX12Buffer> allocate(AllocatorPtr allocator, BufferType type, const UInt32& elements, const size_t& elementSize, const size_t& alignment, const bool& writable, const D3D12_RESOURCE_DESC1& resourceDesc, const D3D12MA::ALLOCATION_DESC& allocationDesc);
-		static UniquePtr<IDirectX12Buffer> allocate(const String& name, AllocatorPtr allocator, BufferType type, const UInt32& elements, const size_t& elementSize, const size_t& alignment, const bool& writable, const D3D12_RESOURCE_DESC1& resourceDesc, const D3D12MA::ALLOCATION_DESC& allocationDesc);
+		static UniquePtr<IDirectX12Buffer> allocate(AllocatorPtr allocator, BufferType type, UInt32 elements, size_t elementSize, size_t alignment, bool writable, const D3D12_RESOURCE_DESC1& resourceDesc, const D3D12MA::ALLOCATION_DESC& allocationDesc);
+		static UniquePtr<IDirectX12Buffer> allocate(const String& name, AllocatorPtr allocator, BufferType type, UInt32 elements, size_t elementSize, size_t alignment, bool writable, const D3D12_RESOURCE_DESC1& resourceDesc, const D3D12MA::ALLOCATION_DESC& allocationDesc);
 	};
 
 	/// <summary>
@@ -84,7 +84,7 @@ namespace LiteFX::Rendering::Backends {
 		LITEFX_IMPLEMENTATION(DirectX12VertexBufferImpl);
 
 	public:
-		explicit DirectX12VertexBuffer(ComPtr<ID3D12Resource>&& buffer, const DirectX12VertexBufferLayout& layout, const UInt32& elements, AllocatorPtr allocator, AllocationPtr&& allocation, const String& name = "");
+		explicit DirectX12VertexBuffer(ComPtr<ID3D12Resource>&& buffer, const DirectX12VertexBufferLayout& layout, UInt32 elements, AllocatorPtr allocator, AllocationPtr&& allocation, const String& name = "");
 		DirectX12VertexBuffer(DirectX12VertexBuffer&&) = delete;
 		DirectX12VertexBuffer(const DirectX12VertexBuffer&) = delete;
 		virtual ~DirectX12VertexBuffer() noexcept;
@@ -100,8 +100,8 @@ namespace LiteFX::Rendering::Backends {
 
 		// DirectX 12 Vertex Buffer.
 	public:
-		static UniquePtr<IDirectX12VertexBuffer> allocate(const DirectX12VertexBufferLayout& layout, AllocatorPtr allocator, const UInt32& elements, const D3D12_RESOURCE_DESC1& resourceDesc, const D3D12MA::ALLOCATION_DESC& allocationDesc);
-		static UniquePtr<IDirectX12VertexBuffer> allocate(const String& name, const DirectX12VertexBufferLayout& layout, AllocatorPtr allocator, const UInt32& elements, const D3D12_RESOURCE_DESC1& resourceDesc, const D3D12MA::ALLOCATION_DESC& allocationDesc);
+		static UniquePtr<IDirectX12VertexBuffer> allocate(const DirectX12VertexBufferLayout& layout, AllocatorPtr allocator, UInt32 elements, const D3D12_RESOURCE_DESC1& resourceDesc, const D3D12MA::ALLOCATION_DESC& allocationDesc);
+		static UniquePtr<IDirectX12VertexBuffer> allocate(const String& name, const DirectX12VertexBufferLayout& layout, AllocatorPtr allocator, UInt32 elements, const D3D12_RESOURCE_DESC1& resourceDesc, const D3D12MA::ALLOCATION_DESC& allocationDesc);
 	};
 
 	/// <summary>
@@ -111,7 +111,7 @@ namespace LiteFX::Rendering::Backends {
 		LITEFX_IMPLEMENTATION(DirectX12IndexBufferImpl);
 
 	public:
-		explicit DirectX12IndexBuffer(ComPtr<ID3D12Resource>&& buffer, const DirectX12IndexBufferLayout& layout, const UInt32& elements, AllocatorPtr allocator, AllocationPtr&& allocation, const String& name = "");
+		explicit DirectX12IndexBuffer(ComPtr<ID3D12Resource>&& buffer, const DirectX12IndexBufferLayout& layout, UInt32 elements, AllocatorPtr allocator, AllocationPtr&& allocation, const String& name = "");
 		DirectX12IndexBuffer(DirectX12IndexBuffer&&) = delete;
 		DirectX12IndexBuffer(const DirectX12IndexBuffer&) = delete;
 		virtual ~DirectX12IndexBuffer() noexcept;
@@ -127,7 +127,7 @@ namespace LiteFX::Rendering::Backends {
 
 		// DirectX 12 Index Buffer.
 	public:
-		static UniquePtr<IDirectX12IndexBuffer> allocate(const DirectX12IndexBufferLayout& layout, AllocatorPtr allocator, const UInt32& elements, const D3D12_RESOURCE_DESC1& resourceDesc, const D3D12MA::ALLOCATION_DESC& allocationDesc);
-		static UniquePtr<IDirectX12IndexBuffer> allocate(const String& name, const DirectX12IndexBufferLayout& layout, AllocatorPtr allocator, const UInt32& elements, const D3D12_RESOURCE_DESC1& resourceDesc, const D3D12MA::ALLOCATION_DESC& allocationDesc);
+		static UniquePtr<IDirectX12IndexBuffer> allocate(const DirectX12IndexBufferLayout& layout, AllocatorPtr allocator, UInt32 elements, const D3D12_RESOURCE_DESC1& resourceDesc, const D3D12MA::ALLOCATION_DESC& allocationDesc);
+		static UniquePtr<IDirectX12IndexBuffer> allocate(const String& name, const DirectX12IndexBufferLayout& layout, AllocatorPtr allocator, UInt32 elements, const D3D12_RESOURCE_DESC1& resourceDesc, const D3D12MA::ALLOCATION_DESC& allocationDesc);
 	};
 }

--- a/src/Backends/DirectX12/src/buffer.h
+++ b/src/Backends/DirectX12/src/buffer.h
@@ -31,41 +31,41 @@ namespace LiteFX::Rendering::Backends {
 		// IBuffer interface.
 	public:
 		/// <inheritdoc />
-		virtual BufferType type() const noexcept override;
+		BufferType type() const noexcept override;
 
 		// IDeviceMemory interface.
 	public:
 		/// <inheritdoc />
-		virtual UInt32 elements() const noexcept override;
+		UInt32 elements() const noexcept override;
 
 		/// <inheritdoc />
-		virtual size_t size() const noexcept override;
+		size_t size() const noexcept override;
 
 		/// <inheritdoc />
-		virtual size_t elementSize() const noexcept override;
+		size_t elementSize() const noexcept override;
 
 		/// <inheritdoc />
-		virtual size_t elementAlignment() const noexcept override;
+		size_t elementAlignment() const noexcept override;
 
 		/// <inheritdoc />
-		virtual size_t alignedElementSize() const noexcept override;
+		size_t alignedElementSize() const noexcept override;
 
 		/// <inheritdoc />
-		virtual bool writable() const noexcept override;
+		bool writable() const noexcept override;
 
 		// IMappable interface.
 	public:
 		/// <inheritdoc />
-		virtual void map(const void* const data, size_t size, UInt32 element = 0) override;
+		void map(const void* const data, size_t size, UInt32 element = 0) override;
 
 		/// <inheritdoc />
-		virtual void map(Span<const void* const> data, size_t elementSize, UInt32 firstElement = 0) override;
+		void map(Span<const void* const> data, size_t elementSize, UInt32 firstElement = 0) override;
 
 		/// <inheritdoc />
-		virtual void map(void* data, size_t size, UInt32 element = 0, bool write = true) override;
+		void map(void* data, size_t size, UInt32 element = 0, bool write = true) override;
 
 		/// <inheritdoc />
-		virtual void map(Span<void*> data, size_t elementSize, UInt32 firstElement = 0, bool write = true) override;
+		void map(Span<void*> data, size_t elementSize, UInt32 firstElement = 0, bool write = true) override;
 
 		// DirectX 12 buffer.
 	protected:
@@ -96,7 +96,7 @@ namespace LiteFX::Rendering::Backends {
 
 		// IDirectX12VertexBuffer interface.
 	public:
-		virtual const D3D12_VERTEX_BUFFER_VIEW& view() const noexcept override;
+		const D3D12_VERTEX_BUFFER_VIEW& view() const noexcept override;
 
 		// DirectX 12 Vertex Buffer.
 	public:
@@ -123,7 +123,7 @@ namespace LiteFX::Rendering::Backends {
 
 		// IDirectX12IndexBuffer interface.
 	public:
-		virtual const D3D12_INDEX_BUFFER_VIEW& view() const noexcept override;
+		const D3D12_INDEX_BUFFER_VIEW& view() const noexcept override;
 
 		// DirectX 12 Index Buffer.
 	public:

--- a/src/Backends/DirectX12/src/buffer.h
+++ b/src/Backends/DirectX12/src/buffer.h
@@ -23,7 +23,7 @@ namespace LiteFX::Rendering::Backends {
 		LITEFX_IMPLEMENTATION(DirectX12BufferImpl);
 
 	public:
-		explicit DirectX12Buffer(ComPtr<ID3D12Resource>&& buffer, const BufferType& type, const UInt32& elements, const size_t& elementSize, const size_t& alignment, const bool& writable, AllocatorPtr allocator = nullptr, AllocationPtr&& allocation = nullptr, const String& name = "");
+		explicit DirectX12Buffer(ComPtr<ID3D12Resource>&& buffer, BufferType type, const UInt32& elements, const size_t& elementSize, const size_t& alignment, const bool& writable, AllocatorPtr allocator = nullptr, AllocationPtr&& allocation = nullptr, const String& name = "");
 		DirectX12Buffer(DirectX12Buffer&&) = delete;
 		DirectX12Buffer(const DirectX12Buffer&) = delete;
 		virtual ~DirectX12Buffer() noexcept;
@@ -31,7 +31,7 @@ namespace LiteFX::Rendering::Backends {
 		// IBuffer interface.
 	public:
 		/// <inheritdoc />
-		virtual const BufferType& type() const noexcept override;
+		virtual BufferType type() const noexcept override;
 
 		// IDeviceMemory interface.
 	public:
@@ -73,8 +73,8 @@ namespace LiteFX::Rendering::Backends {
 		virtual const D3D12MA::Allocation* allocationInfo() const noexcept;
 
 	public:
-		static UniquePtr<IDirectX12Buffer> allocate(AllocatorPtr allocator, const BufferType& type, const UInt32& elements, const size_t& elementSize, const size_t& alignment, const bool& writable, const D3D12_RESOURCE_DESC1& resourceDesc, const D3D12MA::ALLOCATION_DESC& allocationDesc);
-		static UniquePtr<IDirectX12Buffer> allocate(const String& name, AllocatorPtr allocator, const BufferType& type, const UInt32& elements, const size_t& elementSize, const size_t& alignment, const bool& writable, const D3D12_RESOURCE_DESC1& resourceDesc, const D3D12MA::ALLOCATION_DESC& allocationDesc);
+		static UniquePtr<IDirectX12Buffer> allocate(AllocatorPtr allocator, BufferType type, const UInt32& elements, const size_t& elementSize, const size_t& alignment, const bool& writable, const D3D12_RESOURCE_DESC1& resourceDesc, const D3D12MA::ALLOCATION_DESC& allocationDesc);
+		static UniquePtr<IDirectX12Buffer> allocate(const String& name, AllocatorPtr allocator, BufferType type, const UInt32& elements, const size_t& elementSize, const size_t& alignment, const bool& writable, const D3D12_RESOURCE_DESC1& resourceDesc, const D3D12MA::ALLOCATION_DESC& allocationDesc);
 	};
 
 	/// <summary>

--- a/src/Backends/DirectX12/src/command_buffer.cpp
+++ b/src/Backends/DirectX12/src/command_buffer.cpp
@@ -138,7 +138,7 @@ void DirectX12CommandBuffer::setScissors(const IScissor* scissor) const noexcept
 
 void DirectX12CommandBuffer::setBlendFactors(const Vector4f& blendFactors) const noexcept
 {
-	this->handle()->OMSetBlendFactor(&blendFactors[0]);
+	this->handle()->OMSetBlendFactor(blendFactors.elements());
 }
 
 void DirectX12CommandBuffer::setStencilRef(const UInt32& stencilRef) const noexcept

--- a/src/Backends/DirectX12/src/command_buffer.cpp
+++ b/src/Backends/DirectX12/src/command_buffer.cpp
@@ -23,7 +23,7 @@ public:
 	}
 
 public:
-	ComPtr<ID3D12GraphicsCommandList7> initialize(const bool& begin, const bool& primary)
+	ComPtr<ID3D12GraphicsCommandList7> initialize(bool begin, bool primary)
 	{
 		// Create a command allocator.
 		D3D12_COMMAND_LIST_TYPE type;
@@ -72,7 +72,7 @@ public:
 // Shared interface.
 // ------------------------------------------------------------------------------------------------
 
-DirectX12CommandBuffer::DirectX12CommandBuffer(const DirectX12Queue& queue, const bool& begin, const bool& primary) :
+DirectX12CommandBuffer::DirectX12CommandBuffer(const DirectX12Queue& queue, bool begin, bool primary) :
 	m_impl(makePimpl<DirectX12CommandBufferImpl>(this, queue)), ComResource<ID3D12GraphicsCommandList7>(nullptr)
 {
 	this->handle() = m_impl->initialize(begin, primary);
@@ -101,7 +101,7 @@ void DirectX12CommandBuffer::end() const
 	m_impl->m_recording = false;
 }
 
-const bool& DirectX12CommandBuffer::isSecondary() const noexcept
+bool DirectX12CommandBuffer::isSecondary() const noexcept
 {
 	return m_impl->m_secondary;
 }
@@ -141,7 +141,7 @@ void DirectX12CommandBuffer::setBlendFactors(const Vector4f& blendFactors) const
 	this->handle()->OMSetBlendFactor(blendFactors.elements());
 }
 
-void DirectX12CommandBuffer::setStencilRef(const UInt32& stencilRef) const noexcept
+void DirectX12CommandBuffer::setStencilRef(UInt32 stencilRef) const noexcept
 {
 	this->handle()->OMSetStencilRef(stencilRef);
 }
@@ -234,7 +234,7 @@ void DirectX12CommandBuffer::barrier(const DirectX12Barrier& barrier) const noex
 	barrier.execute(*this);
 }
 
-void DirectX12CommandBuffer::transfer(IDirectX12Buffer& source, IDirectX12Buffer& target, const UInt32& sourceElement, const UInt32& targetElement, const UInt32& elements) const
+void DirectX12CommandBuffer::transfer(IDirectX12Buffer& source, IDirectX12Buffer& target, UInt32 sourceElement, UInt32 targetElement, UInt32 elements) const
 {
 	if (source.elements() < sourceElement + elements) [[unlikely]]
 		throw ArgumentOutOfRangeException("The source buffer has only {0} elements, but a transfer for {1} elements starting from element {2} has been requested.", source.elements(), elements, sourceElement);
@@ -245,7 +245,7 @@ void DirectX12CommandBuffer::transfer(IDirectX12Buffer& source, IDirectX12Buffer
 	this->handle()->CopyBufferRegion(std::as_const(target).handle().Get(), targetElement * target.alignedElementSize(), std::as_const(source).handle().Get(), sourceElement * source.alignedElementSize(), elements * source.alignedElementSize());
 }
 
-void DirectX12CommandBuffer::transfer(IDirectX12Buffer& source, IDirectX12Image& target, const UInt32& sourceElement, const UInt32& firstSubresource, const UInt32& elements) const
+void DirectX12CommandBuffer::transfer(IDirectX12Buffer& source, IDirectX12Image& target, UInt32 sourceElement, UInt32 firstSubresource, UInt32 elements) const
 {
 	if (source.elements() < sourceElement + elements) [[unlikely]]
 		throw ArgumentOutOfRangeException("The source buffer has only {0} elements, but a transfer for {1} elements starting from element {2} has been requested.", source.elements(), elements, sourceElement);
@@ -264,7 +264,7 @@ void DirectX12CommandBuffer::transfer(IDirectX12Buffer& source, IDirectX12Image&
 	}
 }
 
-void DirectX12CommandBuffer::transfer(IDirectX12Image& source, IDirectX12Image& target, const UInt32& sourceSubresource, const UInt32& targetSubresource, const UInt32& subresources) const
+void DirectX12CommandBuffer::transfer(IDirectX12Image& source, IDirectX12Image& target, UInt32 sourceSubresource, UInt32 targetSubresource, UInt32 subresources) const
 {
 	if (source.elements() < sourceSubresource + subresources) [[unlikely]]
 		throw ArgumentOutOfRangeException("The source image has only {0} sub-resources, but a transfer for {1} sub-resources starting from sub-resource {2} has been requested.", source.elements(), subresources, sourceSubresource);
@@ -283,7 +283,7 @@ void DirectX12CommandBuffer::transfer(IDirectX12Image& source, IDirectX12Image& 
 	}
 }
 
-void DirectX12CommandBuffer::transfer(IDirectX12Image& source, IDirectX12Buffer& target, const UInt32& firstSubresource, const UInt32& targetElement, const UInt32& subresources) const
+void DirectX12CommandBuffer::transfer(IDirectX12Image& source, IDirectX12Buffer& target, UInt32 firstSubresource, UInt32 targetElement, UInt32 subresources) const
 {
 	if (source.elements() < firstSubresource + subresources) [[unlikely]]
 		throw ArgumentOutOfRangeException("The source image has only {0} sub-resources, but a transfer for {1} sub-resources starting from sub-resource {2} has been requested.", source.elements(), subresources, firstSubresource);
@@ -302,25 +302,25 @@ void DirectX12CommandBuffer::transfer(IDirectX12Image& source, IDirectX12Buffer&
 	}
 }
 
-void DirectX12CommandBuffer::transfer(SharedPtr<IDirectX12Buffer> source, IDirectX12Buffer& target, const UInt32& sourceElement, const UInt32& targetElement, const UInt32& elements) const
+void DirectX12CommandBuffer::transfer(SharedPtr<IDirectX12Buffer> source, IDirectX12Buffer& target, UInt32 sourceElement, UInt32 targetElement, UInt32 elements) const
 {
 	this->transfer(*source, target, sourceElement, targetElement, elements);
 	m_impl->m_sharedResources.push_back(source);
 }
 
-void DirectX12CommandBuffer::transfer(SharedPtr<IDirectX12Buffer> source, IDirectX12Image& target, const UInt32& sourceElement, const UInt32& firstSubresource, const UInt32& elements) const
+void DirectX12CommandBuffer::transfer(SharedPtr<IDirectX12Buffer> source, IDirectX12Image& target, UInt32 sourceElement, UInt32 firstSubresource, UInt32 elements) const
 {
 	this->transfer(*source, target, sourceElement, firstSubresource, elements);
 	m_impl->m_sharedResources.push_back(source);
 }
 
-void DirectX12CommandBuffer::transfer(SharedPtr<IDirectX12Image> source, IDirectX12Image& target, const UInt32& sourceSubresource, const UInt32& targetSubresource, const UInt32& subresources) const
+void DirectX12CommandBuffer::transfer(SharedPtr<IDirectX12Image> source, IDirectX12Image& target, UInt32 sourceSubresource, UInt32 targetSubresource, UInt32 subresources) const
 {
 	this->transfer(*source, target, sourceSubresource, targetSubresource, subresources);
 	m_impl->m_sharedResources.push_back(source);
 }
 
-void DirectX12CommandBuffer::transfer(SharedPtr<IDirectX12Image> source, IDirectX12Buffer& target, const UInt32& firstSubresource, const UInt32& targetElement, const UInt32& subresources) const
+void DirectX12CommandBuffer::transfer(SharedPtr<IDirectX12Image> source, IDirectX12Buffer& target, UInt32 firstSubresource, UInt32 targetElement, UInt32 subresources) const
 {
 	this->transfer(*source, target, firstSubresource, targetElement, subresources);
 	m_impl->m_sharedResources.push_back(source);
@@ -351,12 +351,12 @@ void DirectX12CommandBuffer::dispatch(const Vector3u& threadCount) const noexcep
 	this->handle()->Dispatch(threadCount.x(), threadCount.y(), threadCount.z());
 }
 
-void DirectX12CommandBuffer::draw(const UInt32& vertices, const UInt32& instances, const UInt32& firstVertex, const UInt32& firstInstance) const noexcept
+void DirectX12CommandBuffer::draw(UInt32 vertices, UInt32 instances, UInt32 firstVertex, UInt32 firstInstance) const noexcept
 {
 	this->handle()->DrawInstanced(vertices, instances, firstVertex, firstInstance);
 }
 
-void DirectX12CommandBuffer::drawIndexed(const UInt32& indices, const UInt32& instances, const UInt32& firstIndex, const Int32& vertexOffset, const UInt32& firstInstance) const noexcept
+void DirectX12CommandBuffer::drawIndexed(UInt32 indices, UInt32 instances, UInt32 firstIndex, Int32 vertexOffset, UInt32 firstInstance) const noexcept
 {
 	this->handle()->DrawIndexedInstanced(indices, instances, firstIndex, vertexOffset, firstInstance);
 }

--- a/src/Backends/DirectX12/src/convert.cpp
+++ b/src/Backends/DirectX12/src/convert.cpp
@@ -149,7 +149,7 @@ constexpr Format LiteFX::Rendering::Backends::DX12::getFormat(const DXGI_FORMAT&
 	}
 }
 
-constexpr DXGI_FORMAT LiteFX::Rendering::Backends::DX12::getFormat(const Format& format)
+constexpr DXGI_FORMAT LiteFX::Rendering::Backends::DX12::getFormat(Format format)
 {
 	switch (format)
 	{
@@ -294,7 +294,7 @@ constexpr DXGI_FORMAT LiteFX::Rendering::Backends::DX12::getFormat(const Format&
 	}
 }
 
-constexpr DXGI_FORMAT LiteFX::Rendering::Backends::DX12::getFormat(const BufferFormat& format)
+constexpr DXGI_FORMAT LiteFX::Rendering::Backends::DX12::getFormat(BufferFormat format)
 {
 	switch (format)
 	{
@@ -345,7 +345,7 @@ constexpr DXGI_FORMAT LiteFX::Rendering::Backends::DX12::getFormat(const BufferF
 	}
 }
 
-constexpr bool LiteFX::Rendering::Backends::DX12::isSRGB(const Format& format)
+constexpr bool LiteFX::Rendering::Backends::DX12::isSRGB(Format format)
 {
 	return 
 		format == Format::A8B8G8R8_SRGB || 
@@ -362,7 +362,7 @@ constexpr bool LiteFX::Rendering::Backends::DX12::isSRGB(const Format& format)
 		format == Format::R8_SRGB;
 }
 
-constexpr D3D12_RESOURCE_DIMENSION LiteFX::Rendering::Backends::DX12::getImageType(const ImageDimensions& dimensions)
+constexpr D3D12_RESOURCE_DIMENSION LiteFX::Rendering::Backends::DX12::getImageType(ImageDimensions dimensions)
 {
 	switch (dimensions)
 	{
@@ -391,7 +391,7 @@ constexpr PolygonMode LiteFX::Rendering::Backends::DX12::getPolygonMode(const D3
 	}
 }
 
-constexpr D3D12_FILL_MODE LiteFX::Rendering::Backends::DX12::getPolygonMode(const PolygonMode& mode)
+constexpr D3D12_FILL_MODE LiteFX::Rendering::Backends::DX12::getPolygonMode(PolygonMode mode)
 {
 	switch (mode)
 	{
@@ -419,7 +419,7 @@ constexpr CullMode LiteFX::Rendering::Backends::DX12::getCullMode(const D3D12_CU
 	}
 }
 
-constexpr D3D12_CULL_MODE LiteFX::Rendering::Backends::DX12::getCullMode(const CullMode& mode)
+constexpr D3D12_CULL_MODE LiteFX::Rendering::Backends::DX12::getCullMode(CullMode mode)
 {
 	switch (mode)
 	{
@@ -489,7 +489,7 @@ constexpr D3D12_PRIMITIVE_TOPOLOGY_TYPE LiteFX::Rendering::Backends::DX12::getPr
 	}
 }
 
-constexpr LPCTSTR LITEFX_DIRECTX12_API LiteFX::Rendering::Backends::DX12::getSemanticName(const AttributeSemantic& semantic)
+constexpr LPCTSTR LITEFX_DIRECTX12_API LiteFX::Rendering::Backends::DX12::getSemanticName(AttributeSemantic semantic)
 {
 	switch (semantic)
 	{
@@ -538,7 +538,7 @@ constexpr String LITEFX_DIRECTX12_API LiteFX::Rendering::Backends::DX12::getVend
 	}
 }
 
-constexpr D3D12_COMPARISON_FUNC LITEFX_DIRECTX12_API LiteFX::Rendering::Backends::DX12::getCompareOp(const CompareOperation& compareOp)
+constexpr D3D12_COMPARISON_FUNC LITEFX_DIRECTX12_API LiteFX::Rendering::Backends::DX12::getCompareOp(CompareOperation compareOp)
 {
 	switch (compareOp) {
 	case CompareOperation::Never: return D3D12_COMPARISON_FUNC::D3D12_COMPARISON_FUNC_NEVER;
@@ -553,7 +553,7 @@ constexpr D3D12_COMPARISON_FUNC LITEFX_DIRECTX12_API LiteFX::Rendering::Backends
 	}
 }
 
-constexpr D3D12_STENCIL_OP LITEFX_DIRECTX12_API LiteFX::Rendering::Backends::DX12::getStencilOp(const StencilOperation& stencilOp)
+constexpr D3D12_STENCIL_OP LITEFX_DIRECTX12_API LiteFX::Rendering::Backends::DX12::getStencilOp(StencilOperation stencilOp)
 {
 	switch (stencilOp) {
 	case StencilOperation::Keep: return D3D12_STENCIL_OP::D3D12_STENCIL_OP_KEEP;
@@ -568,7 +568,7 @@ constexpr D3D12_STENCIL_OP LITEFX_DIRECTX12_API LiteFX::Rendering::Backends::DX1
 	}
 }
 
-constexpr D3D12_BLEND LITEFX_DIRECTX12_API LiteFX::Rendering::Backends::DX12::getBlendFactor(const BlendFactor& blendFactor)
+constexpr D3D12_BLEND LITEFX_DIRECTX12_API LiteFX::Rendering::Backends::DX12::getBlendFactor(BlendFactor blendFactor)
 {
 	switch (blendFactor) {
 	case BlendFactor::Zero: return D3D12_BLEND_ZERO;
@@ -594,7 +594,7 @@ constexpr D3D12_BLEND LITEFX_DIRECTX12_API LiteFX::Rendering::Backends::DX12::ge
 	}
 }
 
-constexpr D3D12_BLEND_OP LITEFX_DIRECTX12_API LiteFX::Rendering::Backends::DX12::getBlendOperation(const BlendOperation& blendOperation)
+constexpr D3D12_BLEND_OP LITEFX_DIRECTX12_API LiteFX::Rendering::Backends::DX12::getBlendOperation(BlendOperation blendOperation)
 {
 	switch (blendOperation) {
 	case BlendOperation::Add: return D3D12_BLEND_OP_ADD;
@@ -606,7 +606,7 @@ constexpr D3D12_BLEND_OP LITEFX_DIRECTX12_API LiteFX::Rendering::Backends::DX12:
 	}
 }
 
-constexpr D3D12_BARRIER_SYNC LITEFX_DIRECTX12_API LiteFX::Rendering::Backends::DX12::getPipelineStage(const PipelineStage& pipelineStage)
+constexpr D3D12_BARRIER_SYNC LITEFX_DIRECTX12_API LiteFX::Rendering::Backends::DX12::getPipelineStage(PipelineStage pipelineStage)
 {
 	if (pipelineStage == PipelineStage::None)
 		return D3D12_BARRIER_SYNC_NONE;
@@ -649,7 +649,7 @@ constexpr D3D12_BARRIER_SYNC LITEFX_DIRECTX12_API LiteFX::Rendering::Backends::D
 	return sync;
 }
 
-constexpr D3D12_BARRIER_ACCESS LITEFX_DIRECTX12_API LiteFX::Rendering::Backends::DX12::getResourceAccess(const ResourceAccess& resourceAccess)
+constexpr D3D12_BARRIER_ACCESS LITEFX_DIRECTX12_API LiteFX::Rendering::Backends::DX12::getResourceAccess(ResourceAccess resourceAccess)
 {
 	if (resourceAccess == ResourceAccess::None)
 		return D3D12_BARRIER_ACCESS_NO_ACCESS;
@@ -701,7 +701,7 @@ constexpr D3D12_BARRIER_ACCESS LITEFX_DIRECTX12_API LiteFX::Rendering::Backends:
 	return access;
 }
 
-constexpr D3D12_BARRIER_LAYOUT LITEFX_DIRECTX12_API LiteFX::Rendering::Backends::DX12::getImageLayout(const ImageLayout& imageLayout)
+constexpr D3D12_BARRIER_LAYOUT LITEFX_DIRECTX12_API LiteFX::Rendering::Backends::DX12::getImageLayout(ImageLayout imageLayout)
 {
 	switch (imageLayout) {
 	case ImageLayout::Common: return D3D12_BARRIER_LAYOUT_COMMON;

--- a/src/Backends/DirectX12/src/convert.cpp
+++ b/src/Backends/DirectX12/src/convert.cpp
@@ -2,7 +2,7 @@
 
 using namespace LiteFX::Rendering::Backends;
 
-Format LiteFX::Rendering::Backends::DX12::getFormat(const DXGI_FORMAT& format)
+constexpr Format LiteFX::Rendering::Backends::DX12::getFormat(const DXGI_FORMAT& format)
 {
 	switch (format)
 	{
@@ -149,7 +149,7 @@ Format LiteFX::Rendering::Backends::DX12::getFormat(const DXGI_FORMAT& format)
 	}
 }
 
-DXGI_FORMAT LiteFX::Rendering::Backends::DX12::getFormat(const Format& format)
+constexpr DXGI_FORMAT LiteFX::Rendering::Backends::DX12::getFormat(const Format& format)
 {
 	switch (format)
 	{
@@ -294,7 +294,7 @@ DXGI_FORMAT LiteFX::Rendering::Backends::DX12::getFormat(const Format& format)
 	}
 }
 
-DXGI_FORMAT LiteFX::Rendering::Backends::DX12::getFormat(const BufferFormat& format)
+constexpr DXGI_FORMAT LiteFX::Rendering::Backends::DX12::getFormat(const BufferFormat& format)
 {
 	switch (format)
 	{
@@ -345,7 +345,7 @@ DXGI_FORMAT LiteFX::Rendering::Backends::DX12::getFormat(const BufferFormat& for
 	}
 }
 
-bool LiteFX::Rendering::Backends::DX12::isSRGB(const Format& format)
+constexpr bool LiteFX::Rendering::Backends::DX12::isSRGB(const Format& format)
 {
 	return 
 		format == Format::A8B8G8R8_SRGB || 
@@ -362,7 +362,7 @@ bool LiteFX::Rendering::Backends::DX12::isSRGB(const Format& format)
 		format == Format::R8_SRGB;
 }
 
-D3D12_RESOURCE_DIMENSION LiteFX::Rendering::Backends::DX12::getImageType(const ImageDimensions& dimensions)
+constexpr D3D12_RESOURCE_DIMENSION LiteFX::Rendering::Backends::DX12::getImageType(const ImageDimensions& dimensions)
 {
 	switch (dimensions)
 	{
@@ -378,7 +378,7 @@ D3D12_RESOURCE_DIMENSION LiteFX::Rendering::Backends::DX12::getImageType(const I
 	}
 }
 
-PolygonMode LiteFX::Rendering::Backends::DX12::getPolygonMode(const D3D12_FILL_MODE& mode)
+constexpr PolygonMode LiteFX::Rendering::Backends::DX12::getPolygonMode(const D3D12_FILL_MODE& mode)
 {
 	switch (mode)
 	{
@@ -391,7 +391,7 @@ PolygonMode LiteFX::Rendering::Backends::DX12::getPolygonMode(const D3D12_FILL_M
 	}
 }
 
-D3D12_FILL_MODE LiteFX::Rendering::Backends::DX12::getPolygonMode(const PolygonMode& mode)
+constexpr D3D12_FILL_MODE LiteFX::Rendering::Backends::DX12::getPolygonMode(const PolygonMode& mode)
 {
 	switch (mode)
 	{
@@ -404,7 +404,7 @@ D3D12_FILL_MODE LiteFX::Rendering::Backends::DX12::getPolygonMode(const PolygonM
 	}
 }
 
-CullMode LiteFX::Rendering::Backends::DX12::getCullMode(const D3D12_CULL_MODE& mode)
+constexpr CullMode LiteFX::Rendering::Backends::DX12::getCullMode(const D3D12_CULL_MODE& mode)
 {
 	switch (mode)
 	{
@@ -419,7 +419,7 @@ CullMode LiteFX::Rendering::Backends::DX12::getCullMode(const D3D12_CULL_MODE& m
 	}
 }
 
-D3D12_CULL_MODE LiteFX::Rendering::Backends::DX12::getCullMode(const CullMode& mode)
+constexpr D3D12_CULL_MODE LiteFX::Rendering::Backends::DX12::getCullMode(const CullMode& mode)
 {
 	switch (mode)
 	{
@@ -434,7 +434,7 @@ D3D12_CULL_MODE LiteFX::Rendering::Backends::DX12::getCullMode(const CullMode& m
 	}
 }
 
-PrimitiveTopology LiteFX::Rendering::Backends::DX12::getPrimitiveTopology(const D3D12_PRIMITIVE_TOPOLOGY& topology)
+constexpr PrimitiveTopology LiteFX::Rendering::Backends::DX12::getPrimitiveTopology(const D3D12_PRIMITIVE_TOPOLOGY& topology)
 {
 	switch (topology)
 	{
@@ -453,7 +453,7 @@ PrimitiveTopology LiteFX::Rendering::Backends::DX12::getPrimitiveTopology(const 
 	}
 }
 
-D3D12_PRIMITIVE_TOPOLOGY LiteFX::Rendering::Backends::DX12::getPrimitiveTopology(const PrimitiveTopology& topology)
+constexpr D3D12_PRIMITIVE_TOPOLOGY LiteFX::Rendering::Backends::DX12::getPrimitiveTopology(const PrimitiveTopology& topology)
 {
 	switch (topology)
 	{
@@ -472,7 +472,7 @@ D3D12_PRIMITIVE_TOPOLOGY LiteFX::Rendering::Backends::DX12::getPrimitiveTopology
 	}
 }
 
-D3D12_PRIMITIVE_TOPOLOGY_TYPE LiteFX::Rendering::Backends::DX12::getPrimitiveTopologyType(const PrimitiveTopology& topology)
+constexpr D3D12_PRIMITIVE_TOPOLOGY_TYPE LiteFX::Rendering::Backends::DX12::getPrimitiveTopologyType(const PrimitiveTopology& topology)
 {
 	switch (topology)
 	{
@@ -489,7 +489,7 @@ D3D12_PRIMITIVE_TOPOLOGY_TYPE LiteFX::Rendering::Backends::DX12::getPrimitiveTop
 	}
 }
 
-LPCTSTR LITEFX_DIRECTX12_API LiteFX::Rendering::Backends::DX12::getSemanticName(const AttributeSemantic& semantic)
+constexpr LPCTSTR LITEFX_DIRECTX12_API LiteFX::Rendering::Backends::DX12::getSemanticName(const AttributeSemantic& semantic)
 {
 	switch (semantic)
 	{
@@ -518,7 +518,7 @@ LPCTSTR LITEFX_DIRECTX12_API LiteFX::Rendering::Backends::DX12::getSemanticName(
 	}
 }
 
-String LITEFX_DIRECTX12_API LiteFX::Rendering::Backends::DX12::getVendorName(const UInt32& vendorId)
+constexpr String LITEFX_DIRECTX12_API LiteFX::Rendering::Backends::DX12::getVendorName(const UInt32& vendorId)
 {
 	switch (vendorId)
 	{
@@ -538,7 +538,7 @@ String LITEFX_DIRECTX12_API LiteFX::Rendering::Backends::DX12::getVendorName(con
 	}
 }
 
-D3D12_COMPARISON_FUNC LITEFX_DIRECTX12_API LiteFX::Rendering::Backends::DX12::getCompareOp(const CompareOperation& compareOp)
+constexpr D3D12_COMPARISON_FUNC LITEFX_DIRECTX12_API LiteFX::Rendering::Backends::DX12::getCompareOp(const CompareOperation& compareOp)
 {
 	switch (compareOp) {
 	case CompareOperation::Never: return D3D12_COMPARISON_FUNC::D3D12_COMPARISON_FUNC_NEVER;
@@ -553,7 +553,7 @@ D3D12_COMPARISON_FUNC LITEFX_DIRECTX12_API LiteFX::Rendering::Backends::DX12::ge
 	}
 }
 
-D3D12_STENCIL_OP LITEFX_DIRECTX12_API LiteFX::Rendering::Backends::DX12::getStencilOp(const StencilOperation& stencilOp)
+constexpr D3D12_STENCIL_OP LITEFX_DIRECTX12_API LiteFX::Rendering::Backends::DX12::getStencilOp(const StencilOperation& stencilOp)
 {
 	switch (stencilOp) {
 	case StencilOperation::Keep: return D3D12_STENCIL_OP::D3D12_STENCIL_OP_KEEP;
@@ -568,7 +568,7 @@ D3D12_STENCIL_OP LITEFX_DIRECTX12_API LiteFX::Rendering::Backends::DX12::getSten
 	}
 }
 
-D3D12_BLEND LITEFX_DIRECTX12_API LiteFX::Rendering::Backends::DX12::getBlendFactor(const BlendFactor& blendFactor)
+constexpr D3D12_BLEND LITEFX_DIRECTX12_API LiteFX::Rendering::Backends::DX12::getBlendFactor(const BlendFactor& blendFactor)
 {
 	switch (blendFactor) {
 	case BlendFactor::Zero: return D3D12_BLEND_ZERO;
@@ -594,7 +594,7 @@ D3D12_BLEND LITEFX_DIRECTX12_API LiteFX::Rendering::Backends::DX12::getBlendFact
 	}
 }
 
-D3D12_BLEND_OP LITEFX_DIRECTX12_API LiteFX::Rendering::Backends::DX12::getBlendOperation(const BlendOperation& blendOperation)
+constexpr D3D12_BLEND_OP LITEFX_DIRECTX12_API LiteFX::Rendering::Backends::DX12::getBlendOperation(const BlendOperation& blendOperation)
 {
 	switch (blendOperation) {
 	case BlendOperation::Add: return D3D12_BLEND_OP_ADD;
@@ -606,7 +606,7 @@ D3D12_BLEND_OP LITEFX_DIRECTX12_API LiteFX::Rendering::Backends::DX12::getBlendO
 	}
 }
 
-D3D12_BARRIER_SYNC LITEFX_DIRECTX12_API LiteFX::Rendering::Backends::DX12::getPipelineStage(const PipelineStage& pipelineStage)
+constexpr D3D12_BARRIER_SYNC LITEFX_DIRECTX12_API LiteFX::Rendering::Backends::DX12::getPipelineStage(const PipelineStage& pipelineStage)
 {
 	if (pipelineStage == PipelineStage::None)
 		return D3D12_BARRIER_SYNC_NONE;
@@ -649,7 +649,7 @@ D3D12_BARRIER_SYNC LITEFX_DIRECTX12_API LiteFX::Rendering::Backends::DX12::getPi
 	return sync;
 }
 
-D3D12_BARRIER_ACCESS LITEFX_DIRECTX12_API LiteFX::Rendering::Backends::DX12::getResourceAccess(const ResourceAccess& resourceAccess)
+constexpr D3D12_BARRIER_ACCESS LITEFX_DIRECTX12_API LiteFX::Rendering::Backends::DX12::getResourceAccess(const ResourceAccess& resourceAccess)
 {
 	if (resourceAccess == ResourceAccess::None)
 		return D3D12_BARRIER_ACCESS_NO_ACCESS;
@@ -701,7 +701,7 @@ D3D12_BARRIER_ACCESS LITEFX_DIRECTX12_API LiteFX::Rendering::Backends::DX12::get
 	return access;
 }
 
-D3D12_BARRIER_LAYOUT LITEFX_DIRECTX12_API LiteFX::Rendering::Backends::DX12::getImageLayout(const ImageLayout& imageLayout)
+constexpr D3D12_BARRIER_LAYOUT LITEFX_DIRECTX12_API LiteFX::Rendering::Backends::DX12::getImageLayout(const ImageLayout& imageLayout)
 {
 	switch (imageLayout) {
 	case ImageLayout::Common: return D3D12_BARRIER_LAYOUT_COMMON;

--- a/src/Backends/DirectX12/src/convert.cpp
+++ b/src/Backends/DirectX12/src/convert.cpp
@@ -518,7 +518,7 @@ constexpr LPCTSTR LITEFX_DIRECTX12_API LiteFX::Rendering::Backends::DX12::getSem
 	}
 }
 
-constexpr String LITEFX_DIRECTX12_API LiteFX::Rendering::Backends::DX12::getVendorName(const UInt32& vendorId)
+constexpr String LITEFX_DIRECTX12_API LiteFX::Rendering::Backends::DX12::getVendorName(UInt32 vendorId)
 {
 	switch (vendorId)
 	{

--- a/src/Backends/DirectX12/src/convert.cpp
+++ b/src/Backends/DirectX12/src/convert.cpp
@@ -453,7 +453,7 @@ constexpr PrimitiveTopology LiteFX::Rendering::Backends::DX12::getPrimitiveTopol
 	}
 }
 
-constexpr D3D12_PRIMITIVE_TOPOLOGY LiteFX::Rendering::Backends::DX12::getPrimitiveTopology(const PrimitiveTopology& topology)
+constexpr D3D12_PRIMITIVE_TOPOLOGY LiteFX::Rendering::Backends::DX12::getPrimitiveTopology(PrimitiveTopology topology)
 {
 	switch (topology)
 	{
@@ -472,7 +472,7 @@ constexpr D3D12_PRIMITIVE_TOPOLOGY LiteFX::Rendering::Backends::DX12::getPrimiti
 	}
 }
 
-constexpr D3D12_PRIMITIVE_TOPOLOGY_TYPE LiteFX::Rendering::Backends::DX12::getPrimitiveTopologyType(const PrimitiveTopology& topology)
+constexpr D3D12_PRIMITIVE_TOPOLOGY_TYPE LiteFX::Rendering::Backends::DX12::getPrimitiveTopologyType(PrimitiveTopology topology)
 {
 	switch (topology)
 	{

--- a/src/Backends/DirectX12/src/descriptor_layout.cpp
+++ b/src/Backends/DirectX12/src/descriptor_layout.cpp
@@ -19,7 +19,7 @@ private:
     UniquePtr<IDirectX12Sampler> m_staticSampler;
 
 public:
-    DirectX12DescriptorLayoutImpl(DirectX12DescriptorLayout* parent, const DescriptorType& type, const UInt32& binding, const size_t& elementSize, const UInt32& descriptors) :
+    DirectX12DescriptorLayoutImpl(DirectX12DescriptorLayout* parent, DescriptorType type, const UInt32& binding, const size_t& elementSize, const UInt32& descriptors) :
         base(parent), m_descriptorType(type), m_binding(binding), m_elementSize(elementSize), m_descriptors(descriptors)
     {
         switch (m_descriptorType)
@@ -56,7 +56,7 @@ public:
 // Shared interface.
 // ------------------------------------------------------------------------------------------------
 
-DirectX12DescriptorLayout::DirectX12DescriptorLayout(const DescriptorType& type, const UInt32& binding, const size_t& elementSize, const UInt32& descriptors) :
+DirectX12DescriptorLayout::DirectX12DescriptorLayout(DescriptorType type, const UInt32& binding, const size_t& elementSize, const UInt32& descriptors) :
     m_impl(makePimpl<DirectX12DescriptorLayoutImpl>(this, type, binding, elementSize, descriptors))
 {
 }
@@ -83,12 +83,12 @@ const UInt32& DirectX12DescriptorLayout::binding() const noexcept
     return m_impl->m_binding;
 }
 
-const BufferType& DirectX12DescriptorLayout::type() const noexcept
+BufferType DirectX12DescriptorLayout::type() const noexcept
 {
     return m_impl->m_bufferType;
 }
 
-const DescriptorType& DirectX12DescriptorLayout::descriptorType() const noexcept
+DescriptorType DirectX12DescriptorLayout::descriptorType() const noexcept
 {
     return m_impl->m_descriptorType;
 }

--- a/src/Backends/DirectX12/src/descriptor_layout.cpp
+++ b/src/Backends/DirectX12/src/descriptor_layout.cpp
@@ -19,7 +19,7 @@ private:
     UniquePtr<IDirectX12Sampler> m_staticSampler;
 
 public:
-    DirectX12DescriptorLayoutImpl(DirectX12DescriptorLayout* parent, DescriptorType type, const UInt32& binding, const size_t& elementSize, const UInt32& descriptors) :
+    DirectX12DescriptorLayoutImpl(DirectX12DescriptorLayout* parent, DescriptorType type, UInt32 binding, size_t elementSize, UInt32 descriptors) :
         base(parent), m_descriptorType(type), m_binding(binding), m_elementSize(elementSize), m_descriptors(descriptors)
     {
         switch (m_descriptorType)
@@ -42,7 +42,7 @@ public:
         }
     }
 
-    DirectX12DescriptorLayoutImpl(DirectX12DescriptorLayout* parent, UniquePtr<IDirectX12Sampler>&& staticSampler, const UInt32& binding) :
+    DirectX12DescriptorLayoutImpl(DirectX12DescriptorLayout* parent, UniquePtr<IDirectX12Sampler>&& staticSampler, UInt32 binding) :
         DirectX12DescriptorLayoutImpl(parent, DescriptorType::Sampler, binding, 0, 1)
     {
         if (staticSampler == nullptr)
@@ -56,12 +56,12 @@ public:
 // Shared interface.
 // ------------------------------------------------------------------------------------------------
 
-DirectX12DescriptorLayout::DirectX12DescriptorLayout(DescriptorType type, const UInt32& binding, const size_t& elementSize, const UInt32& descriptors) :
+DirectX12DescriptorLayout::DirectX12DescriptorLayout(DescriptorType type, UInt32 binding, size_t elementSize, UInt32 descriptors) :
     m_impl(makePimpl<DirectX12DescriptorLayoutImpl>(this, type, binding, elementSize, descriptors))
 {
 }
 
-DirectX12DescriptorLayout::DirectX12DescriptorLayout(UniquePtr<IDirectX12Sampler>&& staticSampler, const UInt32& binding) :
+DirectX12DescriptorLayout::DirectX12DescriptorLayout(UniquePtr<IDirectX12Sampler>&& staticSampler, UInt32 binding) :
     m_impl(makePimpl<DirectX12DescriptorLayoutImpl>(this, std::move(staticSampler), binding))
 {
 }
@@ -73,12 +73,12 @@ size_t DirectX12DescriptorLayout::elementSize() const noexcept
     return m_impl->m_elementSize;
 }
 
-const UInt32& DirectX12DescriptorLayout::descriptors() const noexcept
+UInt32 DirectX12DescriptorLayout::descriptors() const noexcept
 {
     return m_impl->m_descriptors;
 }
 
-const UInt32& DirectX12DescriptorLayout::binding() const noexcept
+UInt32 DirectX12DescriptorLayout::binding() const noexcept
 {
     return m_impl->m_binding;
 }

--- a/src/Backends/DirectX12/src/descriptor_set.cpp
+++ b/src/Backends/DirectX12/src/descriptor_set.cpp
@@ -29,7 +29,7 @@ public:
     }
 
 public:
-    D3D12_FILTER getFilterMode(const FilterMode& minFilter, const FilterMode& magFilter, const MipMapMode& mipFilter, const Float& anisotropy = 0.f)
+    D3D12_FILTER getFilterMode(FilterMode minFilter, FilterMode magFilter, MipMapMode mipFilter, const Float& anisotropy = 0.f)
     {
         if (anisotropy > 0.f)
             return D3D12_ENCODE_ANISOTROPIC_FILTER(D3D12_FILTER_REDUCTION_TYPE_STANDARD);
@@ -43,7 +43,7 @@ public:
         }
     }
 
-    D3D12_TEXTURE_ADDRESS_MODE getBorderMode(const BorderMode& mode)
+    D3D12_TEXTURE_ADDRESS_MODE getBorderMode(BorderMode mode)
     {
         switch (mode)
         {

--- a/src/Backends/DirectX12/src/descriptor_set.cpp
+++ b/src/Backends/DirectX12/src/descriptor_set.cpp
@@ -29,7 +29,7 @@ public:
     }
 
 public:
-    D3D12_FILTER getFilterMode(FilterMode minFilter, FilterMode magFilter, MipMapMode mipFilter, const Float& anisotropy = 0.f)
+    D3D12_FILTER getFilterMode(FilterMode minFilter, FilterMode magFilter, MipMapMode mipFilter, Float anisotropy = 0.f)
     {
         if (anisotropy > 0.f)
             return D3D12_ENCODE_ANISOTROPIC_FILTER(D3D12_FILTER_REDUCTION_TYPE_STANDARD);
@@ -56,7 +56,7 @@ public:
         }
     }
 
-    void updateGlobalBuffers(const UInt32& offset, const UInt32& descriptors)
+    void updateGlobalBuffers(UInt32 offset, UInt32 descriptors)
     {
         m_layout.device().updateBufferDescriptors(*this->m_parent, offset, descriptors);
     }
@@ -83,7 +83,7 @@ const DirectX12DescriptorSetLayout& DirectX12DescriptorSet::layout() const noexc
     return m_impl->m_layout;
 }
 
-void DirectX12DescriptorSet::update(const UInt32& binding, const IDirectX12Buffer& buffer, const UInt32& bufferElement, const UInt32& elements, const UInt32& firstDescriptor) const
+void DirectX12DescriptorSet::update(UInt32 binding, const IDirectX12Buffer& buffer, UInt32 bufferElement, UInt32 elements, UInt32 firstDescriptor) const
 {
     UInt32 elementCount = elements > 0 ? elements : buffer.elements() - bufferElement;
 
@@ -219,7 +219,7 @@ void DirectX12DescriptorSet::update(const UInt32& binding, const IDirectX12Buffe
     m_impl->updateGlobalBuffers(offset, elementCount);
 }
 
-void DirectX12DescriptorSet::update(const UInt32& binding, const IDirectX12Image& texture, const UInt32& descriptor, const UInt32& firstLevel, const UInt32& levels, const UInt32& firstLayer, const UInt32& layers) const
+void DirectX12DescriptorSet::update(UInt32 binding, const IDirectX12Image& texture, UInt32 descriptor, UInt32 firstLevel, UInt32 levels, UInt32 firstLayer, UInt32 layers) const
 {
     // TODO: Add LOD lower bound (for clamping) as parameter?
     // Acquire a descriptor handle.
@@ -351,7 +351,7 @@ void DirectX12DescriptorSet::update(const UInt32& binding, const IDirectX12Image
     m_impl->updateGlobalBuffers(offset, 1);
 }
 
-void DirectX12DescriptorSet::update(const UInt32& binding, const IDirectX12Sampler& sampler, const UInt32& descriptor) const
+void DirectX12DescriptorSet::update(UInt32 binding, const IDirectX12Sampler& sampler, UInt32 descriptor) const
 {
     auto offset = m_impl->m_layout.descriptorOffsetForBinding(binding);
 
@@ -373,7 +373,7 @@ void DirectX12DescriptorSet::update(const UInt32& binding, const IDirectX12Sampl
     m_impl->m_layout.device().updateSamplerDescriptors(*this, offset, 1);
 }
 
-void DirectX12DescriptorSet::attach(const UInt32& binding, const IDirectX12Image& image) const
+void DirectX12DescriptorSet::attach(UInt32 binding, const IDirectX12Image& image) const
 {
     auto offset = m_impl->m_layout.descriptorOffsetForBinding(binding);
 
@@ -409,7 +409,7 @@ const ComPtr<ID3D12DescriptorHeap>& DirectX12DescriptorSet::bufferHeap() const n
     return m_impl->m_bufferHeap;
 }
 
-const UInt32& DirectX12DescriptorSet::bufferOffset() const noexcept
+UInt32 DirectX12DescriptorSet::bufferOffset() const noexcept
 {
     return m_impl->m_bufferOffset;
 }
@@ -419,7 +419,7 @@ const ComPtr<ID3D12DescriptorHeap>& DirectX12DescriptorSet::samplerHeap() const 
     return m_impl->m_samplerHeap;
 }
 
-const UInt32& DirectX12DescriptorSet::samplerOffset() const noexcept
+UInt32 DirectX12DescriptorSet::samplerOffset() const noexcept
 {
     return m_impl->m_samplerOffset;
 }

--- a/src/Backends/DirectX12/src/descriptor_set_layout.cpp
+++ b/src/Backends/DirectX12/src/descriptor_set_layout.cpp
@@ -24,7 +24,7 @@ private:
     mutable std::mutex m_mutex;
 
 public:
-    DirectX12DescriptorSetLayoutImpl(DirectX12DescriptorSetLayout* parent, const DirectX12Device& device, Enumerable<UniquePtr<DirectX12DescriptorLayout>>&& descriptorLayouts, const UInt32& space, const ShaderStage& stages) :
+    DirectX12DescriptorSetLayoutImpl(DirectX12DescriptorSetLayout* parent, const DirectX12Device& device, Enumerable<UniquePtr<DirectX12DescriptorLayout>>&& descriptorLayouts, const UInt32& space, ShaderStage stages) :
         base(parent), m_device(device), m_space(space), m_stages(stages)
     {
         m_layouts = descriptorLayouts | std::views::as_rvalue | std::ranges::to<std::vector>();
@@ -127,7 +127,7 @@ public:
 // Shared interface.
 // ------------------------------------------------------------------------------------------------
 
-DirectX12DescriptorSetLayout::DirectX12DescriptorSetLayout(const DirectX12Device& device, Enumerable<UniquePtr<DirectX12DescriptorLayout>>&& descriptorLayouts, const UInt32& space, const ShaderStage& stages) :
+DirectX12DescriptorSetLayout::DirectX12DescriptorSetLayout(const DirectX12Device& device, Enumerable<UniquePtr<DirectX12DescriptorLayout>>&& descriptorLayouts, const UInt32& space, ShaderStage stages) :
     m_impl(makePimpl<DirectX12DescriptorSetLayoutImpl>(this, device, std::move(descriptorLayouts), space, stages))
 {
     m_impl->initialize();
@@ -186,7 +186,7 @@ const UInt32& DirectX12DescriptorSetLayout::space() const noexcept
     return m_impl->m_space;
 }
 
-const ShaderStage& DirectX12DescriptorSetLayout::shaderStages() const noexcept
+ShaderStage DirectX12DescriptorSetLayout::shaderStages() const noexcept
 {
     return m_impl->m_stages;
 }

--- a/src/Backends/DirectX12/src/descriptor_set_layout.cpp
+++ b/src/Backends/DirectX12/src/descriptor_set_layout.cpp
@@ -24,7 +24,7 @@ private:
     mutable std::mutex m_mutex;
 
 public:
-    DirectX12DescriptorSetLayoutImpl(DirectX12DescriptorSetLayout* parent, const DirectX12Device& device, Enumerable<UniquePtr<DirectX12DescriptorLayout>>&& descriptorLayouts, const UInt32& space, ShaderStage stages) :
+    DirectX12DescriptorSetLayoutImpl(DirectX12DescriptorSetLayout* parent, const DirectX12Device& device, Enumerable<UniquePtr<DirectX12DescriptorLayout>>&& descriptorLayouts, UInt32 space, ShaderStage stages) :
         base(parent), m_device(device), m_space(space), m_stages(stages)
     {
         m_layouts = descriptorLayouts | std::views::as_rvalue | std::ranges::to<std::vector>();
@@ -73,7 +73,7 @@ public:
     }
 
 public:
-    void tryAllocate(ComPtr<ID3D12DescriptorHeap>& bufferHeap, ComPtr<ID3D12DescriptorHeap>& samplerHeap, const UInt32& descriptorCount)
+    void tryAllocate(ComPtr<ID3D12DescriptorHeap>& bufferHeap, ComPtr<ID3D12DescriptorHeap>& samplerHeap, UInt32 descriptorCount)
     {
         // Use descriptor heaps from the queues, if possible.
         if (m_descriptors > 0)
@@ -127,7 +127,7 @@ public:
 // Shared interface.
 // ------------------------------------------------------------------------------------------------
 
-DirectX12DescriptorSetLayout::DirectX12DescriptorSetLayout(const DirectX12Device& device, Enumerable<UniquePtr<DirectX12DescriptorLayout>>&& descriptorLayouts, const UInt32& space, ShaderStage stages) :
+DirectX12DescriptorSetLayout::DirectX12DescriptorSetLayout(const DirectX12Device& device, Enumerable<UniquePtr<DirectX12DescriptorLayout>>&& descriptorLayouts, UInt32 space, ShaderStage stages) :
     m_impl(makePimpl<DirectX12DescriptorSetLayoutImpl>(this, device, std::move(descriptorLayouts), space, stages))
 {
     m_impl->initialize();
@@ -140,12 +140,12 @@ DirectX12DescriptorSetLayout::DirectX12DescriptorSetLayout(const DirectX12Device
 
 DirectX12DescriptorSetLayout::~DirectX12DescriptorSetLayout() noexcept = default;
 
-const UInt32& DirectX12DescriptorSetLayout::rootParameterIndex() const noexcept
+UInt32 DirectX12DescriptorSetLayout::rootParameterIndex() const noexcept
 {
     return m_impl->m_rootParameterIndex;
 }
 
-UInt32 DirectX12DescriptorSetLayout::descriptorOffsetForBinding(const UInt32& binding) const
+UInt32 DirectX12DescriptorSetLayout::descriptorOffsetForBinding(UInt32 binding) const
 {
     if (!m_impl->m_bindingToDescriptor.contains(binding)) [[unlikely]]
         throw ArgumentOutOfRangeException("The descriptor set does not contain a descriptor at binding {0}.", binding);
@@ -173,7 +173,7 @@ Enumerable<const DirectX12DescriptorLayout*> DirectX12DescriptorSetLayout::descr
     return m_impl->m_layouts | std::views::transform([](const UniquePtr<DirectX12DescriptorLayout>& layout) { return layout.get(); });
 }
 
-const DirectX12DescriptorLayout& DirectX12DescriptorSetLayout::descriptor(const UInt32& binding) const
+const DirectX12DescriptorLayout& DirectX12DescriptorSetLayout::descriptor(UInt32 binding) const
 {
     if (auto match = std::ranges::find_if(m_impl->m_layouts, [&binding](const UniquePtr<DirectX12DescriptorLayout>& layout) { return layout->binding() == binding; }); match != m_impl->m_layouts.end())
         return *match->get();
@@ -181,7 +181,7 @@ const DirectX12DescriptorLayout& DirectX12DescriptorSetLayout::descriptor(const 
     throw ArgumentOutOfRangeException("No layout has been provided for the binding {0}.", binding);
 }
 
-const UInt32& DirectX12DescriptorSetLayout::space() const noexcept
+UInt32 DirectX12DescriptorSetLayout::space() const noexcept
 {
     return m_impl->m_space;
 }
@@ -231,7 +231,7 @@ UniquePtr<DirectX12DescriptorSet> DirectX12DescriptorSetLayout::allocate(const E
     return this->allocate(0, bindings);
 }
 
-UniquePtr<DirectX12DescriptorSet> DirectX12DescriptorSetLayout::allocate(const UInt32& descriptors, const Enumerable<DescriptorBinding>& bindings) const
+UniquePtr<DirectX12DescriptorSet> DirectX12DescriptorSetLayout::allocate(UInt32 descriptors, const Enumerable<DescriptorBinding>& bindings) const
 {
     // Allocate the descriptor set.
     std::lock_guard<std::mutex> lock(m_impl->m_mutex);
@@ -251,17 +251,17 @@ UniquePtr<DirectX12DescriptorSet> DirectX12DescriptorSetLayout::allocate(const U
     return descriptorSet;
 }
 
-Enumerable<UniquePtr<DirectX12DescriptorSet>> DirectX12DescriptorSetLayout::allocateMultiple(const UInt32& descriptorSets, const Enumerable<Enumerable<DescriptorBinding>>& bindings) const
+Enumerable<UniquePtr<DirectX12DescriptorSet>> DirectX12DescriptorSetLayout::allocateMultiple(UInt32 descriptorSets, const Enumerable<Enumerable<DescriptorBinding>>& bindings) const
 {
     return this->allocateMultiple(descriptorSets, 0, bindings);
 }
 
-Enumerable<UniquePtr<DirectX12DescriptorSet>> DirectX12DescriptorSetLayout::allocateMultiple(const UInt32& descriptorSets, std::function<Enumerable<DescriptorBinding>(const UInt32&)> bindingFactory) const
+Enumerable<UniquePtr<DirectX12DescriptorSet>> DirectX12DescriptorSetLayout::allocateMultiple(UInt32 descriptorSets, std::function<Enumerable<DescriptorBinding>(UInt32)> bindingFactory) const
 {
     return this->allocateMultiple(descriptorSets, 0, bindingFactory);
 }
 
-Enumerable<UniquePtr<DirectX12DescriptorSet>> DirectX12DescriptorSetLayout::allocateMultiple(const UInt32& count, const UInt32& descriptors, const Enumerable<Enumerable<DescriptorBinding>>& bindings) const
+Enumerable<UniquePtr<DirectX12DescriptorSet>> DirectX12DescriptorSetLayout::allocateMultiple(UInt32 count, UInt32 descriptors, const Enumerable<Enumerable<DescriptorBinding>>& bindings) const
 {
     return [this, descriptors, &bindings, &count]() mutable -> std::generator<UniquePtr<DirectX12DescriptorSet>> {
         for (auto& binding : bindings)
@@ -272,7 +272,7 @@ Enumerable<UniquePtr<DirectX12DescriptorSet>> DirectX12DescriptorSetLayout::allo
     }() | std::views::as_rvalue;
 }
 
-Enumerable<UniquePtr<DirectX12DescriptorSet>> DirectX12DescriptorSetLayout::allocateMultiple(const UInt32& count, const UInt32& descriptors, std::function<Enumerable<DescriptorBinding>(const UInt32&)> bindingFactory) const
+Enumerable<UniquePtr<DirectX12DescriptorSet>> DirectX12DescriptorSetLayout::allocateMultiple(UInt32 count, UInt32 descriptors, std::function<Enumerable<DescriptorBinding>(UInt32)> bindingFactory) const
 {
     return [this, descriptors, &bindingFactory, &count]() -> std::generator<UniquePtr<DirectX12DescriptorSet>> {
         for (int i = 0; i < count; ++i)

--- a/src/Backends/DirectX12/src/device.cpp
+++ b/src/Backends/DirectX12/src/device.cpp
@@ -29,7 +29,7 @@ private:
 	Array<std::pair<UInt32, UInt32>> m_bufferDescriptorFragments, m_samplerDescriptorFragments;
 
 public:
-	DirectX12DeviceImpl(DirectX12Device* parent, const DirectX12GraphicsAdapter& adapter, UniquePtr<DirectX12Surface>&& surface, const DirectX12Backend& backend, const UInt32& globalBufferHeapSize, const UInt32& globalSamplerHeapSize) :
+	DirectX12DeviceImpl(DirectX12Device* parent, const DirectX12GraphicsAdapter& adapter, UniquePtr<DirectX12Surface>&& surface, const DirectX12Backend& backend, UInt32 globalBufferHeapSize, UInt32 globalSamplerHeapSize) :
 		base(parent), m_adapter(adapter), m_surface(std::move(surface)), m_backend(backend), m_globalBufferHeapSize(globalBufferHeapSize), m_globalSamplerHeapSize(globalSamplerHeapSize)
 	{
 		if (m_surface == nullptr)
@@ -177,7 +177,7 @@ public:
 		m_factory = makeUnique<DirectX12GraphicsFactory>(*m_parent);
 	}
 
-	void createSwapChain(Format format, const Size2d& frameBufferSize, const UInt32& frameBuffers)
+	void createSwapChain(Format format, const Size2d& frameBufferSize, UInt32 frameBuffers)
 	{
 		m_swapChain = makeUnique<DirectX12SwapChain>(*m_parent, format, frameBufferSize, frameBuffers);
 	}
@@ -253,7 +253,7 @@ DirectX12Device::DirectX12Device(const DirectX12Backend& backend, const DirectX1
 {
 }
 
-DirectX12Device::DirectX12Device(const DirectX12Backend& backend, const DirectX12GraphicsAdapter& adapter, UniquePtr<DirectX12Surface>&& surface, Format format, const Size2d& frameBufferSize, const UInt32& frameBuffers, const UInt32& globalBufferHeapSize, const UInt32& globalSamplerHeapSize) :
+DirectX12Device::DirectX12Device(const DirectX12Backend& backend, const DirectX12GraphicsAdapter& adapter, UniquePtr<DirectX12Surface>&& surface, Format format, const Size2d& frameBufferSize, UInt32 frameBuffers, UInt32 globalBufferHeapSize, UInt32 globalSamplerHeapSize) :
 	ComResource<ID3D12Device10>(nullptr), m_impl(makePimpl<DirectX12DeviceImpl>(this, adapter, std::move(surface), backend, globalBufferHeapSize, globalSamplerHeapSize))
 {
 	LITEFX_DEBUG(DIRECTX12_LOG, "Creating DirectX 12 device {{ Surface: {0}, Adapter: {1} }}...", fmt::ptr(&surface), adapter.deviceId());
@@ -376,7 +376,7 @@ void DirectX12Device::releaseGlobalDescriptors(const DirectX12DescriptorSet& des
 		m_impl->m_samplerDescriptorFragments.push_back(std::make_pair(descriptorSet.samplerOffset(), descriptorSet.samplerHeap()->GetDesc().NumDescriptors));
 }
 
-void DirectX12Device::updateBufferDescriptors(const DirectX12DescriptorSet& descriptorSet, const UInt32& firstDescriptor, const UInt32& descriptors) const noexcept
+void DirectX12Device::updateBufferDescriptors(const DirectX12DescriptorSet& descriptorSet, UInt32 firstDescriptor, UInt32 descriptors) const noexcept
 {
 	if (descriptors > 0) [[likely]]
 	{
@@ -386,7 +386,7 @@ void DirectX12Device::updateBufferDescriptors(const DirectX12DescriptorSet& desc
 	}
 }
 
-void DirectX12Device::updateSamplerDescriptors(const DirectX12DescriptorSet& descriptorSet, const UInt32& firstDescriptor, const UInt32& descriptors) const noexcept
+void DirectX12Device::updateSamplerDescriptors(const DirectX12DescriptorSet& descriptorSet, UInt32 firstDescriptor, UInt32 descriptors) const noexcept
 {
 	if (descriptors > 0) [[likely]]
 	{
@@ -445,12 +445,12 @@ DirectX12ComputePipeline& DirectX12Device::blitPipeline() const noexcept
 }
 
 #if defined(BUILD_DEFINE_BUILDERS)
-DirectX12RenderPassBuilder DirectX12Device::buildRenderPass(MultiSamplingLevel samples, const UInt32& commandBuffers) const
+DirectX12RenderPassBuilder DirectX12Device::buildRenderPass(MultiSamplingLevel samples, UInt32 commandBuffers) const
 {
 	return DirectX12RenderPassBuilder(*this, commandBuffers, samples);
 }
 
-DirectX12RenderPassBuilder DirectX12Device::buildRenderPass(const String& name, MultiSamplingLevel samples, const UInt32& commandBuffers) const
+DirectX12RenderPassBuilder DirectX12Device::buildRenderPass(const String& name, MultiSamplingLevel samples, UInt32 commandBuffers) const
 {
 	return DirectX12RenderPassBuilder(*this, commandBuffers, samples, name);
 }

--- a/src/Backends/DirectX12/src/device.cpp
+++ b/src/Backends/DirectX12/src/device.cpp
@@ -177,7 +177,7 @@ public:
 		m_factory = makeUnique<DirectX12GraphicsFactory>(*m_parent);
 	}
 
-	void createSwapChain(const Format& format, const Size2d& frameBufferSize, const UInt32& frameBuffers)
+	void createSwapChain(Format format, const Size2d& frameBufferSize, const UInt32& frameBuffers)
 	{
 		m_swapChain = makeUnique<DirectX12SwapChain>(*m_parent, format, frameBufferSize, frameBuffers);
 	}
@@ -253,7 +253,7 @@ DirectX12Device::DirectX12Device(const DirectX12Backend& backend, const DirectX1
 {
 }
 
-DirectX12Device::DirectX12Device(const DirectX12Backend& backend, const DirectX12GraphicsAdapter& adapter, UniquePtr<DirectX12Surface>&& surface, const Format& format, const Size2d& frameBufferSize, const UInt32& frameBuffers, const UInt32& globalBufferHeapSize, const UInt32& globalSamplerHeapSize) :
+DirectX12Device::DirectX12Device(const DirectX12Backend& backend, const DirectX12GraphicsAdapter& adapter, UniquePtr<DirectX12Surface>&& surface, Format format, const Size2d& frameBufferSize, const UInt32& frameBuffers, const UInt32& globalBufferHeapSize, const UInt32& globalSamplerHeapSize) :
 	ComResource<ID3D12Device10>(nullptr), m_impl(makePimpl<DirectX12DeviceImpl>(this, adapter, std::move(surface), backend, globalBufferHeapSize, globalSamplerHeapSize))
 {
 	LITEFX_DEBUG(DIRECTX12_LOG, "Creating DirectX 12 device {{ Surface: {0}, Adapter: {1} }}...", fmt::ptr(&surface), adapter.deviceId());
@@ -445,12 +445,12 @@ DirectX12ComputePipeline& DirectX12Device::blitPipeline() const noexcept
 }
 
 #if defined(BUILD_DEFINE_BUILDERS)
-DirectX12RenderPassBuilder DirectX12Device::buildRenderPass(const MultiSamplingLevel& samples, const UInt32& commandBuffers) const
+DirectX12RenderPassBuilder DirectX12Device::buildRenderPass(MultiSamplingLevel samples, const UInt32& commandBuffers) const
 {
 	return DirectX12RenderPassBuilder(*this, commandBuffers, samples);
 }
 
-DirectX12RenderPassBuilder DirectX12Device::buildRenderPass(const String& name, const MultiSamplingLevel& samples, const UInt32& commandBuffers) const
+DirectX12RenderPassBuilder DirectX12Device::buildRenderPass(const String& name, MultiSamplingLevel samples, const UInt32& commandBuffers) const
 {
 	return DirectX12RenderPassBuilder(*this, commandBuffers, samples, name);
 }
@@ -541,12 +541,12 @@ const DirectX12Queue& DirectX12Device::computeQueue() const noexcept
 	return *m_impl->m_computeQueue;
 }
 
-UniquePtr<DirectX12Barrier> DirectX12Device::makeBarrier(const PipelineStage& syncBefore, const PipelineStage& syncAfter) const noexcept
+UniquePtr<DirectX12Barrier> DirectX12Device::makeBarrier(PipelineStage syncBefore, PipelineStage syncAfter) const noexcept
 {
 	return makeUnique<DirectX12Barrier>(syncBefore, syncAfter);
 }
 
-MultiSamplingLevel DirectX12Device::maximumMultiSamplingLevel(const Format& format) const noexcept
+MultiSamplingLevel DirectX12Device::maximumMultiSamplingLevel(Format format) const noexcept
 {
 	constexpr std::array<MultiSamplingLevel, 7> allLevels = { MultiSamplingLevel::x64, MultiSamplingLevel::x32, MultiSamplingLevel::x16, MultiSamplingLevel::x8, MultiSamplingLevel::x4, MultiSamplingLevel::x2, MultiSamplingLevel::x1 };
 	D3D12_FEATURE_DATA_MULTISAMPLE_QUALITY_LEVELS levels{ .Format = DX12::getFormat(format) };

--- a/src/Backends/DirectX12/src/factory.cpp
+++ b/src/Backends/DirectX12/src/factory.cpp
@@ -45,12 +45,12 @@ DirectX12GraphicsFactory::DirectX12GraphicsFactory(const DirectX12Device& device
 
 DirectX12GraphicsFactory::~DirectX12GraphicsFactory() noexcept = default;
 
-UniquePtr<IDirectX12Buffer> DirectX12GraphicsFactory::createBuffer(BufferType type, BufferUsage usage, const size_t& elementSize, const UInt32& elements, const bool& allowWrite) const
+UniquePtr<IDirectX12Buffer> DirectX12GraphicsFactory::createBuffer(BufferType type, BufferUsage usage, size_t elementSize, UInt32 elements, bool allowWrite) const
 {
 	return this->createBuffer("", type, usage, elementSize, elements, allowWrite);
 }
 
-UniquePtr<IDirectX12Buffer> DirectX12GraphicsFactory::createBuffer(const String& name, BufferType type, BufferUsage usage, const size_t& elementSize, const UInt32& elements, const bool& allowWrite) const
+UniquePtr<IDirectX12Buffer> DirectX12GraphicsFactory::createBuffer(const String& name, BufferType type, BufferUsage usage, size_t elementSize, UInt32 elements, bool allowWrite) const
 {
 	// Constant buffers are aligned to 256 byte chunks. All other buffers can be aligned to a multiple of 4 bytes (`sizeof(DWORD)`). The actual amount of memory allocated 
 	// is then defined as the smallest multiple of 64kb, that's greater or equal to `resourceDesc.Width` below. For more info, see:
@@ -92,12 +92,12 @@ UniquePtr<IDirectX12Buffer> DirectX12GraphicsFactory::createBuffer(const String&
 	return DirectX12Buffer::allocate(name, m_impl->m_allocator, type, elements, elementSize, elementAlignment, allowWrite, resourceDesc, allocationDesc);
 }
 
-UniquePtr<IDirectX12VertexBuffer> DirectX12GraphicsFactory::createVertexBuffer(const DirectX12VertexBufferLayout& layout, BufferUsage usage, const UInt32& elements) const
+UniquePtr<IDirectX12VertexBuffer> DirectX12GraphicsFactory::createVertexBuffer(const DirectX12VertexBufferLayout& layout, BufferUsage usage, UInt32 elements) const
 {
 	return this->createVertexBuffer("", layout, usage, elements);
 }
 
-UniquePtr<IDirectX12VertexBuffer> DirectX12GraphicsFactory::createVertexBuffer(const String& name, const DirectX12VertexBufferLayout& layout, BufferUsage usage, const UInt32& elements) const
+UniquePtr<IDirectX12VertexBuffer> DirectX12GraphicsFactory::createVertexBuffer(const String& name, const DirectX12VertexBufferLayout& layout, BufferUsage usage, UInt32 elements) const
 {
 	D3D12_RESOURCE_DESC1 resourceDesc { };
 	resourceDesc.Dimension = D3D12_RESOURCE_DIMENSION_BUFFER;
@@ -133,12 +133,12 @@ UniquePtr<IDirectX12VertexBuffer> DirectX12GraphicsFactory::createVertexBuffer(c
 	return DirectX12VertexBuffer::allocate(name, layout, m_impl->m_allocator, elements, resourceDesc, allocationDesc);
 }
 
-UniquePtr<IDirectX12IndexBuffer> DirectX12GraphicsFactory::createIndexBuffer(const DirectX12IndexBufferLayout& layout, BufferUsage usage, const UInt32& elements) const
+UniquePtr<IDirectX12IndexBuffer> DirectX12GraphicsFactory::createIndexBuffer(const DirectX12IndexBufferLayout& layout, BufferUsage usage, UInt32 elements) const
 {
 	return this->createIndexBuffer("", layout, usage, elements);
 }
 
-UniquePtr<IDirectX12IndexBuffer> DirectX12GraphicsFactory::createIndexBuffer(const String& name, const DirectX12IndexBufferLayout& layout, BufferUsage usage, const UInt32& elements) const
+UniquePtr<IDirectX12IndexBuffer> DirectX12GraphicsFactory::createIndexBuffer(const String& name, const DirectX12IndexBufferLayout& layout, BufferUsage usage, UInt32 elements) const
 {
 	D3D12_RESOURCE_DESC1 resourceDesc { };
 	resourceDesc.Dimension = D3D12_RESOURCE_DIMENSION_BUFFER;
@@ -209,12 +209,12 @@ UniquePtr<IDirectX12Image> DirectX12GraphicsFactory::createAttachment(const Stri
 	}
 }
 
-UniquePtr<IDirectX12Image> DirectX12GraphicsFactory::createTexture(Format format, const Size3d& size, ImageDimensions dimension, const UInt32& levels, const UInt32& layers, MultiSamplingLevel samples, const bool& allowWrite) const
+UniquePtr<IDirectX12Image> DirectX12GraphicsFactory::createTexture(Format format, const Size3d& size, ImageDimensions dimension, UInt32 levels, UInt32 layers, MultiSamplingLevel samples, bool allowWrite) const
 {
 	return this->createTexture("", format, size, dimension, levels, layers, samples, allowWrite);
 }
 
-UniquePtr<IDirectX12Image> DirectX12GraphicsFactory::createTexture(const String& name, Format format, const Size3d& size, ImageDimensions dimension, const UInt32& levels, const UInt32& layers, MultiSamplingLevel samples, const bool& allowWrite) const
+UniquePtr<IDirectX12Image> DirectX12GraphicsFactory::createTexture(const String& name, Format format, const Size3d& size, ImageDimensions dimension, UInt32 levels, UInt32 layers, MultiSamplingLevel samples, bool allowWrite) const
 {
 	if (dimension == ImageDimensions::CUBE && layers != 6) [[unlikely]]
 		throw ArgumentOutOfRangeException("A cube map must be defined with 6 layers, but only {0} are provided.", layers);
@@ -243,7 +243,7 @@ UniquePtr<IDirectX12Image> DirectX12GraphicsFactory::createTexture(const String&
 	return DirectX12Image::allocate(name, m_impl->m_device, m_impl->m_allocator, { width, height, depth }, format, dimension, levels, layers, samples, allowWrite, ImageLayout::Common, resourceDesc, allocationDesc);
 }
 
-Enumerable<UniquePtr<IDirectX12Image>> DirectX12GraphicsFactory::createTextures(const UInt32& elements, Format format, const Size3d& size, ImageDimensions dimension, const UInt32& levels, const UInt32& layers, MultiSamplingLevel samples, const bool& allowWrite) const
+Enumerable<UniquePtr<IDirectX12Image>> DirectX12GraphicsFactory::createTextures(UInt32 elements, Format format, const Size3d& size, ImageDimensions dimension, UInt32 levels, UInt32 layers, MultiSamplingLevel samples, bool allowWrite) const
 {
 	return [&, this]() -> std::generator<UniquePtr<IDirectX12Image>> {
 		for (UInt32 i = 0; i < elements; ++i)
@@ -251,17 +251,17 @@ Enumerable<UniquePtr<IDirectX12Image>> DirectX12GraphicsFactory::createTextures(
 	}() | std::views::as_rvalue;
 }
 
-UniquePtr<IDirectX12Sampler> DirectX12GraphicsFactory::createSampler(FilterMode magFilter, FilterMode minFilter, BorderMode borderU, BorderMode borderV, BorderMode borderW, MipMapMode mipMapMode, const Float& mipMapBias, const Float& maxLod, const Float& minLod, const Float& anisotropy) const
+UniquePtr<IDirectX12Sampler> DirectX12GraphicsFactory::createSampler(FilterMode magFilter, FilterMode minFilter, BorderMode borderU, BorderMode borderV, BorderMode borderW, MipMapMode mipMapMode, Float mipMapBias, Float maxLod, Float minLod, Float anisotropy) const
 {
 	return makeUnique<DirectX12Sampler>(m_impl->m_device, magFilter, minFilter, borderU, borderV, borderW, mipMapMode, mipMapBias, minLod, maxLod, anisotropy);
 }
 
-UniquePtr<IDirectX12Sampler> DirectX12GraphicsFactory::createSampler(const String& name, FilterMode magFilter, FilterMode minFilter, BorderMode borderU, BorderMode borderV, BorderMode borderW, MipMapMode mipMapMode, const Float& mipMapBias, const Float& maxLod, const Float& minLod, const Float& anisotropy) const
+UniquePtr<IDirectX12Sampler> DirectX12GraphicsFactory::createSampler(const String& name, FilterMode magFilter, FilterMode minFilter, BorderMode borderU, BorderMode borderV, BorderMode borderW, MipMapMode mipMapMode, Float mipMapBias, Float maxLod, Float minLod, Float anisotropy) const
 {
 	return makeUnique<DirectX12Sampler>(m_impl->m_device, magFilter, minFilter, borderU, borderV, borderW, mipMapMode, mipMapBias, minLod, maxLod, anisotropy, name);
 }
 
-Enumerable<UniquePtr<IDirectX12Sampler>> DirectX12GraphicsFactory::createSamplers(const UInt32& elements, FilterMode magFilter, FilterMode minFilter, BorderMode borderU, BorderMode borderV, BorderMode borderW, MipMapMode mipMapMode, const Float& mipMapBias, const Float& maxLod, const Float& minLod, const Float& anisotropy) const
+Enumerable<UniquePtr<IDirectX12Sampler>> DirectX12GraphicsFactory::createSamplers(UInt32 elements, FilterMode magFilter, FilterMode minFilter, BorderMode borderU, BorderMode borderV, BorderMode borderW, MipMapMode mipMapMode, Float mipMapBias, Float maxLod, Float minLod, Float anisotropy) const
 {
 	return [&, this]() -> std::generator<UniquePtr<IDirectX12Sampler>> {
 		for (UInt32 i = 0; i < elements; ++i)

--- a/src/Backends/DirectX12/src/factory.cpp
+++ b/src/Backends/DirectX12/src/factory.cpp
@@ -45,12 +45,12 @@ DirectX12GraphicsFactory::DirectX12GraphicsFactory(const DirectX12Device& device
 
 DirectX12GraphicsFactory::~DirectX12GraphicsFactory() noexcept = default;
 
-UniquePtr<IDirectX12Buffer> DirectX12GraphicsFactory::createBuffer(const BufferType& type, const BufferUsage& usage, const size_t& elementSize, const UInt32& elements, const bool& allowWrite) const
+UniquePtr<IDirectX12Buffer> DirectX12GraphicsFactory::createBuffer(BufferType type, BufferUsage usage, const size_t& elementSize, const UInt32& elements, const bool& allowWrite) const
 {
 	return this->createBuffer("", type, usage, elementSize, elements, allowWrite);
 }
 
-UniquePtr<IDirectX12Buffer> DirectX12GraphicsFactory::createBuffer(const String& name, const BufferType& type, const BufferUsage& usage, const size_t& elementSize, const UInt32& elements, const bool& allowWrite) const
+UniquePtr<IDirectX12Buffer> DirectX12GraphicsFactory::createBuffer(const String& name, BufferType type, BufferUsage usage, const size_t& elementSize, const UInt32& elements, const bool& allowWrite) const
 {
 	// Constant buffers are aligned to 256 byte chunks. All other buffers can be aligned to a multiple of 4 bytes (`sizeof(DWORD)`). The actual amount of memory allocated 
 	// is then defined as the smallest multiple of 64kb, that's greater or equal to `resourceDesc.Width` below. For more info, see:
@@ -92,12 +92,12 @@ UniquePtr<IDirectX12Buffer> DirectX12GraphicsFactory::createBuffer(const String&
 	return DirectX12Buffer::allocate(name, m_impl->m_allocator, type, elements, elementSize, elementAlignment, allowWrite, resourceDesc, allocationDesc);
 }
 
-UniquePtr<IDirectX12VertexBuffer> DirectX12GraphicsFactory::createVertexBuffer(const DirectX12VertexBufferLayout& layout, const BufferUsage& usage, const UInt32& elements) const
+UniquePtr<IDirectX12VertexBuffer> DirectX12GraphicsFactory::createVertexBuffer(const DirectX12VertexBufferLayout& layout, BufferUsage usage, const UInt32& elements) const
 {
 	return this->createVertexBuffer("", layout, usage, elements);
 }
 
-UniquePtr<IDirectX12VertexBuffer> DirectX12GraphicsFactory::createVertexBuffer(const String& name, const DirectX12VertexBufferLayout& layout, const BufferUsage& usage, const UInt32& elements) const
+UniquePtr<IDirectX12VertexBuffer> DirectX12GraphicsFactory::createVertexBuffer(const String& name, const DirectX12VertexBufferLayout& layout, BufferUsage usage, const UInt32& elements) const
 {
 	D3D12_RESOURCE_DESC1 resourceDesc { };
 	resourceDesc.Dimension = D3D12_RESOURCE_DIMENSION_BUFFER;
@@ -133,12 +133,12 @@ UniquePtr<IDirectX12VertexBuffer> DirectX12GraphicsFactory::createVertexBuffer(c
 	return DirectX12VertexBuffer::allocate(name, layout, m_impl->m_allocator, elements, resourceDesc, allocationDesc);
 }
 
-UniquePtr<IDirectX12IndexBuffer> DirectX12GraphicsFactory::createIndexBuffer(const DirectX12IndexBufferLayout& layout, const BufferUsage& usage, const UInt32& elements) const
+UniquePtr<IDirectX12IndexBuffer> DirectX12GraphicsFactory::createIndexBuffer(const DirectX12IndexBufferLayout& layout, BufferUsage usage, const UInt32& elements) const
 {
 	return this->createIndexBuffer("", layout, usage, elements);
 }
 
-UniquePtr<IDirectX12IndexBuffer> DirectX12GraphicsFactory::createIndexBuffer(const String& name, const DirectX12IndexBufferLayout& layout, const BufferUsage& usage, const UInt32& elements) const
+UniquePtr<IDirectX12IndexBuffer> DirectX12GraphicsFactory::createIndexBuffer(const String& name, const DirectX12IndexBufferLayout& layout, BufferUsage usage, const UInt32& elements) const
 {
 	D3D12_RESOURCE_DESC1 resourceDesc { };
 	resourceDesc.Dimension = D3D12_RESOURCE_DIMENSION_BUFFER;
@@ -174,12 +174,12 @@ UniquePtr<IDirectX12IndexBuffer> DirectX12GraphicsFactory::createIndexBuffer(con
 	return DirectX12IndexBuffer::allocate(name, layout, m_impl->m_allocator, elements, resourceDesc, allocationDesc);
 }
 
-UniquePtr<IDirectX12Image> DirectX12GraphicsFactory::createAttachment(const Format& format, const Size2d& size, const MultiSamplingLevel& samples) const
+UniquePtr<IDirectX12Image> DirectX12GraphicsFactory::createAttachment(Format format, const Size2d& size, MultiSamplingLevel samples) const
 {
 	return this->createAttachment("", format, size, samples);
 }
 
-UniquePtr<IDirectX12Image> DirectX12GraphicsFactory::createAttachment(const String& name, const Format& format, const Size2d& size, const MultiSamplingLevel& samples) const
+UniquePtr<IDirectX12Image> DirectX12GraphicsFactory::createAttachment(const String& name, Format format, const Size2d& size, MultiSamplingLevel samples) const
 {
 	auto width = std::max<UInt32>(1, size.width());
 	auto height = std::max<UInt32>(1, size.height());
@@ -209,12 +209,12 @@ UniquePtr<IDirectX12Image> DirectX12GraphicsFactory::createAttachment(const Stri
 	}
 }
 
-UniquePtr<IDirectX12Image> DirectX12GraphicsFactory::createTexture(const Format& format, const Size3d& size, const ImageDimensions& dimension, const UInt32& levels, const UInt32& layers, const MultiSamplingLevel& samples, const bool& allowWrite) const
+UniquePtr<IDirectX12Image> DirectX12GraphicsFactory::createTexture(Format format, const Size3d& size, ImageDimensions dimension, const UInt32& levels, const UInt32& layers, MultiSamplingLevel samples, const bool& allowWrite) const
 {
 	return this->createTexture("", format, size, dimension, levels, layers, samples, allowWrite);
 }
 
-UniquePtr<IDirectX12Image> DirectX12GraphicsFactory::createTexture(const String& name, const Format& format, const Size3d& size, const ImageDimensions& dimension, const UInt32& levels, const UInt32& layers, const MultiSamplingLevel& samples, const bool& allowWrite) const
+UniquePtr<IDirectX12Image> DirectX12GraphicsFactory::createTexture(const String& name, Format format, const Size3d& size, ImageDimensions dimension, const UInt32& levels, const UInt32& layers, MultiSamplingLevel samples, const bool& allowWrite) const
 {
 	if (dimension == ImageDimensions::CUBE && layers != 6) [[unlikely]]
 		throw ArgumentOutOfRangeException("A cube map must be defined with 6 layers, but only {0} are provided.", layers);
@@ -243,7 +243,7 @@ UniquePtr<IDirectX12Image> DirectX12GraphicsFactory::createTexture(const String&
 	return DirectX12Image::allocate(name, m_impl->m_device, m_impl->m_allocator, { width, height, depth }, format, dimension, levels, layers, samples, allowWrite, ImageLayout::Common, resourceDesc, allocationDesc);
 }
 
-Enumerable<UniquePtr<IDirectX12Image>> DirectX12GraphicsFactory::createTextures(const UInt32& elements, const Format& format, const Size3d& size, const ImageDimensions& dimension, const UInt32& levels, const UInt32& layers, const MultiSamplingLevel& samples, const bool& allowWrite) const
+Enumerable<UniquePtr<IDirectX12Image>> DirectX12GraphicsFactory::createTextures(const UInt32& elements, Format format, const Size3d& size, ImageDimensions dimension, const UInt32& levels, const UInt32& layers, MultiSamplingLevel samples, const bool& allowWrite) const
 {
 	return [&, this]() -> std::generator<UniquePtr<IDirectX12Image>> {
 		for (UInt32 i = 0; i < elements; ++i)
@@ -251,17 +251,17 @@ Enumerable<UniquePtr<IDirectX12Image>> DirectX12GraphicsFactory::createTextures(
 	}() | std::views::as_rvalue;
 }
 
-UniquePtr<IDirectX12Sampler> DirectX12GraphicsFactory::createSampler(const FilterMode& magFilter, const FilterMode& minFilter, const BorderMode& borderU, const BorderMode& borderV, const BorderMode& borderW, const MipMapMode& mipMapMode, const Float& mipMapBias, const Float& maxLod, const Float& minLod, const Float& anisotropy) const
+UniquePtr<IDirectX12Sampler> DirectX12GraphicsFactory::createSampler(FilterMode magFilter, FilterMode minFilter, BorderMode borderU, BorderMode borderV, BorderMode borderW, MipMapMode mipMapMode, const Float& mipMapBias, const Float& maxLod, const Float& minLod, const Float& anisotropy) const
 {
 	return makeUnique<DirectX12Sampler>(m_impl->m_device, magFilter, minFilter, borderU, borderV, borderW, mipMapMode, mipMapBias, minLod, maxLod, anisotropy);
 }
 
-UniquePtr<IDirectX12Sampler> DirectX12GraphicsFactory::createSampler(const String& name, const FilterMode& magFilter, const FilterMode& minFilter, const BorderMode& borderU, const BorderMode& borderV, const BorderMode& borderW, const MipMapMode& mipMapMode, const Float& mipMapBias, const Float& maxLod, const Float& minLod, const Float& anisotropy) const
+UniquePtr<IDirectX12Sampler> DirectX12GraphicsFactory::createSampler(const String& name, FilterMode magFilter, FilterMode minFilter, BorderMode borderU, BorderMode borderV, BorderMode borderW, MipMapMode mipMapMode, const Float& mipMapBias, const Float& maxLod, const Float& minLod, const Float& anisotropy) const
 {
 	return makeUnique<DirectX12Sampler>(m_impl->m_device, magFilter, minFilter, borderU, borderV, borderW, mipMapMode, mipMapBias, minLod, maxLod, anisotropy, name);
 }
 
-Enumerable<UniquePtr<IDirectX12Sampler>> DirectX12GraphicsFactory::createSamplers(const UInt32& elements, const FilterMode& magFilter, const FilterMode& minFilter, const BorderMode& borderU, const BorderMode& borderV, const BorderMode& borderW, const MipMapMode& mipMapMode, const Float& mipMapBias, const Float& maxLod, const Float& minLod, const Float& anisotropy) const
+Enumerable<UniquePtr<IDirectX12Sampler>> DirectX12GraphicsFactory::createSamplers(const UInt32& elements, FilterMode magFilter, FilterMode minFilter, BorderMode borderU, BorderMode borderV, BorderMode borderW, MipMapMode mipMapMode, const Float& mipMapBias, const Float& maxLod, const Float& minLod, const Float& anisotropy) const
 {
 	return [&, this]() -> std::generator<UniquePtr<IDirectX12Sampler>> {
 		for (UInt32 i = 0; i < elements; ++i)

--- a/src/Backends/DirectX12/src/frame_buffer.cpp
+++ b/src/Backends/DirectX12/src/frame_buffer.cpp
@@ -22,7 +22,7 @@ private:
     const DirectX12RenderPass& m_renderPass;
 
 public:
-    DirectX12FrameBufferImpl(DirectX12FrameBuffer* parent, const DirectX12RenderPass& renderPass, const UInt32& bufferIndex, const Size2d& renderArea, const UInt32& commandBuffers) :
+    DirectX12FrameBufferImpl(DirectX12FrameBuffer* parent, const DirectX12RenderPass& renderPass, UInt32 bufferIndex, const Size2d& renderArea, UInt32 commandBuffers) :
         base(parent), m_renderPass(renderPass), m_bufferIndex(bufferIndex), m_size(renderArea)
     {
         // Initialize the command buffers from the graphics queue.
@@ -121,7 +121,7 @@ public:
 // Shared interface.
 // ------------------------------------------------------------------------------------------------
 
-DirectX12FrameBuffer::DirectX12FrameBuffer(const DirectX12RenderPass& renderPass, const UInt32& bufferIndex, const Size2d& renderArea, const UInt32& commandBuffers) :
+DirectX12FrameBuffer::DirectX12FrameBuffer(const DirectX12RenderPass& renderPass, UInt32 bufferIndex, const Size2d& renderArea, UInt32 commandBuffers) :
     m_impl(makePimpl<DirectX12FrameBufferImpl>(this, renderPass, bufferIndex, renderArea, commandBuffers))
 {
     m_impl->initialize();
@@ -139,12 +139,12 @@ ID3D12DescriptorHeap* DirectX12FrameBuffer::depthStencilTargetHeap() const noexc
     return m_impl->m_depthStencilHeap.Get();
 }
 
-const UInt32& DirectX12FrameBuffer::renderTargetDescriptorSize() const noexcept
+UInt32 DirectX12FrameBuffer::renderTargetDescriptorSize() const noexcept
 {
     return m_impl->m_renderTargetDescriptorSize;
 }
 
-const UInt32& DirectX12FrameBuffer::depthStencilTargetDescriptorSize() const noexcept
+UInt32 DirectX12FrameBuffer::depthStencilTargetDescriptorSize() const noexcept
 {
     return m_impl->m_depthStencilDescriptorSize;
 }
@@ -154,7 +154,7 @@ UInt64& DirectX12FrameBuffer::lastFence() const noexcept
     return m_impl->m_lastFence;
 }
 
-const UInt32& DirectX12FrameBuffer::bufferIndex() const noexcept
+UInt32 DirectX12FrameBuffer::bufferIndex() const noexcept
 {
     return m_impl->m_bufferIndex;
 }
@@ -174,7 +174,7 @@ size_t DirectX12FrameBuffer::getHeight() const noexcept
     return m_impl->m_size.height();
 }
 
-SharedPtr<const DirectX12CommandBuffer> DirectX12FrameBuffer::commandBuffer(const UInt32& index) const
+SharedPtr<const DirectX12CommandBuffer> DirectX12FrameBuffer::commandBuffer(UInt32 index) const
 {
     if (index >= static_cast<UInt32>(m_impl->m_commandBuffers.size())) [[unlikely]]
         throw ArgumentOutOfRangeException("No command buffer with index {1} is stored in the frame buffer. The frame buffer only contains {0} command buffers.", m_impl->m_commandBuffers.size(), index);
@@ -192,7 +192,7 @@ Enumerable<const IDirectX12Image*> DirectX12FrameBuffer::images() const noexcept
     return m_impl->m_renderTargetViews;
 }
 
-const IDirectX12Image& DirectX12FrameBuffer::image(const UInt32& location) const
+const IDirectX12Image& DirectX12FrameBuffer::image(UInt32 location) const
 {
     if (location >= m_impl->m_renderTargetViews.size())
         throw ArgumentOutOfRangeException("No render target is mapped to location {0}.", location);

--- a/src/Backends/DirectX12/src/image.cpp
+++ b/src/Backends/DirectX12/src/image.cpp
@@ -23,7 +23,7 @@ private:
 	const DirectX12Device& m_device;
 
 public:
-	DirectX12ImageImpl(DirectX12Image* parent, const DirectX12Device& device, const Size3d& extent, const Format& format, const ImageDimensions& dimension, const UInt32& levels, const UInt32& layers, const MultiSamplingLevel& samples, const bool& writable, const ImageLayout& initialLayout, AllocatorPtr allocator, AllocationPtr&& allocation) :
+	DirectX12ImageImpl(DirectX12Image* parent, const DirectX12Device& device, const Size3d& extent, Format format, ImageDimensions dimension, const UInt32& levels, const UInt32& layers, MultiSamplingLevel samples, const bool& writable, ImageLayout initialLayout, AllocatorPtr allocator, AllocationPtr&& allocation) :
 		base(parent), m_device(device), m_allocator(allocator), m_allocation(std::move(allocation)), m_extent(extent), m_format(format), m_dimensions(dimension), m_levels(levels), m_layers(layers), m_writable(writable), m_samples(samples)
 	{
 		m_planes = ::D3D12GetFormatPlaneCount(device.handle().Get(), DX12::getFormat(format));
@@ -36,7 +36,7 @@ public:
 // Image Base shared interface.
 // ------------------------------------------------------------------------------------------------
 
-DirectX12Image::DirectX12Image(const DirectX12Device& device, ComPtr<ID3D12Resource>&& image, const Size3d& extent, const Format& format, const ImageDimensions& dimension, const UInt32& levels, const UInt32& layers, const MultiSamplingLevel& samples, const bool& writable, const ImageLayout& initialState, AllocatorPtr allocator, AllocationPtr&& allocation, const String& name) :
+DirectX12Image::DirectX12Image(const DirectX12Device& device, ComPtr<ID3D12Resource>&& image, const Size3d& extent, Format format, ImageDimensions dimension, const UInt32& levels, const UInt32& layers, MultiSamplingLevel samples, const bool& writable, ImageLayout initialState, AllocatorPtr allocator, AllocationPtr&& allocation, const String& name) :
 	m_impl(makePimpl<DirectX12ImageImpl>(this, device, extent, format, dimension, levels, layers, samples, writable, initialState, allocator, std::move(allocation))), ComResource<ID3D12Resource>(nullptr)
 {
 	this->handle() = std::move(image);
@@ -99,7 +99,7 @@ const bool& DirectX12Image::writable() const noexcept
 	return m_impl->m_writable;
 }
 
-const ImageLayout& DirectX12Image::layout(const UInt32& subresource) const
+ImageLayout DirectX12Image::layout(const UInt32& subresource) const
 {
 	if (subresource >= m_impl->m_layouts.size()) [[unlikely]]
 		throw ArgumentOutOfRangeException("The sub-resource with the provided index {0} does not exist.", subresource);
@@ -149,12 +149,12 @@ Size3d DirectX12Image::extent(const UInt32& level) const noexcept
 	return size;
 }
 
-const Format& DirectX12Image::format() const noexcept
+Format DirectX12Image::format() const noexcept
 {
 	return m_impl->m_format;
 }
 
-const ImageDimensions& DirectX12Image::dimensions() const noexcept 
+ImageDimensions DirectX12Image::dimensions() const noexcept 
 {
 	return m_impl->m_dimensions;
 }
@@ -174,7 +174,7 @@ const UInt32& DirectX12Image::planes() const noexcept
 	return m_impl->m_planes;
 }
 
-const MultiSamplingLevel& DirectX12Image::samples() const noexcept
+MultiSamplingLevel DirectX12Image::samples() const noexcept
 {
 	return m_impl->m_samples;
 }
@@ -189,12 +189,12 @@ const D3D12MA::Allocation* DirectX12Image::allocationInfo() const noexcept
 	return m_impl->m_allocation.get();
 }
 
-UniquePtr<DirectX12Image> DirectX12Image::allocate(const DirectX12Device& device, AllocatorPtr allocator, const Size3d& extent, const Format& format, const ImageDimensions& dimension, const UInt32& levels, const UInt32& layers, const MultiSamplingLevel& samples, const bool& writable, const ImageLayout& initialLayout, const D3D12_RESOURCE_DESC1& resourceDesc, const D3D12MA::ALLOCATION_DESC& allocationDesc)
+UniquePtr<DirectX12Image> DirectX12Image::allocate(const DirectX12Device& device, AllocatorPtr allocator, const Size3d& extent, Format format, ImageDimensions dimension, const UInt32& levels, const UInt32& layers, MultiSamplingLevel samples, const bool& writable, ImageLayout initialLayout, const D3D12_RESOURCE_DESC1& resourceDesc, const D3D12MA::ALLOCATION_DESC& allocationDesc)
 {
 	return DirectX12Image::allocate("", device, allocator, extent, format, dimension, levels, layers, samples, writable, initialLayout, resourceDesc, allocationDesc);
 }
 
-UniquePtr<DirectX12Image> DirectX12Image::allocate(const String& name, const DirectX12Device& device, AllocatorPtr allocator, const Size3d& extent, const Format& format, const ImageDimensions& dimension, const UInt32& levels, const UInt32& layers, const MultiSamplingLevel& samples, const bool& writable, const ImageLayout& initialLayout, const D3D12_RESOURCE_DESC1& resourceDesc, const D3D12MA::ALLOCATION_DESC& allocationDesc)
+UniquePtr<DirectX12Image> DirectX12Image::allocate(const String& name, const DirectX12Device& device, AllocatorPtr allocator, const Size3d& extent, Format format, ImageDimensions dimension, const UInt32& levels, const UInt32& layers, MultiSamplingLevel samples, const bool& writable, ImageLayout initialLayout, const D3D12_RESOURCE_DESC1& resourceDesc, const D3D12MA::ALLOCATION_DESC& allocationDesc)
 {
 	if (allocator == nullptr) [[unlikely]]
 		throw ArgumentNotInitializedException("The allocator must be initialized.");
@@ -225,7 +225,7 @@ private:
 	const DirectX12Device& m_device;
 
 public:
-	DirectX12SamplerImpl(DirectX12Sampler* parent, const DirectX12Device& device, const FilterMode& magFilter, const FilterMode& minFilter, const BorderMode& borderU, const BorderMode& borderV, const BorderMode& borderW, const MipMapMode& mipMapMode, const Float& mipMapBias, const Float& minLod, const Float& maxLod, const Float& anisotropy) :
+	DirectX12SamplerImpl(DirectX12Sampler* parent, const DirectX12Device& device, FilterMode magFilter, FilterMode minFilter, BorderMode borderU, BorderMode borderV, BorderMode borderW, MipMapMode mipMapMode, const Float& mipMapBias, const Float& minLod, const Float& maxLod, const Float& anisotropy) :
 		base(parent), m_device(device), m_magFilter(magFilter), m_minFilter(minFilter), m_borderU(borderU), m_borderV(borderV), m_borderW(borderW), m_mipMapMode(mipMapMode), m_mipMapBias(mipMapBias), m_minLod(minLod), m_maxLod(maxLod), m_anisotropy(anisotropy)
 	{
 	}
@@ -235,7 +235,7 @@ public:
 // Sampler shared interface.
 // ------------------------------------------------------------------------------------------------
 
-DirectX12Sampler::DirectX12Sampler(const DirectX12Device& device, const FilterMode& magFilter, const FilterMode& minFilter, const BorderMode& borderU, const BorderMode& borderV, const BorderMode& borderW, const MipMapMode& mipMapMode, const Float& mipMapBias, const Float& minLod, const Float& maxLod, const Float& anisotropy, const String& name) :
+DirectX12Sampler::DirectX12Sampler(const DirectX12Device& device, FilterMode magFilter, FilterMode minFilter, BorderMode borderU, BorderMode borderV, BorderMode borderW, MipMapMode mipMapMode, const Float& mipMapBias, const Float& minLod, const Float& maxLod, const Float& anisotropy, const String& name) :
 	m_impl(makePimpl<DirectX12SamplerImpl>(this, device, magFilter, minFilter, borderU, borderV, borderW, mipMapMode, mipMapBias, minLod, maxLod, anisotropy))
 {
 	if (!name.empty())
@@ -244,27 +244,27 @@ DirectX12Sampler::DirectX12Sampler(const DirectX12Device& device, const FilterMo
 
 DirectX12Sampler::~DirectX12Sampler() noexcept = default;
 
-const FilterMode& DirectX12Sampler::getMinifyingFilter() const noexcept
+FilterMode DirectX12Sampler::getMinifyingFilter() const noexcept
 {
 	return m_impl->m_minFilter;
 }
 
-const FilterMode& DirectX12Sampler::getMagnifyingFilter() const noexcept
+FilterMode DirectX12Sampler::getMagnifyingFilter() const noexcept
 {
 	return m_impl->m_magFilter;
 }
 
-const BorderMode& DirectX12Sampler::getBorderModeU() const noexcept
+BorderMode DirectX12Sampler::getBorderModeU() const noexcept
 {
 	return m_impl->m_borderU;
 }
 
-const BorderMode& DirectX12Sampler::getBorderModeV() const noexcept
+BorderMode DirectX12Sampler::getBorderModeV() const noexcept
 {
 	return m_impl->m_borderV;
 }
 
-const BorderMode& DirectX12Sampler::getBorderModeW() const noexcept
+BorderMode DirectX12Sampler::getBorderModeW() const noexcept
 {
 	return m_impl->m_borderW;
 }
@@ -274,7 +274,7 @@ const Float& DirectX12Sampler::getAnisotropy() const noexcept
 	return m_impl->m_anisotropy;
 }
 
-const MipMapMode& DirectX12Sampler::getMipMapMode() const noexcept
+MipMapMode DirectX12Sampler::getMipMapMode() const noexcept
 {
 	return m_impl->m_mipMapMode;
 }

--- a/src/Backends/DirectX12/src/image.cpp
+++ b/src/Backends/DirectX12/src/image.cpp
@@ -23,7 +23,7 @@ private:
 	const DirectX12Device& m_device;
 
 public:
-	DirectX12ImageImpl(DirectX12Image* parent, const DirectX12Device& device, const Size3d& extent, Format format, ImageDimensions dimension, const UInt32& levels, const UInt32& layers, MultiSamplingLevel samples, const bool& writable, ImageLayout initialLayout, AllocatorPtr allocator, AllocationPtr&& allocation) :
+	DirectX12ImageImpl(DirectX12Image* parent, const DirectX12Device& device, const Size3d& extent, Format format, ImageDimensions dimension, UInt32 levels, UInt32 layers, MultiSamplingLevel samples, bool writable, ImageLayout initialLayout, AllocatorPtr allocator, AllocationPtr&& allocation) :
 		base(parent), m_device(device), m_allocator(allocator), m_allocation(std::move(allocation)), m_extent(extent), m_format(format), m_dimensions(dimension), m_levels(levels), m_layers(layers), m_writable(writable), m_samples(samples)
 	{
 		m_planes = ::D3D12GetFormatPlaneCount(device.handle().Get(), DX12::getFormat(format));
@@ -36,7 +36,7 @@ public:
 // Image Base shared interface.
 // ------------------------------------------------------------------------------------------------
 
-DirectX12Image::DirectX12Image(const DirectX12Device& device, ComPtr<ID3D12Resource>&& image, const Size3d& extent, Format format, ImageDimensions dimension, const UInt32& levels, const UInt32& layers, MultiSamplingLevel samples, const bool& writable, ImageLayout initialState, AllocatorPtr allocator, AllocationPtr&& allocation, const String& name) :
+DirectX12Image::DirectX12Image(const DirectX12Device& device, ComPtr<ID3D12Resource>&& image, const Size3d& extent, Format format, ImageDimensions dimension, UInt32 levels, UInt32 layers, MultiSamplingLevel samples, bool writable, ImageLayout initialState, AllocatorPtr allocator, AllocationPtr&& allocation, const String& name) :
 	m_impl(makePimpl<DirectX12ImageImpl>(this, device, extent, format, dimension, levels, layers, samples, writable, initialState, allocator, std::move(allocation))), ComResource<ID3D12Resource>(nullptr)
 {
 	this->handle() = std::move(image);
@@ -53,7 +53,7 @@ DirectX12Image::DirectX12Image(const DirectX12Device& device, ComPtr<ID3D12Resou
 
 DirectX12Image::~DirectX12Image() noexcept = default;
 
-const UInt32& DirectX12Image::elements() const noexcept
+UInt32 DirectX12Image::elements() const noexcept
 {
 	return m_impl->m_elements;
 }
@@ -94,12 +94,12 @@ size_t DirectX12Image::alignedElementSize() const noexcept
 	return this->elementSize();
 }
 
-const bool& DirectX12Image::writable() const noexcept
+bool DirectX12Image::writable() const noexcept
 {
 	return m_impl->m_writable;
 }
 
-ImageLayout DirectX12Image::layout(const UInt32& subresource) const
+ImageLayout DirectX12Image::layout(UInt32 subresource) const
 {
 	if (subresource >= m_impl->m_layouts.size()) [[unlikely]]
 		throw ArgumentOutOfRangeException("The sub-resource with the provided index {0} does not exist.", subresource);
@@ -107,7 +107,7 @@ ImageLayout DirectX12Image::layout(const UInt32& subresource) const
 	return m_impl->m_layouts[subresource];
 }
 
-ImageLayout& DirectX12Image::layout(const UInt32& subresource)
+ImageLayout& DirectX12Image::layout(UInt32 subresource)
 {
 	if (subresource >= m_impl->m_layouts.size()) [[unlikely]]
 		throw ArgumentOutOfRangeException("The sub-resource with the provided index {0} does not exist.", subresource);
@@ -115,7 +115,7 @@ ImageLayout& DirectX12Image::layout(const UInt32& subresource)
 	return m_impl->m_layouts[subresource];
 }
 
-size_t DirectX12Image::size(const UInt32& level) const noexcept
+size_t DirectX12Image::size(UInt32 level) const noexcept
 {
 	if (level >= m_impl->m_levels)
 		return 0;
@@ -132,7 +132,7 @@ size_t DirectX12Image::size(const UInt32& level) const noexcept
 	}
 }
 
-Size3d DirectX12Image::extent(const UInt32& level) const noexcept
+Size3d DirectX12Image::extent(UInt32 level) const noexcept
 {
 	if (level >= m_impl->m_levels)
 		return Size3d{ 0, 0, 0 };
@@ -159,17 +159,17 @@ ImageDimensions DirectX12Image::dimensions() const noexcept
 	return m_impl->m_dimensions;
 }
 
-const UInt32& DirectX12Image::levels() const noexcept
+UInt32 DirectX12Image::levels() const noexcept
 {
 	return m_impl->m_levels;
 }
 
-const UInt32& DirectX12Image::layers() const noexcept
+UInt32 DirectX12Image::layers() const noexcept
 {
 	return m_impl->m_layers;
 }
 
-const UInt32& DirectX12Image::planes() const noexcept
+UInt32 DirectX12Image::planes() const noexcept
 {
 	return m_impl->m_planes;
 }
@@ -189,12 +189,12 @@ const D3D12MA::Allocation* DirectX12Image::allocationInfo() const noexcept
 	return m_impl->m_allocation.get();
 }
 
-UniquePtr<DirectX12Image> DirectX12Image::allocate(const DirectX12Device& device, AllocatorPtr allocator, const Size3d& extent, Format format, ImageDimensions dimension, const UInt32& levels, const UInt32& layers, MultiSamplingLevel samples, const bool& writable, ImageLayout initialLayout, const D3D12_RESOURCE_DESC1& resourceDesc, const D3D12MA::ALLOCATION_DESC& allocationDesc)
+UniquePtr<DirectX12Image> DirectX12Image::allocate(const DirectX12Device& device, AllocatorPtr allocator, const Size3d& extent, Format format, ImageDimensions dimension, UInt32 levels, UInt32 layers, MultiSamplingLevel samples, bool writable, ImageLayout initialLayout, const D3D12_RESOURCE_DESC1& resourceDesc, const D3D12MA::ALLOCATION_DESC& allocationDesc)
 {
 	return DirectX12Image::allocate("", device, allocator, extent, format, dimension, levels, layers, samples, writable, initialLayout, resourceDesc, allocationDesc);
 }
 
-UniquePtr<DirectX12Image> DirectX12Image::allocate(const String& name, const DirectX12Device& device, AllocatorPtr allocator, const Size3d& extent, Format format, ImageDimensions dimension, const UInt32& levels, const UInt32& layers, MultiSamplingLevel samples, const bool& writable, ImageLayout initialLayout, const D3D12_RESOURCE_DESC1& resourceDesc, const D3D12MA::ALLOCATION_DESC& allocationDesc)
+UniquePtr<DirectX12Image> DirectX12Image::allocate(const String& name, const DirectX12Device& device, AllocatorPtr allocator, const Size3d& extent, Format format, ImageDimensions dimension, UInt32 levels, UInt32 layers, MultiSamplingLevel samples, bool writable, ImageLayout initialLayout, const D3D12_RESOURCE_DESC1& resourceDesc, const D3D12MA::ALLOCATION_DESC& allocationDesc)
 {
 	if (allocator == nullptr) [[unlikely]]
 		throw ArgumentNotInitializedException("The allocator must be initialized.");
@@ -225,7 +225,7 @@ private:
 	const DirectX12Device& m_device;
 
 public:
-	DirectX12SamplerImpl(DirectX12Sampler* parent, const DirectX12Device& device, FilterMode magFilter, FilterMode minFilter, BorderMode borderU, BorderMode borderV, BorderMode borderW, MipMapMode mipMapMode, const Float& mipMapBias, const Float& minLod, const Float& maxLod, const Float& anisotropy) :
+	DirectX12SamplerImpl(DirectX12Sampler* parent, const DirectX12Device& device, FilterMode magFilter, FilterMode minFilter, BorderMode borderU, BorderMode borderV, BorderMode borderW, MipMapMode mipMapMode, Float mipMapBias, Float minLod, Float maxLod, Float anisotropy) :
 		base(parent), m_device(device), m_magFilter(magFilter), m_minFilter(minFilter), m_borderU(borderU), m_borderV(borderV), m_borderW(borderW), m_mipMapMode(mipMapMode), m_mipMapBias(mipMapBias), m_minLod(minLod), m_maxLod(maxLod), m_anisotropy(anisotropy)
 	{
 	}
@@ -235,7 +235,7 @@ public:
 // Sampler shared interface.
 // ------------------------------------------------------------------------------------------------
 
-DirectX12Sampler::DirectX12Sampler(const DirectX12Device& device, FilterMode magFilter, FilterMode minFilter, BorderMode borderU, BorderMode borderV, BorderMode borderW, MipMapMode mipMapMode, const Float& mipMapBias, const Float& minLod, const Float& maxLod, const Float& anisotropy, const String& name) :
+DirectX12Sampler::DirectX12Sampler(const DirectX12Device& device, FilterMode magFilter, FilterMode minFilter, BorderMode borderU, BorderMode borderV, BorderMode borderW, MipMapMode mipMapMode, Float mipMapBias, Float minLod, Float maxLod, Float anisotropy, const String& name) :
 	m_impl(makePimpl<DirectX12SamplerImpl>(this, device, magFilter, minFilter, borderU, borderV, borderW, mipMapMode, mipMapBias, minLod, maxLod, anisotropy))
 {
 	if (!name.empty())
@@ -269,7 +269,7 @@ BorderMode DirectX12Sampler::getBorderModeW() const noexcept
 	return m_impl->m_borderW;
 }
 
-const Float& DirectX12Sampler::getAnisotropy() const noexcept
+Float DirectX12Sampler::getAnisotropy() const noexcept
 {
 	return m_impl->m_anisotropy;
 }
@@ -279,17 +279,17 @@ MipMapMode DirectX12Sampler::getMipMapMode() const noexcept
 	return m_impl->m_mipMapMode;
 }
 
-const Float& DirectX12Sampler::getMipMapBias() const noexcept
+Float DirectX12Sampler::getMipMapBias() const noexcept
 {
 	return m_impl->m_mipMapBias;
 }
 
-const Float& DirectX12Sampler::getMaxLOD() const noexcept
+Float DirectX12Sampler::getMaxLOD() const noexcept
 {
 	return m_impl->m_maxLod;
 }
 
-const Float& DirectX12Sampler::getMinLOD() const noexcept
+Float DirectX12Sampler::getMinLOD() const noexcept
 {
 	return m_impl->m_minLod;
 }

--- a/src/Backends/DirectX12/src/image.h
+++ b/src/Backends/DirectX12/src/image.h
@@ -14,7 +14,7 @@ namespace LiteFX::Rendering::Backends {
 		LITEFX_IMPLEMENTATION(DirectX12ImageImpl);
 
 	public:
-		explicit DirectX12Image(const DirectX12Device& device, ComPtr<ID3D12Resource>&& image, const Size3d& extent, const Format& format, const ImageDimensions& dimension, const UInt32& levels, const UInt32& layers, const MultiSamplingLevel& samples, const bool& writable, const ImageLayout& initialLayout, AllocatorPtr allocator = nullptr, AllocationPtr&& allocation = nullptr, const String& name = "");
+		explicit DirectX12Image(const DirectX12Device& device, ComPtr<ID3D12Resource>&& image, const Size3d& extent, Format format, ImageDimensions dimension, const UInt32& levels, const UInt32& layers, MultiSamplingLevel samples, const bool& writable, ImageLayout initialLayout, AllocatorPtr allocator = nullptr, AllocationPtr&& allocation = nullptr, const String& name = "");
 		DirectX12Image(DirectX12Image&&) = delete;
 		DirectX12Image(const DirectX12Image&) = delete;
 		virtual ~DirectX12Image() noexcept;
@@ -40,7 +40,7 @@ namespace LiteFX::Rendering::Backends {
 		virtual const bool& writable() const noexcept override;
 
 		/// <inheritdoc />
-		virtual const ImageLayout& layout(const UInt32& subresource = 0) const override;
+		virtual ImageLayout layout(const UInt32& subresource = 0) const override;
 
 		/// <inheritdoc />
 		virtual ImageLayout& layout(const UInt32& subresource = 0) override;
@@ -54,10 +54,10 @@ namespace LiteFX::Rendering::Backends {
 		virtual Size3d extent(const UInt32& level = 0) const noexcept override;
 
 		/// <inheritdoc />
-		virtual const Format& format() const noexcept override;
+		virtual Format format() const noexcept override;
 
 		/// <inheritdoc />
-		virtual const ImageDimensions& dimensions() const noexcept override;
+		virtual ImageDimensions dimensions() const noexcept override;
 
 		/// <inheritdoc />
 		virtual const UInt32& levels() const noexcept override;
@@ -69,7 +69,7 @@ namespace LiteFX::Rendering::Backends {
 		virtual const UInt32& planes() const noexcept override;
 
 		/// <inheritdoc />
-		virtual const MultiSamplingLevel& samples() const noexcept override;
+		virtual MultiSamplingLevel samples() const noexcept override;
 
 		// DirectX 12 image.
 	public:
@@ -77,8 +77,8 @@ namespace LiteFX::Rendering::Backends {
 		virtual const D3D12MA::Allocation* allocationInfo() const noexcept;
 
 	public:
-		static UniquePtr<DirectX12Image> allocate(const DirectX12Device& device, AllocatorPtr allocator, const Size3d& extent, const Format& format, const ImageDimensions& dimension, const UInt32& levels, const UInt32& layers, const MultiSamplingLevel& samples, const bool& writable, const ImageLayout& initialLayout, const D3D12_RESOURCE_DESC1& resourceDesc, const D3D12MA::ALLOCATION_DESC& allocationDesc);
-		static UniquePtr<DirectX12Image> allocate(const String& name, const DirectX12Device& device, AllocatorPtr allocator, const Size3d& extent, const Format& format, const ImageDimensions& dimension, const UInt32& levels, const UInt32& layers, const MultiSamplingLevel& samples, const bool& writable, const ImageLayout& initialLayout, const D3D12_RESOURCE_DESC1& resourceDesc, const D3D12MA::ALLOCATION_DESC& allocationDesc);
+		static UniquePtr<DirectX12Image> allocate(const DirectX12Device& device, AllocatorPtr allocator, const Size3d& extent, Format format, ImageDimensions dimension, const UInt32& levels, const UInt32& layers, MultiSamplingLevel samples, const bool& writable, ImageLayout initialLayout, const D3D12_RESOURCE_DESC1& resourceDesc, const D3D12MA::ALLOCATION_DESC& allocationDesc);
+		static UniquePtr<DirectX12Image> allocate(const String& name, const DirectX12Device& device, AllocatorPtr allocator, const Size3d& extent, Format format, ImageDimensions dimension, const UInt32& levels, const UInt32& layers, MultiSamplingLevel samples, const bool& writable, ImageLayout initialLayout, const D3D12_RESOURCE_DESC1& resourceDesc, const D3D12MA::ALLOCATION_DESC& allocationDesc);
 	};
 
 	/// <summary>
@@ -102,7 +102,7 @@ namespace LiteFX::Rendering::Backends {
 		/// <param name="maxLod"></param>
 		/// <param name="minLod"></param>
 		/// <param name="anisotropy"></param>
-		explicit DirectX12Sampler(const DirectX12Device& device, const FilterMode& magFilter = FilterMode::Nearest, const FilterMode& minFilter = FilterMode::Nearest, const BorderMode& borderU = BorderMode::Repeat, const BorderMode& borderV = BorderMode::Repeat, const BorderMode& borderW = BorderMode::Repeat, const MipMapMode& mipMapMode = MipMapMode::Nearest, const Float& mipMapBias = 0.f, const Float& minLod = 0.f, const Float& maxLod = std::numeric_limits<Float>::max(), const Float& anisotropy = 0.f, const String& name = "");
+		explicit DirectX12Sampler(const DirectX12Device& device, FilterMode magFilter = FilterMode::Nearest, FilterMode minFilter = FilterMode::Nearest, BorderMode borderU = BorderMode::Repeat, BorderMode borderV = BorderMode::Repeat, BorderMode borderW = BorderMode::Repeat, MipMapMode mipMapMode = MipMapMode::Nearest, const Float& mipMapBias = 0.f, const Float& minLod = 0.f, const Float& maxLod = std::numeric_limits<Float>::max(), const Float& anisotropy = 0.f, const String& name = "");
 		DirectX12Sampler(DirectX12Sampler&&) = delete;
 		DirectX12Sampler(const DirectX12Sampler&) = delete;
 		virtual ~DirectX12Sampler() noexcept;
@@ -110,25 +110,25 @@ namespace LiteFX::Rendering::Backends {
 		// ISampler interface.
 	public:
 		/// <inheritdoc />
-		virtual const FilterMode& getMinifyingFilter() const noexcept override;
+		virtual FilterMode getMinifyingFilter() const noexcept override;
 
 		/// <inheritdoc />
-		virtual const FilterMode& getMagnifyingFilter() const noexcept override;
+		virtual FilterMode getMagnifyingFilter() const noexcept override;
 
 		/// <inheritdoc />
-		virtual const BorderMode& getBorderModeU() const noexcept override;
+		virtual BorderMode getBorderModeU() const noexcept override;
 
 		/// <inheritdoc />
-		virtual const BorderMode& getBorderModeV() const noexcept override;
+		virtual BorderMode getBorderModeV() const noexcept override;
 
 		/// <inheritdoc />
-		virtual const BorderMode& getBorderModeW() const noexcept override;
+		virtual BorderMode getBorderModeW() const noexcept override;
 
 		/// <inheritdoc />
 		virtual const Float& getAnisotropy() const noexcept override;
 
 		/// <inheritdoc />
-		virtual const MipMapMode& getMipMapMode() const noexcept override;
+		virtual MipMapMode getMipMapMode() const noexcept override;
 
 		/// <inheritdoc />
 		virtual const Float& getMipMapBias() const noexcept override;

--- a/src/Backends/DirectX12/src/image.h
+++ b/src/Backends/DirectX12/src/image.h
@@ -22,54 +22,54 @@ namespace LiteFX::Rendering::Backends {
 		// IDeviceMemory interface.
 	public:
 		/// <inheritdoc />
-		virtual UInt32 elements() const noexcept override;
+		UInt32 elements() const noexcept override;
 
 		/// <inheritdoc />
-		virtual size_t size() const noexcept override;
+		size_t size() const noexcept override;
 
 		/// <inheritdoc />
-		virtual size_t elementSize() const noexcept override;
+		size_t elementSize() const noexcept override;
 
 		/// <inheritdoc />
-		virtual size_t elementAlignment() const noexcept override;
+		size_t elementAlignment() const noexcept override;
 
 		/// <inheritdoc />
-		virtual size_t alignedElementSize() const noexcept override;
+		size_t alignedElementSize() const noexcept override;
 
 		/// <inheritdoc />
-		virtual bool writable() const noexcept override;
+		bool writable() const noexcept override;
 
 		/// <inheritdoc />
-		virtual ImageLayout layout(UInt32 subresource = 0) const override;
+		ImageLayout layout(UInt32 subresource = 0) const override;
 
 		/// <inheritdoc />
-		virtual ImageLayout& layout(UInt32 subresource = 0) override;
+		ImageLayout& layout(UInt32 subresource = 0) override;
 
 		// IImage interface.
 	public:
 		/// <inheritdoc />
-		virtual size_t size(UInt32 level) const noexcept override;
+		size_t size(UInt32 level) const noexcept override;
 
 		/// <inheritdoc />
-		virtual Size3d extent(UInt32 level = 0) const noexcept override;
+		Size3d extent(UInt32 level = 0) const noexcept override;
 
 		/// <inheritdoc />
-		virtual Format format() const noexcept override;
+		Format format() const noexcept override;
 
 		/// <inheritdoc />
-		virtual ImageDimensions dimensions() const noexcept override;
+		ImageDimensions dimensions() const noexcept override;
 
 		/// <inheritdoc />
-		virtual UInt32 levels() const noexcept override;
+		UInt32 levels() const noexcept override;
 
 		/// <inheritdoc />
-		virtual UInt32 layers() const noexcept override;
+		UInt32 layers() const noexcept override;
 
 		/// <inheritdoc />
-		virtual UInt32 planes() const noexcept override;
+		UInt32 planes() const noexcept override;
 
 		/// <inheritdoc />
-		virtual MultiSamplingLevel samples() const noexcept override;
+		MultiSamplingLevel samples() const noexcept override;
 
 		// DirectX 12 image.
 	public:
@@ -110,33 +110,33 @@ namespace LiteFX::Rendering::Backends {
 		// ISampler interface.
 	public:
 		/// <inheritdoc />
-		virtual FilterMode getMinifyingFilter() const noexcept override;
+		FilterMode getMinifyingFilter() const noexcept override;
 
 		/// <inheritdoc />
-		virtual FilterMode getMagnifyingFilter() const noexcept override;
+		FilterMode getMagnifyingFilter() const noexcept override;
 
 		/// <inheritdoc />
-		virtual BorderMode getBorderModeU() const noexcept override;
+		BorderMode getBorderModeU() const noexcept override;
 
 		/// <inheritdoc />
-		virtual BorderMode getBorderModeV() const noexcept override;
+		BorderMode getBorderModeV() const noexcept override;
 
 		/// <inheritdoc />
-		virtual BorderMode getBorderModeW() const noexcept override;
+		BorderMode getBorderModeW() const noexcept override;
 
 		/// <inheritdoc />
-		virtual Float getAnisotropy() const noexcept override;
+		Float getAnisotropy() const noexcept override;
 
 		/// <inheritdoc />
-		virtual MipMapMode getMipMapMode() const noexcept override;
+		MipMapMode getMipMapMode() const noexcept override;
 
 		/// <inheritdoc />
-		virtual Float getMipMapBias() const noexcept override;
+		Float getMipMapBias() const noexcept override;
 
 		/// <inheritdoc />
-		virtual Float getMaxLOD() const noexcept override;
+		Float getMaxLOD() const noexcept override;
 
 		/// <inheritdoc />
-		virtual Float getMinLOD() const noexcept override;
+		Float getMinLOD() const noexcept override;
 	};
 }

--- a/src/Backends/DirectX12/src/image.h
+++ b/src/Backends/DirectX12/src/image.h
@@ -14,7 +14,7 @@ namespace LiteFX::Rendering::Backends {
 		LITEFX_IMPLEMENTATION(DirectX12ImageImpl);
 
 	public:
-		explicit DirectX12Image(const DirectX12Device& device, ComPtr<ID3D12Resource>&& image, const Size3d& extent, Format format, ImageDimensions dimension, const UInt32& levels, const UInt32& layers, MultiSamplingLevel samples, const bool& writable, ImageLayout initialLayout, AllocatorPtr allocator = nullptr, AllocationPtr&& allocation = nullptr, const String& name = "");
+		explicit DirectX12Image(const DirectX12Device& device, ComPtr<ID3D12Resource>&& image, const Size3d& extent, Format format, ImageDimensions dimension, UInt32 levels, UInt32 layers, MultiSamplingLevel samples, bool writable, ImageLayout initialLayout, AllocatorPtr allocator = nullptr, AllocationPtr&& allocation = nullptr, const String& name = "");
 		DirectX12Image(DirectX12Image&&) = delete;
 		DirectX12Image(const DirectX12Image&) = delete;
 		virtual ~DirectX12Image() noexcept;
@@ -22,7 +22,7 @@ namespace LiteFX::Rendering::Backends {
 		// IDeviceMemory interface.
 	public:
 		/// <inheritdoc />
-		virtual const UInt32& elements() const noexcept override;
+		virtual UInt32 elements() const noexcept override;
 
 		/// <inheritdoc />
 		virtual size_t size() const noexcept override;
@@ -37,21 +37,21 @@ namespace LiteFX::Rendering::Backends {
 		virtual size_t alignedElementSize() const noexcept override;
 
 		/// <inheritdoc />
-		virtual const bool& writable() const noexcept override;
+		virtual bool writable() const noexcept override;
 
 		/// <inheritdoc />
-		virtual ImageLayout layout(const UInt32& subresource = 0) const override;
+		virtual ImageLayout layout(UInt32 subresource = 0) const override;
 
 		/// <inheritdoc />
-		virtual ImageLayout& layout(const UInt32& subresource = 0) override;
+		virtual ImageLayout& layout(UInt32 subresource = 0) override;
 
 		// IImage interface.
 	public:
 		/// <inheritdoc />
-		virtual size_t size(const UInt32& level) const noexcept override;
+		virtual size_t size(UInt32 level) const noexcept override;
 
 		/// <inheritdoc />
-		virtual Size3d extent(const UInt32& level = 0) const noexcept override;
+		virtual Size3d extent(UInt32 level = 0) const noexcept override;
 
 		/// <inheritdoc />
 		virtual Format format() const noexcept override;
@@ -60,13 +60,13 @@ namespace LiteFX::Rendering::Backends {
 		virtual ImageDimensions dimensions() const noexcept override;
 
 		/// <inheritdoc />
-		virtual const UInt32& levels() const noexcept override;
+		virtual UInt32 levels() const noexcept override;
 
 		/// <inheritdoc />
-		virtual const UInt32& layers() const noexcept override;
+		virtual UInt32 layers() const noexcept override;
 
 		/// <inheritdoc />
-		virtual const UInt32& planes() const noexcept override;
+		virtual UInt32 planes() const noexcept override;
 
 		/// <inheritdoc />
 		virtual MultiSamplingLevel samples() const noexcept override;
@@ -77,8 +77,8 @@ namespace LiteFX::Rendering::Backends {
 		virtual const D3D12MA::Allocation* allocationInfo() const noexcept;
 
 	public:
-		static UniquePtr<DirectX12Image> allocate(const DirectX12Device& device, AllocatorPtr allocator, const Size3d& extent, Format format, ImageDimensions dimension, const UInt32& levels, const UInt32& layers, MultiSamplingLevel samples, const bool& writable, ImageLayout initialLayout, const D3D12_RESOURCE_DESC1& resourceDesc, const D3D12MA::ALLOCATION_DESC& allocationDesc);
-		static UniquePtr<DirectX12Image> allocate(const String& name, const DirectX12Device& device, AllocatorPtr allocator, const Size3d& extent, Format format, ImageDimensions dimension, const UInt32& levels, const UInt32& layers, MultiSamplingLevel samples, const bool& writable, ImageLayout initialLayout, const D3D12_RESOURCE_DESC1& resourceDesc, const D3D12MA::ALLOCATION_DESC& allocationDesc);
+		static UniquePtr<DirectX12Image> allocate(const DirectX12Device& device, AllocatorPtr allocator, const Size3d& extent, Format format, ImageDimensions dimension, UInt32 levels, UInt32 layers, MultiSamplingLevel samples, bool writable, ImageLayout initialLayout, const D3D12_RESOURCE_DESC1& resourceDesc, const D3D12MA::ALLOCATION_DESC& allocationDesc);
+		static UniquePtr<DirectX12Image> allocate(const String& name, const DirectX12Device& device, AllocatorPtr allocator, const Size3d& extent, Format format, ImageDimensions dimension, UInt32 levels, UInt32 layers, MultiSamplingLevel samples, bool writable, ImageLayout initialLayout, const D3D12_RESOURCE_DESC1& resourceDesc, const D3D12MA::ALLOCATION_DESC& allocationDesc);
 	};
 
 	/// <summary>
@@ -102,7 +102,7 @@ namespace LiteFX::Rendering::Backends {
 		/// <param name="maxLod"></param>
 		/// <param name="minLod"></param>
 		/// <param name="anisotropy"></param>
-		explicit DirectX12Sampler(const DirectX12Device& device, FilterMode magFilter = FilterMode::Nearest, FilterMode minFilter = FilterMode::Nearest, BorderMode borderU = BorderMode::Repeat, BorderMode borderV = BorderMode::Repeat, BorderMode borderW = BorderMode::Repeat, MipMapMode mipMapMode = MipMapMode::Nearest, const Float& mipMapBias = 0.f, const Float& minLod = 0.f, const Float& maxLod = std::numeric_limits<Float>::max(), const Float& anisotropy = 0.f, const String& name = "");
+		explicit DirectX12Sampler(const DirectX12Device& device, FilterMode magFilter = FilterMode::Nearest, FilterMode minFilter = FilterMode::Nearest, BorderMode borderU = BorderMode::Repeat, BorderMode borderV = BorderMode::Repeat, BorderMode borderW = BorderMode::Repeat, MipMapMode mipMapMode = MipMapMode::Nearest, Float mipMapBias = 0.f, Float minLod = 0.f, Float maxLod = std::numeric_limits<Float>::max(), Float anisotropy = 0.f, const String& name = "");
 		DirectX12Sampler(DirectX12Sampler&&) = delete;
 		DirectX12Sampler(const DirectX12Sampler&) = delete;
 		virtual ~DirectX12Sampler() noexcept;
@@ -125,18 +125,18 @@ namespace LiteFX::Rendering::Backends {
 		virtual BorderMode getBorderModeW() const noexcept override;
 
 		/// <inheritdoc />
-		virtual const Float& getAnisotropy() const noexcept override;
+		virtual Float getAnisotropy() const noexcept override;
 
 		/// <inheritdoc />
 		virtual MipMapMode getMipMapMode() const noexcept override;
 
 		/// <inheritdoc />
-		virtual const Float& getMipMapBias() const noexcept override;
+		virtual Float getMipMapBias() const noexcept override;
 
 		/// <inheritdoc />
-		virtual const Float& getMaxLOD() const noexcept override;
+		virtual Float getMaxLOD() const noexcept override;
 
 		/// <inheritdoc />
-		virtual const Float& getMinLOD() const noexcept override;
+		virtual Float getMinLOD() const noexcept override;
 	};
 }

--- a/src/Backends/DirectX12/src/index_buffer_layout.cpp
+++ b/src/Backends/DirectX12/src/index_buffer_layout.cpp
@@ -38,7 +38,7 @@ size_t DirectX12IndexBufferLayout::elementSize() const noexcept
     return static_cast<UInt32>(m_impl->m_indexType) >> 3;
 }
 
-const UInt32& DirectX12IndexBufferLayout::binding() const noexcept
+UInt32 DirectX12IndexBufferLayout::binding() const noexcept
 {
     return m_impl->m_binding;
 }

--- a/src/Backends/DirectX12/src/index_buffer_layout.cpp
+++ b/src/Backends/DirectX12/src/index_buffer_layout.cpp
@@ -16,7 +16,7 @@ private:
     BufferType m_bufferType{ BufferType::Index };
 
 public:
-    DirectX12IndexBufferLayoutImpl(DirectX12IndexBufferLayout* parent, const IndexType& type) : 
+    DirectX12IndexBufferLayoutImpl(DirectX12IndexBufferLayout* parent, IndexType type) : 
         base(parent), m_indexType(type) 
     {
     }
@@ -26,7 +26,7 @@ public:
 // Shared interface.
 // ------------------------------------------------------------------------------------------------
 
-DirectX12IndexBufferLayout::DirectX12IndexBufferLayout(const IndexType& type) :
+DirectX12IndexBufferLayout::DirectX12IndexBufferLayout(IndexType type) :
     m_impl(makePimpl<DirectX12IndexBufferLayoutImpl>(this, type))
 {
 }
@@ -43,12 +43,12 @@ const UInt32& DirectX12IndexBufferLayout::binding() const noexcept
     return m_impl->m_binding;
 }
 
-const BufferType& DirectX12IndexBufferLayout::type() const noexcept
+BufferType DirectX12IndexBufferLayout::type() const noexcept
 {
     return m_impl->m_bufferType;
 }
 
-const IndexType& DirectX12IndexBufferLayout::indexType() const noexcept
+IndexType DirectX12IndexBufferLayout::indexType() const noexcept
 {
     return m_impl->m_indexType;
 }

--- a/src/Backends/DirectX12/src/input_assembler.cpp
+++ b/src/Backends/DirectX12/src/input_assembler.cpp
@@ -22,7 +22,7 @@ public:
     }
 
 public:
-    void initialize(Enumerable<UniquePtr<DirectX12VertexBufferLayout>>&& vertexBufferLayouts, UniquePtr<DirectX12IndexBufferLayout>&& indexBufferLayout, const PrimitiveTopology& primitiveTopology)
+    void initialize(Enumerable<UniquePtr<DirectX12VertexBufferLayout>>&& vertexBufferLayouts, UniquePtr<DirectX12IndexBufferLayout>&& indexBufferLayout, PrimitiveTopology primitiveTopology)
     {
         m_primitiveTopology = primitiveTopology;
 
@@ -48,7 +48,7 @@ public:
 // Shared interface.
 // ------------------------------------------------------------------------------------------------
 
-DirectX12InputAssembler::DirectX12InputAssembler(Enumerable<UniquePtr<DirectX12VertexBufferLayout>>&& vertexBufferLayouts, UniquePtr<DirectX12IndexBufferLayout>&& indexBufferLayout, const PrimitiveTopology& primitiveTopology) :
+DirectX12InputAssembler::DirectX12InputAssembler(Enumerable<UniquePtr<DirectX12VertexBufferLayout>>&& vertexBufferLayouts, UniquePtr<DirectX12IndexBufferLayout>&& indexBufferLayout, PrimitiveTopology primitiveTopology) :
     m_impl(makePimpl<DirectX12InputAssemblerImpl>(this))
 {
     m_impl->initialize(std::move(vertexBufferLayouts), std::move(indexBufferLayout), primitiveTopology);
@@ -79,7 +79,7 @@ const DirectX12IndexBufferLayout& DirectX12InputAssembler::indexBufferLayout() c
     return *m_impl->m_indexBufferLayout;
 }
 
-const PrimitiveTopology& DirectX12InputAssembler::topology() const noexcept
+PrimitiveTopology DirectX12InputAssembler::topology() const noexcept
 {
     return m_impl->m_primitiveTopology;
 }

--- a/src/Backends/DirectX12/src/input_assembler.cpp
+++ b/src/Backends/DirectX12/src/input_assembler.cpp
@@ -66,7 +66,7 @@ Enumerable<const DirectX12VertexBufferLayout*> DirectX12InputAssembler::vertexBu
     return m_impl->m_vertexBufferLayouts | std::views::transform([](const auto& pair) { return pair.second.get(); });
 }
 
-const DirectX12VertexBufferLayout& DirectX12InputAssembler::vertexBufferLayout(const UInt32 & binding) const
+const DirectX12VertexBufferLayout& DirectX12InputAssembler::vertexBufferLayout(UInt32 binding) const
 {
     [[likely]] if (m_impl->m_vertexBufferLayouts.contains(binding))
         return *m_impl->m_vertexBufferLayouts[binding];

--- a/src/Backends/DirectX12/src/input_attachment_mapping.cpp
+++ b/src/Backends/DirectX12/src/input_attachment_mapping.cpp
@@ -16,7 +16,7 @@ private:
     UInt32 m_location;
 
 public:
-    DirectX12InputAttachmentMappingImpl(DirectX12InputAttachmentMapping* parent, const DirectX12RenderPass* renderPass, const RenderTarget& renderTarget, const UInt32& location) :
+    DirectX12InputAttachmentMappingImpl(DirectX12InputAttachmentMapping* parent, const DirectX12RenderPass* renderPass, const RenderTarget& renderTarget, UInt32 location) :
         base(parent), m_renderPass(renderPass), m_location(location), m_renderTarget(renderTarget)
     {
     }
@@ -31,7 +31,7 @@ DirectX12InputAttachmentMapping::DirectX12InputAttachmentMapping() noexcept :
 {
 }
 
-DirectX12InputAttachmentMapping::DirectX12InputAttachmentMapping(const DirectX12RenderPass& renderPass, const RenderTarget& renderTarget, const UInt32& location) :
+DirectX12InputAttachmentMapping::DirectX12InputAttachmentMapping(const DirectX12RenderPass& renderPass, const RenderTarget& renderTarget, UInt32 location) :
     m_impl(makePimpl<DirectX12InputAttachmentMappingImpl>(this, &renderPass, renderTarget, location))
 {
 }
@@ -71,7 +71,7 @@ const DirectX12RenderPass* DirectX12InputAttachmentMapping::inputAttachmentSourc
     return m_impl->m_renderPass;
 }
 
-const UInt32& DirectX12InputAttachmentMapping::location() const noexcept
+UInt32 DirectX12InputAttachmentMapping::location() const noexcept
 {
     return m_impl->m_location;
 }

--- a/src/Backends/DirectX12/src/pipeline_layout.cpp
+++ b/src/Backends/DirectX12/src/pipeline_layout.cpp
@@ -30,7 +30,7 @@ public:
     }
 
 private:
-    D3D12_FILTER getFilterMode(FilterMode minFilter, FilterMode magFilter, MipMapMode mipFilter, const Float& anisotropy = 0.f)
+    D3D12_FILTER getFilterMode(FilterMode minFilter, FilterMode magFilter, MipMapMode mipFilter, Float anisotropy = 0.f)
     {
         if (anisotropy > 0.f)
             return D3D12_ENCODE_ANISOTROPIC_FILTER(D3D12_FILTER_REDUCTION_TYPE_STANDARD);
@@ -225,7 +225,7 @@ const DirectX12Device& DirectX12PipelineLayout::device() const noexcept
     return m_impl->m_device;
 }
 
-const DirectX12DescriptorSetLayout& DirectX12PipelineLayout::descriptorSet(const UInt32& space) const
+const DirectX12DescriptorSetLayout& DirectX12PipelineLayout::descriptorSet(UInt32 space) const
 {
     if (auto match = std::ranges::find_if(m_impl->m_descriptorSetLayouts, [&space](const UniquePtr<DirectX12DescriptorSetLayout>& layout) { return layout->space() == space; }); match != m_impl->m_descriptorSetLayouts.end())
         return *match->get();

--- a/src/Backends/DirectX12/src/pipeline_layout.cpp
+++ b/src/Backends/DirectX12/src/pipeline_layout.cpp
@@ -30,7 +30,7 @@ public:
     }
 
 private:
-    D3D12_FILTER getFilterMode(const FilterMode& minFilter, const FilterMode& magFilter, const MipMapMode& mipFilter, const Float& anisotropy = 0.f)
+    D3D12_FILTER getFilterMode(FilterMode minFilter, FilterMode magFilter, MipMapMode mipFilter, const Float& anisotropy = 0.f)
     {
         if (anisotropy > 0.f)
             return D3D12_ENCODE_ANISOTROPIC_FILTER(D3D12_FILTER_REDUCTION_TYPE_STANDARD);
@@ -44,7 +44,7 @@ private:
         }
     }
 
-    D3D12_TEXTURE_ADDRESS_MODE getBorderMode(const BorderMode& mode)
+    D3D12_TEXTURE_ADDRESS_MODE getBorderMode(BorderMode mode)
     {
         switch (mode)
         {

--- a/src/Backends/DirectX12/src/push_constants_layout.cpp
+++ b/src/Backends/DirectX12/src/push_constants_layout.cpp
@@ -65,7 +65,7 @@ const UInt32& DirectX12PushConstantsLayout::size() const noexcept
     return m_impl->m_size;
 }
 
-const DirectX12PushConstantsRange& DirectX12PushConstantsLayout::range(const ShaderStage& stage) const
+const DirectX12PushConstantsRange& DirectX12PushConstantsLayout::range(ShaderStage stage) const
 {
     auto bits = std::to_underlying(stage);
 

--- a/src/Backends/DirectX12/src/push_constants_layout.cpp
+++ b/src/Backends/DirectX12/src/push_constants_layout.cpp
@@ -18,7 +18,7 @@ private:
     UInt32 m_size;
 
 public:
-    DirectX12PushConstantsLayoutImpl(DirectX12PushConstantsLayout* parent, const UInt32& size) :
+    DirectX12PushConstantsLayoutImpl(DirectX12PushConstantsLayout* parent, UInt32 size) :
         base(parent), m_size(size)
     {
         // Align the size to 4 bytes.
@@ -47,20 +47,20 @@ private:
 // Shared interface.
 // ------------------------------------------------------------------------------------------------
 
-DirectX12PushConstantsLayout::DirectX12PushConstantsLayout(Enumerable<UniquePtr<DirectX12PushConstantsRange>>&& ranges, const UInt32& size) :
+DirectX12PushConstantsLayout::DirectX12PushConstantsLayout(Enumerable<UniquePtr<DirectX12PushConstantsRange>>&& ranges, UInt32 size) :
     m_impl(makePimpl<DirectX12PushConstantsLayoutImpl>(this, size))
 {
     m_impl->setRanges(std::move(ranges));
 }
 
-DirectX12PushConstantsLayout::DirectX12PushConstantsLayout(const UInt32& size) :
+DirectX12PushConstantsLayout::DirectX12PushConstantsLayout(UInt32 size) :
     m_impl(makePimpl<DirectX12PushConstantsLayoutImpl>(this, size))
 {
 }
 
 DirectX12PushConstantsLayout::~DirectX12PushConstantsLayout() noexcept = default;
 
-const UInt32& DirectX12PushConstantsLayout::size() const noexcept
+UInt32 DirectX12PushConstantsLayout::size() const noexcept
 {
     return m_impl->m_size;
 }

--- a/src/Backends/DirectX12/src/push_constants_range.cpp
+++ b/src/Backends/DirectX12/src/push_constants_range.cpp
@@ -15,7 +15,7 @@ private:
     UInt32 m_offset, m_size, m_space, m_binding, m_rootParameterIndex{ 0 };
 
 public:
-    DirectX12PushConstantsRangeImpl(DirectX12PushConstantsRange* parent, ShaderStage shaderStage, const UInt32& offset, const UInt32& size, const UInt32& space, const UInt32& binding) :
+    DirectX12PushConstantsRangeImpl(DirectX12PushConstantsRange* parent, ShaderStage shaderStage, UInt32 offset, UInt32 size, UInt32 space, UInt32 binding) :
         base(parent), m_stage(shaderStage), m_offset(offset), m_size(size), m_space(space), m_binding(binding)
     {
         if (offset % 4 != 0)
@@ -33,29 +33,29 @@ public:
 // Shared interface.
 // ------------------------------------------------------------------------------------------------
 
-DirectX12PushConstantsRange::DirectX12PushConstantsRange(ShaderStage shaderStage, const UInt32& offset, const UInt32& size, const UInt32& space, const UInt32& binding) :
+DirectX12PushConstantsRange::DirectX12PushConstantsRange(ShaderStage shaderStage, UInt32 offset, UInt32 size, UInt32 space, UInt32 binding) :
     m_impl(makePimpl<DirectX12PushConstantsRangeImpl>(this, shaderStage, offset, size, space, binding))
 {
 }
 
 DirectX12PushConstantsRange::~DirectX12PushConstantsRange() noexcept = default;
 
-const UInt32& DirectX12PushConstantsRange::space() const noexcept
+UInt32 DirectX12PushConstantsRange::space() const noexcept
 {
     return m_impl->m_space;
 }
 
-const UInt32& DirectX12PushConstantsRange::binding() const noexcept
+UInt32 DirectX12PushConstantsRange::binding() const noexcept
 {
     return m_impl->m_binding;
 }
 
-const UInt32& DirectX12PushConstantsRange::offset() const noexcept
+UInt32 DirectX12PushConstantsRange::offset() const noexcept
 {
     return m_impl->m_offset;
 }
 
-const UInt32& DirectX12PushConstantsRange::size() const noexcept
+UInt32 DirectX12PushConstantsRange::size() const noexcept
 {
     return m_impl->m_size;
 }
@@ -65,7 +65,7 @@ ShaderStage DirectX12PushConstantsRange::stage() const noexcept
     return m_impl->m_stage;
 }
 
-const UInt32& DirectX12PushConstantsRange::rootParameterIndex() const noexcept
+UInt32 DirectX12PushConstantsRange::rootParameterIndex() const noexcept
 {
     return m_impl->m_rootParameterIndex;
 }

--- a/src/Backends/DirectX12/src/push_constants_range.cpp
+++ b/src/Backends/DirectX12/src/push_constants_range.cpp
@@ -15,7 +15,7 @@ private:
     UInt32 m_offset, m_size, m_space, m_binding, m_rootParameterIndex{ 0 };
 
 public:
-    DirectX12PushConstantsRangeImpl(DirectX12PushConstantsRange* parent, const ShaderStage& shaderStage, const UInt32& offset, const UInt32& size, const UInt32& space, const UInt32& binding) :
+    DirectX12PushConstantsRangeImpl(DirectX12PushConstantsRange* parent, ShaderStage shaderStage, const UInt32& offset, const UInt32& size, const UInt32& space, const UInt32& binding) :
         base(parent), m_stage(shaderStage), m_offset(offset), m_size(size), m_space(space), m_binding(binding)
     {
         if (offset % 4 != 0)
@@ -33,7 +33,7 @@ public:
 // Shared interface.
 // ------------------------------------------------------------------------------------------------
 
-DirectX12PushConstantsRange::DirectX12PushConstantsRange(const ShaderStage& shaderStage, const UInt32& offset, const UInt32& size, const UInt32& space, const UInt32& binding) :
+DirectX12PushConstantsRange::DirectX12PushConstantsRange(ShaderStage shaderStage, const UInt32& offset, const UInt32& size, const UInt32& space, const UInt32& binding) :
     m_impl(makePimpl<DirectX12PushConstantsRangeImpl>(this, shaderStage, offset, size, space, binding))
 {
 }
@@ -60,7 +60,7 @@ const UInt32& DirectX12PushConstantsRange::size() const noexcept
     return m_impl->m_size;
 }
 
-const ShaderStage& DirectX12PushConstantsRange::stage() const noexcept
+ShaderStage DirectX12PushConstantsRange::stage() const noexcept
 {
     return m_impl->m_stage;
 }

--- a/src/Backends/DirectX12/src/queue.cpp
+++ b/src/Backends/DirectX12/src/queue.cpp
@@ -149,7 +149,7 @@ void DirectX12Queue::release()
 	this->released(this, { });
 }
 
-SharedPtr<DirectX12CommandBuffer> DirectX12Queue::createCommandBuffer(const bool& beginRecording, const bool& secondary) const
+SharedPtr<DirectX12CommandBuffer> DirectX12Queue::createCommandBuffer(bool beginRecording, bool secondary) const
 {
 	return makeShared<DirectX12CommandBuffer>(*this, beginRecording, !secondary);
 }
@@ -224,7 +224,7 @@ UInt64 DirectX12Queue::submit(const Enumerable<SharedPtr<const DirectX12CommandB
 	return fence;
 }
 
-void DirectX12Queue::waitFor(const UInt64& fence) const noexcept
+void DirectX12Queue::waitFor(UInt64 fence) const noexcept
 {
 	auto completedValue = m_impl->m_fence->GetCompletedValue();
 

--- a/src/Backends/DirectX12/src/queue.cpp
+++ b/src/Backends/DirectX12/src/queue.cpp
@@ -22,7 +22,7 @@ private:
 	Array<Tuple<UInt64, SharedPtr<const DirectX12CommandBuffer>>> m_submittedCommandBuffers;
 
 public:
-	DirectX12QueueImpl(DirectX12Queue* parent, const DirectX12Device& device, const QueueType& type, const QueuePriority& priority) :
+	DirectX12QueueImpl(DirectX12Queue* parent, const DirectX12Device& device, QueueType type, QueuePriority priority) :
 		base(parent), m_device(device), m_bound(false), m_type(type), m_priority(priority)
 	{
 	}
@@ -89,7 +89,7 @@ public:
 // Shared interface.
 // ------------------------------------------------------------------------------------------------
 
-DirectX12Queue::DirectX12Queue(const DirectX12Device& device, const QueueType& type, const QueuePriority& priority) :
+DirectX12Queue::DirectX12Queue(const DirectX12Device& device, QueueType type, QueuePriority priority) :
 	ComResource<ID3D12CommandQueue>(nullptr), m_impl(makePimpl<DirectX12QueueImpl>(this, device, type, priority))
 {
 	this->handle() = m_impl->initialize();
@@ -110,7 +110,7 @@ bool DirectX12Queue::isBound() const noexcept
 	return m_impl->m_bound;
 }
 
-const QueueType& DirectX12Queue::type() const noexcept
+QueueType DirectX12Queue::type() const noexcept
 {
 	return m_impl->m_type;
 }
@@ -132,7 +132,7 @@ void DirectX12Queue::SetDebugMarker(const String& label, const Vectors::ByteVect
 }
 #endif // !defined(NDEBUG) && defined(_WIN64)
 
-const QueuePriority& DirectX12Queue::priority() const noexcept
+QueuePriority DirectX12Queue::priority() const noexcept
 {
 	return m_impl->m_priority;
 }

--- a/src/Backends/DirectX12/src/rasterizer.cpp
+++ b/src/Backends/DirectX12/src/rasterizer.cpp
@@ -7,7 +7,7 @@ using namespace LiteFX::Rendering::Backends;
 // Shared interface.
 // ------------------------------------------------------------------------------------------------
 
-DirectX12Rasterizer::DirectX12Rasterizer(const PolygonMode& polygonMode, const CullMode& cullMode, const CullOrder& cullOrder, const Float& lineWidth, const DepthStencilState& depthStencilState) noexcept :
+DirectX12Rasterizer::DirectX12Rasterizer(PolygonMode polygonMode, CullMode cullMode, CullOrder cullOrder, const Float& lineWidth, const DepthStencilState& depthStencilState) noexcept :
     Rasterizer(polygonMode, cullMode, cullOrder, lineWidth, depthStencilState)
 {
 }

--- a/src/Backends/DirectX12/src/rasterizer.cpp
+++ b/src/Backends/DirectX12/src/rasterizer.cpp
@@ -7,7 +7,7 @@ using namespace LiteFX::Rendering::Backends;
 // Shared interface.
 // ------------------------------------------------------------------------------------------------
 
-DirectX12Rasterizer::DirectX12Rasterizer(PolygonMode polygonMode, CullMode cullMode, CullOrder cullOrder, const Float& lineWidth, const DepthStencilState& depthStencilState) noexcept :
+DirectX12Rasterizer::DirectX12Rasterizer(PolygonMode polygonMode, CullMode cullMode, CullOrder cullOrder, Float lineWidth, const DepthStencilState& depthStencilState) noexcept :
     Rasterizer(polygonMode, cullMode, cullOrder, lineWidth, depthStencilState)
 {
 }

--- a/src/Backends/DirectX12/src/render_pass.cpp
+++ b/src/Backends/DirectX12/src/render_pass.cpp
@@ -67,7 +67,7 @@ public:
         std::sort(std::begin(m_inputAttachments), std::end(m_inputAttachments), [](const DirectX12InputAttachmentMapping& a, const DirectX12InputAttachmentMapping& b) { return a.location() < b.location(); });
     }
 
-    void initRenderTargetViews(const UInt32& backBuffer)
+    void initRenderTargetViews(UInt32 backBuffer)
     {
         auto& frameBuffer = m_frameBuffers[backBuffer];
         
@@ -126,7 +126,7 @@ public:
         }
     }
 
-    void initializeFrameBuffers(const UInt32& commandBuffers)
+    void initializeFrameBuffers(UInt32 commandBuffers)
     {
         // Initialize the frame buffers.
         this->m_frameBuffers.resize(m_device.swapChain().buffers());
@@ -180,13 +180,13 @@ public:
 // Interface.
 // ------------------------------------------------------------------------------------------------
 
-DirectX12RenderPass::DirectX12RenderPass(const DirectX12Device& device, Span<RenderTarget> renderTargets, const UInt32& commandBuffers, MultiSamplingLevel samples, Span<DirectX12InputAttachmentMapping> inputAttachments) :
+DirectX12RenderPass::DirectX12RenderPass(const DirectX12Device& device, Span<RenderTarget> renderTargets, UInt32 commandBuffers, MultiSamplingLevel samples, Span<DirectX12InputAttachmentMapping> inputAttachments) :
     m_impl(makePimpl<DirectX12RenderPassImpl>(this, device, renderTargets, samples, inputAttachments))
 {
     m_impl->initializeFrameBuffers(commandBuffers);
 }
 
-DirectX12RenderPass::DirectX12RenderPass(const DirectX12Device& device, const String& name, Span<RenderTarget> renderTargets, const UInt32& commandBuffers, MultiSamplingLevel samples, Span<DirectX12InputAttachmentMapping> inputAttachments) :
+DirectX12RenderPass::DirectX12RenderPass(const DirectX12Device& device, const String& name, Span<RenderTarget> renderTargets, UInt32 commandBuffers, MultiSamplingLevel samples, Span<DirectX12InputAttachmentMapping> inputAttachments) :
     DirectX12RenderPass(device, renderTargets, commandBuffers, samples, inputAttachments)
 {
     if (!name.empty())
@@ -213,7 +213,7 @@ const DirectX12Device& DirectX12RenderPass::device() const noexcept
     return m_impl->m_device;
 }
 
-const DirectX12FrameBuffer& DirectX12RenderPass::frameBuffer(const UInt32& buffer) const
+const DirectX12FrameBuffer& DirectX12RenderPass::frameBuffer(UInt32 buffer) const
 {
     if (buffer >= m_impl->m_frameBuffers.size()) [[unlikely]]
         throw ArgumentOutOfRangeException("The buffer {0} does not exist in this render pass. The render pass only contains {1} frame buffers.", buffer, m_impl->m_frameBuffers.size());
@@ -239,7 +239,7 @@ Enumerable<const DirectX12RenderPipeline*> DirectX12RenderPass::pipelines() cons
     return m_impl->m_pipelines | std::views::transform([](const UniquePtr<DirectX12RenderPipeline>& pipeline) { return pipeline.get(); }) | std::ranges::to<Array<const DirectX12RenderPipeline*>>();
 }
 
-const RenderTarget& DirectX12RenderPass::renderTarget(const UInt32& location) const
+const RenderTarget& DirectX12RenderPass::renderTarget(UInt32 location) const
 {
     if (auto match = std::ranges::find_if(m_impl->m_renderTargets, [&location](const RenderTarget& renderTarget) { return renderTarget.location() == location; }); match != m_impl->m_renderTargets.end())
         return *match;
@@ -267,7 +267,7 @@ MultiSamplingLevel DirectX12RenderPass::multiSamplingLevel() const noexcept
     return m_impl->m_multiSamplingLevel;
 }
 
-void DirectX12RenderPass::begin(const UInt32& buffer)
+void DirectX12RenderPass::begin(UInt32 buffer)
 {
     // Only begin, if we are currently not running.
     if (m_impl->m_activeFrameBuffer != nullptr)

--- a/src/Backends/DirectX12/src/render_pass.cpp
+++ b/src/Backends/DirectX12/src/render_pass.cpp
@@ -30,7 +30,7 @@ private:
     String m_name;
 
 public:
-    DirectX12RenderPassImpl(DirectX12RenderPass* parent, const DirectX12Device& device, Span<RenderTarget> renderTargets, const MultiSamplingLevel& samples, Span<DirectX12InputAttachmentMapping> inputAttachments) :
+    DirectX12RenderPassImpl(DirectX12RenderPass* parent, const DirectX12Device& device, Span<RenderTarget> renderTargets, MultiSamplingLevel samples, Span<DirectX12InputAttachmentMapping> inputAttachments) :
         base(parent), m_device(device), m_multiSamplingLevel(samples)
     {
         this->mapRenderTargets(renderTargets);
@@ -180,13 +180,13 @@ public:
 // Interface.
 // ------------------------------------------------------------------------------------------------
 
-DirectX12RenderPass::DirectX12RenderPass(const DirectX12Device& device, Span<RenderTarget> renderTargets, const UInt32& commandBuffers, const MultiSamplingLevel& samples, Span<DirectX12InputAttachmentMapping> inputAttachments) :
+DirectX12RenderPass::DirectX12RenderPass(const DirectX12Device& device, Span<RenderTarget> renderTargets, const UInt32& commandBuffers, MultiSamplingLevel samples, Span<DirectX12InputAttachmentMapping> inputAttachments) :
     m_impl(makePimpl<DirectX12RenderPassImpl>(this, device, renderTargets, samples, inputAttachments))
 {
     m_impl->initializeFrameBuffers(commandBuffers);
 }
 
-DirectX12RenderPass::DirectX12RenderPass(const DirectX12Device& device, const String& name, Span<RenderTarget> renderTargets, const UInt32& commandBuffers, const MultiSamplingLevel& samples, Span<DirectX12InputAttachmentMapping> inputAttachments) :
+DirectX12RenderPass::DirectX12RenderPass(const DirectX12Device& device, const String& name, Span<RenderTarget> renderTargets, const UInt32& commandBuffers, MultiSamplingLevel samples, Span<DirectX12InputAttachmentMapping> inputAttachments) :
     DirectX12RenderPass(device, renderTargets, commandBuffers, samples, inputAttachments)
 {
     if (!name.empty())
@@ -262,7 +262,7 @@ Span<const DirectX12InputAttachmentMapping> DirectX12RenderPass::inputAttachment
     return m_impl->m_inputAttachments;
 }
 
-const MultiSamplingLevel& DirectX12RenderPass::multiSamplingLevel() const noexcept
+MultiSamplingLevel DirectX12RenderPass::multiSamplingLevel() const noexcept
 {
     return m_impl->m_multiSamplingLevel;
 }
@@ -423,7 +423,7 @@ void DirectX12RenderPass::resizeFrameBuffers(const Size2d& renderArea)
     std::ranges::for_each(m_impl->m_frameBuffers, [&](UniquePtr<DirectX12FrameBuffer>& frameBuffer) { frameBuffer->resize(renderArea); });
 }
 
-void DirectX12RenderPass::changeMultiSamplingLevel(const MultiSamplingLevel& samples)
+void DirectX12RenderPass::changeMultiSamplingLevel(MultiSamplingLevel samples)
 {
     // Check if we're currently running.
     if (m_impl->m_activeFrameBuffer != nullptr)

--- a/src/Backends/DirectX12/src/render_pipeline.cpp
+++ b/src/Backends/DirectX12/src/render_pipeline.cpp
@@ -23,7 +23,7 @@ private:
 	const DirectX12RenderPass& m_renderPass;
 
 public:
-	DirectX12RenderPipelineImpl(DirectX12RenderPipeline* parent, const DirectX12RenderPass& renderPass, const bool& alphaToCoverage, SharedPtr<DirectX12PipelineLayout> layout, SharedPtr<DirectX12ShaderProgram> shaderProgram, SharedPtr<DirectX12InputAssembler> inputAssembler, SharedPtr<DirectX12Rasterizer> rasterizer) :
+	DirectX12RenderPipelineImpl(DirectX12RenderPipeline* parent, const DirectX12RenderPass& renderPass, bool alphaToCoverage, SharedPtr<DirectX12PipelineLayout> layout, SharedPtr<DirectX12ShaderProgram> shaderProgram, SharedPtr<DirectX12InputAssembler> inputAssembler, SharedPtr<DirectX12Rasterizer> rasterizer) :
 		base(parent), m_renderPass(renderPass), m_alphaToCoverage(alphaToCoverage), m_layout(layout), m_program(shaderProgram), m_inputAssembler(inputAssembler), m_rasterizer(rasterizer)
 	{
 	}
@@ -263,7 +263,7 @@ SharedPtr<DirectX12Rasterizer> DirectX12RenderPipeline::rasterizer() const noexc
 	return m_impl->m_rasterizer;
 }
 
-const bool& DirectX12RenderPipeline::alphaToCoverage() const noexcept
+bool DirectX12RenderPipeline::alphaToCoverage() const noexcept
 {
 	return m_impl->m_alphaToCoverage;
 }

--- a/src/Backends/DirectX12/src/shader_module.cpp
+++ b/src/Backends/DirectX12/src/shader_module.cpp
@@ -16,7 +16,7 @@ private:
 	const DirectX12Device& m_device;
 
 public:
-	DirectX12ShaderModuleImpl(DirectX12ShaderModule* parent, const DirectX12Device& device, const ShaderStage& type, const String& fileName, const String& entryPoint) :
+	DirectX12ShaderModuleImpl(DirectX12ShaderModule* parent, const DirectX12Device& device, ShaderStage type, const String& fileName, const String& entryPoint) :
 		base(parent), m_device(device), m_fileName(fileName), m_entryPoint(entryPoint), m_type(type) 
 	{
 	}
@@ -54,13 +54,13 @@ public:
 // Interface.
 // ------------------------------------------------------------------------------------------------
 
-DirectX12ShaderModule::DirectX12ShaderModule(const DirectX12Device& device, const ShaderStage& type, const String& fileName, const String& entryPoint) :
+DirectX12ShaderModule::DirectX12ShaderModule(const DirectX12Device& device, ShaderStage type, const String& fileName, const String& entryPoint) :
 	m_impl(makePimpl<DirectX12ShaderModuleImpl>(this, device, type, fileName, entryPoint)), ComResource<IDxcBlob>(nullptr)
 {
 	this->handle() = m_impl->initialize();
 }
 
-DirectX12ShaderModule::DirectX12ShaderModule(const DirectX12Device& device, const ShaderStage& type, std::istream& stream, const String& name, const String& entryPoint) :
+DirectX12ShaderModule::DirectX12ShaderModule(const DirectX12Device& device, ShaderStage type, std::istream& stream, const String& name, const String& entryPoint) :
 	m_impl(makePimpl<DirectX12ShaderModuleImpl>(this, device, type, name, entryPoint)), ComResource<IDxcBlob>(nullptr)
 {
 	this->handle() = m_impl->initialize(stream);
@@ -68,7 +68,7 @@ DirectX12ShaderModule::DirectX12ShaderModule(const DirectX12Device& device, cons
 
 DirectX12ShaderModule::~DirectX12ShaderModule() noexcept = default;
 
-const ShaderStage& DirectX12ShaderModule::type() const noexcept
+ShaderStage DirectX12ShaderModule::type() const noexcept
 {
 	return m_impl->m_type;
 }

--- a/src/Backends/DirectX12/src/swapchain.cpp
+++ b/src/Backends/DirectX12/src/swapchain.cpp
@@ -46,9 +46,9 @@ private:
 
 public:
 	[[nodiscard]]
-	ComPtr<IDXGISwapChain4> initialize(const Format& format, const Size2d& frameBufferSize, const UInt32& frameBuffers)
+	ComPtr<IDXGISwapChain4> initialize(Format format, const Size2d& frameBufferSize, const UInt32& frameBuffers)
 	{
-		if (!std::ranges::any_of(m_parent->getSurfaceFormats(), [&format](const Format& surfaceFormat) { return surfaceFormat == format; }))
+		if (!std::ranges::any_of(m_parent->getSurfaceFormats(), [&format](Format surfaceFormat) { return surfaceFormat == format; }))
 			throw InvalidArgumentException("The provided surface format {0} it not a supported. Must be one of the following: {1}.", format, this->joinSupportedSurfaceFormats());
 
 		auto adapter = m_device.adapter().handle();
@@ -97,9 +97,9 @@ public:
 		return swapChain;
 	}
 
-	void reset(const Format& format, const Size2d& frameBufferSize, const UInt32& frameBuffers)
+	void reset(Format format, const Size2d& frameBufferSize, const UInt32& frameBuffers)
 	{
-		if (!std::ranges::any_of(m_parent->getSurfaceFormats(), [&format](const Format& surfaceFormat) { return surfaceFormat == format; }))
+		if (!std::ranges::any_of(m_parent->getSurfaceFormats(), [&format](Format surfaceFormat) { return surfaceFormat == format; }))
 			throw InvalidArgumentException("The provided surface format {0} it not a supported. Must be one of the following: {1}.", format, this->joinSupportedSurfaceFormats());
 
 		// Release all back buffers.
@@ -184,7 +184,7 @@ private:
 		auto formats = m_parent->getSurfaceFormats();
 
 		return Join(formats |
-			std::views::transform([](const Format& format) { return fmt::to_string(format); }) |
+			std::views::transform([](Format format) { return fmt::to_string(format); }) |
 			std::ranges::to<Array<String>>(), ", ");
 	}
 };
@@ -193,7 +193,7 @@ private:
 // Shared interface.
 // ------------------------------------------------------------------------------------------------
 
-DirectX12SwapChain::DirectX12SwapChain(const DirectX12Device& device, const Format& format, const Size2d& frameBufferSize, const UInt32& frameBuffers) :
+DirectX12SwapChain::DirectX12SwapChain(const DirectX12Device& device, Format format, const Size2d& frameBufferSize, const UInt32& frameBuffers) :
 	m_impl(makePimpl<DirectX12SwapChainImpl>(this, device)), ComResource<IDXGISwapChain4>(nullptr)
 {
 	this->handle() = m_impl->initialize(format, frameBufferSize, frameBuffers);
@@ -246,7 +246,7 @@ UInt32 DirectX12SwapChain::resolveQueryId(SharedPtr<const TimingEvent> timingEve
 	throw InvalidArgumentException("The timing event is not registered on the swap chain.");
 }
 
-const Format& DirectX12SwapChain::surfaceFormat() const noexcept
+Format DirectX12SwapChain::surfaceFormat() const noexcept
 {
 	return m_impl->m_format;
 }
@@ -308,7 +308,7 @@ void DirectX12SwapChain::addTimingEvent(SharedPtr<TimingEvent> timingEvent)
 	m_impl->resetQueryHeaps(events);
 }
 
-void DirectX12SwapChain::reset(const Format& surfaceFormat, const Size2d& renderArea, const UInt32& buffers)
+void DirectX12SwapChain::reset(Format surfaceFormat, const Size2d& renderArea, const UInt32& buffers)
 {
 	m_impl->reset(surfaceFormat, renderArea, buffers);
 }

--- a/src/Backends/DirectX12/src/swapchain.cpp
+++ b/src/Backends/DirectX12/src/swapchain.cpp
@@ -46,7 +46,7 @@ private:
 
 public:
 	[[nodiscard]]
-	ComPtr<IDXGISwapChain4> initialize(Format format, const Size2d& frameBufferSize, const UInt32& frameBuffers)
+	ComPtr<IDXGISwapChain4> initialize(Format format, const Size2d& frameBufferSize, UInt32 frameBuffers)
 	{
 		if (!std::ranges::any_of(m_parent->getSurfaceFormats(), [&format](Format surfaceFormat) { return surfaceFormat == format; }))
 			throw InvalidArgumentException("The provided surface format {0} it not a supported. Must be one of the following: {1}.", format, this->joinSupportedSurfaceFormats());
@@ -97,7 +97,7 @@ public:
 		return swapChain;
 	}
 
-	void reset(Format format, const Size2d& frameBufferSize, const UInt32& frameBuffers)
+	void reset(Format format, const Size2d& frameBufferSize, UInt32 frameBuffers)
 	{
 		if (!std::ranges::any_of(m_parent->getSurfaceFormats(), [&format](Format surfaceFormat) { return surfaceFormat == format; }))
 			throw InvalidArgumentException("The provided surface format {0} it not a supported. Must be one of the following: {1}.", format, this->joinSupportedSurfaceFormats());
@@ -193,7 +193,7 @@ private:
 // Shared interface.
 // ------------------------------------------------------------------------------------------------
 
-DirectX12SwapChain::DirectX12SwapChain(const DirectX12Device& device, Format format, const Size2d& frameBufferSize, const UInt32& frameBuffers) :
+DirectX12SwapChain::DirectX12SwapChain(const DirectX12Device& device, Format format, const Size2d& frameBufferSize, UInt32 frameBuffers) :
 	m_impl(makePimpl<DirectX12SwapChainImpl>(this, device)), ComResource<IDXGISwapChain4>(nullptr)
 {
 	this->handle() = m_impl->initialize(format, frameBufferSize, frameBuffers);
@@ -201,7 +201,7 @@ DirectX12SwapChain::DirectX12SwapChain(const DirectX12Device& device, Format for
 
 DirectX12SwapChain::~DirectX12SwapChain() noexcept = default;
 
-const bool& DirectX12SwapChain::supportsVariableRefreshRate() const noexcept
+bool DirectX12SwapChain::supportsVariableRefreshRate() const noexcept
 {
 	return m_impl->m_supportsVariableRefreshRates;
 }
@@ -216,7 +216,7 @@ Enumerable<SharedPtr<TimingEvent>> DirectX12SwapChain::timingEvents() const noex
 	return m_impl->m_timingEvents;
 }
 
-SharedPtr<TimingEvent> DirectX12SwapChain::timingEvent(const UInt32& queryId) const
+SharedPtr<TimingEvent> DirectX12SwapChain::timingEvent(UInt32 queryId) const
 {
 	if (queryId >= m_impl->m_timingEvents.size())
 		throw ArgumentOutOfRangeException("No timing event has been registered for query ID {0}.", queryId);
@@ -251,7 +251,7 @@ Format DirectX12SwapChain::surfaceFormat() const noexcept
 	return m_impl->m_format;
 }
 
-const UInt32& DirectX12SwapChain::buffers() const noexcept
+UInt32 DirectX12SwapChain::buffers() const noexcept
 {
 	return m_impl->m_buffers;
 }
@@ -261,7 +261,7 @@ const Size2d& DirectX12SwapChain::renderArea() const noexcept
 	return m_impl->m_renderArea;
 }
 
-const IDirectX12Image* DirectX12SwapChain::image(const UInt32& backBuffer) const
+const IDirectX12Image* DirectX12SwapChain::image(UInt32 backBuffer) const
 {
 	if (backBuffer >= m_impl->m_presentImages.size()) [[unlikely]]
 		throw ArgumentOutOfRangeException("The back buffer must be a valid index.");
@@ -308,7 +308,7 @@ void DirectX12SwapChain::addTimingEvent(SharedPtr<TimingEvent> timingEvent)
 	m_impl->resetQueryHeaps(events);
 }
 
-void DirectX12SwapChain::reset(Format surfaceFormat, const Size2d& renderArea, const UInt32& buffers)
+void DirectX12SwapChain::reset(Format surfaceFormat, const Size2d& renderArea, UInt32 buffers)
 {
 	m_impl->reset(surfaceFormat, renderArea, buffers);
 }

--- a/src/Backends/DirectX12/src/vertex_buffer_layout.cpp
+++ b/src/Backends/DirectX12/src/vertex_buffer_layout.cpp
@@ -19,7 +19,7 @@ private:
     BufferType m_bufferType{ BufferType::Vertex };
 
 public:
-    DirectX12VertexBufferLayoutImpl(DirectX12VertexBufferLayout* parent, const size_t& vertexSize, const UInt32& binding) :
+    DirectX12VertexBufferLayoutImpl(DirectX12VertexBufferLayout* parent, size_t vertexSize, UInt32 binding) :
         base(parent), m_vertexSize(vertexSize), m_binding(binding)
     {
     }
@@ -29,7 +29,7 @@ public:
 // Shared interface.
 // ------------------------------------------------------------------------------------------------
 
-DirectX12VertexBufferLayout::DirectX12VertexBufferLayout(const size_t& vertexSize, const UInt32& binding) :
+DirectX12VertexBufferLayout::DirectX12VertexBufferLayout(size_t vertexSize, UInt32 binding) :
     m_impl(makePimpl<DirectX12VertexBufferLayoutImpl>(this, vertexSize, binding))
 {
 }
@@ -41,7 +41,7 @@ size_t DirectX12VertexBufferLayout::elementSize() const noexcept
     return m_impl->m_vertexSize;
 }
 
-const UInt32& DirectX12VertexBufferLayout::binding() const noexcept
+UInt32 DirectX12VertexBufferLayout::binding() const noexcept
 {
     return m_impl->m_binding;
 }

--- a/src/Backends/DirectX12/src/vertex_buffer_layout.cpp
+++ b/src/Backends/DirectX12/src/vertex_buffer_layout.cpp
@@ -46,7 +46,7 @@ const UInt32& DirectX12VertexBufferLayout::binding() const noexcept
     return m_impl->m_binding;
 }
 
-const BufferType& DirectX12VertexBufferLayout::type() const noexcept
+BufferType DirectX12VertexBufferLayout::type() const noexcept
 {
     return m_impl->m_bufferType;
 }

--- a/src/Backends/Vulkan/include/litefx/backends/vulkan.hpp
+++ b/src/Backends/Vulkan/include/litefx/backends/vulkan.hpp
@@ -33,18 +33,18 @@ namespace LiteFX::Rendering::Backends {
 		// IVertexBufferLayout interface.
 	public:
 		/// <inheritdoc />
-		virtual Enumerable<const BufferAttribute*> attributes() const noexcept override;
+		Enumerable<const BufferAttribute*> attributes() const noexcept override;
 
 		// IBufferLayout interface.
 	public:
 		/// <inheritdoc />
-		virtual size_t elementSize() const noexcept override;
+		size_t elementSize() const noexcept override;
 
 		/// <inheritdoc />
-		virtual UInt32 binding() const noexcept override;
+		UInt32 binding() const noexcept override;
 
 		/// <inheritdoc />
-		virtual BufferType type() const noexcept override;
+		BufferType type() const noexcept override;
 	};
 
 	/// <summary>
@@ -68,18 +68,18 @@ namespace LiteFX::Rendering::Backends {
 		// IIndexBufferLayout interface.
 	public:
 		/// <inheritdoc />
-		virtual IndexType indexType() const noexcept override;
+		IndexType indexType() const noexcept override;
 
 		// IBufferLayout interface.
 	public:
 		/// <inheritdoc />
-		virtual size_t elementSize() const noexcept override;
+		size_t elementSize() const noexcept override;
 
 		/// <inheritdoc />
-		virtual UInt32 binding() const noexcept override;
+		UInt32 binding() const noexcept override;
 
 		/// <inheritdoc />
-		virtual BufferType type() const noexcept override;
+		BufferType type() const noexcept override;
 	};
 
 	/// <summary>
@@ -270,13 +270,13 @@ namespace LiteFX::Rendering::Backends {
 		// ShaderModule interface.
 	public:
 		/// <inheritdoc />
-		virtual const String& fileName() const noexcept override;
+		const String& fileName() const noexcept override;
 
 		/// <inheritdoc />
-		virtual const String& entryPoint() const noexcept override;
+		const String& entryPoint() const noexcept override;
 
 		/// <inheritdoc />
-		virtual ShaderStage type() const noexcept override;
+		ShaderStage type() const noexcept override;
 
 	public:
 		/// <summary>
@@ -322,13 +322,13 @@ namespace LiteFX::Rendering::Backends {
 
 	public:
 		/// <inheritdoc />
-		virtual Enumerable<const VulkanShaderModule*> modules() const noexcept override;
+		Enumerable<const VulkanShaderModule*> modules() const noexcept override;
 
 		/// <inheritdoc />
 		virtual SharedPtr<VulkanPipelineLayout> reflectPipelineLayout() const;
 
 	private:
-		virtual SharedPtr<IPipelineLayout> parsePipelineLayout() const override {
+		SharedPtr<IPipelineLayout> parsePipelineLayout() const override {
 			return std::static_pointer_cast<IPipelineLayout>(this->reflectPipelineLayout());
 		}
 	};
@@ -365,16 +365,16 @@ namespace LiteFX::Rendering::Backends {
 
 	public:
 		/// <inheritdoc />
-		virtual void update(UInt32 binding, const IVulkanBuffer& buffer, UInt32 bufferElement = 0, UInt32 elements = 0, UInt32 firstDescriptor = 0) const override;
+		void update(UInt32 binding, const IVulkanBuffer& buffer, UInt32 bufferElement = 0, UInt32 elements = 0, UInt32 firstDescriptor = 0) const override;
 
 		/// <inheritdoc />
-		virtual void update(UInt32 binding, const IVulkanImage& texture, UInt32 descriptor = 0, UInt32 firstLevel = 0, UInt32 levels = 0, UInt32 firstLayer = 0, UInt32 layers = 0) const override;
+		void update(UInt32 binding, const IVulkanImage& texture, UInt32 descriptor = 0, UInt32 firstLevel = 0, UInt32 levels = 0, UInt32 firstLayer = 0, UInt32 layers = 0) const override;
 
 		/// <inheritdoc />
-		virtual void update(UInt32 binding, const IVulkanSampler& sampler, UInt32 descriptor = 0) const override;
+		void update(UInt32 binding, const IVulkanSampler& sampler, UInt32 descriptor = 0) const override;
 
 		/// <inheritdoc />
-		virtual void attach(UInt32 binding, const IVulkanImage& image) const override;
+		void attach(UInt32 binding, const IVulkanImage& image) const override;
 	};
 
 	/// <summary>
@@ -413,24 +413,24 @@ namespace LiteFX::Rendering::Backends {
 		// IDescriptorLayout interface.
 	public:
 		/// <inheritdoc />
-		virtual DescriptorType descriptorType() const noexcept override;
+		DescriptorType descriptorType() const noexcept override;
 
 		/// <inheritdoc />
-		virtual UInt32 descriptors() const noexcept override;
+		UInt32 descriptors() const noexcept override;
 
 		/// <inheritdoc />
-		virtual const IVulkanSampler* staticSampler() const noexcept override;
+		const IVulkanSampler* staticSampler() const noexcept override;
 
 		// IBufferLayout interface.
 	public:
 		/// <inheritdoc />
-		virtual size_t elementSize() const noexcept override;
+		size_t elementSize() const noexcept override;
 
 		/// <inheritdoc />
-		virtual UInt32 binding() const noexcept override;
+		UInt32 binding() const noexcept override;
 
 		/// <inheritdoc />
-		virtual BufferType type() const noexcept override;
+		BufferType type() const noexcept override;
 	};
 
 	/// <summary>
@@ -482,59 +482,59 @@ namespace LiteFX::Rendering::Backends {
 
 	public:
 		/// <inheritdoc />
-		virtual Enumerable<const VulkanDescriptorLayout*> descriptors() const noexcept override;
+		Enumerable<const VulkanDescriptorLayout*> descriptors() const noexcept override;
 
 		/// <inheritdoc />
-		virtual const VulkanDescriptorLayout& descriptor(UInt32 binding) const override;
+		const VulkanDescriptorLayout& descriptor(UInt32 binding) const override;
 
 		/// <inheritdoc />
-		virtual UInt32 space() const noexcept override;
+		UInt32 space() const noexcept override;
 
 		/// <inheritdoc />
-		virtual ShaderStage shaderStages() const noexcept override;
+		ShaderStage shaderStages() const noexcept override;
 
 		/// <inheritdoc />
-		virtual UInt32 uniforms() const noexcept override;
+		UInt32 uniforms() const noexcept override;
 
 		/// <inheritdoc />
-		virtual UInt32 storages() const noexcept override;
+		UInt32 storages() const noexcept override;
 
 		/// <inheritdoc />
-		virtual UInt32 images() const noexcept override;
+		UInt32 images() const noexcept override;
 
 		/// <inheritdoc />
-		virtual UInt32 buffers() const noexcept override;
+		UInt32 buffers() const noexcept override;
 
 		/// <inheritdoc />
-		virtual UInt32 samplers() const noexcept override;
+		UInt32 samplers() const noexcept override;
 
 		/// <inheritdoc />
-		virtual UInt32 staticSamplers() const noexcept override;
+		UInt32 staticSamplers() const noexcept override;
 
 		/// <inheritdoc />
-		virtual UInt32 inputAttachments() const noexcept override;
+		UInt32 inputAttachments() const noexcept override;
 
 	public:
 		/// <inheritdoc />
-		virtual UniquePtr<VulkanDescriptorSet> allocate(const Enumerable<DescriptorBinding>& bindings = { }) const override;
+		UniquePtr<VulkanDescriptorSet> allocate(const Enumerable<DescriptorBinding>& bindings = { }) const override;
 
 		/// <inheritdoc />
-		virtual UniquePtr<VulkanDescriptorSet> allocate(UInt32 descriptors, const Enumerable<DescriptorBinding>& bindings = { }) const override;
+		UniquePtr<VulkanDescriptorSet> allocate(UInt32 descriptors, const Enumerable<DescriptorBinding>& bindings = { }) const override;
 
 		/// <inheritdoc />
-		virtual Enumerable<UniquePtr<VulkanDescriptorSet>> allocateMultiple(UInt32 descriptorSets, const Enumerable<Enumerable<DescriptorBinding>>& bindings = { }) const override;
+		Enumerable<UniquePtr<VulkanDescriptorSet>> allocateMultiple(UInt32 descriptorSets, const Enumerable<Enumerable<DescriptorBinding>>& bindings = { }) const override;
 
 		/// <inheritdoc />
-		virtual Enumerable<UniquePtr<VulkanDescriptorSet>> allocateMultiple(UInt32 descriptorSets, std::function<Enumerable<DescriptorBinding>(UInt32)> bindingFactory) const override;
+		Enumerable<UniquePtr<VulkanDescriptorSet>> allocateMultiple(UInt32 descriptorSets, std::function<Enumerable<DescriptorBinding>(UInt32)> bindingFactory) const override;
 
 		/// <inheritdoc />
-		virtual Enumerable<UniquePtr<VulkanDescriptorSet>> allocateMultiple(UInt32 descriptorSets, UInt32 descriptors, const Enumerable<Enumerable<DescriptorBinding>>& bindings = { }) const override;
+		Enumerable<UniquePtr<VulkanDescriptorSet>> allocateMultiple(UInt32 descriptorSets, UInt32 descriptors, const Enumerable<Enumerable<DescriptorBinding>>& bindings = { }) const override;
 
 		/// <inheritdoc />
-		virtual Enumerable<UniquePtr<VulkanDescriptorSet>> allocateMultiple(UInt32 descriptorSets, UInt32 descriptors, std::function<Enumerable<DescriptorBinding>(UInt32)> bindingFactory) const override;
+		Enumerable<UniquePtr<VulkanDescriptorSet>> allocateMultiple(UInt32 descriptorSets, UInt32 descriptors, std::function<Enumerable<DescriptorBinding>(UInt32)> bindingFactory) const override;
 
 		/// <inheritdoc />
-		virtual void free(const VulkanDescriptorSet& descriptorSet) const noexcept override;
+		void free(const VulkanDescriptorSet& descriptorSet) const noexcept override;
 
 	public:
 		/// <summary>
@@ -590,19 +590,19 @@ namespace LiteFX::Rendering::Backends {
 
 	public:
 		/// <inheritdoc />
-		virtual UInt32 space() const noexcept override;
+		UInt32 space() const noexcept override;
 
 		/// <inheritdoc />
-		virtual UInt32 binding() const noexcept override;
+		UInt32 binding() const noexcept override;
 
 		/// <inheritdoc />
-		virtual UInt32 offset() const noexcept override;
+		UInt32 offset() const noexcept override;
 
 		/// <inheritdoc />
-		virtual UInt32 size() const noexcept override;
+		UInt32 size() const noexcept override;
 
 		/// <inheritdoc />
-		virtual ShaderStage stage() const noexcept override;
+		ShaderStage stage() const noexcept override;
 	};
 
 	/// <summary>
@@ -650,13 +650,13 @@ namespace LiteFX::Rendering::Backends {
 	
 	public:
 		/// <inheritdoc />
-		virtual UInt32 size() const noexcept override;
+		UInt32 size() const noexcept override;
 
 		/// <inheritdoc />
-		virtual const VulkanPushConstantsRange& range(ShaderStage stage) const override;
+		const VulkanPushConstantsRange& range(ShaderStage stage) const override;
 
 		/// <inheritdoc />
-		virtual Enumerable<const VulkanPushConstantsRange*> ranges() const noexcept override;
+		Enumerable<const VulkanPushConstantsRange*> ranges() const noexcept override;
 	};
 
 	/// <summary>
@@ -696,13 +696,13 @@ namespace LiteFX::Rendering::Backends {
 		// PipelineLayout interface.
 	public:
 		/// <inheritdoc />
-		virtual const VulkanDescriptorSetLayout& descriptorSet(UInt32 space) const override;
+		const VulkanDescriptorSetLayout& descriptorSet(UInt32 space) const override;
 
 		/// <inheritdoc />
-		virtual Enumerable<const VulkanDescriptorSetLayout*> descriptorSets() const noexcept override;
+		Enumerable<const VulkanDescriptorSetLayout*> descriptorSets() const noexcept override;
 
 		/// <inheritdoc />
-		virtual const VulkanPushConstantsLayout* pushConstants() const noexcept override;
+		const VulkanPushConstantsLayout* pushConstants() const noexcept override;
 	};
 
 	/// <summary>
@@ -733,16 +733,16 @@ namespace LiteFX::Rendering::Backends {
 
 	public:
 		/// <inheritdoc />
-		virtual Enumerable<const VulkanVertexBufferLayout*> vertexBufferLayouts() const noexcept override;
+		Enumerable<const VulkanVertexBufferLayout*> vertexBufferLayouts() const noexcept override;
 
 		/// <inheritdoc />
-		virtual const VulkanVertexBufferLayout& vertexBufferLayout(UInt32 binding) const override;
+		const VulkanVertexBufferLayout& vertexBufferLayout(UInt32 binding) const override;
 
 		/// <inheritdoc />
-		virtual const VulkanIndexBufferLayout& indexBufferLayout() const override;
+		const VulkanIndexBufferLayout& indexBufferLayout() const override;
 
 		/// <inheritdoc />
-		virtual PrimitiveTopology topology() const noexcept override;
+		PrimitiveTopology topology() const noexcept override;
 	};
 
 	/// <summary>
@@ -855,97 +855,97 @@ namespace LiteFX::Rendering::Backends {
 		// CommandBuffer interface.
 	public:
 		/// <inheritdoc />
-		virtual void begin() const override;
+		void begin() const override;
 
 		/// <inheritdoc />
-		virtual void end() const override;
+		void end() const override;
 
 		/// <inheritdoc />
-		virtual bool isSecondary() const noexcept override;
+		bool isSecondary() const noexcept override;
 
 		/// <inheritdoc />
-		virtual void setViewports(Span<const IViewport*> viewports) const noexcept override;
+		void setViewports(Span<const IViewport*> viewports) const noexcept override;
 
 		/// <inheritdoc />
-		virtual void setViewports(const IViewport* viewport) const noexcept override;
+		void setViewports(const IViewport* viewport) const noexcept override;
 
 		/// <inheritdoc />
-		virtual void setScissors(Span<const IScissor*> scissors) const noexcept override;
+		void setScissors(Span<const IScissor*> scissors) const noexcept override;
 
 		/// <inheritdoc />
-		virtual void setScissors(const IScissor* scissor) const noexcept override;
+		void setScissors(const IScissor* scissor) const noexcept override;
 
 		/// <inheritdoc />
-		virtual void setBlendFactors(const Vector4f& blendFactors) const noexcept override;
+		void setBlendFactors(const Vector4f& blendFactors) const noexcept override;
 
 		/// <inheritdoc />
-		virtual void setStencilRef(UInt32 stencilRef) const noexcept override;
+		void setStencilRef(UInt32 stencilRef) const noexcept override;
 
 		/// <inheritdoc />
-		virtual void generateMipMaps(IVulkanImage& image) noexcept override;
+		void generateMipMaps(IVulkanImage& image) noexcept override;
 
 		/// <inheritdoc />
-		virtual void barrier(const VulkanBarrier& barrier) const noexcept override;
+		void barrier(const VulkanBarrier& barrier) const noexcept override;
 
 		/// <inheritdoc />
-		virtual void transfer(IVulkanBuffer& source, IVulkanBuffer& target, UInt32 sourceElement = 0, UInt32 targetElement = 0, UInt32 elements = 1) const override;
+		void transfer(IVulkanBuffer& source, IVulkanBuffer& target, UInt32 sourceElement = 0, UInt32 targetElement = 0, UInt32 elements = 1) const override;
 
 		/// <inheritdoc />
-		virtual void transfer(IVulkanBuffer& source, IVulkanImage& target, UInt32 sourceElement = 0, UInt32 firstSubresource = 0, UInt32 elements = 1) const override;
+		void transfer(IVulkanBuffer& source, IVulkanImage& target, UInt32 sourceElement = 0, UInt32 firstSubresource = 0, UInt32 elements = 1) const override;
 
 		/// <inheritdoc />
-		virtual void transfer(IVulkanImage& source, IVulkanImage& target, UInt32 sourceSubresource = 0, UInt32 targetSubresource = 0, UInt32 subresources = 1) const override;
+		void transfer(IVulkanImage& source, IVulkanImage& target, UInt32 sourceSubresource = 0, UInt32 targetSubresource = 0, UInt32 subresources = 1) const override;
 
 		/// <inheritdoc />
-		virtual void transfer(IVulkanImage& source, IVulkanBuffer& target, UInt32 firstSubresource = 0, UInt32 targetElement = 0, UInt32 subresources = 1) const override;
+		void transfer(IVulkanImage& source, IVulkanBuffer& target, UInt32 firstSubresource = 0, UInt32 targetElement = 0, UInt32 subresources = 1) const override;
 
 		/// <inheritdoc />
-		virtual void transfer(SharedPtr<IVulkanBuffer> source, IVulkanBuffer& target, UInt32 sourceElement = 0, UInt32 targetElement = 0, UInt32 elements = 1) const override;
+		void transfer(SharedPtr<IVulkanBuffer> source, IVulkanBuffer& target, UInt32 sourceElement = 0, UInt32 targetElement = 0, UInt32 elements = 1) const override;
 
 		/// <inheritdoc />
-		virtual void transfer(SharedPtr<IVulkanBuffer> source, IVulkanImage& target, UInt32 sourceElement = 0, UInt32 firstSubresource = 0, UInt32 elements = 1) const override;
+		void transfer(SharedPtr<IVulkanBuffer> source, IVulkanImage& target, UInt32 sourceElement = 0, UInt32 firstSubresource = 0, UInt32 elements = 1) const override;
 
 		/// <inheritdoc />
-		virtual void transfer(SharedPtr<IVulkanImage> source, IVulkanImage& target, UInt32 sourceSubresource = 0, UInt32 targetSubresource = 0, UInt32 subresources = 1) const override;
+		void transfer(SharedPtr<IVulkanImage> source, IVulkanImage& target, UInt32 sourceSubresource = 0, UInt32 targetSubresource = 0, UInt32 subresources = 1) const override;
 
 		/// <inheritdoc />
-		virtual void transfer(SharedPtr<IVulkanImage> source, IVulkanBuffer& target, UInt32 firstSubresource = 0, UInt32 targetElement = 0, UInt32 subresources = 1) const override;
+		void transfer(SharedPtr<IVulkanImage> source, IVulkanBuffer& target, UInt32 firstSubresource = 0, UInt32 targetElement = 0, UInt32 subresources = 1) const override;
 
 		/// <inheritdoc />
-		virtual void use(const VulkanPipelineState& pipeline) const noexcept override;
+		void use(const VulkanPipelineState& pipeline) const noexcept override;
 
 		/// <inheritdoc />
-		virtual void bind(const VulkanDescriptorSet& descriptorSet, const VulkanPipelineState& pipeline) const noexcept override;
+		void bind(const VulkanDescriptorSet& descriptorSet, const VulkanPipelineState& pipeline) const noexcept override;
 
 		/// <inheritdoc />
-		virtual void bind(const IVulkanVertexBuffer& buffer) const noexcept override;
+		void bind(const IVulkanVertexBuffer& buffer) const noexcept override;
 
 		/// <inheritdoc />
-		virtual void bind(const IVulkanIndexBuffer& buffer) const noexcept override;
+		void bind(const IVulkanIndexBuffer& buffer) const noexcept override;
 
 		/// <inheritdoc />
-		virtual void dispatch(const Vector3u& threadCount) const noexcept override;
+		void dispatch(const Vector3u& threadCount) const noexcept override;
 
 		/// <inheritdoc />
-		virtual void draw(UInt32 vertices, UInt32 instances = 1, UInt32 firstVertex = 0, UInt32 firstInstance = 0) const noexcept override;
+		void draw(UInt32 vertices, UInt32 instances = 1, UInt32 firstVertex = 0, UInt32 firstInstance = 0) const noexcept override;
 
 		/// <inheritdoc />
-		virtual void drawIndexed(UInt32 indices, UInt32 instances = 1, UInt32 firstIndex = 0, Int32 vertexOffset = 0, UInt32 firstInstance = 0) const noexcept override;
+		void drawIndexed(UInt32 indices, UInt32 instances = 1, UInt32 firstIndex = 0, Int32 vertexOffset = 0, UInt32 firstInstance = 0) const noexcept override;
 
 		/// <inheritdoc />
-		virtual void pushConstants(const VulkanPushConstantsLayout& layout, const void* const memory) const noexcept override;
+		void pushConstants(const VulkanPushConstantsLayout& layout, const void* const memory) const noexcept override;
 
 		/// <inheritdoc />
-		virtual void writeTimingEvent(SharedPtr<const TimingEvent> timingEvent) const override;
+		void writeTimingEvent(SharedPtr<const TimingEvent> timingEvent) const override;
 
 		/// <inheritdoc />
-		virtual void execute(SharedPtr<const VulkanCommandBuffer> commandBuffer) const override;
+		void execute(SharedPtr<const VulkanCommandBuffer> commandBuffer) const override;
 
 		/// <inheritdoc />
-		virtual void execute(Enumerable<SharedPtr<const VulkanCommandBuffer>> commandBuffers) const override;
+		void execute(Enumerable<SharedPtr<const VulkanCommandBuffer>> commandBuffers) const override;
 
 	private:
-		virtual void releaseSharedState() const override;
+		void releaseSharedState() const override;
 	};
 
 	/// <summary>
@@ -984,29 +984,29 @@ namespace LiteFX::Rendering::Backends {
 		// Pipeline interface.
 	public:
 		/// <inheritdoc />
-		virtual SharedPtr<const VulkanShaderProgram> program() const noexcept override;
+		SharedPtr<const VulkanShaderProgram> program() const noexcept override;
 
 		/// <inheritdoc />
-		virtual SharedPtr<const VulkanPipelineLayout> layout() const noexcept override;
+		SharedPtr<const VulkanPipelineLayout> layout() const noexcept override;
 
 		// RenderPipeline interface.
 	public:
 		/// <inheritdoc />
-		virtual SharedPtr<VulkanInputAssembler> inputAssembler() const noexcept override;
+		SharedPtr<VulkanInputAssembler> inputAssembler() const noexcept override;
 
 		/// <inheritdoc />
-		virtual SharedPtr<VulkanRasterizer> rasterizer() const noexcept override;
+		SharedPtr<VulkanRasterizer> rasterizer() const noexcept override;
 
 		/// <inheritdoc />
-		virtual bool alphaToCoverage() const noexcept override;
+		bool alphaToCoverage() const noexcept override;
 
 		// VulkanPipelineState interface.
 	public:
 		/// <inheritdoc />
-		virtual void use(const VulkanCommandBuffer& commandBuffer) const noexcept override;
+		void use(const VulkanCommandBuffer& commandBuffer) const noexcept override;
 
 		/// <inheritdoc />
-		virtual void bind(const VulkanCommandBuffer& commandBuffer, const VulkanDescriptorSet& descriptorSet) const noexcept override;
+		void bind(const VulkanCommandBuffer& commandBuffer, const VulkanDescriptorSet& descriptorSet) const noexcept override;
 	};
 
 	/// <summary>
@@ -1041,18 +1041,18 @@ namespace LiteFX::Rendering::Backends {
 		// Pipeline interface.
 	public:
 		/// <inheritdoc />
-		virtual SharedPtr<const VulkanShaderProgram> program() const noexcept override;
+		SharedPtr<const VulkanShaderProgram> program() const noexcept override;
 
 		/// <inheritdoc />
-		virtual SharedPtr<const VulkanPipelineLayout> layout() const noexcept override;
+		SharedPtr<const VulkanPipelineLayout> layout() const noexcept override;
 
 		// VulkanPipelineState interface.
 	public:
 		/// <inheritdoc />
-		virtual void use(const VulkanCommandBuffer& commandBuffer) const noexcept override;
+		void use(const VulkanCommandBuffer& commandBuffer) const noexcept override;
 
 		/// <inheritdoc />
-		virtual void bind(const VulkanCommandBuffer& commandBuffer, const VulkanDescriptorSet& descriptorSet) const noexcept override;
+		void bind(const VulkanCommandBuffer& commandBuffer, const VulkanDescriptorSet& descriptorSet) const noexcept override;
 	};
 
 	/// <summary>
@@ -1095,32 +1095,32 @@ namespace LiteFX::Rendering::Backends {
 		// FrameBuffer interface.
 	public:
 		/// <inheritdoc />
-		virtual UInt32 bufferIndex() const noexcept override;
+		UInt32 bufferIndex() const noexcept override;
 
 		/// <inheritdoc />
-		virtual const Size2d& size() const noexcept override;
+		const Size2d& size() const noexcept override;
 
 		/// <inheritdoc />
-		virtual size_t getWidth() const noexcept override;
+		size_t getWidth() const noexcept override;
 
 		/// <inheritdoc />
-		virtual size_t getHeight() const noexcept override;
+		size_t getHeight() const noexcept override;
 
 		/// <inheritdoc />
-		virtual SharedPtr<const VulkanCommandBuffer> commandBuffer(UInt32 index) const override;
+		SharedPtr<const VulkanCommandBuffer> commandBuffer(UInt32 index) const override;
 
 		/// <inheritdoc />
-		virtual Enumerable<SharedPtr<const VulkanCommandBuffer>> commandBuffers() const noexcept override;
+		Enumerable<SharedPtr<const VulkanCommandBuffer>> commandBuffers() const noexcept override;
 
 		/// <inheritdoc />
-		virtual Enumerable<const IVulkanImage*> images() const noexcept override;
+		Enumerable<const IVulkanImage*> images() const noexcept override;
 
 		/// <inheritdoc />
-		virtual const IVulkanImage& image(UInt32 location) const override;
+		const IVulkanImage& image(UInt32 location) const override;
 
 	public:
 		/// <inheritdoc />
-		virtual void resize(const Size2d& renderArea) override;
+		void resize(const Size2d& renderArea) override;
 	};
 
 	/// <summary>
@@ -1176,7 +1176,7 @@ namespace LiteFX::Rendering::Backends {
 		// IInputAttachmentMappingSource interface.
 	public:
 		/// <inheritdoc />
-		virtual const VulkanFrameBuffer& frameBuffer(UInt32 buffer) const override;
+		const VulkanFrameBuffer& frameBuffer(UInt32 buffer) const override;
 
 		// RenderPass interface.
 	public:
@@ -1187,44 +1187,44 @@ namespace LiteFX::Rendering::Backends {
 		virtual const VulkanDevice& device() const noexcept;
 
 		/// <inheritdoc />
-		virtual const VulkanFrameBuffer& activeFrameBuffer() const override;
+		const VulkanFrameBuffer& activeFrameBuffer() const override;
 
 		/// <inheritdoc />
-		virtual Enumerable<const VulkanFrameBuffer*> frameBuffers() const noexcept override;
+		Enumerable<const VulkanFrameBuffer*> frameBuffers() const noexcept override;
 
 		/// <inheritdoc />
-		virtual Enumerable<const VulkanRenderPipeline*> pipelines() const noexcept override;
+		Enumerable<const VulkanRenderPipeline*> pipelines() const noexcept override;
 
 		/// <inheritdoc />
-		virtual const RenderTarget& renderTarget(UInt32 location) const override;
+		const RenderTarget& renderTarget(UInt32 location) const override;
 
 		/// <inheritdoc />
-		virtual Span<const RenderTarget> renderTargets() const noexcept override;
+		Span<const RenderTarget> renderTargets() const noexcept override;
 
 		/// <inheritdoc />
-		virtual bool hasPresentTarget() const noexcept override;
+		bool hasPresentTarget() const noexcept override;
 
 		/// <inheritdoc />
-		virtual Span<const VulkanInputAttachmentMapping> inputAttachments() const noexcept override;
+		Span<const VulkanInputAttachmentMapping> inputAttachments() const noexcept override;
 
 		/// <inheritdoc />
-		virtual MultiSamplingLevel multiSamplingLevel() const noexcept override;
+		MultiSamplingLevel multiSamplingLevel() const noexcept override;
 
 	public:
 		/// <inheritdoc />
-		virtual void begin(UInt32 buffer) override;
+		void begin(UInt32 buffer) override;
 		
 		/// <inheritdoc />
-		virtual void end() const override;
+		void end() const override;
 
 		/// <inheritdoc />
-		virtual void resizeFrameBuffers(const Size2d& renderArea) override;
+		void resizeFrameBuffers(const Size2d& renderArea) override;
 
 		/// <inheritdoc />
-		virtual void changeMultiSamplingLevel(MultiSamplingLevel samples) override;
+		void changeMultiSamplingLevel(MultiSamplingLevel samples) override;
 
 		/// <inheritdoc />
-		virtual void updateAttachments(const VulkanDescriptorSet& descriptorSet) const override;
+		void updateAttachments(const VulkanDescriptorSet& descriptorSet) const override;
 	};
 
 	/// <summary>
@@ -1323,47 +1323,47 @@ namespace LiteFX::Rendering::Backends {
 		// SwapChain interface.
 	public:
 		/// <inheritdoc />
-		virtual Enumerable<SharedPtr<TimingEvent>> timingEvents() const noexcept override;
+		Enumerable<SharedPtr<TimingEvent>> timingEvents() const noexcept override;
 
 		/// <inheritdoc />
-		virtual SharedPtr<TimingEvent> timingEvent(UInt32 queryId) const override;
+		SharedPtr<TimingEvent> timingEvent(UInt32 queryId) const override;
 
 		/// <inheritdoc />
-		virtual UInt64 readTimingEvent(SharedPtr<const TimingEvent> timingEvent) const override;
+		UInt64 readTimingEvent(SharedPtr<const TimingEvent> timingEvent) const override;
 
 		/// <inheritdoc />
-		virtual UInt32 resolveQueryId(SharedPtr<const TimingEvent> timingEvent) const override;
+		UInt32 resolveQueryId(SharedPtr<const TimingEvent> timingEvent) const override;
 
 		/// <inheritdoc />
-		virtual Format surfaceFormat() const noexcept override;
+		Format surfaceFormat() const noexcept override;
 
 		/// <inheritdoc />
-		virtual UInt32 buffers() const noexcept override;
+		UInt32 buffers() const noexcept override;
 
 		/// <inheritdoc />
-		virtual const Size2d& renderArea() const noexcept override;
+		const Size2d& renderArea() const noexcept override;
 
 		/// <inheritdoc />
-		virtual const IVulkanImage* image(UInt32 backBuffer) const override;
+		const IVulkanImage* image(UInt32 backBuffer) const override;
 
 		/// <inheritdoc />
-		virtual Enumerable<const IVulkanImage*> images() const noexcept override;
+		Enumerable<const IVulkanImage*> images() const noexcept override;
 
 		/// <inheritdoc />
-		virtual void present(const VulkanFrameBuffer& frameBuffer) const override;
+		void present(const VulkanFrameBuffer& frameBuffer) const override;
 
 	public:
 		/// <inheritdoc />
-		virtual Enumerable<Format> getSurfaceFormats() const noexcept override;
+		Enumerable<Format> getSurfaceFormats() const noexcept override;
 
 		/// <inheritdoc />
-		virtual void addTimingEvent(SharedPtr<TimingEvent> timingEvent) override;
+		void addTimingEvent(SharedPtr<TimingEvent> timingEvent) override;
 
 		/// <inheritdoc />
-		virtual void reset(Format surfaceFormat, const Size2d& renderArea, UInt32 buffers) override;
+		void reset(Format surfaceFormat, const Size2d& renderArea, UInt32 buffers) override;
 
 		/// <inheritdoc />
-		[[nodiscard]] virtual UInt32 swapBackBuffer() const override;
+		[[nodiscard]] UInt32 swapBackBuffer() const override;
 	};
 
 	/// <summary>
@@ -1466,47 +1466,47 @@ namespace LiteFX::Rendering::Backends {
 		// CommandQueue interface.
 	public:
 		/// <inheritdoc />
-		virtual bool isBound() const noexcept override;
+		bool isBound() const noexcept override;
 
 		/// <inheritdoc />
-		virtual QueuePriority priority() const noexcept override;
+		QueuePriority priority() const noexcept override;
 
 		/// <inheritdoc />
-		virtual QueueType type() const noexcept override;
+		QueueType type() const noexcept override;
 
 #ifndef NDEBUG
 	public:
 		/// <inheritdoc />
-		virtual void BeginDebugRegion(const String& label, const Vectors::ByteVector3& color = { 128_b, 128_b, 128_b }) const noexcept override;
+		void BeginDebugRegion(const String& label, const Vectors::ByteVector3& color = { 128_b, 128_b, 128_b }) const noexcept override;
 
 		/// <inheritdoc />
-		virtual void EndDebugRegion() const noexcept override;
+		void EndDebugRegion() const noexcept override;
 
 		/// <inheritdoc />
-		virtual void SetDebugMarker(const String& label, const Vectors::ByteVector3& color = { 128_b, 128_b, 128_b }) const noexcept override;
+		void SetDebugMarker(const String& label, const Vectors::ByteVector3& color = { 128_b, 128_b, 128_b }) const noexcept override;
 #endif
 
 	public:
 		/// <inheritdoc />
-		virtual void bind() override;
+		void bind() override;
 
 		/// <inheritdoc />
-		virtual void release() override;
+		void release() override;
 
 		/// <inheritdoc />
-		virtual SharedPtr<VulkanCommandBuffer> createCommandBuffer(bool beginRecording = false, bool secondary = false) const override;
+		SharedPtr<VulkanCommandBuffer> createCommandBuffer(bool beginRecording = false, bool secondary = false) const override;
 
 		/// <inheritdoc />
-		virtual UInt64 submit(SharedPtr<const VulkanCommandBuffer> commandBuffer) const override;
+		UInt64 submit(SharedPtr<const VulkanCommandBuffer> commandBuffer) const override;
 
 		/// <inheritdoc />
-		virtual UInt64 submit(const Enumerable<SharedPtr<const VulkanCommandBuffer>>& commandBuffers) const override;
+		UInt64 submit(const Enumerable<SharedPtr<const VulkanCommandBuffer>>& commandBuffers) const override;
 
 		/// <inheritdoc />
-		virtual void waitFor(UInt64 fence) const noexcept override;
+		void waitFor(UInt64 fence) const noexcept override;
 
 		/// <inheritdoc />
-		virtual UInt64 currentFence() const noexcept override;
+		UInt64 currentFence() const noexcept override;
 	};
 
 	/// <summary>
@@ -1541,46 +1541,46 @@ namespace LiteFX::Rendering::Backends {
 
 	public:
 		/// <inheritdoc />
-		virtual UniquePtr<IVulkanBuffer> createBuffer(BufferType type, BufferUsage usage, size_t elementSize, UInt32 elements = 1, bool allowWrite = false) const override;
+		UniquePtr<IVulkanBuffer> createBuffer(BufferType type, BufferUsage usage, size_t elementSize, UInt32 elements = 1, bool allowWrite = false) const override;
 
 		/// <inheritdoc />
-		virtual UniquePtr<IVulkanBuffer> createBuffer(const String& name, BufferType type, BufferUsage usage, size_t elementSize, UInt32 elements = 1, bool allowWrite = false) const override;
+		UniquePtr<IVulkanBuffer> createBuffer(const String& name, BufferType type, BufferUsage usage, size_t elementSize, UInt32 elements = 1, bool allowWrite = false) const override;
 
 		/// <inheritdoc />
-		virtual UniquePtr<IVulkanVertexBuffer> createVertexBuffer(const VulkanVertexBufferLayout& layout, BufferUsage usage, UInt32 elements = 1) const override;
+		UniquePtr<IVulkanVertexBuffer> createVertexBuffer(const VulkanVertexBufferLayout& layout, BufferUsage usage, UInt32 elements = 1) const override;
 
 		/// <inheritdoc />
-		virtual UniquePtr<IVulkanVertexBuffer> createVertexBuffer(const String& name, const VulkanVertexBufferLayout& layout, BufferUsage usage, UInt32 elements = 1) const override;
+		UniquePtr<IVulkanVertexBuffer> createVertexBuffer(const String& name, const VulkanVertexBufferLayout& layout, BufferUsage usage, UInt32 elements = 1) const override;
 
 		/// <inheritdoc />
-		virtual UniquePtr<IVulkanIndexBuffer> createIndexBuffer(const VulkanIndexBufferLayout& layout, BufferUsage usage, UInt32 elements) const override;
+		UniquePtr<IVulkanIndexBuffer> createIndexBuffer(const VulkanIndexBufferLayout& layout, BufferUsage usage, UInt32 elements) const override;
 
 		/// <inheritdoc />
-		virtual UniquePtr<IVulkanIndexBuffer> createIndexBuffer(const String& name, const VulkanIndexBufferLayout& layout, BufferUsage usage, UInt32 elements) const override;
+		UniquePtr<IVulkanIndexBuffer> createIndexBuffer(const String& name, const VulkanIndexBufferLayout& layout, BufferUsage usage, UInt32 elements) const override;
 
 		/// <inheritdoc />
-		virtual UniquePtr<IVulkanImage> createAttachment(Format format, const Size2d& size, MultiSamplingLevel samples = MultiSamplingLevel::x1) const override;
+		UniquePtr<IVulkanImage> createAttachment(Format format, const Size2d& size, MultiSamplingLevel samples = MultiSamplingLevel::x1) const override;
 
 		/// <inheritdoc />
-		virtual UniquePtr<IVulkanImage> createAttachment(const String& name, Format format, const Size2d& size, MultiSamplingLevel samples = MultiSamplingLevel::x1) const override;
+		UniquePtr<IVulkanImage> createAttachment(const String& name, Format format, const Size2d& size, MultiSamplingLevel samples = MultiSamplingLevel::x1) const override;
 
 		/// <inheritdoc />
-		virtual UniquePtr<IVulkanImage> createTexture(Format format, const Size3d& size, ImageDimensions dimension = ImageDimensions::DIM_2, UInt32 levels = 1, UInt32 layers = 1, MultiSamplingLevel samples = MultiSamplingLevel::x1, bool allowWrite = false) const override;
+		UniquePtr<IVulkanImage> createTexture(Format format, const Size3d& size, ImageDimensions dimension = ImageDimensions::DIM_2, UInt32 levels = 1, UInt32 layers = 1, MultiSamplingLevel samples = MultiSamplingLevel::x1, bool allowWrite = false) const override;
 
 		/// <inheritdoc />
-		virtual UniquePtr<IVulkanImage> createTexture(const String& name, Format format, const Size3d& size, ImageDimensions dimension = ImageDimensions::DIM_2, UInt32 levels = 1, UInt32 layers = 1, MultiSamplingLevel samples = MultiSamplingLevel::x1, bool allowWrite = false) const override;
+		UniquePtr<IVulkanImage> createTexture(const String& name, Format format, const Size3d& size, ImageDimensions dimension = ImageDimensions::DIM_2, UInt32 levels = 1, UInt32 layers = 1, MultiSamplingLevel samples = MultiSamplingLevel::x1, bool allowWrite = false) const override;
 
 		/// <inheritdoc />
-		virtual Enumerable<UniquePtr<IVulkanImage>> createTextures(UInt32 elements, Format format, const Size3d& size, ImageDimensions dimension = ImageDimensions::DIM_2, UInt32 levels = 1, UInt32 layers = 1, MultiSamplingLevel samples = MultiSamplingLevel::x1, bool allowWrite = false) const override;
+		Enumerable<UniquePtr<IVulkanImage>> createTextures(UInt32 elements, Format format, const Size3d& size, ImageDimensions dimension = ImageDimensions::DIM_2, UInt32 levels = 1, UInt32 layers = 1, MultiSamplingLevel samples = MultiSamplingLevel::x1, bool allowWrite = false) const override;
 
 		/// <inheritdoc />
-		virtual UniquePtr<IVulkanSampler> createSampler(FilterMode magFilter = FilterMode::Nearest, FilterMode minFilter = FilterMode::Nearest, BorderMode borderU = BorderMode::Repeat, BorderMode borderV = BorderMode::Repeat, BorderMode borderW = BorderMode::Repeat, MipMapMode mipMapMode = MipMapMode::Nearest, Float mipMapBias = 0.f, Float maxLod = std::numeric_limits<Float>::max(), Float minLod = 0.f, Float anisotropy = 0.f) const override;
+		UniquePtr<IVulkanSampler> createSampler(FilterMode magFilter = FilterMode::Nearest, FilterMode minFilter = FilterMode::Nearest, BorderMode borderU = BorderMode::Repeat, BorderMode borderV = BorderMode::Repeat, BorderMode borderW = BorderMode::Repeat, MipMapMode mipMapMode = MipMapMode::Nearest, Float mipMapBias = 0.f, Float maxLod = std::numeric_limits<Float>::max(), Float minLod = 0.f, Float anisotropy = 0.f) const override;
 
 		/// <inheritdoc />
-		virtual UniquePtr<IVulkanSampler> createSampler(const String& name, FilterMode magFilter = FilterMode::Nearest, FilterMode minFilter = FilterMode::Nearest, BorderMode borderU = BorderMode::Repeat, BorderMode borderV = BorderMode::Repeat, BorderMode borderW = BorderMode::Repeat, MipMapMode mipMapMode = MipMapMode::Nearest, Float mipMapBias = 0.f, Float maxLod = std::numeric_limits<Float>::max(), Float minLod = 0.f, Float anisotropy = 0.f) const override;
+		UniquePtr<IVulkanSampler> createSampler(const String& name, FilterMode magFilter = FilterMode::Nearest, FilterMode minFilter = FilterMode::Nearest, BorderMode borderU = BorderMode::Repeat, BorderMode borderV = BorderMode::Repeat, BorderMode borderW = BorderMode::Repeat, MipMapMode mipMapMode = MipMapMode::Nearest, Float mipMapBias = 0.f, Float maxLod = std::numeric_limits<Float>::max(), Float minLod = 0.f, Float anisotropy = 0.f) const override;
 
 		/// <inheritdoc />
-		virtual Enumerable<UniquePtr<IVulkanSampler>> createSamplers(UInt32 elements, FilterMode magFilter = FilterMode::Nearest, FilterMode minFilter = FilterMode::Nearest, BorderMode borderU = BorderMode::Repeat, BorderMode borderV = BorderMode::Repeat, BorderMode borderW = BorderMode::Repeat, MipMapMode mipMapMode = MipMapMode::Nearest, Float mipMapBias = 0.f, Float maxLod = std::numeric_limits<Float>::max(), Float minLod = 0.f, Float anisotropy = 0.f) const override;
+		Enumerable<UniquePtr<IVulkanSampler>> createSamplers(UInt32 elements, FilterMode magFilter = FilterMode::Nearest, FilterMode minFilter = FilterMode::Nearest, BorderMode borderU = BorderMode::Repeat, BorderMode borderV = BorderMode::Repeat, BorderMode borderW = BorderMode::Repeat, MipMapMode mipMapMode = MipMapMode::Nearest, Float mipMapBias = 0.f, Float maxLod = std::numeric_limits<Float>::max(), Float minLod = 0.f, Float anisotropy = 0.f) const override;
 	};
 
 	/// <summary>
@@ -1638,78 +1638,78 @@ namespace LiteFX::Rendering::Backends {
 		// GraphicsDevice interface.
 	public:
 		/// <inheritdoc />
-		virtual DeviceState& state() const noexcept override;
+		DeviceState& state() const noexcept override;
 
 		/// <inheritdoc />
-		virtual const VulkanSwapChain& swapChain() const noexcept override;
+		const VulkanSwapChain& swapChain() const noexcept override;
 
 		/// <inheritdoc />
-		virtual VulkanSwapChain& swapChain() noexcept override;
+		VulkanSwapChain& swapChain() noexcept override;
 
 		/// <inheritdoc />
-		virtual const VulkanSurface& surface() const noexcept override;
+		const VulkanSurface& surface() const noexcept override;
 
 		/// <inheritdoc />
-		virtual const VulkanGraphicsAdapter& adapter() const noexcept override;
+		const VulkanGraphicsAdapter& adapter() const noexcept override;
 
 		/// <inheritdoc />
-		virtual const VulkanGraphicsFactory& factory() const noexcept override;
+		const VulkanGraphicsFactory& factory() const noexcept override;
 		
 		/// <inheritdoc />
-		virtual const VulkanQueue& graphicsQueue() const noexcept override;
+		const VulkanQueue& graphicsQueue() const noexcept override;
 		
 		/// <inheritdoc />
-		virtual const VulkanQueue& transferQueue() const noexcept override;
+		const VulkanQueue& transferQueue() const noexcept override;
 
 		/// <inheritdoc />
-		virtual const VulkanQueue& bufferQueue() const noexcept override;
+		const VulkanQueue& bufferQueue() const noexcept override;
 
 		/// <inheritdoc />
-		virtual const VulkanQueue& computeQueue() const noexcept override;
+		const VulkanQueue& computeQueue() const noexcept override;
 
 		/// <inheritdoc />
-		[[nodiscard]] virtual UniquePtr<VulkanBarrier> makeBarrier(PipelineStage syncBefore, PipelineStage syncAfter) const noexcept override;
+		[[nodiscard]] UniquePtr<VulkanBarrier> makeBarrier(PipelineStage syncBefore, PipelineStage syncAfter) const noexcept override;
 
 		/// <inheritdoc />
-		virtual MultiSamplingLevel maximumMultiSamplingLevel(Format format) const noexcept override;
+		MultiSamplingLevel maximumMultiSamplingLevel(Format format) const noexcept override;
 
 		/// <inheritdoc />
-		virtual double ticksPerMillisecond() const noexcept override;
+		double ticksPerMillisecond() const noexcept override;
 
 		/// <inheritdoc />
-		virtual void wait() const override;
+		void wait() const override;
 
 #if defined(BUILD_DEFINE_BUILDERS)
 	public:
 		/// <inheritdoc />
-		[[nodiscard]] virtual VulkanRenderPassBuilder buildRenderPass(MultiSamplingLevel samples = MultiSamplingLevel::x1, UInt32 commandBuffers = 1) const override;
+		[[nodiscard]] VulkanRenderPassBuilder buildRenderPass(MultiSamplingLevel samples = MultiSamplingLevel::x1, UInt32 commandBuffers = 1) const override;
 
 		/// <inheritdoc />
-		[[nodiscard]] virtual VulkanRenderPassBuilder buildRenderPass(const String& name, MultiSamplingLevel samples = MultiSamplingLevel::x1, UInt32 commandBuffers = 1) const override;
+		[[nodiscard]] VulkanRenderPassBuilder buildRenderPass(const String& name, MultiSamplingLevel samples = MultiSamplingLevel::x1, UInt32 commandBuffers = 1) const override;
 
 		/// <inheritdoc />
-		//[[nodiscard]] virtual VulkanRenderPipelineBuilder buildRenderPipeline(const String& name) const override;
+		//[[nodiscard]] VulkanRenderPipelineBuilder buildRenderPipeline(const String& name) const override;
 
 		/// <inheritdoc />
-		[[nodiscard]] virtual VulkanRenderPipelineBuilder buildRenderPipeline(const VulkanRenderPass& renderPass, const String& name) const override;
+		[[nodiscard]] VulkanRenderPipelineBuilder buildRenderPipeline(const VulkanRenderPass& renderPass, const String& name) const override;
 
 		/// <inheritdoc />
-		[[nodiscard]] virtual VulkanComputePipelineBuilder buildComputePipeline(const String& name) const override;
+		[[nodiscard]] VulkanComputePipelineBuilder buildComputePipeline(const String& name) const override;
 		
 		/// <inheritdoc />
-		[[nodiscard]] virtual VulkanPipelineLayoutBuilder buildPipelineLayout() const override;
+		[[nodiscard]] VulkanPipelineLayoutBuilder buildPipelineLayout() const override;
 
 		/// <inheritdoc />
-		[[nodiscard]] virtual VulkanInputAssemblerBuilder buildInputAssembler() const override;
+		[[nodiscard]] VulkanInputAssemblerBuilder buildInputAssembler() const override;
 
 		/// <inheritdoc />
-		[[nodiscard]] virtual VulkanRasterizerBuilder buildRasterizer() const override;
+		[[nodiscard]] VulkanRasterizerBuilder buildRasterizer() const override;
 
 		/// <inheritdoc />
-		[[nodiscard]] virtual VulkanShaderProgramBuilder buildShaderProgram() const override;
+		[[nodiscard]] VulkanShaderProgramBuilder buildShaderProgram() const override;
 
 		/// <inheritdoc />
-		[[nodiscard]] virtual VulkanBarrierBuilder buildBarrier() const override;
+		[[nodiscard]] VulkanBarrierBuilder buildBarrier() const override;
 #endif // defined(BUILD_DEFINE_BUILDERS)
 	};
 
@@ -1793,36 +1793,36 @@ namespace LiteFX::Rendering::Backends {
 		// IBackend interface.
 	public:
 		/// <inheritdoc />
-		virtual BackendType type() const noexcept override;
+		BackendType type() const noexcept override;
 
 		/// <inheritdoc />
-		virtual String name() const noexcept override;
+		String name() const noexcept override;
 
 	protected:
 		/// <inheritdoc />
-		virtual void activate() override;
+		void activate() override;
 
 		/// <inheritdoc />
-		virtual void deactivate() override;
+		void deactivate() override;
 
 		// RenderBackend interface.
 	public:
 		/// <inheritdoc />
-		virtual Enumerable<const VulkanGraphicsAdapter*> listAdapters() const override;
+		Enumerable<const VulkanGraphicsAdapter*> listAdapters() const override;
 
 		/// <inheritdoc />
-		virtual const VulkanGraphicsAdapter* findAdapter(const Optional<UInt64>& adapterId = std::nullopt) const override;
+		const VulkanGraphicsAdapter* findAdapter(const Optional<UInt64>& adapterId = std::nullopt) const override;
 
 		/// <inheritdoc />
-		virtual void registerDevice(String name, UniquePtr<VulkanDevice>&& device) override;
+		void registerDevice(String name, UniquePtr<VulkanDevice>&& device) override;
 
 		/// <inheritdoc />
-		virtual void releaseDevice(const String& name) override;
+		void releaseDevice(const String& name) override;
 
 		/// <inheritdoc />
-		virtual VulkanDevice* device(const String& name) noexcept override;
+		VulkanDevice* device(const String& name) noexcept override;
 
 		/// <inheritdoc />
-		virtual const VulkanDevice* device(const String& name) const noexcept override;
+		const VulkanDevice* device(const String& name) const noexcept override;
 	};
 }

--- a/src/Backends/Vulkan/include/litefx/backends/vulkan.hpp
+++ b/src/Backends/Vulkan/include/litefx/backends/vulkan.hpp
@@ -44,7 +44,7 @@ namespace LiteFX::Rendering::Backends {
 		virtual const UInt32& binding() const noexcept override;
 
 		/// <inheritdoc />
-		virtual const BufferType& type() const noexcept override;
+		virtual BufferType type() const noexcept override;
 	};
 
 	/// <summary>
@@ -60,7 +60,7 @@ namespace LiteFX::Rendering::Backends {
 		/// Initializes a new index buffer layout
 		/// </summary>
 		/// <param name="type">The type of the indices within the index buffer.</param>
-		explicit VulkanIndexBufferLayout(const IndexType& type);
+		explicit VulkanIndexBufferLayout(IndexType type);
 		VulkanIndexBufferLayout(VulkanIndexBufferLayout&&) = delete;
 		VulkanIndexBufferLayout(const VulkanIndexBufferLayout&) = delete;
 		virtual ~VulkanIndexBufferLayout() noexcept;
@@ -68,7 +68,7 @@ namespace LiteFX::Rendering::Backends {
 		// IIndexBufferLayout interface.
 	public:
 		/// <inheritdoc />
-		virtual const IndexType& indexType() const noexcept override;
+		virtual IndexType indexType() const noexcept override;
 
 		// IBufferLayout interface.
 	public:
@@ -79,7 +79,7 @@ namespace LiteFX::Rendering::Backends {
 		virtual const UInt32& binding() const noexcept override;
 
 		/// <inheritdoc />
-		virtual const BufferType& type() const noexcept override;
+		virtual BufferType type() const noexcept override;
 	};
 
 	/// <summary>
@@ -187,7 +187,7 @@ namespace LiteFX::Rendering::Backends {
 		/// </summary>
 		/// <param name="syncBefore">The pipeline stage(s) all previous commands have to finish before the barrier is executed.</param>
 		/// <param name="syncAfter">The pipeline stage(s) all subsequent commands are blocked at until the barrier is executed.</param>
-		constexpr inline explicit VulkanBarrier(const PipelineStage& syncBefore, const PipelineStage& syncAfter) noexcept;
+		constexpr inline explicit VulkanBarrier(PipelineStage syncBefore, PipelineStage syncAfter) noexcept;
 		VulkanBarrier(const VulkanBarrier&) = delete;
 		VulkanBarrier(VulkanBarrier&&) = delete;
 		constexpr inline virtual ~VulkanBarrier() noexcept;
@@ -200,31 +200,31 @@ namespace LiteFX::Rendering::Backends {
 		// Barrier interface.
 	public:
 		/// <inheritdoc />
-		constexpr inline const PipelineStage& syncBefore() const noexcept override;
+		constexpr inline PipelineStage syncBefore() const noexcept override;
 
 		/// <inheritdoc />
-		constexpr inline const PipelineStage& syncAfter() const noexcept override;
+		constexpr inline PipelineStage syncAfter() const noexcept override;
 
 		/// <inheritdoc />
-		constexpr inline void wait(const ResourceAccess& accessBefore, const ResourceAccess& accessAfter) noexcept override;
+		constexpr inline void wait(ResourceAccess accessBefore, ResourceAccess accessAfter) noexcept override;
 
 		/// <inheritdoc />
-		constexpr inline void transition(IVulkanBuffer& buffer, const ResourceAccess& accessBefore, const ResourceAccess& accessAfter) override;
+		constexpr inline void transition(IVulkanBuffer& buffer, ResourceAccess accessBefore, ResourceAccess accessAfter) override;
 
 		/// <inheritdoc />
-		constexpr inline void transition(IVulkanBuffer& buffer, const UInt32& element, const ResourceAccess& accessBefore, const ResourceAccess& accessAfter) override;
+		constexpr inline void transition(IVulkanBuffer& buffer, const UInt32& element, ResourceAccess accessBefore, ResourceAccess accessAfter) override;
 
 		/// <inheritdoc />
-		constexpr inline void transition(IVulkanImage& image, const ResourceAccess& accessBefore, const ResourceAccess& accessAfter, const ImageLayout& layout) override;
+		constexpr inline void transition(IVulkanImage& image, ResourceAccess accessBefore, ResourceAccess accessAfter, ImageLayout layout) override;
 
 		/// <inheritdoc />
-		constexpr inline void transition(IVulkanImage& image, const ResourceAccess& accessBefore, const ResourceAccess& accessAfter, const ImageLayout& fromLayout, const ImageLayout& toLayout) override;
+		constexpr inline void transition(IVulkanImage& image, ResourceAccess accessBefore, ResourceAccess accessAfter, ImageLayout fromLayout, ImageLayout toLayout) override;
 
 		/// <inheritdoc />
-		constexpr inline void transition(IVulkanImage& image, const UInt32& level, const UInt32& levels, const UInt32& layer, const UInt32& layers, const UInt32& plane, const ResourceAccess& accessBefore, const ResourceAccess& accessAfter, const ImageLayout& layout) override;
+		constexpr inline void transition(IVulkanImage& image, const UInt32& level, const UInt32& levels, const UInt32& layer, const UInt32& layers, const UInt32& plane, ResourceAccess accessBefore, ResourceAccess accessAfter, ImageLayout layout) override;
 
 		/// <inheritdoc />
-		constexpr inline void transition(IVulkanImage& image, const UInt32& level, const UInt32& levels, const UInt32& layer, const UInt32& layers, const UInt32& plane, const ResourceAccess& accessBefore, const ResourceAccess& accessAfter, const ImageLayout& fromLayout, const ImageLayout& toLayout) override;
+		constexpr inline void transition(IVulkanImage& image, const UInt32& level, const UInt32& levels, const UInt32& layer, const UInt32& layers, const UInt32& plane, ResourceAccess accessBefore, ResourceAccess accessAfter, ImageLayout fromLayout, ImageLayout toLayout) override;
 
 	public:
 		/// <summary>
@@ -252,7 +252,7 @@ namespace LiteFX::Rendering::Backends {
 		/// <param name="type">The shader stage, this module is used in.</param>
 		/// <param name="fileName">The file name of the module source.</param>
 		/// <param name="entryPoint">The name of the module entry point.</param>
-		explicit VulkanShaderModule(const VulkanDevice& device, const ShaderStage& type, const String& fileName, const String& entryPoint = "main");
+		explicit VulkanShaderModule(const VulkanDevice& device, ShaderStage type, const String& fileName, const String& entryPoint = "main");
 
 		/// <summary>
 		/// Initializes a new Vulkan shader module.
@@ -262,7 +262,7 @@ namespace LiteFX::Rendering::Backends {
 		/// <param name="stream">The file stream of the module source.</param>
 		/// <param name="name">The file name of the module source.</param>
 		/// <param name="entryPoint">The name of the module entry point.</param>
-		explicit VulkanShaderModule(const VulkanDevice& device, const ShaderStage& type, std::istream& stream, const String& name, const String& entryPoint = "main");
+		explicit VulkanShaderModule(const VulkanDevice& device, ShaderStage type, std::istream& stream, const String& name, const String& entryPoint = "main");
 		VulkanShaderModule(const VulkanShaderModule&) noexcept = delete;
 		VulkanShaderModule(VulkanShaderModule&&) noexcept = delete;
 		virtual ~VulkanShaderModule() noexcept;
@@ -276,7 +276,7 @@ namespace LiteFX::Rendering::Backends {
 		virtual const String& entryPoint() const noexcept override;
 
 		/// <inheritdoc />
-		virtual const ShaderStage& type() const noexcept override;
+		virtual ShaderStage type() const noexcept override;
 
 	public:
 		/// <summary>
@@ -397,7 +397,7 @@ namespace LiteFX::Rendering::Backends {
 		/// <param name="elementSize">The size of the descriptor.</param>
 		/// <param name="descriptors">The number of descriptors in the descriptor array. If set to `-1`, the descriptor will be unbounded.</param>
 		/// <seealso cref="descriptors" />
-		explicit VulkanDescriptorLayout(const DescriptorType& type, const UInt32& binding, const size_t& elementSize, const UInt32& descriptors = 1);
+		explicit VulkanDescriptorLayout(DescriptorType type, const UInt32& binding, const size_t& elementSize, const UInt32& descriptors = 1);
 
 		/// <summary>
 		/// Initializes a new Vulkan descriptor layout for a static sampler.
@@ -413,7 +413,7 @@ namespace LiteFX::Rendering::Backends {
 		// IDescriptorLayout interface.
 	public:
 		/// <inheritdoc />
-		virtual const DescriptorType& descriptorType() const noexcept override;
+		virtual DescriptorType descriptorType() const noexcept override;
 
 		/// <inheritdoc />
 		virtual const UInt32& descriptors() const noexcept override;
@@ -430,7 +430,7 @@ namespace LiteFX::Rendering::Backends {
 		virtual const UInt32& binding() const noexcept override;
 
 		/// <inheritdoc />
-		virtual const BufferType& type() const noexcept override;
+		virtual BufferType type() const noexcept override;
 	};
 
 	/// <summary>
@@ -461,7 +461,7 @@ namespace LiteFX::Rendering::Backends {
 		/// <param name="stages">The shader stages, the descriptor sets are bound to.</param>
 		/// <param name="poolSize">The size of a descriptor pool.</param>
 		/// <param name="maxUnboundedArraySize">The maximum number of descriptors in an unbounded array.</param>
-		explicit VulkanDescriptorSetLayout(const VulkanDevice& device, Enumerable<UniquePtr<VulkanDescriptorLayout>>&& descriptorLayouts, const UInt32& space, const ShaderStage& stages, const UInt32& poolSize = 1024, const UInt32& maxUnboundedArraySize = 104857);
+		explicit VulkanDescriptorSetLayout(const VulkanDevice& device, Enumerable<UniquePtr<VulkanDescriptorLayout>>&& descriptorLayouts, const UInt32& space, ShaderStage stages, const UInt32& poolSize = 1024, const UInt32& maxUnboundedArraySize = 104857);
 		VulkanDescriptorSetLayout(VulkanDescriptorSetLayout&&) = delete;
 		VulkanDescriptorSetLayout(const VulkanDescriptorSetLayout&) = delete;
 		virtual ~VulkanDescriptorSetLayout() noexcept;
@@ -491,7 +491,7 @@ namespace LiteFX::Rendering::Backends {
 		virtual const UInt32& space() const noexcept override;
 
 		/// <inheritdoc />
-		virtual const ShaderStage& shaderStages() const noexcept override;
+		virtual ShaderStage shaderStages() const noexcept override;
 
 		/// <inheritdoc />
 		virtual UInt32 uniforms() const noexcept override;
@@ -583,7 +583,7 @@ namespace LiteFX::Rendering::Backends {
 		/// <param name="size">The size of the push constants range.</param>
 		/// <param name="space">The space from which the push constants of the range will be accessible in the shader.</param>
 		/// <param name="binding">The register from which the push constants of the range will be accessible in the shader.</param>
-		explicit VulkanPushConstantsRange(const ShaderStage& shaderStage, const UInt32& offset, const UInt32& size, const UInt32& space, const UInt32& binding);
+		explicit VulkanPushConstantsRange(ShaderStage shaderStage, const UInt32& offset, const UInt32& size, const UInt32& space, const UInt32& binding);
 		VulkanPushConstantsRange(const VulkanPushConstantsRange&) = delete;
 		VulkanPushConstantsRange(VulkanPushConstantsRange&&) = delete;
 		virtual ~VulkanPushConstantsRange() noexcept;
@@ -602,7 +602,7 @@ namespace LiteFX::Rendering::Backends {
 		virtual const UInt32& size() const noexcept override;
 
 		/// <inheritdoc />
-		virtual const ShaderStage& stage() const noexcept override;
+		virtual ShaderStage stage() const noexcept override;
 	};
 
 	/// <summary>
@@ -653,7 +653,7 @@ namespace LiteFX::Rendering::Backends {
 		virtual const UInt32& size() const noexcept override;
 
 		/// <inheritdoc />
-		virtual const VulkanPushConstantsRange& range(const ShaderStage& stage) const override;
+		virtual const VulkanPushConstantsRange& range(ShaderStage stage) const override;
 
 		/// <inheritdoc />
 		virtual Enumerable<const VulkanPushConstantsRange*> ranges() const noexcept override;
@@ -761,7 +761,7 @@ namespace LiteFX::Rendering::Backends {
 		/// <param name="cullOrder">The cull order used by the pipeline.</param>
 		/// <param name="lineWidth">The line width used by the pipeline.</param>
 		/// <param name="depthStencilState">The rasterizer depth/stencil state.</param>
-		explicit VulkanRasterizer(const PolygonMode& polygonMode, const CullMode& cullMode, const CullOrder& cullOrder, const Float& lineWidth = 1.f, const DepthStencilState& depthStencilState = {}) noexcept;
+		explicit VulkanRasterizer(PolygonMode polygonMode, CullMode cullMode, CullOrder cullOrder, const Float& lineWidth = 1.f, const DepthStencilState& depthStencilState = {}) noexcept;
 		VulkanRasterizer(VulkanRasterizer&&) noexcept = delete;
 		VulkanRasterizer(const VulkanRasterizer&) noexcept = delete;
 		virtual ~VulkanRasterizer() noexcept;
@@ -1144,7 +1144,7 @@ namespace LiteFX::Rendering::Backends {
 		/// <param name="renderTargets">The render targets that are output by the render pass.</param>
 		/// <param name="samples">The number of samples for the render targets in this render pass.</param>
 		/// <param name="inputAttachments">The input attachments that are read by the render pass.</param>
-		explicit VulkanRenderPass(const VulkanDevice& device, Span<RenderTarget> renderTargets, const UInt32& commandBuffers = 1, const MultiSamplingLevel& samples = MultiSamplingLevel::x1, Span<VulkanInputAttachmentMapping> inputAttachments = { });
+		explicit VulkanRenderPass(const VulkanDevice& device, Span<RenderTarget> renderTargets, const UInt32& commandBuffers = 1, MultiSamplingLevel samples = MultiSamplingLevel::x1, Span<VulkanInputAttachmentMapping> inputAttachments = { });
 
 		/// <summary>
 		/// Creates and initializes a new Vulkan render pass instance.
@@ -1155,7 +1155,7 @@ namespace LiteFX::Rendering::Backends {
 		/// <param name="renderTargets">The render targets that are output by the render pass.</param>
 		/// <param name="samples">The number of samples for the render targets in this render pass.</param>
 		/// <param name="inputAttachments">The input attachments that are read by the render pass.</param>
-		explicit VulkanRenderPass(const VulkanDevice& device, const String& name, Span<RenderTarget> renderTargets, const UInt32& commandBuffers = 1, const MultiSamplingLevel& samples = MultiSamplingLevel::x1, Span<VulkanInputAttachmentMapping> inputAttachments = { });
+		explicit VulkanRenderPass(const VulkanDevice& device, const String& name, Span<RenderTarget> renderTargets, const UInt32& commandBuffers = 1, MultiSamplingLevel samples = MultiSamplingLevel::x1, Span<VulkanInputAttachmentMapping> inputAttachments = { });
 		
 		VulkanRenderPass(const VulkanRenderPass&) = delete;
 		VulkanRenderPass(VulkanRenderPass&&) = delete;
@@ -1208,7 +1208,7 @@ namespace LiteFX::Rendering::Backends {
 		virtual Span<const VulkanInputAttachmentMapping> inputAttachments() const noexcept override;
 
 		/// <inheritdoc />
-		virtual const MultiSamplingLevel& multiSamplingLevel() const noexcept override;
+		virtual MultiSamplingLevel multiSamplingLevel() const noexcept override;
 
 	public:
 		/// <inheritdoc />
@@ -1221,7 +1221,7 @@ namespace LiteFX::Rendering::Backends {
 		virtual void resizeFrameBuffers(const Size2d& renderArea) override;
 
 		/// <inheritdoc />
-		virtual void changeMultiSamplingLevel(const MultiSamplingLevel& samples) override;
+		virtual void changeMultiSamplingLevel(MultiSamplingLevel samples) override;
 
 		/// <inheritdoc />
 		virtual void updateAttachments(const VulkanDescriptorSet& descriptorSet) const override;
@@ -1301,7 +1301,7 @@ namespace LiteFX::Rendering::Backends {
 		/// <param name="format">The initial surface format.</param>
 		/// <param name="renderArea">The initial size of the render area.</param>
 		/// <param name="buffers">The initial number of buffers.</param>
-		explicit VulkanSwapChain(const VulkanDevice& device, const Format& surfaceFormat = Format::B8G8R8A8_SRGB, const Size2d& renderArea = { 800, 600 }, const UInt32& buffers = 3);
+		explicit VulkanSwapChain(const VulkanDevice& device, Format surfaceFormat = Format::B8G8R8A8_SRGB, const Size2d& renderArea = { 800, 600 }, const UInt32& buffers = 3);
 		VulkanSwapChain(const VulkanSwapChain&) = delete;
 		VulkanSwapChain(VulkanSwapChain&&) = delete;
 		virtual ~VulkanSwapChain() noexcept;
@@ -1335,7 +1335,7 @@ namespace LiteFX::Rendering::Backends {
 		virtual UInt32 resolveQueryId(SharedPtr<const TimingEvent> timingEvent) const override;
 
 		/// <inheritdoc />
-		virtual const Format& surfaceFormat() const noexcept override;
+		virtual Format surfaceFormat() const noexcept override;
 
 		/// <inheritdoc />
 		virtual const UInt32& buffers() const noexcept override;
@@ -1360,7 +1360,7 @@ namespace LiteFX::Rendering::Backends {
 		virtual void addTimingEvent(SharedPtr<TimingEvent> timingEvent) override;
 
 		/// <inheritdoc />
-		virtual void reset(const Format& surfaceFormat, const Size2d& renderArea, const UInt32& buffers) override;
+		virtual void reset(Format surfaceFormat, const Size2d& renderArea, const UInt32& buffers) override;
 
 		/// <inheritdoc />
 		[[nodiscard]] virtual UInt32 swapBackBuffer() const override;
@@ -1386,7 +1386,7 @@ namespace LiteFX::Rendering::Backends {
 		/// <param name="priority">The priority, of which commands are issued on the device.</param>
 		/// <param name="familyId">The ID of the queue family.</param>
 		/// <param name="queueId">The ID of the queue.</param>
-		explicit VulkanQueue(const VulkanDevice& device, const QueueType& type, const QueuePriority& priority, const UInt32& familyId, const UInt32& queueId);
+		explicit VulkanQueue(const VulkanDevice& device, QueueType type, QueuePriority priority, const UInt32& familyId, const UInt32& queueId);
 		VulkanQueue(const VulkanQueue&) = delete;
 		VulkanQueue(VulkanQueue&&) = delete;
 		virtual ~VulkanQueue() noexcept;
@@ -1469,10 +1469,10 @@ namespace LiteFX::Rendering::Backends {
 		virtual bool isBound() const noexcept override;
 
 		/// <inheritdoc />
-		virtual const QueuePriority& priority() const noexcept override;
+		virtual QueuePriority priority() const noexcept override;
 
 		/// <inheritdoc />
-		virtual const QueueType& type() const noexcept override;
+		virtual QueueType type() const noexcept override;
 
 #ifndef NDEBUG
 	public:
@@ -1541,46 +1541,46 @@ namespace LiteFX::Rendering::Backends {
 
 	public:
 		/// <inheritdoc />
-		virtual UniquePtr<IVulkanBuffer> createBuffer(const BufferType& type, const BufferUsage& usage, const size_t& elementSize, const UInt32& elements = 1, const bool& allowWrite = false) const override;
+		virtual UniquePtr<IVulkanBuffer> createBuffer(BufferType type, BufferUsage usage, const size_t& elementSize, const UInt32& elements = 1, const bool& allowWrite = false) const override;
 
 		/// <inheritdoc />
-		virtual UniquePtr<IVulkanBuffer> createBuffer(const String& name, const BufferType& type, const BufferUsage& usage, const size_t& elementSize, const UInt32& elements = 1, const bool& allowWrite = false) const override;
+		virtual UniquePtr<IVulkanBuffer> createBuffer(const String& name, BufferType type, BufferUsage usage, const size_t& elementSize, const UInt32& elements = 1, const bool& allowWrite = false) const override;
 
 		/// <inheritdoc />
-		virtual UniquePtr<IVulkanVertexBuffer> createVertexBuffer(const VulkanVertexBufferLayout& layout, const BufferUsage& usage, const UInt32& elements = 1) const override;
+		virtual UniquePtr<IVulkanVertexBuffer> createVertexBuffer(const VulkanVertexBufferLayout& layout, BufferUsage usage, const UInt32& elements = 1) const override;
 
 		/// <inheritdoc />
-		virtual UniquePtr<IVulkanVertexBuffer> createVertexBuffer(const String& name, const VulkanVertexBufferLayout& layout, const BufferUsage& usage, const UInt32& elements = 1) const override;
+		virtual UniquePtr<IVulkanVertexBuffer> createVertexBuffer(const String& name, const VulkanVertexBufferLayout& layout, BufferUsage usage, const UInt32& elements = 1) const override;
 
 		/// <inheritdoc />
-		virtual UniquePtr<IVulkanIndexBuffer> createIndexBuffer(const VulkanIndexBufferLayout& layout, const BufferUsage& usage, const UInt32& elements) const override;
+		virtual UniquePtr<IVulkanIndexBuffer> createIndexBuffer(const VulkanIndexBufferLayout& layout, BufferUsage usage, const UInt32& elements) const override;
 
 		/// <inheritdoc />
-		virtual UniquePtr<IVulkanIndexBuffer> createIndexBuffer(const String& name, const VulkanIndexBufferLayout& layout, const BufferUsage& usage, const UInt32& elements) const override;
+		virtual UniquePtr<IVulkanIndexBuffer> createIndexBuffer(const String& name, const VulkanIndexBufferLayout& layout, BufferUsage usage, const UInt32& elements) const override;
 
 		/// <inheritdoc />
-		virtual UniquePtr<IVulkanImage> createAttachment(const Format& format, const Size2d& size, const MultiSamplingLevel& samples = MultiSamplingLevel::x1) const override;
+		virtual UniquePtr<IVulkanImage> createAttachment(Format format, const Size2d& size, MultiSamplingLevel samples = MultiSamplingLevel::x1) const override;
 
 		/// <inheritdoc />
-		virtual UniquePtr<IVulkanImage> createAttachment(const String& name, const Format& format, const Size2d& size, const MultiSamplingLevel& samples = MultiSamplingLevel::x1) const override;
+		virtual UniquePtr<IVulkanImage> createAttachment(const String& name, Format format, const Size2d& size, MultiSamplingLevel samples = MultiSamplingLevel::x1) const override;
 
 		/// <inheritdoc />
-		virtual UniquePtr<IVulkanImage> createTexture(const Format& format, const Size3d& size, const ImageDimensions& dimension = ImageDimensions::DIM_2, const UInt32& levels = 1, const UInt32& layers = 1, const MultiSamplingLevel& samples = MultiSamplingLevel::x1, const bool& allowWrite = false) const override;
+		virtual UniquePtr<IVulkanImage> createTexture(Format format, const Size3d& size, ImageDimensions dimension = ImageDimensions::DIM_2, const UInt32& levels = 1, const UInt32& layers = 1, MultiSamplingLevel samples = MultiSamplingLevel::x1, const bool& allowWrite = false) const override;
 
 		/// <inheritdoc />
-		virtual UniquePtr<IVulkanImage> createTexture(const String& name, const Format& format, const Size3d& size, const ImageDimensions& dimension = ImageDimensions::DIM_2, const UInt32& levels = 1, const UInt32& layers = 1, const MultiSamplingLevel& samples = MultiSamplingLevel::x1, const bool& allowWrite = false) const override;
+		virtual UniquePtr<IVulkanImage> createTexture(const String& name, Format format, const Size3d& size, ImageDimensions dimension = ImageDimensions::DIM_2, const UInt32& levels = 1, const UInt32& layers = 1, MultiSamplingLevel samples = MultiSamplingLevel::x1, const bool& allowWrite = false) const override;
 
 		/// <inheritdoc />
-		virtual Enumerable<UniquePtr<IVulkanImage>> createTextures(const UInt32& elements, const Format& format, const Size3d& size, const ImageDimensions& dimension = ImageDimensions::DIM_2, const UInt32& levels = 1, const UInt32& layers = 1, const MultiSamplingLevel& samples = MultiSamplingLevel::x1, const bool& allowWrite = false) const override;
+		virtual Enumerable<UniquePtr<IVulkanImage>> createTextures(const UInt32& elements, Format format, const Size3d& size, ImageDimensions dimension = ImageDimensions::DIM_2, const UInt32& levels = 1, const UInt32& layers = 1, MultiSamplingLevel samples = MultiSamplingLevel::x1, const bool& allowWrite = false) const override;
 
 		/// <inheritdoc />
-		virtual UniquePtr<IVulkanSampler> createSampler(const FilterMode& magFilter = FilterMode::Nearest, const FilterMode& minFilter = FilterMode::Nearest, const BorderMode& borderU = BorderMode::Repeat, const BorderMode& borderV = BorderMode::Repeat, const BorderMode& borderW = BorderMode::Repeat, const MipMapMode& mipMapMode = MipMapMode::Nearest, const Float& mipMapBias = 0.f, const Float& maxLod = std::numeric_limits<Float>::max(), const Float& minLod = 0.f, const Float& anisotropy = 0.f) const override;
+		virtual UniquePtr<IVulkanSampler> createSampler(FilterMode magFilter = FilterMode::Nearest, FilterMode minFilter = FilterMode::Nearest, BorderMode borderU = BorderMode::Repeat, BorderMode borderV = BorderMode::Repeat, BorderMode borderW = BorderMode::Repeat, MipMapMode mipMapMode = MipMapMode::Nearest, const Float& mipMapBias = 0.f, const Float& maxLod = std::numeric_limits<Float>::max(), const Float& minLod = 0.f, const Float& anisotropy = 0.f) const override;
 
 		/// <inheritdoc />
-		virtual UniquePtr<IVulkanSampler> createSampler(const String& name, const FilterMode& magFilter = FilterMode::Nearest, const FilterMode& minFilter = FilterMode::Nearest, const BorderMode& borderU = BorderMode::Repeat, const BorderMode& borderV = BorderMode::Repeat, const BorderMode& borderW = BorderMode::Repeat, const MipMapMode& mipMapMode = MipMapMode::Nearest, const Float& mipMapBias = 0.f, const Float& maxLod = std::numeric_limits<Float>::max(), const Float& minLod = 0.f, const Float& anisotropy = 0.f) const override;
+		virtual UniquePtr<IVulkanSampler> createSampler(const String& name, FilterMode magFilter = FilterMode::Nearest, FilterMode minFilter = FilterMode::Nearest, BorderMode borderU = BorderMode::Repeat, BorderMode borderV = BorderMode::Repeat, BorderMode borderW = BorderMode::Repeat, MipMapMode mipMapMode = MipMapMode::Nearest, const Float& mipMapBias = 0.f, const Float& maxLod = std::numeric_limits<Float>::max(), const Float& minLod = 0.f, const Float& anisotropy = 0.f) const override;
 
 		/// <inheritdoc />
-		virtual Enumerable<UniquePtr<IVulkanSampler>> createSamplers(const UInt32& elements, const FilterMode& magFilter = FilterMode::Nearest, const FilterMode& minFilter = FilterMode::Nearest, const BorderMode& borderU = BorderMode::Repeat, const BorderMode& borderV = BorderMode::Repeat, const BorderMode& borderW = BorderMode::Repeat, const MipMapMode& mipMapMode = MipMapMode::Nearest, const Float& mipMapBias = 0.f, const Float& maxLod = std::numeric_limits<Float>::max(), const Float& minLod = 0.f, const Float& anisotropy = 0.f) const override;
+		virtual Enumerable<UniquePtr<IVulkanSampler>> createSamplers(const UInt32& elements, FilterMode magFilter = FilterMode::Nearest, FilterMode minFilter = FilterMode::Nearest, BorderMode borderU = BorderMode::Repeat, BorderMode borderV = BorderMode::Repeat, BorderMode borderW = BorderMode::Repeat, MipMapMode mipMapMode = MipMapMode::Nearest, const Float& mipMapBias = 0.f, const Float& maxLod = std::numeric_limits<Float>::max(), const Float& minLod = 0.f, const Float& anisotropy = 0.f) const override;
 	};
 
 	/// <summary>
@@ -1609,7 +1609,7 @@ namespace LiteFX::Rendering::Backends {
 		/// <param name="frameBufferSize">The initial size of the frame buffers.</param>
 		/// <param name="frameBuffers">The initial number of frame buffers.</param>
 		/// <param name="extensions">The required extensions the device gets initialized with.</param>
-		explicit VulkanDevice(const VulkanBackend& backend, const VulkanGraphicsAdapter& adapter, UniquePtr<VulkanSurface>&& surface, const Format& format, const Size2d& frameBufferSize, const UInt32& frameBuffers, Span<String> extensions = { });
+		explicit VulkanDevice(const VulkanBackend& backend, const VulkanGraphicsAdapter& adapter, UniquePtr<VulkanSurface>&& surface, Format format, const Size2d& frameBufferSize, const UInt32& frameBuffers, Span<String> extensions = { });
 
 		VulkanDevice(const VulkanDevice&) = delete;
 		VulkanDevice(VulkanDevice&&) = delete;
@@ -1668,10 +1668,10 @@ namespace LiteFX::Rendering::Backends {
 		virtual const VulkanQueue& computeQueue() const noexcept override;
 
 		/// <inheritdoc />
-		[[nodiscard]] virtual UniquePtr<VulkanBarrier> makeBarrier(const PipelineStage& syncBefore, const PipelineStage& syncAfter) const noexcept override;
+		[[nodiscard]] virtual UniquePtr<VulkanBarrier> makeBarrier(PipelineStage syncBefore, PipelineStage syncAfter) const noexcept override;
 
 		/// <inheritdoc />
-		virtual MultiSamplingLevel maximumMultiSamplingLevel(const Format& format) const noexcept override;
+		virtual MultiSamplingLevel maximumMultiSamplingLevel(Format format) const noexcept override;
 
 		/// <inheritdoc />
 		virtual double ticksPerMillisecond() const noexcept override;
@@ -1682,10 +1682,10 @@ namespace LiteFX::Rendering::Backends {
 #if defined(BUILD_DEFINE_BUILDERS)
 	public:
 		/// <inheritdoc />
-		[[nodiscard]] virtual VulkanRenderPassBuilder buildRenderPass(const MultiSamplingLevel& samples = MultiSamplingLevel::x1, const UInt32& commandBuffers = 1) const override;
+		[[nodiscard]] virtual VulkanRenderPassBuilder buildRenderPass(MultiSamplingLevel samples = MultiSamplingLevel::x1, const UInt32& commandBuffers = 1) const override;
 
 		/// <inheritdoc />
-		[[nodiscard]] virtual VulkanRenderPassBuilder buildRenderPass(const String& name, const MultiSamplingLevel& samples = MultiSamplingLevel::x1, const UInt32& commandBuffers = 1) const override;
+		[[nodiscard]] virtual VulkanRenderPassBuilder buildRenderPass(const String& name, MultiSamplingLevel samples = MultiSamplingLevel::x1, const UInt32& commandBuffers = 1) const override;
 
 		/// <inheritdoc />
 		//[[nodiscard]] virtual VulkanRenderPipelineBuilder buildRenderPipeline(const String& name) const override;

--- a/src/Backends/Vulkan/include/litefx/backends/vulkan.hpp
+++ b/src/Backends/Vulkan/include/litefx/backends/vulkan.hpp
@@ -25,7 +25,7 @@ namespace LiteFX::Rendering::Backends {
 		/// </summary>
 		/// <param name="vertexSize">The size of a single vertex.</param>
 		/// <param name="binding">The binding point of the vertex buffers using this layout.</param>
-		explicit VulkanVertexBufferLayout(const size_t& vertexSize, const UInt32& binding = 0);
+		explicit VulkanVertexBufferLayout(size_t vertexSize, UInt32 binding = 0);
 		VulkanVertexBufferLayout(VulkanVertexBufferLayout&&) = delete;
 		VulkanVertexBufferLayout(const VulkanVertexBufferLayout&) = delete;
 		virtual ~VulkanVertexBufferLayout() noexcept;
@@ -41,7 +41,7 @@ namespace LiteFX::Rendering::Backends {
 		virtual size_t elementSize() const noexcept override;
 
 		/// <inheritdoc />
-		virtual const UInt32& binding() const noexcept override;
+		virtual UInt32 binding() const noexcept override;
 
 		/// <inheritdoc />
 		virtual BufferType type() const noexcept override;
@@ -76,7 +76,7 @@ namespace LiteFX::Rendering::Backends {
 		virtual size_t elementSize() const noexcept override;
 
 		/// <inheritdoc />
-		virtual const UInt32& binding() const noexcept override;
+		virtual UInt32 binding() const noexcept override;
 
 		/// <inheritdoc />
 		virtual BufferType type() const noexcept override;
@@ -141,17 +141,17 @@ namespace LiteFX::Rendering::Backends {
 		/// </summary>
 		/// <param name="plane">The sub-resource identifier to query the aspect mask from.</param>
 		/// <returns>The image resource aspect mask.</returns>
-		virtual VkImageAspectFlags aspectMask(const UInt32& plane) const = 0;
+		virtual VkImageAspectFlags aspectMask(UInt32 plane) const = 0;
 
 		/// <summary>
 		/// Returns the image view for a sub-resource.
 		/// </summary>
 		/// <param name="plane">The sub-resource index to return the image view for.</param>
 		/// <returns>The image view for the sub-resource.</returns>
-		virtual const VkImageView& imageView(const UInt32& plane = 0) const = 0;
+		virtual const VkImageView& imageView(UInt32 plane = 0) const = 0;
 		
 	private:
-		virtual ImageLayout& layout(const UInt32& subresource) = 0;
+		virtual ImageLayout& layout(UInt32 subresource) = 0;
 	};
 
 	/// <summary>
@@ -212,7 +212,7 @@ namespace LiteFX::Rendering::Backends {
 		constexpr inline void transition(IVulkanBuffer& buffer, ResourceAccess accessBefore, ResourceAccess accessAfter) override;
 
 		/// <inheritdoc />
-		constexpr inline void transition(IVulkanBuffer& buffer, const UInt32& element, ResourceAccess accessBefore, ResourceAccess accessAfter) override;
+		constexpr inline void transition(IVulkanBuffer& buffer, UInt32 element, ResourceAccess accessBefore, ResourceAccess accessAfter) override;
 
 		/// <inheritdoc />
 		constexpr inline void transition(IVulkanImage& image, ResourceAccess accessBefore, ResourceAccess accessAfter, ImageLayout layout) override;
@@ -221,10 +221,10 @@ namespace LiteFX::Rendering::Backends {
 		constexpr inline void transition(IVulkanImage& image, ResourceAccess accessBefore, ResourceAccess accessAfter, ImageLayout fromLayout, ImageLayout toLayout) override;
 
 		/// <inheritdoc />
-		constexpr inline void transition(IVulkanImage& image, const UInt32& level, const UInt32& levels, const UInt32& layer, const UInt32& layers, const UInt32& plane, ResourceAccess accessBefore, ResourceAccess accessAfter, ImageLayout layout) override;
+		constexpr inline void transition(IVulkanImage& image, UInt32 level, UInt32 levels, UInt32 layer, UInt32 layers, UInt32 plane, ResourceAccess accessBefore, ResourceAccess accessAfter, ImageLayout layout) override;
 
 		/// <inheritdoc />
-		constexpr inline void transition(IVulkanImage& image, const UInt32& level, const UInt32& levels, const UInt32& layer, const UInt32& layers, const UInt32& plane, ResourceAccess accessBefore, ResourceAccess accessAfter, ImageLayout fromLayout, ImageLayout toLayout) override;
+		constexpr inline void transition(IVulkanImage& image, UInt32 level, UInt32 levels, UInt32 layer, UInt32 layers, UInt32 plane, ResourceAccess accessBefore, ResourceAccess accessAfter, ImageLayout fromLayout, ImageLayout toLayout) override;
 
 	public:
 		/// <summary>
@@ -365,16 +365,16 @@ namespace LiteFX::Rendering::Backends {
 
 	public:
 		/// <inheritdoc />
-		virtual void update(const UInt32& binding, const IVulkanBuffer& buffer, const UInt32& bufferElement = 0, const UInt32& elements = 0, const UInt32& firstDescriptor = 0) const override;
+		virtual void update(UInt32 binding, const IVulkanBuffer& buffer, UInt32 bufferElement = 0, UInt32 elements = 0, UInt32 firstDescriptor = 0) const override;
 
 		/// <inheritdoc />
-		virtual void update(const UInt32& binding, const IVulkanImage& texture, const UInt32& descriptor = 0, const UInt32& firstLevel = 0, const UInt32& levels = 0, const UInt32& firstLayer = 0, const UInt32& layers = 0) const override;
+		virtual void update(UInt32 binding, const IVulkanImage& texture, UInt32 descriptor = 0, UInt32 firstLevel = 0, UInt32 levels = 0, UInt32 firstLayer = 0, UInt32 layers = 0) const override;
 
 		/// <inheritdoc />
-		virtual void update(const UInt32& binding, const IVulkanSampler& sampler, const UInt32& descriptor = 0) const override;
+		virtual void update(UInt32 binding, const IVulkanSampler& sampler, UInt32 descriptor = 0) const override;
 
 		/// <inheritdoc />
-		virtual void attach(const UInt32& binding, const IVulkanImage& image) const override;
+		virtual void attach(UInt32 binding, const IVulkanImage& image) const override;
 	};
 
 	/// <summary>
@@ -397,14 +397,14 @@ namespace LiteFX::Rendering::Backends {
 		/// <param name="elementSize">The size of the descriptor.</param>
 		/// <param name="descriptors">The number of descriptors in the descriptor array. If set to `-1`, the descriptor will be unbounded.</param>
 		/// <seealso cref="descriptors" />
-		explicit VulkanDescriptorLayout(DescriptorType type, const UInt32& binding, const size_t& elementSize, const UInt32& descriptors = 1);
+		explicit VulkanDescriptorLayout(DescriptorType type, UInt32 binding, size_t elementSize, UInt32 descriptors = 1);
 
 		/// <summary>
 		/// Initializes a new Vulkan descriptor layout for a static sampler.
 		/// </summary>
 		/// <param name="staticSampler">The static sampler to initialize the state with.</param>
 		/// <param name="binding">The binding point for the descriptor.</param>
-		explicit VulkanDescriptorLayout(UniquePtr<IVulkanSampler>&& staticSampler, const UInt32& binding);
+		explicit VulkanDescriptorLayout(UniquePtr<IVulkanSampler>&& staticSampler, UInt32 binding);
 
 		VulkanDescriptorLayout(VulkanDescriptorLayout&&) = delete;
 		VulkanDescriptorLayout(const VulkanDescriptorLayout&) = delete;
@@ -416,7 +416,7 @@ namespace LiteFX::Rendering::Backends {
 		virtual DescriptorType descriptorType() const noexcept override;
 
 		/// <inheritdoc />
-		virtual const UInt32& descriptors() const noexcept override;
+		virtual UInt32 descriptors() const noexcept override;
 
 		/// <inheritdoc />
 		virtual const IVulkanSampler* staticSampler() const noexcept override;
@@ -427,7 +427,7 @@ namespace LiteFX::Rendering::Backends {
 		virtual size_t elementSize() const noexcept override;
 
 		/// <inheritdoc />
-		virtual const UInt32& binding() const noexcept override;
+		virtual UInt32 binding() const noexcept override;
 
 		/// <inheritdoc />
 		virtual BufferType type() const noexcept override;
@@ -461,7 +461,7 @@ namespace LiteFX::Rendering::Backends {
 		/// <param name="stages">The shader stages, the descriptor sets are bound to.</param>
 		/// <param name="poolSize">The size of a descriptor pool.</param>
 		/// <param name="maxUnboundedArraySize">The maximum number of descriptors in an unbounded array.</param>
-		explicit VulkanDescriptorSetLayout(const VulkanDevice& device, Enumerable<UniquePtr<VulkanDescriptorLayout>>&& descriptorLayouts, const UInt32& space, ShaderStage stages, const UInt32& poolSize = 1024, const UInt32& maxUnboundedArraySize = 104857);
+		explicit VulkanDescriptorSetLayout(const VulkanDevice& device, Enumerable<UniquePtr<VulkanDescriptorLayout>>&& descriptorLayouts, UInt32 space, ShaderStage stages, UInt32 poolSize = 1024, UInt32 maxUnboundedArraySize = 104857);
 		VulkanDescriptorSetLayout(VulkanDescriptorSetLayout&&) = delete;
 		VulkanDescriptorSetLayout(const VulkanDescriptorSetLayout&) = delete;
 		virtual ~VulkanDescriptorSetLayout() noexcept;
@@ -485,10 +485,10 @@ namespace LiteFX::Rendering::Backends {
 		virtual Enumerable<const VulkanDescriptorLayout*> descriptors() const noexcept override;
 
 		/// <inheritdoc />
-		virtual const VulkanDescriptorLayout& descriptor(const UInt32& binding) const override;
+		virtual const VulkanDescriptorLayout& descriptor(UInt32 binding) const override;
 
 		/// <inheritdoc />
-		virtual const UInt32& space() const noexcept override;
+		virtual UInt32 space() const noexcept override;
 
 		/// <inheritdoc />
 		virtual ShaderStage shaderStages() const noexcept override;
@@ -519,19 +519,19 @@ namespace LiteFX::Rendering::Backends {
 		virtual UniquePtr<VulkanDescriptorSet> allocate(const Enumerable<DescriptorBinding>& bindings = { }) const override;
 
 		/// <inheritdoc />
-		virtual UniquePtr<VulkanDescriptorSet> allocate(const UInt32& descriptors, const Enumerable<DescriptorBinding>& bindings = { }) const override;
+		virtual UniquePtr<VulkanDescriptorSet> allocate(UInt32 descriptors, const Enumerable<DescriptorBinding>& bindings = { }) const override;
 
 		/// <inheritdoc />
-		virtual Enumerable<UniquePtr<VulkanDescriptorSet>> allocateMultiple(const UInt32& descriptorSets, const Enumerable<Enumerable<DescriptorBinding>>& bindings = { }) const override;
+		virtual Enumerable<UniquePtr<VulkanDescriptorSet>> allocateMultiple(UInt32 descriptorSets, const Enumerable<Enumerable<DescriptorBinding>>& bindings = { }) const override;
 
 		/// <inheritdoc />
-		virtual Enumerable<UniquePtr<VulkanDescriptorSet>> allocateMultiple(const UInt32& descriptorSets, std::function<Enumerable<DescriptorBinding>(const UInt32&)> bindingFactory) const override;
+		virtual Enumerable<UniquePtr<VulkanDescriptorSet>> allocateMultiple(UInt32 descriptorSets, std::function<Enumerable<DescriptorBinding>(UInt32)> bindingFactory) const override;
 
 		/// <inheritdoc />
-		virtual Enumerable<UniquePtr<VulkanDescriptorSet>> allocateMultiple(const UInt32& descriptorSets, const UInt32& descriptors, const Enumerable<Enumerable<DescriptorBinding>>& bindings = { }) const override;
+		virtual Enumerable<UniquePtr<VulkanDescriptorSet>> allocateMultiple(UInt32 descriptorSets, UInt32 descriptors, const Enumerable<Enumerable<DescriptorBinding>>& bindings = { }) const override;
 
 		/// <inheritdoc />
-		virtual Enumerable<UniquePtr<VulkanDescriptorSet>> allocateMultiple(const UInt32& descriptorSets, const UInt32& descriptors, std::function<Enumerable<DescriptorBinding>(const UInt32&)> bindingFactory) const override;
+		virtual Enumerable<UniquePtr<VulkanDescriptorSet>> allocateMultiple(UInt32 descriptorSets, UInt32 descriptors, std::function<Enumerable<DescriptorBinding>(UInt32)> bindingFactory) const override;
 
 		/// <inheritdoc />
 		virtual void free(const VulkanDescriptorSet& descriptorSet) const noexcept override;
@@ -555,7 +555,7 @@ namespace LiteFX::Rendering::Backends {
 		/// <seealso cref="allocate" />
 		/// <seealso cref="free" />
 		/// <seealso cref="pools" />
-		virtual const UInt32& poolSize() const noexcept;
+		virtual UInt32 poolSize() const noexcept;
 
 		/// <summary>
 		/// Returns the number of active descriptor pools.
@@ -583,23 +583,23 @@ namespace LiteFX::Rendering::Backends {
 		/// <param name="size">The size of the push constants range.</param>
 		/// <param name="space">The space from which the push constants of the range will be accessible in the shader.</param>
 		/// <param name="binding">The register from which the push constants of the range will be accessible in the shader.</param>
-		explicit VulkanPushConstantsRange(ShaderStage shaderStage, const UInt32& offset, const UInt32& size, const UInt32& space, const UInt32& binding);
+		explicit VulkanPushConstantsRange(ShaderStage shaderStage, UInt32 offset, UInt32 size, UInt32 space, UInt32 binding);
 		VulkanPushConstantsRange(const VulkanPushConstantsRange&) = delete;
 		VulkanPushConstantsRange(VulkanPushConstantsRange&&) = delete;
 		virtual ~VulkanPushConstantsRange() noexcept;
 
 	public:
 		/// <inheritdoc />
-		virtual const UInt32& space() const noexcept override;
+		virtual UInt32 space() const noexcept override;
 
 		/// <inheritdoc />
-		virtual const UInt32& binding() const noexcept override;
+		virtual UInt32 binding() const noexcept override;
 
 		/// <inheritdoc />
-		virtual const UInt32& offset() const noexcept override;
+		virtual UInt32 offset() const noexcept override;
 
 		/// <inheritdoc />
-		virtual const UInt32& size() const noexcept override;
+		virtual UInt32 size() const noexcept override;
 
 		/// <inheritdoc />
 		virtual ShaderStage stage() const noexcept override;
@@ -622,7 +622,7 @@ namespace LiteFX::Rendering::Backends {
 		/// </summary>
 		/// <param name="ranges">The ranges contained by the layout.</param>
 		/// <param name="size">The overall size (in bytes) of the push constants backing memory.</param>
-		explicit VulkanPushConstantsLayout(Enumerable<UniquePtr<VulkanPushConstantsRange>>&& ranges, const UInt32& size);
+		explicit VulkanPushConstantsLayout(Enumerable<UniquePtr<VulkanPushConstantsRange>>&& ranges, UInt32 size);
 		VulkanPushConstantsLayout(const VulkanPushConstantsLayout&) = delete;
 		VulkanPushConstantsLayout(VulkanPushConstantsLayout&&) = delete;
 		virtual ~VulkanPushConstantsLayout() noexcept;
@@ -632,7 +632,7 @@ namespace LiteFX::Rendering::Backends {
 		/// Initializes a new push constants layout.
 		/// </summary>
 		/// <param name="size">The overall size (in bytes) of the push constants backing memory.</param>
-		explicit VulkanPushConstantsLayout(const UInt32& size);
+		explicit VulkanPushConstantsLayout(UInt32 size);
 
 	public:
 		/// <summary>
@@ -650,7 +650,7 @@ namespace LiteFX::Rendering::Backends {
 	
 	public:
 		/// <inheritdoc />
-		virtual const UInt32& size() const noexcept override;
+		virtual UInt32 size() const noexcept override;
 
 		/// <inheritdoc />
 		virtual const VulkanPushConstantsRange& range(ShaderStage stage) const override;
@@ -696,7 +696,7 @@ namespace LiteFX::Rendering::Backends {
 		// PipelineLayout interface.
 	public:
 		/// <inheritdoc />
-		virtual const VulkanDescriptorSetLayout& descriptorSet(const UInt32& space) const override;
+		virtual const VulkanDescriptorSetLayout& descriptorSet(UInt32 space) const override;
 
 		/// <inheritdoc />
 		virtual Enumerable<const VulkanDescriptorSetLayout*> descriptorSets() const noexcept override;
@@ -736,7 +736,7 @@ namespace LiteFX::Rendering::Backends {
 		virtual Enumerable<const VulkanVertexBufferLayout*> vertexBufferLayouts() const noexcept override;
 
 		/// <inheritdoc />
-		virtual const VulkanVertexBufferLayout& vertexBufferLayout(const UInt32& binding) const override;
+		virtual const VulkanVertexBufferLayout& vertexBufferLayout(UInt32 binding) const override;
 
 		/// <inheritdoc />
 		virtual const VulkanIndexBufferLayout& indexBufferLayout() const override;
@@ -761,7 +761,7 @@ namespace LiteFX::Rendering::Backends {
 		/// <param name="cullOrder">The cull order used by the pipeline.</param>
 		/// <param name="lineWidth">The line width used by the pipeline.</param>
 		/// <param name="depthStencilState">The rasterizer depth/stencil state.</param>
-		explicit VulkanRasterizer(PolygonMode polygonMode, CullMode cullMode, CullOrder cullOrder, const Float& lineWidth = 1.f, const DepthStencilState& depthStencilState = {}) noexcept;
+		explicit VulkanRasterizer(PolygonMode polygonMode, CullMode cullMode, CullOrder cullOrder, Float lineWidth = 1.f, const DepthStencilState& depthStencilState = {}) noexcept;
 		VulkanRasterizer(VulkanRasterizer&&) noexcept = delete;
 		VulkanRasterizer(const VulkanRasterizer&) noexcept = delete;
 		virtual ~VulkanRasterizer() noexcept;
@@ -785,7 +785,7 @@ namespace LiteFX::Rendering::Backends {
 		/// </remarks>
 		/// <returns>A reference to the line width.</returns>
 		/// <seealso href="https://www.khronos.org/registry/vulkan/specs/1.2-extensions/html/vkspec.html#features-wideLines" />
-		virtual void updateLineWidth(const Float& lineWidth) noexcept;
+		virtual void updateLineWidth(Float lineWidth) noexcept;
 	};
 
 	/// <summary>
@@ -839,7 +839,7 @@ namespace LiteFX::Rendering::Backends {
 		/// <param name="queue">The parent command queue, the buffer gets submitted to.</param>
 		/// <param name="begin">If set to <c>true</c>, the command buffer automatically starts recording by calling <see cref="begin" />.</param>
 		/// <param name="primary"><c>true</c>, if the command buffer is a primary command buffer.</param>
-		explicit VulkanCommandBuffer(const VulkanQueue& queue, const bool& begin = false, const bool& primary = true);
+		explicit VulkanCommandBuffer(const VulkanQueue& queue, bool begin = false, bool primary = true);
 		VulkanCommandBuffer(const VulkanCommandBuffer&) = delete;
 		VulkanCommandBuffer(VulkanCommandBuffer&&) = delete;
 		virtual ~VulkanCommandBuffer() noexcept;
@@ -861,7 +861,7 @@ namespace LiteFX::Rendering::Backends {
 		virtual void end() const override;
 
 		/// <inheritdoc />
-		virtual const bool& isSecondary() const noexcept override;
+		virtual bool isSecondary() const noexcept override;
 
 		/// <inheritdoc />
 		virtual void setViewports(Span<const IViewport*> viewports) const noexcept override;
@@ -879,7 +879,7 @@ namespace LiteFX::Rendering::Backends {
 		virtual void setBlendFactors(const Vector4f& blendFactors) const noexcept override;
 
 		/// <inheritdoc />
-		virtual void setStencilRef(const UInt32& stencilRef) const noexcept override;
+		virtual void setStencilRef(UInt32 stencilRef) const noexcept override;
 
 		/// <inheritdoc />
 		virtual void generateMipMaps(IVulkanImage& image) noexcept override;
@@ -888,28 +888,28 @@ namespace LiteFX::Rendering::Backends {
 		virtual void barrier(const VulkanBarrier& barrier) const noexcept override;
 
 		/// <inheritdoc />
-		virtual void transfer(IVulkanBuffer& source, IVulkanBuffer& target, const UInt32& sourceElement = 0, const UInt32& targetElement = 0, const UInt32& elements = 1) const override;
+		virtual void transfer(IVulkanBuffer& source, IVulkanBuffer& target, UInt32 sourceElement = 0, UInt32 targetElement = 0, UInt32 elements = 1) const override;
 
 		/// <inheritdoc />
-		virtual void transfer(IVulkanBuffer& source, IVulkanImage& target, const UInt32& sourceElement = 0, const UInt32& firstSubresource = 0, const UInt32& elements = 1) const override;
+		virtual void transfer(IVulkanBuffer& source, IVulkanImage& target, UInt32 sourceElement = 0, UInt32 firstSubresource = 0, UInt32 elements = 1) const override;
 
 		/// <inheritdoc />
-		virtual void transfer(IVulkanImage& source, IVulkanImage& target, const UInt32& sourceSubresource = 0, const UInt32& targetSubresource = 0, const UInt32& subresources = 1) const override;
+		virtual void transfer(IVulkanImage& source, IVulkanImage& target, UInt32 sourceSubresource = 0, UInt32 targetSubresource = 0, UInt32 subresources = 1) const override;
 
 		/// <inheritdoc />
-		virtual void transfer(IVulkanImage& source, IVulkanBuffer& target, const UInt32& firstSubresource = 0, const UInt32& targetElement = 0, const UInt32& subresources = 1) const override;
+		virtual void transfer(IVulkanImage& source, IVulkanBuffer& target, UInt32 firstSubresource = 0, UInt32 targetElement = 0, UInt32 subresources = 1) const override;
 
 		/// <inheritdoc />
-		virtual void transfer(SharedPtr<IVulkanBuffer> source, IVulkanBuffer& target, const UInt32& sourceElement = 0, const UInt32& targetElement = 0, const UInt32& elements = 1) const override;
+		virtual void transfer(SharedPtr<IVulkanBuffer> source, IVulkanBuffer& target, UInt32 sourceElement = 0, UInt32 targetElement = 0, UInt32 elements = 1) const override;
 
 		/// <inheritdoc />
-		virtual void transfer(SharedPtr<IVulkanBuffer> source, IVulkanImage& target, const UInt32& sourceElement = 0, const UInt32& firstSubresource = 0, const UInt32& elements = 1) const override;
+		virtual void transfer(SharedPtr<IVulkanBuffer> source, IVulkanImage& target, UInt32 sourceElement = 0, UInt32 firstSubresource = 0, UInt32 elements = 1) const override;
 
 		/// <inheritdoc />
-		virtual void transfer(SharedPtr<IVulkanImage> source, IVulkanImage& target, const UInt32& sourceSubresource = 0, const UInt32& targetSubresource = 0, const UInt32& subresources = 1) const override;
+		virtual void transfer(SharedPtr<IVulkanImage> source, IVulkanImage& target, UInt32 sourceSubresource = 0, UInt32 targetSubresource = 0, UInt32 subresources = 1) const override;
 
 		/// <inheritdoc />
-		virtual void transfer(SharedPtr<IVulkanImage> source, IVulkanBuffer& target, const UInt32& firstSubresource = 0, const UInt32& targetElement = 0, const UInt32& subresources = 1) const override;
+		virtual void transfer(SharedPtr<IVulkanImage> source, IVulkanBuffer& target, UInt32 firstSubresource = 0, UInt32 targetElement = 0, UInt32 subresources = 1) const override;
 
 		/// <inheritdoc />
 		virtual void use(const VulkanPipelineState& pipeline) const noexcept override;
@@ -927,10 +927,10 @@ namespace LiteFX::Rendering::Backends {
 		virtual void dispatch(const Vector3u& threadCount) const noexcept override;
 
 		/// <inheritdoc />
-		virtual void draw(const UInt32& vertices, const UInt32& instances = 1, const UInt32& firstVertex = 0, const UInt32& firstInstance = 0) const noexcept override;
+		virtual void draw(UInt32 vertices, UInt32 instances = 1, UInt32 firstVertex = 0, UInt32 firstInstance = 0) const noexcept override;
 
 		/// <inheritdoc />
-		virtual void drawIndexed(const UInt32& indices, const UInt32& instances = 1, const UInt32& firstIndex = 0, const Int32& vertexOffset = 0, const UInt32& firstInstance = 0) const noexcept override;
+		virtual void drawIndexed(UInt32 indices, UInt32 instances = 1, UInt32 firstIndex = 0, Int32 vertexOffset = 0, UInt32 firstInstance = 0) const noexcept override;
 
 		/// <inheritdoc />
 		virtual void pushConstants(const VulkanPushConstantsLayout& layout, const void* const memory) const noexcept override;
@@ -968,7 +968,7 @@ namespace LiteFX::Rendering::Backends {
 		/// <param name="rasterizer">The rasterizer state of the pipeline.</param>
 		/// <param name="name">The optional name of the render pipeline.</param>
 		/// <param name="enableAlphaToCoverage">Whether or not to enable Alpha-to-Coverage multi-sampling.</param>
-		explicit VulkanRenderPipeline(const VulkanRenderPass& renderPass, SharedPtr<VulkanShaderProgram> shaderProgram, SharedPtr<VulkanPipelineLayout> layout, SharedPtr<VulkanInputAssembler> inputAssembler, SharedPtr<VulkanRasterizer> rasterizer, const bool& enableAlphaToCoverage = false, const String& name = "");
+		explicit VulkanRenderPipeline(const VulkanRenderPass& renderPass, SharedPtr<VulkanShaderProgram> shaderProgram, SharedPtr<VulkanPipelineLayout> layout, SharedPtr<VulkanInputAssembler> inputAssembler, SharedPtr<VulkanRasterizer> rasterizer, bool enableAlphaToCoverage = false, const String& name = "");
 		VulkanRenderPipeline(VulkanRenderPipeline&&) noexcept = delete;
 		VulkanRenderPipeline(const VulkanRenderPipeline&) noexcept = delete;
 		virtual ~VulkanRenderPipeline() noexcept;
@@ -998,7 +998,7 @@ namespace LiteFX::Rendering::Backends {
 		virtual SharedPtr<VulkanRasterizer> rasterizer() const noexcept override;
 
 		/// <inheritdoc />
-		virtual const bool& alphaToCoverage() const noexcept override;
+		virtual bool alphaToCoverage() const noexcept override;
 
 		// VulkanPipelineState interface.
 	public:
@@ -1070,7 +1070,7 @@ namespace LiteFX::Rendering::Backends {
 		/// <param name="bufferIndex">The index of the frame buffer within the parent render pass.</param>
 		/// <param name="renderArea">The initial size of the render area.</param>
 		/// <param name="commandBuffers">The number of command buffers, the frame buffer stores.</param>
-		VulkanFrameBuffer(const VulkanRenderPass& renderPass, const UInt32& bufferIndex, const Size2d& renderArea, const UInt32& commandBuffers = 1);
+		VulkanFrameBuffer(const VulkanRenderPass& renderPass, UInt32 bufferIndex, const Size2d& renderArea, UInt32 commandBuffers = 1);
 		VulkanFrameBuffer(const VulkanFrameBuffer&) noexcept = delete;
 		VulkanFrameBuffer(VulkanFrameBuffer&&) noexcept = delete;
 		virtual ~VulkanFrameBuffer() noexcept;
@@ -1095,7 +1095,7 @@ namespace LiteFX::Rendering::Backends {
 		// FrameBuffer interface.
 	public:
 		/// <inheritdoc />
-		virtual const UInt32& bufferIndex() const noexcept override;
+		virtual UInt32 bufferIndex() const noexcept override;
 
 		/// <inheritdoc />
 		virtual const Size2d& size() const noexcept override;
@@ -1107,7 +1107,7 @@ namespace LiteFX::Rendering::Backends {
 		virtual size_t getHeight() const noexcept override;
 
 		/// <inheritdoc />
-		virtual SharedPtr<const VulkanCommandBuffer> commandBuffer(const UInt32& index) const override;
+		virtual SharedPtr<const VulkanCommandBuffer> commandBuffer(UInt32 index) const override;
 
 		/// <inheritdoc />
 		virtual Enumerable<SharedPtr<const VulkanCommandBuffer>> commandBuffers() const noexcept override;
@@ -1116,7 +1116,7 @@ namespace LiteFX::Rendering::Backends {
 		virtual Enumerable<const IVulkanImage*> images() const noexcept override;
 
 		/// <inheritdoc />
-		virtual const IVulkanImage& image(const UInt32& location) const override;
+		virtual const IVulkanImage& image(UInt32 location) const override;
 
 	public:
 		/// <inheritdoc />
@@ -1144,7 +1144,7 @@ namespace LiteFX::Rendering::Backends {
 		/// <param name="renderTargets">The render targets that are output by the render pass.</param>
 		/// <param name="samples">The number of samples for the render targets in this render pass.</param>
 		/// <param name="inputAttachments">The input attachments that are read by the render pass.</param>
-		explicit VulkanRenderPass(const VulkanDevice& device, Span<RenderTarget> renderTargets, const UInt32& commandBuffers = 1, MultiSamplingLevel samples = MultiSamplingLevel::x1, Span<VulkanInputAttachmentMapping> inputAttachments = { });
+		explicit VulkanRenderPass(const VulkanDevice& device, Span<RenderTarget> renderTargets, UInt32 commandBuffers = 1, MultiSamplingLevel samples = MultiSamplingLevel::x1, Span<VulkanInputAttachmentMapping> inputAttachments = { });
 
 		/// <summary>
 		/// Creates and initializes a new Vulkan render pass instance.
@@ -1155,7 +1155,7 @@ namespace LiteFX::Rendering::Backends {
 		/// <param name="renderTargets">The render targets that are output by the render pass.</param>
 		/// <param name="samples">The number of samples for the render targets in this render pass.</param>
 		/// <param name="inputAttachments">The input attachments that are read by the render pass.</param>
-		explicit VulkanRenderPass(const VulkanDevice& device, const String& name, Span<RenderTarget> renderTargets, const UInt32& commandBuffers = 1, MultiSamplingLevel samples = MultiSamplingLevel::x1, Span<VulkanInputAttachmentMapping> inputAttachments = { });
+		explicit VulkanRenderPass(const VulkanDevice& device, const String& name, Span<RenderTarget> renderTargets, UInt32 commandBuffers = 1, MultiSamplingLevel samples = MultiSamplingLevel::x1, Span<VulkanInputAttachmentMapping> inputAttachments = { });
 		
 		VulkanRenderPass(const VulkanRenderPass&) = delete;
 		VulkanRenderPass(VulkanRenderPass&&) = delete;
@@ -1176,7 +1176,7 @@ namespace LiteFX::Rendering::Backends {
 		// IInputAttachmentMappingSource interface.
 	public:
 		/// <inheritdoc />
-		virtual const VulkanFrameBuffer& frameBuffer(const UInt32& buffer) const override;
+		virtual const VulkanFrameBuffer& frameBuffer(UInt32 buffer) const override;
 
 		// RenderPass interface.
 	public:
@@ -1196,7 +1196,7 @@ namespace LiteFX::Rendering::Backends {
 		virtual Enumerable<const VulkanRenderPipeline*> pipelines() const noexcept override;
 
 		/// <inheritdoc />
-		virtual const RenderTarget& renderTarget(const UInt32& location) const override;
+		virtual const RenderTarget& renderTarget(UInt32 location) const override;
 
 		/// <inheritdoc />
 		virtual Span<const RenderTarget> renderTargets() const noexcept override;
@@ -1212,7 +1212,7 @@ namespace LiteFX::Rendering::Backends {
 
 	public:
 		/// <inheritdoc />
-		virtual void begin(const UInt32& buffer) override;
+		virtual void begin(UInt32 buffer) override;
 		
 		/// <inheritdoc />
 		virtual void end() const override;
@@ -1247,7 +1247,7 @@ namespace LiteFX::Rendering::Backends {
 		/// <param name="renderPass">The render pass to fetch the input attachment from.</param>
 		/// <param name="renderTarget">The render target of the <paramref name="renderPass"/> that is used for the input attachment.</param>
 		/// <param name="location">The location to bind the input attachment to.</param>
-		VulkanInputAttachmentMapping(const VulkanRenderPass& renderPass, const RenderTarget& renderTarget, const UInt32& location);
+		VulkanInputAttachmentMapping(const VulkanRenderPass& renderPass, const RenderTarget& renderTarget, UInt32 location);
 
 		/// <summary>
 		/// Copies another input attachment mapping.
@@ -1280,7 +1280,7 @@ namespace LiteFX::Rendering::Backends {
 		const RenderTarget& renderTarget() const noexcept override;
 
 		/// <inheritdoc />
-		const UInt32& location() const noexcept override;
+		UInt32 location() const noexcept override;
 	};
 
 	/// <summary>
@@ -1301,7 +1301,7 @@ namespace LiteFX::Rendering::Backends {
 		/// <param name="format">The initial surface format.</param>
 		/// <param name="renderArea">The initial size of the render area.</param>
 		/// <param name="buffers">The initial number of buffers.</param>
-		explicit VulkanSwapChain(const VulkanDevice& device, Format surfaceFormat = Format::B8G8R8A8_SRGB, const Size2d& renderArea = { 800, 600 }, const UInt32& buffers = 3);
+		explicit VulkanSwapChain(const VulkanDevice& device, Format surfaceFormat = Format::B8G8R8A8_SRGB, const Size2d& renderArea = { 800, 600 }, UInt32 buffers = 3);
 		VulkanSwapChain(const VulkanSwapChain&) = delete;
 		VulkanSwapChain(VulkanSwapChain&&) = delete;
 		virtual ~VulkanSwapChain() noexcept;
@@ -1326,7 +1326,7 @@ namespace LiteFX::Rendering::Backends {
 		virtual Enumerable<SharedPtr<TimingEvent>> timingEvents() const noexcept override;
 
 		/// <inheritdoc />
-		virtual SharedPtr<TimingEvent> timingEvent(const UInt32& queryId) const override;
+		virtual SharedPtr<TimingEvent> timingEvent(UInt32 queryId) const override;
 
 		/// <inheritdoc />
 		virtual UInt64 readTimingEvent(SharedPtr<const TimingEvent> timingEvent) const override;
@@ -1338,13 +1338,13 @@ namespace LiteFX::Rendering::Backends {
 		virtual Format surfaceFormat() const noexcept override;
 
 		/// <inheritdoc />
-		virtual const UInt32& buffers() const noexcept override;
+		virtual UInt32 buffers() const noexcept override;
 
 		/// <inheritdoc />
 		virtual const Size2d& renderArea() const noexcept override;
 
 		/// <inheritdoc />
-		virtual const IVulkanImage* image(const UInt32& backBuffer) const override;
+		virtual const IVulkanImage* image(UInt32 backBuffer) const override;
 
 		/// <inheritdoc />
 		virtual Enumerable<const IVulkanImage*> images() const noexcept override;
@@ -1360,7 +1360,7 @@ namespace LiteFX::Rendering::Backends {
 		virtual void addTimingEvent(SharedPtr<TimingEvent> timingEvent) override;
 
 		/// <inheritdoc />
-		virtual void reset(Format surfaceFormat, const Size2d& renderArea, const UInt32& buffers) override;
+		virtual void reset(Format surfaceFormat, const Size2d& renderArea, UInt32 buffers) override;
 
 		/// <inheritdoc />
 		[[nodiscard]] virtual UInt32 swapBackBuffer() const override;
@@ -1386,7 +1386,7 @@ namespace LiteFX::Rendering::Backends {
 		/// <param name="priority">The priority, of which commands are issued on the device.</param>
 		/// <param name="familyId">The ID of the queue family.</param>
 		/// <param name="queueId">The ID of the queue.</param>
-		explicit VulkanQueue(const VulkanDevice& device, QueueType type, QueuePriority priority, const UInt32& familyId, const UInt32& queueId);
+		explicit VulkanQueue(const VulkanDevice& device, QueueType type, QueuePriority priority, UInt32 familyId, UInt32 queueId);
 		VulkanQueue(const VulkanQueue&) = delete;
 		VulkanQueue(VulkanQueue&&) = delete;
 		virtual ~VulkanQueue() noexcept;
@@ -1415,13 +1415,13 @@ namespace LiteFX::Rendering::Backends {
 		/// Returns the queue family ID.
 		/// </summary>
 		/// <returns>The queue family ID.</returns>
-		virtual const UInt32& familyId() const noexcept;
+		virtual UInt32 familyId() const noexcept;
 
 		/// <summary>
 		/// Returns the queue ID.
 		/// </summary>
 		/// <returns>The queue ID.</returns>
-		virtual const UInt32& queueId() const noexcept;
+		virtual UInt32 queueId() const noexcept;
 
 		/// <summary>
 		/// Returns the internal timeline semaphore used to synchronize the queue execution.
@@ -1494,7 +1494,7 @@ namespace LiteFX::Rendering::Backends {
 		virtual void release() override;
 
 		/// <inheritdoc />
-		virtual SharedPtr<VulkanCommandBuffer> createCommandBuffer(const bool& beginRecording = false, const bool& secondary = false) const override;
+		virtual SharedPtr<VulkanCommandBuffer> createCommandBuffer(bool beginRecording = false, bool secondary = false) const override;
 
 		/// <inheritdoc />
 		virtual UInt64 submit(SharedPtr<const VulkanCommandBuffer> commandBuffer) const override;
@@ -1503,7 +1503,7 @@ namespace LiteFX::Rendering::Backends {
 		virtual UInt64 submit(const Enumerable<SharedPtr<const VulkanCommandBuffer>>& commandBuffers) const override;
 
 		/// <inheritdoc />
-		virtual void waitFor(const UInt64& fence) const noexcept override;
+		virtual void waitFor(UInt64 fence) const noexcept override;
 
 		/// <inheritdoc />
 		virtual UInt64 currentFence() const noexcept override;
@@ -1541,22 +1541,22 @@ namespace LiteFX::Rendering::Backends {
 
 	public:
 		/// <inheritdoc />
-		virtual UniquePtr<IVulkanBuffer> createBuffer(BufferType type, BufferUsage usage, const size_t& elementSize, const UInt32& elements = 1, const bool& allowWrite = false) const override;
+		virtual UniquePtr<IVulkanBuffer> createBuffer(BufferType type, BufferUsage usage, size_t elementSize, UInt32 elements = 1, bool allowWrite = false) const override;
 
 		/// <inheritdoc />
-		virtual UniquePtr<IVulkanBuffer> createBuffer(const String& name, BufferType type, BufferUsage usage, const size_t& elementSize, const UInt32& elements = 1, const bool& allowWrite = false) const override;
+		virtual UniquePtr<IVulkanBuffer> createBuffer(const String& name, BufferType type, BufferUsage usage, size_t elementSize, UInt32 elements = 1, bool allowWrite = false) const override;
 
 		/// <inheritdoc />
-		virtual UniquePtr<IVulkanVertexBuffer> createVertexBuffer(const VulkanVertexBufferLayout& layout, BufferUsage usage, const UInt32& elements = 1) const override;
+		virtual UniquePtr<IVulkanVertexBuffer> createVertexBuffer(const VulkanVertexBufferLayout& layout, BufferUsage usage, UInt32 elements = 1) const override;
 
 		/// <inheritdoc />
-		virtual UniquePtr<IVulkanVertexBuffer> createVertexBuffer(const String& name, const VulkanVertexBufferLayout& layout, BufferUsage usage, const UInt32& elements = 1) const override;
+		virtual UniquePtr<IVulkanVertexBuffer> createVertexBuffer(const String& name, const VulkanVertexBufferLayout& layout, BufferUsage usage, UInt32 elements = 1) const override;
 
 		/// <inheritdoc />
-		virtual UniquePtr<IVulkanIndexBuffer> createIndexBuffer(const VulkanIndexBufferLayout& layout, BufferUsage usage, const UInt32& elements) const override;
+		virtual UniquePtr<IVulkanIndexBuffer> createIndexBuffer(const VulkanIndexBufferLayout& layout, BufferUsage usage, UInt32 elements) const override;
 
 		/// <inheritdoc />
-		virtual UniquePtr<IVulkanIndexBuffer> createIndexBuffer(const String& name, const VulkanIndexBufferLayout& layout, BufferUsage usage, const UInt32& elements) const override;
+		virtual UniquePtr<IVulkanIndexBuffer> createIndexBuffer(const String& name, const VulkanIndexBufferLayout& layout, BufferUsage usage, UInt32 elements) const override;
 
 		/// <inheritdoc />
 		virtual UniquePtr<IVulkanImage> createAttachment(Format format, const Size2d& size, MultiSamplingLevel samples = MultiSamplingLevel::x1) const override;
@@ -1565,22 +1565,22 @@ namespace LiteFX::Rendering::Backends {
 		virtual UniquePtr<IVulkanImage> createAttachment(const String& name, Format format, const Size2d& size, MultiSamplingLevel samples = MultiSamplingLevel::x1) const override;
 
 		/// <inheritdoc />
-		virtual UniquePtr<IVulkanImage> createTexture(Format format, const Size3d& size, ImageDimensions dimension = ImageDimensions::DIM_2, const UInt32& levels = 1, const UInt32& layers = 1, MultiSamplingLevel samples = MultiSamplingLevel::x1, const bool& allowWrite = false) const override;
+		virtual UniquePtr<IVulkanImage> createTexture(Format format, const Size3d& size, ImageDimensions dimension = ImageDimensions::DIM_2, UInt32 levels = 1, UInt32 layers = 1, MultiSamplingLevel samples = MultiSamplingLevel::x1, bool allowWrite = false) const override;
 
 		/// <inheritdoc />
-		virtual UniquePtr<IVulkanImage> createTexture(const String& name, Format format, const Size3d& size, ImageDimensions dimension = ImageDimensions::DIM_2, const UInt32& levels = 1, const UInt32& layers = 1, MultiSamplingLevel samples = MultiSamplingLevel::x1, const bool& allowWrite = false) const override;
+		virtual UniquePtr<IVulkanImage> createTexture(const String& name, Format format, const Size3d& size, ImageDimensions dimension = ImageDimensions::DIM_2, UInt32 levels = 1, UInt32 layers = 1, MultiSamplingLevel samples = MultiSamplingLevel::x1, bool allowWrite = false) const override;
 
 		/// <inheritdoc />
-		virtual Enumerable<UniquePtr<IVulkanImage>> createTextures(const UInt32& elements, Format format, const Size3d& size, ImageDimensions dimension = ImageDimensions::DIM_2, const UInt32& levels = 1, const UInt32& layers = 1, MultiSamplingLevel samples = MultiSamplingLevel::x1, const bool& allowWrite = false) const override;
+		virtual Enumerable<UniquePtr<IVulkanImage>> createTextures(UInt32 elements, Format format, const Size3d& size, ImageDimensions dimension = ImageDimensions::DIM_2, UInt32 levels = 1, UInt32 layers = 1, MultiSamplingLevel samples = MultiSamplingLevel::x1, bool allowWrite = false) const override;
 
 		/// <inheritdoc />
-		virtual UniquePtr<IVulkanSampler> createSampler(FilterMode magFilter = FilterMode::Nearest, FilterMode minFilter = FilterMode::Nearest, BorderMode borderU = BorderMode::Repeat, BorderMode borderV = BorderMode::Repeat, BorderMode borderW = BorderMode::Repeat, MipMapMode mipMapMode = MipMapMode::Nearest, const Float& mipMapBias = 0.f, const Float& maxLod = std::numeric_limits<Float>::max(), const Float& minLod = 0.f, const Float& anisotropy = 0.f) const override;
+		virtual UniquePtr<IVulkanSampler> createSampler(FilterMode magFilter = FilterMode::Nearest, FilterMode minFilter = FilterMode::Nearest, BorderMode borderU = BorderMode::Repeat, BorderMode borderV = BorderMode::Repeat, BorderMode borderW = BorderMode::Repeat, MipMapMode mipMapMode = MipMapMode::Nearest, Float mipMapBias = 0.f, Float maxLod = std::numeric_limits<Float>::max(), Float minLod = 0.f, Float anisotropy = 0.f) const override;
 
 		/// <inheritdoc />
-		virtual UniquePtr<IVulkanSampler> createSampler(const String& name, FilterMode magFilter = FilterMode::Nearest, FilterMode minFilter = FilterMode::Nearest, BorderMode borderU = BorderMode::Repeat, BorderMode borderV = BorderMode::Repeat, BorderMode borderW = BorderMode::Repeat, MipMapMode mipMapMode = MipMapMode::Nearest, const Float& mipMapBias = 0.f, const Float& maxLod = std::numeric_limits<Float>::max(), const Float& minLod = 0.f, const Float& anisotropy = 0.f) const override;
+		virtual UniquePtr<IVulkanSampler> createSampler(const String& name, FilterMode magFilter = FilterMode::Nearest, FilterMode minFilter = FilterMode::Nearest, BorderMode borderU = BorderMode::Repeat, BorderMode borderV = BorderMode::Repeat, BorderMode borderW = BorderMode::Repeat, MipMapMode mipMapMode = MipMapMode::Nearest, Float mipMapBias = 0.f, Float maxLod = std::numeric_limits<Float>::max(), Float minLod = 0.f, Float anisotropy = 0.f) const override;
 
 		/// <inheritdoc />
-		virtual Enumerable<UniquePtr<IVulkanSampler>> createSamplers(const UInt32& elements, FilterMode magFilter = FilterMode::Nearest, FilterMode minFilter = FilterMode::Nearest, BorderMode borderU = BorderMode::Repeat, BorderMode borderV = BorderMode::Repeat, BorderMode borderW = BorderMode::Repeat, MipMapMode mipMapMode = MipMapMode::Nearest, const Float& mipMapBias = 0.f, const Float& maxLod = std::numeric_limits<Float>::max(), const Float& minLod = 0.f, const Float& anisotropy = 0.f) const override;
+		virtual Enumerable<UniquePtr<IVulkanSampler>> createSamplers(UInt32 elements, FilterMode magFilter = FilterMode::Nearest, FilterMode minFilter = FilterMode::Nearest, BorderMode borderU = BorderMode::Repeat, BorderMode borderV = BorderMode::Repeat, BorderMode borderW = BorderMode::Repeat, MipMapMode mipMapMode = MipMapMode::Nearest, Float mipMapBias = 0.f, Float maxLod = std::numeric_limits<Float>::max(), Float minLod = 0.f, Float anisotropy = 0.f) const override;
 	};
 
 	/// <summary>
@@ -1609,7 +1609,7 @@ namespace LiteFX::Rendering::Backends {
 		/// <param name="frameBufferSize">The initial size of the frame buffers.</param>
 		/// <param name="frameBuffers">The initial number of frame buffers.</param>
 		/// <param name="extensions">The required extensions the device gets initialized with.</param>
-		explicit VulkanDevice(const VulkanBackend& backend, const VulkanGraphicsAdapter& adapter, UniquePtr<VulkanSurface>&& surface, Format format, const Size2d& frameBufferSize, const UInt32& frameBuffers, Span<String> extensions = { });
+		explicit VulkanDevice(const VulkanBackend& backend, const VulkanGraphicsAdapter& adapter, UniquePtr<VulkanSurface>&& surface, Format format, const Size2d& frameBufferSize, UInt32 frameBuffers, Span<String> extensions = { });
 
 		VulkanDevice(const VulkanDevice&) = delete;
 		VulkanDevice(VulkanDevice&&) = delete;
@@ -1682,10 +1682,10 @@ namespace LiteFX::Rendering::Backends {
 #if defined(BUILD_DEFINE_BUILDERS)
 	public:
 		/// <inheritdoc />
-		[[nodiscard]] virtual VulkanRenderPassBuilder buildRenderPass(MultiSamplingLevel samples = MultiSamplingLevel::x1, const UInt32& commandBuffers = 1) const override;
+		[[nodiscard]] virtual VulkanRenderPassBuilder buildRenderPass(MultiSamplingLevel samples = MultiSamplingLevel::x1, UInt32 commandBuffers = 1) const override;
 
 		/// <inheritdoc />
-		[[nodiscard]] virtual VulkanRenderPassBuilder buildRenderPass(const String& name, MultiSamplingLevel samples = MultiSamplingLevel::x1, const UInt32& commandBuffers = 1) const override;
+		[[nodiscard]] virtual VulkanRenderPassBuilder buildRenderPass(const String& name, MultiSamplingLevel samples = MultiSamplingLevel::x1, UInt32 commandBuffers = 1) const override;
 
 		/// <inheritdoc />
 		//[[nodiscard]] virtual VulkanRenderPipelineBuilder buildRenderPipeline(const String& name) const override;

--- a/src/Backends/Vulkan/include/litefx/backends/vulkan.hpp
+++ b/src/Backends/Vulkan/include/litefx/backends/vulkan.hpp
@@ -720,7 +720,7 @@ namespace LiteFX::Rendering::Backends {
 		/// <param name="vertexBufferLayouts">The vertex buffer layouts supported by the input assembler state. Each layout must have a unique binding.</param>
 		/// <param name="indexBufferLayout">The index buffer layout.</param>
 		/// <param name="primitiveTopology">The primitive topology.</param>
-		explicit VulkanInputAssembler(Enumerable<UniquePtr<VulkanVertexBufferLayout>>&& vertexBufferLayouts, UniquePtr<VulkanIndexBufferLayout>&& indexBufferLayout, const PrimitiveTopology& primitiveTopology = PrimitiveTopology::TriangleList);
+		explicit VulkanInputAssembler(Enumerable<UniquePtr<VulkanVertexBufferLayout>>&& vertexBufferLayouts, UniquePtr<VulkanIndexBufferLayout>&& indexBufferLayout, PrimitiveTopology primitiveTopology = PrimitiveTopology::TriangleList);
 		VulkanInputAssembler(VulkanInputAssembler&&) noexcept = delete;
 		VulkanInputAssembler(const VulkanInputAssembler&) noexcept = delete;
 		virtual ~VulkanInputAssembler() noexcept;
@@ -742,7 +742,7 @@ namespace LiteFX::Rendering::Backends {
 		virtual const VulkanIndexBufferLayout& indexBufferLayout() const override;
 
 		/// <inheritdoc />
-		virtual const PrimitiveTopology& topology() const noexcept override;
+		virtual PrimitiveTopology topology() const noexcept override;
 	};
 
 	/// <summary>

--- a/src/Backends/Vulkan/include/litefx/backends/vulkan.hpp
+++ b/src/Backends/Vulkan/include/litefx/backends/vulkan.hpp
@@ -15,7 +15,7 @@ namespace LiteFX::Rendering::Backends {
 	/// <seealso cref="VulkanVertexBuffer" />
 	/// <seealso cref="VulkanIndexBufferLayout" />
 	/// <seealso cref="VulkanVertexBufferLayoutBuilder" />
-	class LITEFX_VULKAN_API VulkanVertexBufferLayout : public IVertexBufferLayout {
+	class LITEFX_VULKAN_API VulkanVertexBufferLayout final : public IVertexBufferLayout {
 		LITEFX_IMPLEMENTATION(VulkanVertexBufferLayoutImpl);
 		LITEFX_BUILDER(VulkanVertexBufferLayoutBuilder);
 
@@ -52,7 +52,7 @@ namespace LiteFX::Rendering::Backends {
 	/// </summary>
 	/// <seealso cref="VulkanIndexBuffer" />
 	/// <seealso cref="VulkanVertexBufferLayout" />
-	class LITEFX_VULKAN_API VulkanIndexBufferLayout : public IIndexBufferLayout {
+	class LITEFX_VULKAN_API VulkanIndexBufferLayout final : public IIndexBufferLayout {
 		LITEFX_IMPLEMENTATION(VulkanIndexBufferLayoutImpl);
 
 	public:
@@ -173,7 +173,7 @@ namespace LiteFX::Rendering::Backends {
 	/// <seealso cref="IVulkanBuffer" />
 	/// <seealso cref="IVulkanImage" />
 	/// <seealso cref="Barrier" />
-	class LITEFX_VULKAN_API VulkanBarrier : public Barrier<IVulkanBuffer, IVulkanImage> {
+	class LITEFX_VULKAN_API VulkanBarrier final : public Barrier<IVulkanBuffer, IVulkanImage> {
 		LITEFX_IMPLEMENTATION(VulkanBarrierImpl);
 		LITEFX_BUILDER(VulkanBarrierBuilder);
 
@@ -241,7 +241,7 @@ namespace LiteFX::Rendering::Backends {
 	/// <seealso cref="VulkanShaderProgram" />
 	/// <seealso cref="VulkanDevice" />
 	/// <seealso href="https://github.com/crud89/LiteFX/wiki/Shader-Development" />
-	class LITEFX_VULKAN_API VulkanShaderModule : public IShaderModule, public Resource<VkShaderModule> {
+	class LITEFX_VULKAN_API VulkanShaderModule final : public IShaderModule, public Resource<VkShaderModule> {
 		LITEFX_IMPLEMENTATION(VulkanShaderModuleImpl);
 
 	public:
@@ -298,7 +298,7 @@ namespace LiteFX::Rendering::Backends {
 	/// <seealso cref="VulkanShaderProgramBuilder" />
 	/// <seealso cref="VulkanShaderModule" />
 	/// <seealso href="https://github.com/crud89/LiteFX/wiki/Shader-Development" />
-	class LITEFX_VULKAN_API VulkanShaderProgram : public ShaderProgram<VulkanShaderModule> {
+	class LITEFX_VULKAN_API VulkanShaderProgram final : public ShaderProgram<VulkanShaderModule> {
 		LITEFX_IMPLEMENTATION(VulkanShaderProgramImpl);
 		LITEFX_BUILDER(VulkanShaderProgramBuilder);
 
@@ -337,7 +337,7 @@ namespace LiteFX::Rendering::Backends {
 	/// Implements a Vulkan <see cref="DescriptorSet" />.
 	/// </summary>
 	/// <seealso cref="VulkanDescriptorSetLayout" />
-	class LITEFX_VULKAN_API VulkanDescriptorSet : public DescriptorSet<IVulkanBuffer, IVulkanImage, IVulkanSampler>, public Resource<VkDescriptorSet> {
+	class LITEFX_VULKAN_API VulkanDescriptorSet final : public DescriptorSet<IVulkanBuffer, IVulkanImage, IVulkanSampler>, public Resource<VkDescriptorSet> {
 		LITEFX_IMPLEMENTATION(VulkanDescriptorSetImpl);
 
 	public:
@@ -385,7 +385,7 @@ namespace LiteFX::Rendering::Backends {
 	/// <seealso cref="IVulkanSampler" />
 	/// <seealso cref="VulkanDescriptorSet" />
 	/// <seealso cref="VulkanDescriptorSetLayout" />
-	class LITEFX_VULKAN_API VulkanDescriptorLayout : public IDescriptorLayout {
+	class LITEFX_VULKAN_API VulkanDescriptorLayout final : public IDescriptorLayout {
 		LITEFX_IMPLEMENTATION(VulkanDescriptorLayoutImpl);
 
 	public:
@@ -438,7 +438,7 @@ namespace LiteFX::Rendering::Backends {
 	/// </summary>
 	/// <seealso cref="VulkanDescriptorSet" />
 	/// <seealso cref="VulkanDescriptorSetLayoutBuilder" />
-	class LITEFX_VULKAN_API VulkanDescriptorSetLayout : public DescriptorSetLayout<VulkanDescriptorLayout, VulkanDescriptorSet>, public Resource<VkDescriptorSetLayout> {
+	class LITEFX_VULKAN_API VulkanDescriptorSetLayout final : public DescriptorSetLayout<VulkanDescriptorLayout, VulkanDescriptorSet>, public Resource<VkDescriptorSetLayout> {
 		LITEFX_IMPLEMENTATION(VulkanDescriptorSetLayoutImpl);
 		LITEFX_BUILDER(VulkanDescriptorSetLayoutBuilder);
 
@@ -571,7 +571,7 @@ namespace LiteFX::Rendering::Backends {
 	/// Implements the Vulkan <see cref="IPushConstantsRange" />.
 	/// </summary>
 	/// <seealso cref="VulkanPushConstantsLayout" />
-	class LITEFX_VULKAN_API VulkanPushConstantsRange : public IPushConstantsRange {
+	class LITEFX_VULKAN_API VulkanPushConstantsRange final : public IPushConstantsRange {
 		LITEFX_IMPLEMENTATION(VulkanPushConstantsRangeImpl);
 
 	public:
@@ -611,7 +611,7 @@ namespace LiteFX::Rendering::Backends {
 	/// <seealso cref="VulkanPushConstantsRange" />
 	/// <seealso cref="VulkanPushConstantsLayoutBuilder" />
 	/// <seealso cref="VulkanPushConstantsLayoutBuilder" />
-	class LITEFX_VULKAN_API VulkanPushConstantsLayout : public PushConstantsLayout<VulkanPushConstantsRange> {
+	class LITEFX_VULKAN_API VulkanPushConstantsLayout final : public PushConstantsLayout<VulkanPushConstantsRange> {
 		LITEFX_IMPLEMENTATION(VulkanPushConstantsLayoutImpl);
 		LITEFX_BUILDER(VulkanPushConstantsLayoutBuilder);
 		friend class VulkanPipelineLayout;
@@ -663,7 +663,7 @@ namespace LiteFX::Rendering::Backends {
 	/// Implements a Vulkan <see cref="PipelineLayout" />.
 	/// </summary>
 	/// <seealso cref="VulkanPipelineLayoutBuilder" />
-	class LITEFX_VULKAN_API VulkanPipelineLayout : public PipelineLayout<VulkanDescriptorSetLayout, VulkanPushConstantsLayout>, public Resource<VkPipelineLayout> {
+	class LITEFX_VULKAN_API VulkanPipelineLayout final : public PipelineLayout<VulkanDescriptorSetLayout, VulkanPushConstantsLayout>, public Resource<VkPipelineLayout> {
 		LITEFX_IMPLEMENTATION(VulkanPipelineLayoutImpl);
 		LITEFX_BUILDER(VulkanPipelineLayoutBuilder);
 
@@ -709,7 +709,7 @@ namespace LiteFX::Rendering::Backends {
 	/// Implements the Vulkan input assembler state.
 	/// </summary>
 	/// <seealso cref="VulkanInputAssemblerBuilder" />
-	class LITEFX_VULKAN_API VulkanInputAssembler : public InputAssembler<VulkanVertexBufferLayout, VulkanIndexBufferLayout> {
+	class LITEFX_VULKAN_API VulkanInputAssembler final : public InputAssembler<VulkanVertexBufferLayout, VulkanIndexBufferLayout> {
 		LITEFX_IMPLEMENTATION(VulkanInputAssemblerImpl);
 		LITEFX_BUILDER(VulkanInputAssemblerBuilder);
 
@@ -749,7 +749,7 @@ namespace LiteFX::Rendering::Backends {
 	/// Implements a Vulkan <see cref="IRasterizer" />.
 	/// </summary>
 	/// <seealso cref="VulkanRasterizerBuilder" />
-	class LITEFX_VULKAN_API VulkanRasterizer : public Rasterizer {
+	class LITEFX_VULKAN_API VulkanRasterizer final : public Rasterizer {
 		LITEFX_BUILDER(VulkanRasterizerBuilder);
 
 	public:
@@ -817,7 +817,7 @@ namespace LiteFX::Rendering::Backends {
 	/// Records commands for a <see cref="VulkanCommandQueue" />
 	/// </summary>
 	/// <seealso cref="VulkanQueue" />
-	class LITEFX_VULKAN_API VulkanCommandBuffer : public CommandBuffer<VulkanCommandBuffer, IVulkanBuffer, IVulkanVertexBuffer, IVulkanIndexBuffer, IVulkanImage, VulkanBarrier, VulkanPipelineState>, public Resource<VkCommandBuffer> {
+	class LITEFX_VULKAN_API VulkanCommandBuffer final : public CommandBuffer<VulkanCommandBuffer, IVulkanBuffer, IVulkanVertexBuffer, IVulkanIndexBuffer, IVulkanImage, VulkanBarrier, VulkanPipelineState>, public Resource<VkCommandBuffer> {
 		LITEFX_IMPLEMENTATION(VulkanCommandBufferImpl);
 
 	public:
@@ -953,7 +953,7 @@ namespace LiteFX::Rendering::Backends {
 	/// </summary>
 	/// <seealso cref="VulkanComputePipeline" />
 	/// <seealso cref="VulkanRenderPipelineBuilder" />
-	class LITEFX_VULKAN_API VulkanRenderPipeline : public RenderPipeline<VulkanPipelineLayout, VulkanShaderProgram, VulkanInputAssembler, VulkanRasterizer>, public VulkanPipelineState {
+	class LITEFX_VULKAN_API VulkanRenderPipeline final : public RenderPipeline<VulkanPipelineLayout, VulkanShaderProgram, VulkanInputAssembler, VulkanRasterizer>, public VulkanPipelineState {
 		LITEFX_IMPLEMENTATION(VulkanRenderPipelineImpl);
 		LITEFX_BUILDER(VulkanRenderPipelineBuilder);
 
@@ -1014,7 +1014,7 @@ namespace LiteFX::Rendering::Backends {
 	/// </summary>
 	/// <seealso cref="VulkanRenderPipeline" />
 	/// <seealso cref="VulkanComputePipelineBuilder" />
-	class LITEFX_VULKAN_API VulkanComputePipeline : public ComputePipeline<VulkanPipelineLayout, VulkanShaderProgram>, public VulkanPipelineState {
+	class LITEFX_VULKAN_API VulkanComputePipeline final : public ComputePipeline<VulkanPipelineLayout, VulkanShaderProgram>, public VulkanPipelineState {
 		LITEFX_IMPLEMENTATION(VulkanComputePipelineImpl);
 		LITEFX_BUILDER(VulkanComputePipelineBuilder);
 
@@ -1059,7 +1059,7 @@ namespace LiteFX::Rendering::Backends {
 	/// Implements a Vulkan frame buffer.
 	/// </summary>
 	/// <seealso cref="VulkanRenderPass" />
-	class LITEFX_VULKAN_API VulkanFrameBuffer : public FrameBuffer<VulkanCommandBuffer>, public Resource<VkFramebuffer> {
+	class LITEFX_VULKAN_API VulkanFrameBuffer final : public FrameBuffer<VulkanCommandBuffer>, public Resource<VkFramebuffer> {
 		LITEFX_IMPLEMENTATION(VulkanFrameBufferImpl);
 
 	public:
@@ -1127,7 +1127,7 @@ namespace LiteFX::Rendering::Backends {
 	/// Implements a Vulkan render pass.
 	/// </summary>
 	/// <seealso cref="VulkanRenderPassBuilder" />
-	class LITEFX_VULKAN_API VulkanRenderPass : public RenderPass<VulkanRenderPipeline, VulkanFrameBuffer, VulkanInputAttachmentMapping>, public Resource<VkRenderPass> {
+	class LITEFX_VULKAN_API VulkanRenderPass final : public RenderPass<VulkanRenderPipeline, VulkanFrameBuffer, VulkanInputAttachmentMapping>, public Resource<VkRenderPass> {
 		LITEFX_IMPLEMENTATION(VulkanRenderPassImpl);
 		LITEFX_BUILDER(VulkanRenderPassBuilder);
 
@@ -1232,7 +1232,7 @@ namespace LiteFX::Rendering::Backends {
 	/// </summary>
 	/// <seealso cref="VulkanRenderPass" />
 	/// <seealso cref="VulkanRenderPassBuilder" />
-	class LITEFX_VULKAN_API VulkanInputAttachmentMapping : public IInputAttachmentMapping<VulkanRenderPass> {
+	class LITEFX_VULKAN_API VulkanInputAttachmentMapping final : public IInputAttachmentMapping<VulkanRenderPass> {
 		LITEFX_IMPLEMENTATION(VulkanInputAttachmentMappingImpl);
 
 	public:
@@ -1286,7 +1286,7 @@ namespace LiteFX::Rendering::Backends {
 	/// <summary>
 	/// Implements a Vulkan swap chain.
 	/// </summary>
-	class LITEFX_VULKAN_API VulkanSwapChain : public SwapChain<IVulkanImage, VulkanFrameBuffer> {
+	class LITEFX_VULKAN_API VulkanSwapChain final : public SwapChain<IVulkanImage, VulkanFrameBuffer> {
 		LITEFX_IMPLEMENTATION(VulkanSwapChainImpl);
 
 	public:
@@ -1370,7 +1370,7 @@ namespace LiteFX::Rendering::Backends {
 	/// Implements a Vulkan command queue.
 	/// </summary>
 	/// <seealso cref="VulkanCommandBuffer" />
-	class LITEFX_VULKAN_API VulkanQueue : public CommandQueue<VulkanCommandBuffer>, public Resource<VkQueue> {
+	class LITEFX_VULKAN_API VulkanQueue final : public CommandQueue<VulkanCommandBuffer>, public Resource<VkQueue> {
 		LITEFX_IMPLEMENTATION(VulkanQueueImpl);
 
 	public:
@@ -1515,7 +1515,7 @@ namespace LiteFX::Rendering::Backends {
 	/// <remarks>
 	/// Internally this factory implementation is based on <a href="https://gpuopen.com/vulkan-memory-allocator/" target="_blank">Vulkan Memory Allocator</a>.
 	/// </remarks>
-	class LITEFX_VULKAN_API VulkanGraphicsFactory : public GraphicsFactory<VulkanDescriptorLayout, IVulkanBuffer, IVulkanVertexBuffer, IVulkanIndexBuffer, IVulkanImage, IVulkanSampler> {
+	class LITEFX_VULKAN_API VulkanGraphicsFactory final : public GraphicsFactory<VulkanDescriptorLayout, IVulkanBuffer, IVulkanVertexBuffer, IVulkanIndexBuffer, IVulkanImage, IVulkanSampler> {
 		LITEFX_IMPLEMENTATION(VulkanGraphicsFactoryImpl);
 
 	public:
@@ -1586,7 +1586,7 @@ namespace LiteFX::Rendering::Backends {
 	/// <summary>
 	/// Implements a Vulkan graphics device.
 	/// </summary>
-	class LITEFX_VULKAN_API VulkanDevice : public GraphicsDevice<VulkanGraphicsFactory, VulkanSurface, VulkanGraphicsAdapter, VulkanSwapChain, VulkanQueue, VulkanRenderPass, VulkanComputePipeline, VulkanBarrier>, public Resource<VkDevice> {
+	class LITEFX_VULKAN_API VulkanDevice final : public GraphicsDevice<VulkanGraphicsFactory, VulkanSurface, VulkanGraphicsAdapter, VulkanSwapChain, VulkanQueue, VulkanRenderPass, VulkanComputePipeline, VulkanBarrier>, public Resource<VkDevice> {
 		LITEFX_IMPLEMENTATION(VulkanDeviceImpl);
 
 	public:
@@ -1716,7 +1716,7 @@ namespace LiteFX::Rendering::Backends {
 	/// <summary>
 	/// Defines a rendering backend that creates a Vulkan device.
 	/// </summary>
-	class LITEFX_VULKAN_API VulkanBackend : public RenderBackend<VulkanDevice>, public Resource<VkInstance> {
+	class LITEFX_VULKAN_API VulkanBackend final : public RenderBackend<VulkanDevice>, public Resource<VkInstance> {
 		LITEFX_IMPLEMENTATION(VulkanBackendImpl);
 
 	public:
@@ -1825,4 +1825,5 @@ namespace LiteFX::Rendering::Backends {
 		/// <inheritdoc />
 		const VulkanDevice* device(const String& name) const noexcept override;
 	};
+
 }

--- a/src/Backends/Vulkan/include/litefx/backends/vulkan_api.hpp
+++ b/src/Backends/Vulkan/include/litefx/backends/vulkan_api.hpp
@@ -202,7 +202,7 @@ namespace LiteFX::Rendering::Backends {
     /// <summary>
     /// Represents a Vulkan <see cref="IGraphicsAdapter" />.
     /// </summary>
-    class LITEFX_VULKAN_API VulkanGraphicsAdapter : public IGraphicsAdapter, public Resource<VkPhysicalDevice> {
+    class LITEFX_VULKAN_API VulkanGraphicsAdapter final : public IGraphicsAdapter, public Resource<VkPhysicalDevice> {
         LITEFX_IMPLEMENTATION(VulkanGraphicsAdapterImpl);
 
     public:
@@ -279,7 +279,7 @@ namespace LiteFX::Rendering::Backends {
     /// <summary>
     /// Represents a Vulkan <see cref="ISurface" />.
     /// </summary>
-    class LITEFX_VULKAN_API VulkanSurface : public ISurface, public Resource<VkSurfaceKHR> {
+    class LITEFX_VULKAN_API VulkanSurface final : public ISurface, public Resource<VkSurfaceKHR> {
         LITEFX_IMPLEMENTATION(VulkanSurfaceImpl)
 
     public:

--- a/src/Backends/Vulkan/include/litefx/backends/vulkan_api.hpp
+++ b/src/Backends/Vulkan/include/litefx/backends/vulkan_api.hpp
@@ -86,117 +86,117 @@ namespace LiteFX::Rendering::Backends {
         /// <summary>
         /// 
         /// </summary>
-        Format LITEFX_VULKAN_API getFormat(const VkFormat& format);
+        constexpr inline Format LITEFX_VULKAN_API getFormat(const VkFormat& format);
 
         /// <summary>
         /// 
         /// </summary>
-        VkFormat LITEFX_VULKAN_API getFormat(const Format& format);
+        constexpr inline VkFormat LITEFX_VULKAN_API getFormat(const Format& format);
 
         /// <summary>
         /// 
         /// </summary>
-        //BufferFormat LITEFX_VULKAN_API getFormat(const VkFormat& format);
+        //constexpr inline BufferFormat LITEFX_VULKAN_API getFormat(const VkFormat& format);
 
         /// <summary>
         /// 
         /// </summary>
-        VkFormat LITEFX_VULKAN_API getFormat(const BufferFormat& format);
+        constexpr inline VkFormat LITEFX_VULKAN_API getFormat(const BufferFormat& format);
 
         /// <summary>
         /// 
         /// </summary>
-        PolygonMode LITEFX_VULKAN_API getPolygonMode(const VkPolygonMode& mode);
+        constexpr inline PolygonMode LITEFX_VULKAN_API getPolygonMode(const VkPolygonMode& mode);
 
         /// <summary>
         /// 
         /// </summary>
-        VkPolygonMode LITEFX_VULKAN_API getPolygonMode(const PolygonMode& mode);
+        constexpr inline VkPolygonMode LITEFX_VULKAN_API getPolygonMode(const PolygonMode& mode);
 
         /// <summary>
         /// 
         /// </summary>
-        CullMode LITEFX_VULKAN_API getCullMode(const VkCullModeFlags& mode);
+        constexpr inline CullMode LITEFX_VULKAN_API getCullMode(const VkCullModeFlags& mode);
 
         /// <summary>
         /// 
         /// </summary>
-        VkCullModeFlags LITEFX_VULKAN_API getCullMode(const CullMode& mode);
+        constexpr inline VkCullModeFlags LITEFX_VULKAN_API getCullMode(const CullMode& mode);
 
         /// <summary>
         /// 
         /// </summary>
-        PrimitiveTopology LITEFX_VULKAN_API getPrimitiveTopology(const VkPrimitiveTopology& topology);
+        constexpr inline PrimitiveTopology LITEFX_VULKAN_API getPrimitiveTopology(const VkPrimitiveTopology& topology);
 
         /// <summary>
         /// 
         /// </summary>
-        VkPrimitiveTopology LITEFX_VULKAN_API getPrimitiveTopology(const PrimitiveTopology& topology);
+        constexpr inline VkPrimitiveTopology LITEFX_VULKAN_API getPrimitiveTopology(const PrimitiveTopology& topology);
 
         /// <summary>
         /// 
         /// </summary>
-        ShaderStage LITEFX_VULKAN_API getShaderStage(const VkShaderStageFlagBits& shaderType);
+        constexpr inline ShaderStage LITEFX_VULKAN_API getShaderStage(const VkShaderStageFlagBits& shaderType);
 
         /// <summary>
         /// 
         /// </summary>
-        VkShaderStageFlagBits LITEFX_VULKAN_API getShaderStage(const ShaderStage& shaderType);
+        constexpr inline VkShaderStageFlagBits LITEFX_VULKAN_API getShaderStage(const ShaderStage& shaderType);
 
         /// <summary>
         /// 
         /// </summary>
-        MultiSamplingLevel LITEFX_VULKAN_API getSamples(const VkSampleCountFlagBits& samples);
+        constexpr inline MultiSamplingLevel LITEFX_VULKAN_API getSamples(const VkSampleCountFlagBits& samples);
 
         /// <summary>
         /// 
         /// </summary>
-        VkImageType LITEFX_VULKAN_API getImageType(const ImageDimensions& dimension);
+        constexpr inline VkImageType LITEFX_VULKAN_API getImageType(const ImageDimensions& dimension);
 
         /// <summary>
         /// 
         /// </summary>
-        VkImageViewType LITEFX_VULKAN_API getImageViewType(const ImageDimensions& dimension, const UInt32& layers = 1);
+        constexpr inline VkImageViewType LITEFX_VULKAN_API getImageViewType(const ImageDimensions& dimension, const UInt32& layers = 1);
 
         /// <summary>
         /// 
         /// </summary>
-        VkSampleCountFlagBits LITEFX_VULKAN_API getSamples(const MultiSamplingLevel& samples);
+        constexpr inline VkSampleCountFlagBits LITEFX_VULKAN_API getSamples(const MultiSamplingLevel& samples);
 
         /// <summary>
         /// 
         /// </summary>
-        VkCompareOp LITEFX_VULKAN_API getCompareOp(const CompareOperation& compareOp);
+        constexpr inline VkCompareOp LITEFX_VULKAN_API getCompareOp(const CompareOperation& compareOp);
 
         /// <summary>
         /// 
         /// </summary>
-        VkStencilOp LITEFX_VULKAN_API getStencilOp(const StencilOperation& stencilOp);
+        constexpr inline VkStencilOp LITEFX_VULKAN_API getStencilOp(const StencilOperation& stencilOp);
 
         /// <summary>
         /// 
         /// </summary>
-        VkBlendFactor LITEFX_VULKAN_API getBlendFactor(const BlendFactor& blendFactor);
+        constexpr inline VkBlendFactor LITEFX_VULKAN_API getBlendFactor(const BlendFactor& blendFactor);
 
         /// <summary>
         /// 
         /// </summary>
-        VkBlendOp LITEFX_VULKAN_API getBlendOperation(const BlendOperation& blendOperation);
+        constexpr inline VkBlendOp LITEFX_VULKAN_API getBlendOperation(const BlendOperation& blendOperation);
 
         /// <summary>
         /// 
         /// </summary>
-        VkPipelineStageFlags LITEFX_VULKAN_API getPipelineStage(const PipelineStage& pipelineStage);
+        constexpr inline VkPipelineStageFlags LITEFX_VULKAN_API getPipelineStage(const PipelineStage& pipelineStage);
 
         /// <summary>
         /// 
         /// </summary>
-        VkAccessFlags LITEFX_VULKAN_API getResourceAccess(const ResourceAccess& resourceAccess);
+        constexpr inline VkAccessFlags LITEFX_VULKAN_API getResourceAccess(const ResourceAccess& resourceAccess);
 
         /// <summary>
         /// 
         /// </summary>
-        VkImageLayout LITEFX_VULKAN_API getImageLayout(const ImageLayout& imageLayout);
+        constexpr inline VkImageLayout LITEFX_VULKAN_API getImageLayout(const ImageLayout& imageLayout);
     }
 
     /// <summary>

--- a/src/Backends/Vulkan/include/litefx/backends/vulkan_api.hpp
+++ b/src/Backends/Vulkan/include/litefx/backends/vulkan_api.hpp
@@ -91,7 +91,7 @@ namespace LiteFX::Rendering::Backends {
         /// <summary>
         /// 
         /// </summary>
-        constexpr inline VkFormat LITEFX_VULKAN_API getFormat(const Format& format);
+        constexpr inline VkFormat LITEFX_VULKAN_API getFormat(Format format);
 
         /// <summary>
         /// 
@@ -101,7 +101,7 @@ namespace LiteFX::Rendering::Backends {
         /// <summary>
         /// 
         /// </summary>
-        constexpr inline VkFormat LITEFX_VULKAN_API getFormat(const BufferFormat& format);
+        constexpr inline VkFormat LITEFX_VULKAN_API getFormat(BufferFormat format);
 
         /// <summary>
         /// 
@@ -111,7 +111,7 @@ namespace LiteFX::Rendering::Backends {
         /// <summary>
         /// 
         /// </summary>
-        constexpr inline VkPolygonMode LITEFX_VULKAN_API getPolygonMode(const PolygonMode& mode);
+        constexpr inline VkPolygonMode LITEFX_VULKAN_API getPolygonMode(PolygonMode mode);
 
         /// <summary>
         /// 
@@ -121,7 +121,7 @@ namespace LiteFX::Rendering::Backends {
         /// <summary>
         /// 
         /// </summary>
-        constexpr inline VkCullModeFlags LITEFX_VULKAN_API getCullMode(const CullMode& mode);
+        constexpr inline VkCullModeFlags LITEFX_VULKAN_API getCullMode(CullMode mode);
 
         /// <summary>
         /// 
@@ -141,7 +141,7 @@ namespace LiteFX::Rendering::Backends {
         /// <summary>
         /// 
         /// </summary>
-        constexpr inline VkShaderStageFlagBits LITEFX_VULKAN_API getShaderStage(const ShaderStage& shaderType);
+        constexpr inline VkShaderStageFlagBits LITEFX_VULKAN_API getShaderStage(ShaderStage shaderType);
 
         /// <summary>
         /// 
@@ -151,52 +151,52 @@ namespace LiteFX::Rendering::Backends {
         /// <summary>
         /// 
         /// </summary>
-        constexpr inline VkImageType LITEFX_VULKAN_API getImageType(const ImageDimensions& dimension);
+        constexpr inline VkImageType LITEFX_VULKAN_API getImageType(ImageDimensions dimension);
 
         /// <summary>
         /// 
         /// </summary>
-        constexpr inline VkImageViewType LITEFX_VULKAN_API getImageViewType(const ImageDimensions& dimension, const UInt32& layers = 1);
+        constexpr inline VkImageViewType LITEFX_VULKAN_API getImageViewType(ImageDimensions dimension, const UInt32& layers = 1);
 
         /// <summary>
         /// 
         /// </summary>
-        constexpr inline VkSampleCountFlagBits LITEFX_VULKAN_API getSamples(const MultiSamplingLevel& samples);
+        constexpr inline VkSampleCountFlagBits LITEFX_VULKAN_API getSamples(MultiSamplingLevel samples);
 
         /// <summary>
         /// 
         /// </summary>
-        constexpr inline VkCompareOp LITEFX_VULKAN_API getCompareOp(const CompareOperation& compareOp);
+        constexpr inline VkCompareOp LITEFX_VULKAN_API getCompareOp(CompareOperation compareOp);
 
         /// <summary>
         /// 
         /// </summary>
-        constexpr inline VkStencilOp LITEFX_VULKAN_API getStencilOp(const StencilOperation& stencilOp);
+        constexpr inline VkStencilOp LITEFX_VULKAN_API getStencilOp(StencilOperation stencilOp);
 
         /// <summary>
         /// 
         /// </summary>
-        constexpr inline VkBlendFactor LITEFX_VULKAN_API getBlendFactor(const BlendFactor& blendFactor);
+        constexpr inline VkBlendFactor LITEFX_VULKAN_API getBlendFactor(BlendFactor blendFactor);
 
         /// <summary>
         /// 
         /// </summary>
-        constexpr inline VkBlendOp LITEFX_VULKAN_API getBlendOperation(const BlendOperation& blendOperation);
+        constexpr inline VkBlendOp LITEFX_VULKAN_API getBlendOperation(BlendOperation blendOperation);
 
         /// <summary>
         /// 
         /// </summary>
-        constexpr inline VkPipelineStageFlags LITEFX_VULKAN_API getPipelineStage(const PipelineStage& pipelineStage);
+        constexpr inline VkPipelineStageFlags LITEFX_VULKAN_API getPipelineStage(PipelineStage pipelineStage);
 
         /// <summary>
         /// 
         /// </summary>
-        constexpr inline VkAccessFlags LITEFX_VULKAN_API getResourceAccess(const ResourceAccess& resourceAccess);
+        constexpr inline VkAccessFlags LITEFX_VULKAN_API getResourceAccess(ResourceAccess resourceAccess);
 
         /// <summary>
         /// 
         /// </summary>
-        constexpr inline VkImageLayout LITEFX_VULKAN_API getImageLayout(const ImageLayout& imageLayout);
+        constexpr inline VkImageLayout LITEFX_VULKAN_API getImageLayout(ImageLayout imageLayout);
     }
 
     /// <summary>

--- a/src/Backends/Vulkan/include/litefx/backends/vulkan_api.hpp
+++ b/src/Backends/Vulkan/include/litefx/backends/vulkan_api.hpp
@@ -217,28 +217,28 @@ namespace LiteFX::Rendering::Backends {
 
     public:
         /// <inheritdoc />
-        virtual String name() const noexcept override;
+        String name() const noexcept override;
 
         /// <inheritdoc />
-        virtual UInt64 uniqueId() const noexcept override;
+        UInt64 uniqueId() const noexcept override;
 
         /// <inheritdoc />
-        virtual UInt32 vendorId() const noexcept override;
+        UInt32 vendorId() const noexcept override;
 
         /// <inheritdoc />
-        virtual UInt32 deviceId() const noexcept override;
+        UInt32 deviceId() const noexcept override;
 
         /// <inheritdoc />
-        virtual GraphicsAdapterType type() const noexcept override;
+        GraphicsAdapterType type() const noexcept override;
 
         /// <inheritdoc />
-        virtual UInt32 driverVersion() const noexcept override;
+        UInt32 driverVersion() const noexcept override;
 
         /// <inheritdoc />
-        virtual UInt32 apiVersion() const noexcept override;
+        UInt32 apiVersion() const noexcept override;
 
         /// <inheritdoc />
-        virtual UInt64 dedicatedMemory() const noexcept override;
+        UInt64 dedicatedMemory() const noexcept override;
 
     public:
         /// <summary>

--- a/src/Backends/Vulkan/include/litefx/backends/vulkan_api.hpp
+++ b/src/Backends/Vulkan/include/litefx/backends/vulkan_api.hpp
@@ -156,7 +156,7 @@ namespace LiteFX::Rendering::Backends {
         /// <summary>
         /// 
         /// </summary>
-        constexpr inline VkImageViewType LITEFX_VULKAN_API getImageViewType(ImageDimensions dimension, const UInt32& layers = 1);
+        constexpr inline VkImageViewType LITEFX_VULKAN_API getImageViewType(ImageDimensions dimension, UInt32 layers = 1);
 
         /// <summary>
         /// 

--- a/src/Backends/Vulkan/include/litefx/backends/vulkan_api.hpp
+++ b/src/Backends/Vulkan/include/litefx/backends/vulkan_api.hpp
@@ -131,7 +131,7 @@ namespace LiteFX::Rendering::Backends {
         /// <summary>
         /// 
         /// </summary>
-        constexpr inline VkPrimitiveTopology LITEFX_VULKAN_API getPrimitiveTopology(const PrimitiveTopology& topology);
+        constexpr inline VkPrimitiveTopology LITEFX_VULKAN_API getPrimitiveTopology(PrimitiveTopology topology);
 
         /// <summary>
         /// 

--- a/src/Backends/Vulkan/src/barrier.cpp
+++ b/src/Backends/Vulkan/src/barrier.cpp
@@ -22,7 +22,7 @@ private:
     Array<ImageBarrier> m_imageBarriers;
 
 public:
-    VulkanBarrierImpl(VulkanBarrier* parent, const PipelineStage& syncBefore, const PipelineStage& syncAfter) :
+    VulkanBarrierImpl(VulkanBarrier* parent, PipelineStage syncBefore, PipelineStage syncAfter) :
         base(parent), m_syncBefore(syncBefore), m_syncAfter(syncAfter)
     {
     }
@@ -32,7 +32,7 @@ public:
 // Shared interface.
 // ------------------------------------------------------------------------------------------------
 
-constexpr VulkanBarrier::VulkanBarrier(const PipelineStage& syncBefore, const PipelineStage& syncAfter) noexcept :
+constexpr VulkanBarrier::VulkanBarrier(PipelineStage syncBefore, PipelineStage syncAfter) noexcept :
     m_impl(makePimpl<VulkanBarrierImpl>(this, syncBefore, syncAfter))
 {
 }
@@ -44,7 +44,7 @@ constexpr VulkanBarrier::VulkanBarrier() noexcept :
 
 constexpr VulkanBarrier::~VulkanBarrier() noexcept = default;
 
-constexpr const PipelineStage& VulkanBarrier::syncBefore() const noexcept
+constexpr PipelineStage VulkanBarrier::syncBefore() const noexcept
 {
     return m_impl->m_syncBefore;
 }
@@ -54,7 +54,7 @@ constexpr PipelineStage& VulkanBarrier::syncBefore() noexcept
     return m_impl->m_syncBefore;
 }
 
-constexpr const PipelineStage& VulkanBarrier::syncAfter() const noexcept
+constexpr PipelineStage VulkanBarrier::syncAfter() const noexcept
 {
     return m_impl->m_syncAfter;
 }
@@ -64,37 +64,37 @@ constexpr PipelineStage& VulkanBarrier::syncAfter() noexcept
     return m_impl->m_syncAfter;
 }
 
-constexpr void VulkanBarrier::wait(const ResourceAccess& accessBefore, const ResourceAccess& accessAfter) noexcept
+constexpr void VulkanBarrier::wait(ResourceAccess accessBefore, ResourceAccess accessAfter) noexcept
 {
     m_impl->m_globalBarriers.push_back({ accessBefore, accessAfter });
 }
 
-constexpr void VulkanBarrier::transition(IVulkanBuffer& buffer, const ResourceAccess& accessBefore, const ResourceAccess& accessAfter)
+constexpr void VulkanBarrier::transition(IVulkanBuffer& buffer, ResourceAccess accessBefore, ResourceAccess accessAfter)
 {
     m_impl->m_bufferBarriers.push_back({ accessBefore, accessAfter, buffer, std::numeric_limits<UInt32>::max() });
 }
 
-constexpr void VulkanBarrier::transition(IVulkanBuffer& buffer, const UInt32& element, const ResourceAccess& accessBefore, const ResourceAccess& accessAfter)
+constexpr void VulkanBarrier::transition(IVulkanBuffer& buffer, const UInt32& element, ResourceAccess accessBefore, ResourceAccess accessAfter)
 {
     m_impl->m_bufferBarriers.push_back({ accessBefore, accessAfter, buffer, element });
 }
 
-constexpr void VulkanBarrier::transition(IVulkanImage& image, const ResourceAccess& accessBefore, const ResourceAccess& accessAfter, const ImageLayout& layout)
+constexpr void VulkanBarrier::transition(IVulkanImage& image, ResourceAccess accessBefore, ResourceAccess accessAfter, ImageLayout layout)
 {
     m_impl->m_imageBarriers.push_back({ accessBefore, accessAfter, image, std::nullopt, layout, 0, image.levels(), 0, image.layers(), 0 });
 }
 
-constexpr void VulkanBarrier::transition(IVulkanImage& image, const ResourceAccess& accessBefore, const ResourceAccess& accessAfter, const ImageLayout& fromLayout, const ImageLayout& toLayout)
+constexpr void VulkanBarrier::transition(IVulkanImage& image, ResourceAccess accessBefore, ResourceAccess accessAfter, ImageLayout fromLayout, ImageLayout toLayout)
 {
     m_impl->m_imageBarriers.push_back({ accessBefore, accessAfter, image, fromLayout, toLayout, 0, image.levels(), 0, image.layers(), 0 });
 }
 
-constexpr void VulkanBarrier::transition(IVulkanImage& image, const UInt32& level, const UInt32& levels, const UInt32& layer, const UInt32& layers, const UInt32& plane, const ResourceAccess& accessBefore, const ResourceAccess& accessAfter, const ImageLayout& layout)
+constexpr void VulkanBarrier::transition(IVulkanImage& image, const UInt32& level, const UInt32& levels, const UInt32& layer, const UInt32& layers, const UInt32& plane, ResourceAccess accessBefore, ResourceAccess accessAfter, ImageLayout layout)
 {
     m_impl->m_imageBarriers.push_back({ accessBefore, accessAfter, image, std::nullopt, layout, level, levels, layer, layers, plane });
 }
 
-constexpr void VulkanBarrier::transition(IVulkanImage& image, const UInt32& level, const UInt32& levels, const UInt32& layer, const UInt32& layers, const UInt32& plane, const ResourceAccess& accessBefore, const ResourceAccess& accessAfter, const ImageLayout& fromLayout, const ImageLayout& toLayout)
+constexpr void VulkanBarrier::transition(IVulkanImage& image, const UInt32& level, const UInt32& levels, const UInt32& layer, const UInt32& layers, const UInt32& plane, ResourceAccess accessBefore, ResourceAccess accessAfter, ImageLayout fromLayout, ImageLayout toLayout)
 {
     m_impl->m_imageBarriers.push_back({ accessBefore, accessAfter, image, fromLayout, toLayout, level, levels, layer, layers, plane });
 }

--- a/src/Backends/Vulkan/src/barrier.cpp
+++ b/src/Backends/Vulkan/src/barrier.cpp
@@ -74,7 +74,7 @@ constexpr void VulkanBarrier::transition(IVulkanBuffer& buffer, ResourceAccess a
     m_impl->m_bufferBarriers.push_back({ accessBefore, accessAfter, buffer, std::numeric_limits<UInt32>::max() });
 }
 
-constexpr void VulkanBarrier::transition(IVulkanBuffer& buffer, const UInt32& element, ResourceAccess accessBefore, ResourceAccess accessAfter)
+constexpr void VulkanBarrier::transition(IVulkanBuffer& buffer, UInt32 element, ResourceAccess accessBefore, ResourceAccess accessAfter)
 {
     m_impl->m_bufferBarriers.push_back({ accessBefore, accessAfter, buffer, element });
 }
@@ -89,12 +89,12 @@ constexpr void VulkanBarrier::transition(IVulkanImage& image, ResourceAccess acc
     m_impl->m_imageBarriers.push_back({ accessBefore, accessAfter, image, fromLayout, toLayout, 0, image.levels(), 0, image.layers(), 0 });
 }
 
-constexpr void VulkanBarrier::transition(IVulkanImage& image, const UInt32& level, const UInt32& levels, const UInt32& layer, const UInt32& layers, const UInt32& plane, ResourceAccess accessBefore, ResourceAccess accessAfter, ImageLayout layout)
+constexpr void VulkanBarrier::transition(IVulkanImage& image, UInt32 level, UInt32 levels, UInt32 layer, UInt32 layers, UInt32 plane, ResourceAccess accessBefore, ResourceAccess accessAfter, ImageLayout layout)
 {
     m_impl->m_imageBarriers.push_back({ accessBefore, accessAfter, image, std::nullopt, layout, level, levels, layer, layers, plane });
 }
 
-constexpr void VulkanBarrier::transition(IVulkanImage& image, const UInt32& level, const UInt32& levels, const UInt32& layer, const UInt32& layers, const UInt32& plane, ResourceAccess accessBefore, ResourceAccess accessAfter, ImageLayout fromLayout, ImageLayout toLayout)
+constexpr void VulkanBarrier::transition(IVulkanImage& image, UInt32 level, UInt32 levels, UInt32 layer, UInt32 layers, UInt32 plane, ResourceAccess accessBefore, ResourceAccess accessAfter, ImageLayout fromLayout, ImageLayout toLayout)
 {
     m_impl->m_imageBarriers.push_back({ accessBefore, accessAfter, image, fromLayout, toLayout, level, levels, layer, layers, plane });
 }

--- a/src/Backends/Vulkan/src/buffer.cpp
+++ b/src/Backends/Vulkan/src/buffer.cpp
@@ -19,7 +19,7 @@ private:
 	bool m_writable;
 
 public:
-	VulkanBufferImpl(VulkanBuffer* parent, BufferType type, const UInt32& elements, const size_t& elementSize, const size_t& alignment, const bool& writable, const VmaAllocator& allocator, const VmaAllocation& allocation) :
+	VulkanBufferImpl(VulkanBuffer* parent, BufferType type, UInt32 elements, size_t elementSize, size_t alignment, bool writable, const VmaAllocator& allocator, const VmaAllocation& allocation) :
 		base(parent), m_type(type), m_elements(elements), m_elementSize(elementSize), m_alignment(alignment), m_writable(writable), m_allocator(allocator), m_allocation(allocation)
 	{
 	}
@@ -29,7 +29,7 @@ public:
 // Buffer shared interface.
 // ------------------------------------------------------------------------------------------------
 
-VulkanBuffer::VulkanBuffer(VkBuffer buffer, BufferType type, const UInt32& elements, const size_t& elementSize, const size_t& alignment, const bool& writable, const VmaAllocator& allocator, const VmaAllocation& allocation, const String& name) :
+VulkanBuffer::VulkanBuffer(VkBuffer buffer, BufferType type, UInt32 elements, size_t elementSize, size_t alignment, bool writable, const VmaAllocator& allocator, const VmaAllocation& allocation, const String& name) :
 	m_impl(makePimpl<VulkanBufferImpl>(this, type, elements, elementSize, alignment, writable, allocator, allocation)), Resource<VkBuffer>(buffer)
 {
 	if (!name.empty())
@@ -47,7 +47,7 @@ BufferType VulkanBuffer::type() const noexcept
 	return m_impl->m_type;
 }
 
-const UInt32& VulkanBuffer::elements() const noexcept
+UInt32 VulkanBuffer::elements() const noexcept
 {
 	return m_impl->m_elements;
 }
@@ -72,12 +72,12 @@ size_t VulkanBuffer::alignedElementSize() const noexcept
 	return m_impl->m_alignment == 0 ? m_impl->m_elementSize : (m_impl->m_elementSize + m_impl->m_alignment - 1) & ~(m_impl->m_alignment - 1);
 }
 
-const bool& VulkanBuffer::writable() const noexcept
+bool VulkanBuffer::writable() const noexcept
 {
 	return m_impl->m_writable;
 }
 
-void VulkanBuffer::map(const void* const data, const size_t& size, const UInt32& element)
+void VulkanBuffer::map(const void* const data, size_t size, UInt32 element)
 {
 	if (element >= m_impl->m_elements)
 		throw ArgumentOutOfRangeException("The element {0} is out of range. The buffer only contains {1} elements.", element, m_impl->m_elements);
@@ -98,12 +98,12 @@ void VulkanBuffer::map(const void* const data, const size_t& size, const UInt32&
 		throw RuntimeException("Error mapping buffer to device memory: {#X}.", result);
 }
 
-void VulkanBuffer::map(Span<const void* const> data, const size_t& elementSize, const UInt32& firstElement)
+void VulkanBuffer::map(Span<const void* const> data, size_t elementSize, UInt32 firstElement)
 {
 	std::ranges::for_each(data, [this, &elementSize, i = firstElement](const void* const mem) mutable { this->map(mem, elementSize, i++); });
 }
 
-void VulkanBuffer::map(void* data, const size_t& size, const UInt32& element, bool write)
+void VulkanBuffer::map(void* data, size_t size, UInt32 element, bool write)
 {
 	if (element >= m_impl->m_elements)
 		throw ArgumentOutOfRangeException("The element {0} is out of range. The buffer only contains {1} elements.", element, m_impl->m_elements);
@@ -126,17 +126,17 @@ void VulkanBuffer::map(void* data, const size_t& size, const UInt32& element, bo
 		throw RuntimeException("Error mapping buffer to device memory: {#X}.", result);
 }
 
-void VulkanBuffer::map(Span<void*> data, const size_t& elementSize, const UInt32& firstElement, bool write)
+void VulkanBuffer::map(Span<void*> data, size_t elementSize, UInt32 firstElement, bool write)
 {
 	std::ranges::for_each(data, [this, &elementSize, &write, i = firstElement](void* mem) mutable { this->map(mem, elementSize, i++, write); });
 }
 
-UniquePtr<IVulkanBuffer> VulkanBuffer::allocate(BufferType type, const UInt32& elements, const size_t& elementSize, const size_t& alignment, const bool& writable, const VmaAllocator& allocator, const VkBufferCreateInfo& createInfo, const VmaAllocationCreateInfo& allocationInfo, VmaAllocationInfo* allocationResult)
+UniquePtr<IVulkanBuffer> VulkanBuffer::allocate(BufferType type, UInt32 elements, size_t elementSize, size_t alignment, bool writable, const VmaAllocator& allocator, const VkBufferCreateInfo& createInfo, const VmaAllocationCreateInfo& allocationInfo, VmaAllocationInfo* allocationResult)
 {
 	return VulkanBuffer::allocate("", type, elements, elementSize, alignment, writable, allocator, createInfo, allocationInfo, allocationResult);
 }
 
-UniquePtr<IVulkanBuffer> VulkanBuffer::allocate(const String& name, BufferType type, const UInt32& elements, const size_t& elementSize, const size_t& alignment, const bool& writable, const VmaAllocator& allocator, const VkBufferCreateInfo& createInfo, const VmaAllocationCreateInfo& allocationInfo, VmaAllocationInfo* allocationResult)
+UniquePtr<IVulkanBuffer> VulkanBuffer::allocate(const String& name, BufferType type, UInt32 elements, size_t elementSize, size_t alignment, bool writable, const VmaAllocator& allocator, const VkBufferCreateInfo& createInfo, const VmaAllocationCreateInfo& allocationInfo, VmaAllocationInfo* allocationResult)
 {
 	VkBuffer buffer;
 	VmaAllocation allocation;
@@ -169,7 +169,7 @@ public:
 // Vertex buffer shared interface.
 // ------------------------------------------------------------------------------------------------
 
-VulkanVertexBuffer::VulkanVertexBuffer(VkBuffer buffer, const VulkanVertexBufferLayout& layout, const UInt32& elements, const VmaAllocator& allocator, const VmaAllocation& allocation, const String& name) :
+VulkanVertexBuffer::VulkanVertexBuffer(VkBuffer buffer, const VulkanVertexBufferLayout& layout, UInt32 elements, const VmaAllocator& allocator, const VmaAllocation& allocation, const String& name) :
 	m_impl(makePimpl<VulkanVertexBufferImpl>(this, layout)), VulkanBuffer(buffer, BufferType::Vertex, elements, layout.elementSize(), 0, false, allocator, allocation, name)
 {
 }
@@ -181,12 +181,12 @@ const VulkanVertexBufferLayout& VulkanVertexBuffer::layout() const noexcept
 	return m_impl->m_layout;
 }
 
-UniquePtr<IVulkanVertexBuffer> VulkanVertexBuffer::allocate(const VulkanVertexBufferLayout& layout, const UInt32& elements, const VmaAllocator& allocator, const VkBufferCreateInfo& createInfo, const VmaAllocationCreateInfo& allocationInfo, VmaAllocationInfo* allocationResult)
+UniquePtr<IVulkanVertexBuffer> VulkanVertexBuffer::allocate(const VulkanVertexBufferLayout& layout, UInt32 elements, const VmaAllocator& allocator, const VkBufferCreateInfo& createInfo, const VmaAllocationCreateInfo& allocationInfo, VmaAllocationInfo* allocationResult)
 {
 	return VulkanVertexBuffer::allocate("", layout, elements, allocator, createInfo, allocationInfo, allocationResult);
 }
 
-UniquePtr<IVulkanVertexBuffer> VulkanVertexBuffer::allocate(const String& name, const VulkanVertexBufferLayout& layout, const UInt32& elements, const VmaAllocator& allocator, const VkBufferCreateInfo& createInfo, const VmaAllocationCreateInfo& allocationInfo, VmaAllocationInfo* allocationResult)
+UniquePtr<IVulkanVertexBuffer> VulkanVertexBuffer::allocate(const String& name, const VulkanVertexBufferLayout& layout, UInt32 elements, const VmaAllocator& allocator, const VkBufferCreateInfo& createInfo, const VmaAllocationCreateInfo& allocationInfo, VmaAllocationInfo* allocationResult)
 {
 	VkBuffer buffer;
 	VmaAllocation allocation;
@@ -219,7 +219,7 @@ public:
 // Index buffer shared interface.
 // ------------------------------------------------------------------------------------------------
 
-VulkanIndexBuffer::VulkanIndexBuffer(VkBuffer buffer, const VulkanIndexBufferLayout& layout, const UInt32& elements, const VmaAllocator& allocator, const VmaAllocation& allocation, const String& name) :
+VulkanIndexBuffer::VulkanIndexBuffer(VkBuffer buffer, const VulkanIndexBufferLayout& layout, UInt32 elements, const VmaAllocator& allocator, const VmaAllocation& allocation, const String& name) :
 	m_impl(makePimpl<VulkanIndexBufferImpl>(this, layout)), VulkanBuffer(buffer, BufferType::Index, elements, layout.elementSize(), 0, false, allocator, allocation, name)
 {
 }
@@ -231,12 +231,12 @@ const VulkanIndexBufferLayout& VulkanIndexBuffer::layout() const noexcept
 	return m_impl->m_layout;
 }
 
-UniquePtr<IVulkanIndexBuffer> VulkanIndexBuffer::allocate(const VulkanIndexBufferLayout& layout, const UInt32& elements, const VmaAllocator& allocator, const VkBufferCreateInfo& createInfo, const VmaAllocationCreateInfo& allocationInfo, VmaAllocationInfo* allocationResult)
+UniquePtr<IVulkanIndexBuffer> VulkanIndexBuffer::allocate(const VulkanIndexBufferLayout& layout, UInt32 elements, const VmaAllocator& allocator, const VkBufferCreateInfo& createInfo, const VmaAllocationCreateInfo& allocationInfo, VmaAllocationInfo* allocationResult)
 {
 	return VulkanIndexBuffer::allocate("", layout, elements, allocator, createInfo, allocationInfo, allocationResult);
 }
 
-UniquePtr<IVulkanIndexBuffer> VulkanIndexBuffer::allocate(const String& name, const VulkanIndexBufferLayout& layout, const UInt32& elements, const VmaAllocator& allocator, const VkBufferCreateInfo& createInfo, const VmaAllocationCreateInfo& allocationInfo, VmaAllocationInfo* allocationResult)
+UniquePtr<IVulkanIndexBuffer> VulkanIndexBuffer::allocate(const String& name, const VulkanIndexBufferLayout& layout, UInt32 elements, const VmaAllocator& allocator, const VkBufferCreateInfo& createInfo, const VmaAllocationCreateInfo& allocationInfo, VmaAllocationInfo* allocationResult)
 {
 	VkBuffer buffer;
 	VmaAllocation allocation;

--- a/src/Backends/Vulkan/src/buffer.cpp
+++ b/src/Backends/Vulkan/src/buffer.cpp
@@ -19,7 +19,7 @@ private:
 	bool m_writable;
 
 public:
-	VulkanBufferImpl(VulkanBuffer* parent, const BufferType& type, const UInt32& elements, const size_t& elementSize, const size_t& alignment, const bool& writable, const VmaAllocator& allocator, const VmaAllocation& allocation) :
+	VulkanBufferImpl(VulkanBuffer* parent, BufferType type, const UInt32& elements, const size_t& elementSize, const size_t& alignment, const bool& writable, const VmaAllocator& allocator, const VmaAllocation& allocation) :
 		base(parent), m_type(type), m_elements(elements), m_elementSize(elementSize), m_alignment(alignment), m_writable(writable), m_allocator(allocator), m_allocation(allocation)
 	{
 	}
@@ -29,7 +29,7 @@ public:
 // Buffer shared interface.
 // ------------------------------------------------------------------------------------------------
 
-VulkanBuffer::VulkanBuffer(VkBuffer buffer, const BufferType& type, const UInt32& elements, const size_t& elementSize, const size_t& alignment, const bool& writable, const VmaAllocator& allocator, const VmaAllocation& allocation, const String& name) :
+VulkanBuffer::VulkanBuffer(VkBuffer buffer, BufferType type, const UInt32& elements, const size_t& elementSize, const size_t& alignment, const bool& writable, const VmaAllocator& allocator, const VmaAllocation& allocation, const String& name) :
 	m_impl(makePimpl<VulkanBufferImpl>(this, type, elements, elementSize, alignment, writable, allocator, allocation)), Resource<VkBuffer>(buffer)
 {
 	if (!name.empty())
@@ -42,7 +42,7 @@ VulkanBuffer::~VulkanBuffer() noexcept
 	LITEFX_TRACE(VULKAN_LOG, "Destroyed buffer {0}", fmt::ptr(reinterpret_cast<void*>(this->handle())));
 }
 
-const BufferType& VulkanBuffer::type() const noexcept
+BufferType VulkanBuffer::type() const noexcept
 {
 	return m_impl->m_type;
 }
@@ -131,12 +131,12 @@ void VulkanBuffer::map(Span<void*> data, const size_t& elementSize, const UInt32
 	std::ranges::for_each(data, [this, &elementSize, &write, i = firstElement](void* mem) mutable { this->map(mem, elementSize, i++, write); });
 }
 
-UniquePtr<IVulkanBuffer> VulkanBuffer::allocate(const BufferType& type, const UInt32& elements, const size_t& elementSize, const size_t& alignment, const bool& writable, const VmaAllocator& allocator, const VkBufferCreateInfo& createInfo, const VmaAllocationCreateInfo& allocationInfo, VmaAllocationInfo* allocationResult)
+UniquePtr<IVulkanBuffer> VulkanBuffer::allocate(BufferType type, const UInt32& elements, const size_t& elementSize, const size_t& alignment, const bool& writable, const VmaAllocator& allocator, const VkBufferCreateInfo& createInfo, const VmaAllocationCreateInfo& allocationInfo, VmaAllocationInfo* allocationResult)
 {
 	return VulkanBuffer::allocate("", type, elements, elementSize, alignment, writable, allocator, createInfo, allocationInfo, allocationResult);
 }
 
-UniquePtr<IVulkanBuffer> VulkanBuffer::allocate(const String& name, const BufferType& type, const UInt32& elements, const size_t& elementSize, const size_t& alignment, const bool& writable, const VmaAllocator& allocator, const VkBufferCreateInfo& createInfo, const VmaAllocationCreateInfo& allocationInfo, VmaAllocationInfo* allocationResult)
+UniquePtr<IVulkanBuffer> VulkanBuffer::allocate(const String& name, BufferType type, const UInt32& elements, const size_t& elementSize, const size_t& alignment, const bool& writable, const VmaAllocator& allocator, const VkBufferCreateInfo& createInfo, const VmaAllocationCreateInfo& allocationInfo, VmaAllocationInfo* allocationResult)
 {
 	VkBuffer buffer;
 	VmaAllocation allocation;

--- a/src/Backends/Vulkan/src/buffer.h
+++ b/src/Backends/Vulkan/src/buffer.h
@@ -22,41 +22,41 @@ namespace LiteFX::Rendering::Backends {
 		// IBuffer interface.
 	public:
 		/// <inheritdoc />
-		virtual BufferType type() const noexcept override;
+		BufferType type() const noexcept override;
 
 		// IDeviceMemory interface.
 	public:
 		/// <inheritdoc />
-		virtual UInt32 elements() const noexcept override;
+		UInt32 elements() const noexcept override;
 
 		/// <inheritdoc />
-		virtual size_t size() const noexcept override;
+		size_t size() const noexcept override;
 
 		/// <inheritdoc />
-		virtual size_t elementSize() const noexcept override;
+		size_t elementSize() const noexcept override;
 
 		/// <inheritdoc />
-		virtual size_t elementAlignment() const noexcept override;
+		size_t elementAlignment() const noexcept override;
 
 		/// <inheritdoc />
-		virtual size_t alignedElementSize() const noexcept override;
+		size_t alignedElementSize() const noexcept override;
 
 		/// <inheritdoc />
-		virtual bool writable() const noexcept override;
+		bool writable() const noexcept override;
 
 		// IMappable interface.
 	public:
 		/// <inheritdoc />
-		virtual void map(const void* const data, size_t size, UInt32 element = 0) override;
+		void map(const void* const data, size_t size, UInt32 element = 0) override;
 
 		/// <inheritdoc />
-		virtual void map(Span<const void* const> data, size_t elementSize, UInt32 firstElement = 0) override;
+		void map(Span<const void* const> data, size_t elementSize, UInt32 firstElement = 0) override;
 
 		/// <inheritdoc />
-		virtual void map(void* data, size_t size, UInt32 element = 0, bool write = true) override;
+		void map(void* data, size_t size, UInt32 element = 0, bool write = true) override;
 
 		/// <inheritdoc />
-		virtual void map(Span<void*> data, size_t elementSize, UInt32 firstElement = 0, bool write = true) override;
+		void map(Span<void*> data, size_t elementSize, UInt32 firstElement = 0, bool write = true) override;
 
 		// VulkanBuffer.
 	public:
@@ -102,7 +102,7 @@ namespace LiteFX::Rendering::Backends {
 		// IndexBuffer interface.
 	public:
 		/// <inheritdoc />
-		virtual const VulkanIndexBufferLayout& layout() const noexcept override;
+		const VulkanIndexBufferLayout& layout() const noexcept override;
 
 		// VulkanIndexBuffer.
 	public:

--- a/src/Backends/Vulkan/src/buffer.h
+++ b/src/Backends/Vulkan/src/buffer.h
@@ -14,7 +14,7 @@ namespace LiteFX::Rendering::Backends {
 		LITEFX_IMPLEMENTATION(VulkanBufferImpl);
 
 	public:
-		explicit VulkanBuffer(VkBuffer buffer, BufferType type, const UInt32& elements, const size_t& elementSize, const size_t& alignment, const bool& writable, const VmaAllocator& allocator, const VmaAllocation& allocation, const String& name);
+		explicit VulkanBuffer(VkBuffer buffer, BufferType type, UInt32 elements, size_t elementSize, size_t alignment, bool writable, const VmaAllocator& allocator, const VmaAllocation& allocation, const String& name);
 		VulkanBuffer(VulkanBuffer&&) = delete;
 		VulkanBuffer(const VulkanBuffer&) = delete;
 		virtual ~VulkanBuffer() noexcept;
@@ -27,7 +27,7 @@ namespace LiteFX::Rendering::Backends {
 		// IDeviceMemory interface.
 	public:
 		/// <inheritdoc />
-		virtual const UInt32& elements() const noexcept override;
+		virtual UInt32 elements() const noexcept override;
 
 		/// <inheritdoc />
 		virtual size_t size() const noexcept override;
@@ -42,26 +42,26 @@ namespace LiteFX::Rendering::Backends {
 		virtual size_t alignedElementSize() const noexcept override;
 
 		/// <inheritdoc />
-		virtual const bool& writable() const noexcept override;
+		virtual bool writable() const noexcept override;
 
 		// IMappable interface.
 	public:
 		/// <inheritdoc />
-		virtual void map(const void* const data, const size_t& size, const UInt32& element = 0) override;
+		virtual void map(const void* const data, size_t size, UInt32 element = 0) override;
 
 		/// <inheritdoc />
-		virtual void map(Span<const void* const> data, const size_t& elementSize, const UInt32& firstElement = 0) override;
+		virtual void map(Span<const void* const> data, size_t elementSize, UInt32 firstElement = 0) override;
 
 		/// <inheritdoc />
-		virtual void map(void* data, const size_t& size, const UInt32& element = 0, bool write = true) override;
+		virtual void map(void* data, size_t size, UInt32 element = 0, bool write = true) override;
 
 		/// <inheritdoc />
-		virtual void map(Span<void*> data, const size_t& elementSize, const UInt32& firstElement = 0, bool write = true) override;
+		virtual void map(Span<void*> data, size_t elementSize, UInt32 firstElement = 0, bool write = true) override;
 
 		// VulkanBuffer.
 	public:
-		static UniquePtr<IVulkanBuffer> allocate(BufferType type, const UInt32& elements, const size_t& elementSize, const size_t& alignment, const bool& writable, const VmaAllocator& allocator, const VkBufferCreateInfo& createInfo, const VmaAllocationCreateInfo& allocationInfo, VmaAllocationInfo* allocationResult = nullptr);
-		static UniquePtr<IVulkanBuffer> allocate(const String& name, BufferType type, const UInt32& elements, const size_t& elementSize, const size_t& alignment, const bool& writable, const VmaAllocator& allocator, const VkBufferCreateInfo& createInfo, const VmaAllocationCreateInfo& allocationInfo, VmaAllocationInfo* allocationResult = nullptr);
+		static UniquePtr<IVulkanBuffer> allocate(BufferType type, UInt32 elements, size_t elementSize, size_t alignment, bool writable, const VmaAllocator& allocator, const VkBufferCreateInfo& createInfo, const VmaAllocationCreateInfo& allocationInfo, VmaAllocationInfo* allocationResult = nullptr);
+		static UniquePtr<IVulkanBuffer> allocate(const String& name, BufferType type, UInt32 elements, size_t elementSize, size_t alignment, bool writable, const VmaAllocator& allocator, const VkBufferCreateInfo& createInfo, const VmaAllocationCreateInfo& allocationInfo, VmaAllocationInfo* allocationResult = nullptr);
 	};
 
 	/// <summary>
@@ -71,7 +71,7 @@ namespace LiteFX::Rendering::Backends {
 		LITEFX_IMPLEMENTATION(VulkanVertexBufferImpl);
 
 	public:
-		explicit VulkanVertexBuffer(VkBuffer buffer, const VulkanVertexBufferLayout& layout, const UInt32& elements, const VmaAllocator& allocator, const VmaAllocation& allocation, const String& name = "");
+		explicit VulkanVertexBuffer(VkBuffer buffer, const VulkanVertexBufferLayout& layout, UInt32 elements, const VmaAllocator& allocator, const VmaAllocation& allocation, const String& name = "");
 		VulkanVertexBuffer(VulkanVertexBuffer&&) = delete;
 		VulkanVertexBuffer(const VulkanVertexBuffer&) = delete;
 		virtual ~VulkanVertexBuffer() noexcept;
@@ -83,8 +83,8 @@ namespace LiteFX::Rendering::Backends {
 
 		// VulkanVertexBuffer.
 	public:
-		static UniquePtr<IVulkanVertexBuffer> allocate(const VulkanVertexBufferLayout& layout, const UInt32& elements, const VmaAllocator& allocator, const VkBufferCreateInfo& createInfo, const VmaAllocationCreateInfo& allocationInfo, VmaAllocationInfo* allocationResult = nullptr);
-		static UniquePtr<IVulkanVertexBuffer> allocate(const String& name, const VulkanVertexBufferLayout& layout, const UInt32& elements, const VmaAllocator& allocator, const VkBufferCreateInfo& createInfo, const VmaAllocationCreateInfo& allocationInfo, VmaAllocationInfo* allocationResult = nullptr);
+		static UniquePtr<IVulkanVertexBuffer> allocate(const VulkanVertexBufferLayout& layout, UInt32 elements, const VmaAllocator& allocator, const VkBufferCreateInfo& createInfo, const VmaAllocationCreateInfo& allocationInfo, VmaAllocationInfo* allocationResult = nullptr);
+		static UniquePtr<IVulkanVertexBuffer> allocate(const String& name, const VulkanVertexBufferLayout& layout, UInt32 elements, const VmaAllocator& allocator, const VkBufferCreateInfo& createInfo, const VmaAllocationCreateInfo& allocationInfo, VmaAllocationInfo* allocationResult = nullptr);
 	};
 
 	/// <summary>
@@ -94,7 +94,7 @@ namespace LiteFX::Rendering::Backends {
 		LITEFX_IMPLEMENTATION(VulkanIndexBufferImpl);
 
 	public:
-		explicit VulkanIndexBuffer(VkBuffer buffer, const VulkanIndexBufferLayout& layout, const UInt32& elements, const VmaAllocator& allocator, const VmaAllocation& allocation, const String& name = "");
+		explicit VulkanIndexBuffer(VkBuffer buffer, const VulkanIndexBufferLayout& layout, UInt32 elements, const VmaAllocator& allocator, const VmaAllocation& allocation, const String& name = "");
 		VulkanIndexBuffer(VulkanIndexBuffer&&) = delete;
 		VulkanIndexBuffer(const VulkanIndexBuffer&) = delete;
 		virtual ~VulkanIndexBuffer() noexcept;
@@ -106,7 +106,7 @@ namespace LiteFX::Rendering::Backends {
 
 		// VulkanIndexBuffer.
 	public:
-		static UniquePtr<IVulkanIndexBuffer> allocate(const VulkanIndexBufferLayout& layout, const UInt32& elements, const VmaAllocator& allocator, const VkBufferCreateInfo& createInfo, const VmaAllocationCreateInfo& allocationInfo, VmaAllocationInfo* allocationResult = nullptr);
-		static UniquePtr<IVulkanIndexBuffer> allocate(const String& name, const VulkanIndexBufferLayout& layout, const UInt32& elements, const VmaAllocator& allocator, const VkBufferCreateInfo& createInfo, const VmaAllocationCreateInfo& allocationInfo, VmaAllocationInfo* allocationResult = nullptr);
+		static UniquePtr<IVulkanIndexBuffer> allocate(const VulkanIndexBufferLayout& layout, UInt32 elements, const VmaAllocator& allocator, const VkBufferCreateInfo& createInfo, const VmaAllocationCreateInfo& allocationInfo, VmaAllocationInfo* allocationResult = nullptr);
+		static UniquePtr<IVulkanIndexBuffer> allocate(const String& name, const VulkanIndexBufferLayout& layout, UInt32 elements, const VmaAllocator& allocator, const VkBufferCreateInfo& createInfo, const VmaAllocationCreateInfo& allocationInfo, VmaAllocationInfo* allocationResult = nullptr);
 	};
 }

--- a/src/Backends/Vulkan/src/buffer.h
+++ b/src/Backends/Vulkan/src/buffer.h
@@ -14,7 +14,7 @@ namespace LiteFX::Rendering::Backends {
 		LITEFX_IMPLEMENTATION(VulkanBufferImpl);
 
 	public:
-		explicit VulkanBuffer(VkBuffer buffer, const BufferType& type, const UInt32& elements, const size_t& elementSize, const size_t& alignment, const bool& writable, const VmaAllocator& allocator, const VmaAllocation& allocation, const String& name);
+		explicit VulkanBuffer(VkBuffer buffer, BufferType type, const UInt32& elements, const size_t& elementSize, const size_t& alignment, const bool& writable, const VmaAllocator& allocator, const VmaAllocation& allocation, const String& name);
 		VulkanBuffer(VulkanBuffer&&) = delete;
 		VulkanBuffer(const VulkanBuffer&) = delete;
 		virtual ~VulkanBuffer() noexcept;
@@ -22,7 +22,7 @@ namespace LiteFX::Rendering::Backends {
 		// IBuffer interface.
 	public:
 		/// <inheritdoc />
-		virtual const BufferType& type() const noexcept override;
+		virtual BufferType type() const noexcept override;
 
 		// IDeviceMemory interface.
 	public:
@@ -60,8 +60,8 @@ namespace LiteFX::Rendering::Backends {
 
 		// VulkanBuffer.
 	public:
-		static UniquePtr<IVulkanBuffer> allocate(const BufferType& type, const UInt32& elements, const size_t& elementSize, const size_t& alignment, const bool& writable, const VmaAllocator& allocator, const VkBufferCreateInfo& createInfo, const VmaAllocationCreateInfo& allocationInfo, VmaAllocationInfo* allocationResult = nullptr);
-		static UniquePtr<IVulkanBuffer> allocate(const String& name, const BufferType& type, const UInt32& elements, const size_t& elementSize, const size_t& alignment, const bool& writable, const VmaAllocator& allocator, const VkBufferCreateInfo& createInfo, const VmaAllocationCreateInfo& allocationInfo, VmaAllocationInfo* allocationResult = nullptr);
+		static UniquePtr<IVulkanBuffer> allocate(BufferType type, const UInt32& elements, const size_t& elementSize, const size_t& alignment, const bool& writable, const VmaAllocator& allocator, const VkBufferCreateInfo& createInfo, const VmaAllocationCreateInfo& allocationInfo, VmaAllocationInfo* allocationResult = nullptr);
+		static UniquePtr<IVulkanBuffer> allocate(const String& name, BufferType type, const UInt32& elements, const size_t& elementSize, const size_t& alignment, const bool& writable, const VmaAllocator& allocator, const VkBufferCreateInfo& createInfo, const VmaAllocationCreateInfo& allocationInfo, VmaAllocationInfo* allocationResult = nullptr);
 	};
 
 	/// <summary>

--- a/src/Backends/Vulkan/src/command_buffer.cpp
+++ b/src/Backends/Vulkan/src/command_buffer.cpp
@@ -166,7 +166,7 @@ void VulkanCommandBuffer::setScissors(const IScissor* scissor) const noexcept
 
 void VulkanCommandBuffer::setBlendFactors(const Vector4f& blendFactors) const noexcept
 {
-	::vkCmdSetBlendConstants(this->handle(), &blendFactors[0]);
+	::vkCmdSetBlendConstants(this->handle(), blendFactors.elements());
 }
 
 void VulkanCommandBuffer::setStencilRef(const UInt32& stencilRef) const noexcept

--- a/src/Backends/Vulkan/src/command_buffer.cpp
+++ b/src/Backends/Vulkan/src/command_buffer.cpp
@@ -23,7 +23,7 @@ public:
 	}
 
 public:
-	VkCommandBuffer initialize(const bool& primary)
+	VkCommandBuffer initialize(bool primary)
 	{
 		// Secondary command buffers have their own command pool.
 		if (!primary)
@@ -58,7 +58,7 @@ public:
 // Shared interface.
 // ------------------------------------------------------------------------------------------------
 
-VulkanCommandBuffer::VulkanCommandBuffer(const VulkanQueue& queue, const bool& begin, const bool& primary) :
+VulkanCommandBuffer::VulkanCommandBuffer(const VulkanQueue& queue, bool begin, bool primary) :
 	m_impl(makePimpl<VulkanCommandBufferImpl>(this, queue)), Resource<VkCommandBuffer>(nullptr)
 {
 	if (!queue.isBound())
@@ -129,7 +129,7 @@ void VulkanCommandBuffer::end() const
 	m_impl->m_recording = false;
 }
 
-const bool& VulkanCommandBuffer::isSecondary() const noexcept
+bool VulkanCommandBuffer::isSecondary() const noexcept
 {
 	return m_impl->m_secondary;
 }
@@ -169,7 +169,7 @@ void VulkanCommandBuffer::setBlendFactors(const Vector4f& blendFactors) const no
 	::vkCmdSetBlendConstants(this->handle(), blendFactors.elements());
 }
 
-void VulkanCommandBuffer::setStencilRef(const UInt32& stencilRef) const noexcept
+void VulkanCommandBuffer::setStencilRef(UInt32 stencilRef) const noexcept
 {
 	::vkCmdSetStencilReference(this->handle(), VK_STENCIL_FACE_FRONT_AND_BACK, stencilRef);
 }
@@ -237,7 +237,7 @@ void VulkanCommandBuffer::barrier(const VulkanBarrier& barrier) const noexcept
 	barrier.execute(*this);
 }
 
-void VulkanCommandBuffer::transfer(IVulkanBuffer& source, IVulkanBuffer& target, const UInt32& sourceElement, const UInt32& targetElement, const UInt32& elements) const
+void VulkanCommandBuffer::transfer(IVulkanBuffer& source, IVulkanBuffer& target, UInt32 sourceElement, UInt32 targetElement, UInt32 elements) const
 {
 	if (source.elements() < sourceElement + elements) [[unlikely]]
 		throw ArgumentOutOfRangeException("The source buffer has only {0} elements, but a transfer for {1} elements starting from element {2} has been requested.", source.elements(), elements, sourceElement);
@@ -254,7 +254,7 @@ void VulkanCommandBuffer::transfer(IVulkanBuffer& source, IVulkanBuffer& target,
 	::vkCmdCopyBuffer(this->handle(), std::as_const(source).handle(), std::as_const(target).handle(), 1, &copyInfo);
 }
 
-void VulkanCommandBuffer::transfer(IVulkanBuffer& source, IVulkanImage& target, const UInt32& sourceElement, const UInt32& firstSubresource, const UInt32& elements) const
+void VulkanCommandBuffer::transfer(IVulkanBuffer& source, IVulkanImage& target, UInt32 sourceElement, UInt32 firstSubresource, UInt32 elements) const
 {
 	if (source.elements() < sourceElement + elements) [[unlikely]]
 		throw ArgumentOutOfRangeException("The source buffer has only {0} elements, but a transfer for {1} elements starting from element {2} has been requested.", source.elements(), elements, sourceElement);
@@ -292,7 +292,7 @@ void VulkanCommandBuffer::transfer(IVulkanBuffer& source, IVulkanImage& target, 
 	::vkCmdCopyBufferToImage(this->handle(), std::as_const(source).handle(), std::as_const(target).handle(), VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL, static_cast<UInt32>(copyInfos.size()), copyInfos.data());
 }
 
-void VulkanCommandBuffer::transfer(IVulkanImage& source, IVulkanImage& target, const UInt32& sourceSubresource, const UInt32& targetSubresource, const UInt32& subresources) const
+void VulkanCommandBuffer::transfer(IVulkanImage& source, IVulkanImage& target, UInt32 sourceSubresource, UInt32 targetSubresource, UInt32 subresources) const
 {
 	if (source.elements() < sourceSubresource + subresources) [[unlikely]]
 		throw ArgumentOutOfRangeException("The source image has only {0} sub-resources, but a transfer for {1} sub-resources starting from sub-resource {2} has been requested.", source.elements(), subresources, sourceSubresource);
@@ -340,7 +340,7 @@ void VulkanCommandBuffer::transfer(IVulkanImage& source, IVulkanImage& target, c
 	::vkCmdCopyImage(this->handle(), std::as_const(source).handle(), VK_IMAGE_LAYOUT_TRANSFER_SRC_OPTIMAL, std::as_const(target).handle(), VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL, static_cast<UInt32>(copyInfos.size()), copyInfos.data());
 }
 
-void VulkanCommandBuffer::transfer(IVulkanImage& source, IVulkanBuffer& target, const UInt32& firstSubresource, const UInt32& targetElement, const UInt32& subresources) const
+void VulkanCommandBuffer::transfer(IVulkanImage& source, IVulkanBuffer& target, UInt32 firstSubresource, UInt32 targetElement, UInt32 subresources) const
 {
 	if (source.elements() < firstSubresource + subresources) [[unlikely]]
 		throw ArgumentOutOfRangeException("The source image has only {0} sub-resources, but a transfer for {1} sub-resources starting from sub-resource {2} has been requested.", source.elements(), subresources, firstSubresource);
@@ -372,25 +372,25 @@ void VulkanCommandBuffer::transfer(IVulkanImage& source, IVulkanBuffer& target, 
 	::vkCmdCopyImageToBuffer(this->handle(), std::as_const(source).handle(), VK_IMAGE_LAYOUT_TRANSFER_SRC_OPTIMAL, std::as_const(target).handle(), static_cast<UInt32>(copyInfos.size()), copyInfos.data());
 }
 
-void VulkanCommandBuffer::transfer(SharedPtr<IVulkanBuffer> source, IVulkanBuffer& target, const UInt32& sourceElement, const UInt32& targetElement, const UInt32& elements) const
+void VulkanCommandBuffer::transfer(SharedPtr<IVulkanBuffer> source, IVulkanBuffer& target, UInt32 sourceElement, UInt32 targetElement, UInt32 elements) const
 {
 	this->transfer(*source, target, sourceElement, targetElement, elements);
 	m_impl->m_sharedResources.push_back(source);
 }
 
-void VulkanCommandBuffer::transfer(SharedPtr<IVulkanBuffer> source, IVulkanImage& target, const UInt32& sourceElement, const UInt32& firstSubresource, const UInt32& elements) const
+void VulkanCommandBuffer::transfer(SharedPtr<IVulkanBuffer> source, IVulkanImage& target, UInt32 sourceElement, UInt32 firstSubresource, UInt32 elements) const
 {
 	this->transfer(*source, target, sourceElement, firstSubresource, elements);
 	m_impl->m_sharedResources.push_back(source);
 }
 
-void VulkanCommandBuffer::transfer(SharedPtr<IVulkanImage> source, IVulkanImage& target, const UInt32& sourceSubresource, const UInt32& targetSubresource, const UInt32& subresources) const
+void VulkanCommandBuffer::transfer(SharedPtr<IVulkanImage> source, IVulkanImage& target, UInt32 sourceSubresource, UInt32 targetSubresource, UInt32 subresources) const
 {
 	this->transfer(*source, target, sourceSubresource, targetSubresource, subresources);
 	m_impl->m_sharedResources.push_back(source);
 }
 
-void VulkanCommandBuffer::transfer(SharedPtr<IVulkanImage> source, IVulkanBuffer& target, const UInt32& firstSubresource, const UInt32& targetElement, const UInt32& subresources) const
+void VulkanCommandBuffer::transfer(SharedPtr<IVulkanImage> source, IVulkanBuffer& target, UInt32 firstSubresource, UInt32 targetElement, UInt32 subresources) const
 {
 	this->transfer(*source, target, firstSubresource, targetElement, subresources);
 	m_impl->m_sharedResources.push_back(source);
@@ -422,12 +422,12 @@ void VulkanCommandBuffer::dispatch(const Vector3u& threadCount) const noexcept
 	::vkCmdDispatch(this->handle(), threadCount.x(), threadCount.y(), threadCount.z());
 }
 
-void VulkanCommandBuffer::draw(const UInt32& vertices, const UInt32& instances, const UInt32& firstVertex, const UInt32& firstInstance) const noexcept
+void VulkanCommandBuffer::draw(UInt32 vertices, UInt32 instances, UInt32 firstVertex, UInt32 firstInstance) const noexcept
 {
 	::vkCmdDraw(this->handle(), vertices, instances, firstVertex, firstInstance);
 }
 
-void VulkanCommandBuffer::drawIndexed(const UInt32& indices, const UInt32& instances, const UInt32& firstIndex, const Int32& vertexOffset, const UInt32& firstInstance) const noexcept
+void VulkanCommandBuffer::drawIndexed(UInt32 indices, UInt32 instances, UInt32 firstIndex, Int32 vertexOffset, UInt32 firstInstance) const noexcept
 {
 	::vkCmdDrawIndexed(this->handle(), indices, instances, firstIndex, vertexOffset, firstInstance);
 }

--- a/src/Backends/Vulkan/src/convert.cpp
+++ b/src/Backends/Vulkan/src/convert.cpp
@@ -303,7 +303,7 @@ constexpr Format LiteFX::Rendering::Backends::Vk::getFormat(const VkFormat& form
 	}
 }
 
-constexpr VkFormat LiteFX::Rendering::Backends::Vk::getFormat(const Format& format)
+constexpr VkFormat LiteFX::Rendering::Backends::Vk::getFormat(Format format)
 {
 	switch (format)
 	{
@@ -604,7 +604,7 @@ constexpr VkFormat LiteFX::Rendering::Backends::Vk::getFormat(const Format& form
 	}
 }
 
-constexpr VkFormat LiteFX::Rendering::Backends::Vk::getFormat(const BufferFormat& format)
+constexpr VkFormat LiteFX::Rendering::Backends::Vk::getFormat(BufferFormat format)
 {
 	switch (format)
 	{
@@ -676,7 +676,7 @@ constexpr PolygonMode LiteFX::Rendering::Backends::Vk::getPolygonMode(const VkPo
 	}
 }
 
-constexpr VkPolygonMode LiteFX::Rendering::Backends::Vk::getPolygonMode(const PolygonMode& mode)
+constexpr VkPolygonMode LiteFX::Rendering::Backends::Vk::getPolygonMode(PolygonMode mode)
 {
 	switch (mode)
 	{
@@ -708,7 +708,7 @@ constexpr CullMode LiteFX::Rendering::Backends::Vk::getCullMode(const VkCullMode
 	}
 }
 
-constexpr VkCullModeFlags LiteFX::Rendering::Backends::Vk::getCullMode(const CullMode& mode)
+constexpr VkCullModeFlags LiteFX::Rendering::Backends::Vk::getCullMode(CullMode mode)
 {
 	switch (mode)
 	{
@@ -784,7 +784,7 @@ constexpr ShaderStage LiteFX::Rendering::Backends::Vk::getShaderStage(const VkSh
 	}
 }
 
-constexpr VkShaderStageFlagBits LiteFX::Rendering::Backends::Vk::getShaderStage(const ShaderStage& shaderType)
+constexpr VkShaderStageFlagBits LiteFX::Rendering::Backends::Vk::getShaderStage(ShaderStage shaderType)
 {
 	switch (shaderType)
 	{
@@ -829,7 +829,7 @@ constexpr MultiSamplingLevel LiteFX::Rendering::Backends::Vk::getSamples(const V
 	}
 }
 
-constexpr VkImageType LiteFX::Rendering::Backends::Vk::getImageType(const ImageDimensions& dimension)
+constexpr VkImageType LiteFX::Rendering::Backends::Vk::getImageType(ImageDimensions dimension)
 {
 	switch (dimension)
 	{
@@ -845,7 +845,7 @@ constexpr VkImageType LiteFX::Rendering::Backends::Vk::getImageType(const ImageD
 	}
 }
 
-constexpr VkImageViewType LiteFX::Rendering::Backends::Vk::getImageViewType(const ImageDimensions& dimension, const UInt32& layers)
+constexpr VkImageViewType LiteFX::Rendering::Backends::Vk::getImageViewType(ImageDimensions dimension, const UInt32& layers)
 {
 	switch (dimension)
 	{
@@ -862,7 +862,7 @@ constexpr VkImageViewType LiteFX::Rendering::Backends::Vk::getImageViewType(cons
 	}
 }
 
-constexpr VkSampleCountFlagBits LiteFX::Rendering::Backends::Vk::getSamples(const MultiSamplingLevel& samples)
+constexpr VkSampleCountFlagBits LiteFX::Rendering::Backends::Vk::getSamples(MultiSamplingLevel samples)
 {
 	switch (samples)
 	{
@@ -885,7 +885,7 @@ constexpr VkSampleCountFlagBits LiteFX::Rendering::Backends::Vk::getSamples(cons
 	}
 }
 
-constexpr VkCompareOp LiteFX::Rendering::Backends::Vk::getCompareOp(const CompareOperation& compareOp)
+constexpr VkCompareOp LiteFX::Rendering::Backends::Vk::getCompareOp(CompareOperation compareOp)
 {
 	switch (compareOp) {
 	case CompareOperation::Never: return VkCompareOp::VK_COMPARE_OP_NEVER;
@@ -900,7 +900,7 @@ constexpr VkCompareOp LiteFX::Rendering::Backends::Vk::getCompareOp(const Compar
 	}
 }
 
-constexpr VkStencilOp LiteFX::Rendering::Backends::Vk::getStencilOp(const StencilOperation& stencilOp)
+constexpr VkStencilOp LiteFX::Rendering::Backends::Vk::getStencilOp(StencilOperation stencilOp)
 {
 	switch (stencilOp) {
 	case StencilOperation::Keep: return VkStencilOp::VK_STENCIL_OP_KEEP;
@@ -915,7 +915,7 @@ constexpr VkStencilOp LiteFX::Rendering::Backends::Vk::getStencilOp(const Stenci
 	}
 }
 
-constexpr VkBlendFactor LITEFX_VULKAN_API LiteFX::Rendering::Backends::Vk::getBlendFactor(const BlendFactor& blendFactor)
+constexpr VkBlendFactor LITEFX_VULKAN_API LiteFX::Rendering::Backends::Vk::getBlendFactor(BlendFactor blendFactor)
 {
 	switch (blendFactor) {
 	case BlendFactor::Zero: return VkBlendFactor::VK_BLEND_FACTOR_ZERO;
@@ -941,7 +941,7 @@ constexpr VkBlendFactor LITEFX_VULKAN_API LiteFX::Rendering::Backends::Vk::getBl
 	}
 }
 
-constexpr VkBlendOp LITEFX_VULKAN_API LiteFX::Rendering::Backends::Vk::getBlendOperation(const BlendOperation& blendOperation)
+constexpr VkBlendOp LITEFX_VULKAN_API LiteFX::Rendering::Backends::Vk::getBlendOperation(BlendOperation blendOperation)
 {
 	switch (blendOperation) {
 	case BlendOperation::Add: return VkBlendOp::VK_BLEND_OP_ADD;
@@ -953,7 +953,7 @@ constexpr VkBlendOp LITEFX_VULKAN_API LiteFX::Rendering::Backends::Vk::getBlendO
 	}
 }
 
-constexpr VkPipelineStageFlags LITEFX_VULKAN_API LiteFX::Rendering::Backends::Vk::getPipelineStage(const PipelineStage& pipelineStage)
+constexpr VkPipelineStageFlags LITEFX_VULKAN_API LiteFX::Rendering::Backends::Vk::getPipelineStage(PipelineStage pipelineStage)
 {
 	if (pipelineStage == PipelineStage::None)
 		return VK_PIPELINE_STAGE_NONE;
@@ -1000,7 +1000,7 @@ constexpr VkPipelineStageFlags LITEFX_VULKAN_API LiteFX::Rendering::Backends::Vk
 	return sync;
 }
 
-constexpr VkAccessFlags LITEFX_VULKAN_API LiteFX::Rendering::Backends::Vk::getResourceAccess(const ResourceAccess& resourceAccess)
+constexpr VkAccessFlags LITEFX_VULKAN_API LiteFX::Rendering::Backends::Vk::getResourceAccess(ResourceAccess resourceAccess)
 {
 	if (resourceAccess == ResourceAccess::None)
 		return VK_ACCESS_NONE;
@@ -1052,7 +1052,7 @@ constexpr VkAccessFlags LITEFX_VULKAN_API LiteFX::Rendering::Backends::Vk::getRe
 	return access;
 }
 
-constexpr VkImageLayout LITEFX_VULKAN_API LiteFX::Rendering::Backends::Vk::getImageLayout(const ImageLayout& imageLayout)
+constexpr VkImageLayout LITEFX_VULKAN_API LiteFX::Rendering::Backends::Vk::getImageLayout(ImageLayout imageLayout)
 {
 	switch (imageLayout) {
 	case ImageLayout::Common: return VK_IMAGE_LAYOUT_GENERAL;

--- a/src/Backends/Vulkan/src/convert.cpp
+++ b/src/Backends/Vulkan/src/convert.cpp
@@ -845,7 +845,7 @@ constexpr VkImageType LiteFX::Rendering::Backends::Vk::getImageType(ImageDimensi
 	}
 }
 
-constexpr VkImageViewType LiteFX::Rendering::Backends::Vk::getImageViewType(ImageDimensions dimension, const UInt32& layers)
+constexpr VkImageViewType LiteFX::Rendering::Backends::Vk::getImageViewType(ImageDimensions dimension, UInt32 layers)
 {
 	switch (dimension)
 	{

--- a/src/Backends/Vulkan/src/convert.cpp
+++ b/src/Backends/Vulkan/src/convert.cpp
@@ -2,7 +2,7 @@
 
 using namespace LiteFX::Rendering::Backends;
 
-Format LiteFX::Rendering::Backends::Vk::getFormat(const VkFormat& format)
+constexpr Format LiteFX::Rendering::Backends::Vk::getFormat(const VkFormat& format)
 {
 	switch (format)
 	{
@@ -303,7 +303,7 @@ Format LiteFX::Rendering::Backends::Vk::getFormat(const VkFormat& format)
 	}
 }
 
-VkFormat LiteFX::Rendering::Backends::Vk::getFormat(const Format& format)
+constexpr VkFormat LiteFX::Rendering::Backends::Vk::getFormat(const Format& format)
 {
 	switch (format)
 	{
@@ -604,7 +604,7 @@ VkFormat LiteFX::Rendering::Backends::Vk::getFormat(const Format& format)
 	}
 }
 
-VkFormat LiteFX::Rendering::Backends::Vk::getFormat(const BufferFormat& format)
+constexpr VkFormat LiteFX::Rendering::Backends::Vk::getFormat(const BufferFormat& format)
 {
 	switch (format)
 	{
@@ -661,7 +661,7 @@ VkFormat LiteFX::Rendering::Backends::Vk::getFormat(const BufferFormat& format)
 	}
 }
 
-PolygonMode LiteFX::Rendering::Backends::Vk::getPolygonMode(const VkPolygonMode& mode)
+constexpr PolygonMode LiteFX::Rendering::Backends::Vk::getPolygonMode(const VkPolygonMode& mode)
 {
 	switch (mode)
 	{
@@ -676,7 +676,7 @@ PolygonMode LiteFX::Rendering::Backends::Vk::getPolygonMode(const VkPolygonMode&
 	}
 }
 
-VkPolygonMode LiteFX::Rendering::Backends::Vk::getPolygonMode(const PolygonMode& mode)
+constexpr VkPolygonMode LiteFX::Rendering::Backends::Vk::getPolygonMode(const PolygonMode& mode)
 {
 	switch (mode)
 	{
@@ -691,7 +691,7 @@ VkPolygonMode LiteFX::Rendering::Backends::Vk::getPolygonMode(const PolygonMode&
 	}
 }
 
-CullMode LiteFX::Rendering::Backends::Vk::getCullMode(const VkCullModeFlags& mode)
+constexpr CullMode LiteFX::Rendering::Backends::Vk::getCullMode(const VkCullModeFlags& mode)
 {
 	switch (mode)
 	{
@@ -708,7 +708,7 @@ CullMode LiteFX::Rendering::Backends::Vk::getCullMode(const VkCullModeFlags& mod
 	}
 }
 
-VkCullModeFlags LiteFX::Rendering::Backends::Vk::getCullMode(const CullMode& mode)
+constexpr VkCullModeFlags LiteFX::Rendering::Backends::Vk::getCullMode(const CullMode& mode)
 {
 	switch (mode)
 	{
@@ -725,7 +725,7 @@ VkCullModeFlags LiteFX::Rendering::Backends::Vk::getCullMode(const CullMode& mod
 	}
 }
 
-PrimitiveTopology LiteFX::Rendering::Backends::Vk::getPrimitiveTopology(const VkPrimitiveTopology& topology)
+constexpr PrimitiveTopology LiteFX::Rendering::Backends::Vk::getPrimitiveTopology(const VkPrimitiveTopology& topology)
 {
 	switch (topology)
 	{
@@ -744,7 +744,7 @@ PrimitiveTopology LiteFX::Rendering::Backends::Vk::getPrimitiveTopology(const Vk
 	}
 }
 
-VkPrimitiveTopology LiteFX::Rendering::Backends::Vk::getPrimitiveTopology(const PrimitiveTopology& topology)
+constexpr VkPrimitiveTopology LiteFX::Rendering::Backends::Vk::getPrimitiveTopology(const PrimitiveTopology& topology)
 {
 	switch (topology)
 	{
@@ -763,7 +763,7 @@ VkPrimitiveTopology LiteFX::Rendering::Backends::Vk::getPrimitiveTopology(const 
 	}
 }
 
-ShaderStage LiteFX::Rendering::Backends::Vk::getShaderStage(const VkShaderStageFlagBits& shaderType)
+constexpr ShaderStage LiteFX::Rendering::Backends::Vk::getShaderStage(const VkShaderStageFlagBits& shaderType)
 {
 	switch (shaderType)
 	{
@@ -784,7 +784,7 @@ ShaderStage LiteFX::Rendering::Backends::Vk::getShaderStage(const VkShaderStageF
 	}
 }
 
-VkShaderStageFlagBits LiteFX::Rendering::Backends::Vk::getShaderStage(const ShaderStage& shaderType)
+constexpr VkShaderStageFlagBits LiteFX::Rendering::Backends::Vk::getShaderStage(const ShaderStage& shaderType)
 {
 	switch (shaderType)
 	{
@@ -806,7 +806,7 @@ VkShaderStageFlagBits LiteFX::Rendering::Backends::Vk::getShaderStage(const Shad
 	}
 }
 
-MultiSamplingLevel LiteFX::Rendering::Backends::Vk::getSamples(const VkSampleCountFlagBits& samples)
+constexpr MultiSamplingLevel LiteFX::Rendering::Backends::Vk::getSamples(const VkSampleCountFlagBits& samples)
 {
 	switch (samples)
 	{
@@ -829,7 +829,7 @@ MultiSamplingLevel LiteFX::Rendering::Backends::Vk::getSamples(const VkSampleCou
 	}
 }
 
-VkImageType LiteFX::Rendering::Backends::Vk::getImageType(const ImageDimensions& dimension)
+constexpr VkImageType LiteFX::Rendering::Backends::Vk::getImageType(const ImageDimensions& dimension)
 {
 	switch (dimension)
 	{
@@ -845,7 +845,7 @@ VkImageType LiteFX::Rendering::Backends::Vk::getImageType(const ImageDimensions&
 	}
 }
 
-VkImageViewType LiteFX::Rendering::Backends::Vk::getImageViewType(const ImageDimensions& dimension, const UInt32& layers)
+constexpr VkImageViewType LiteFX::Rendering::Backends::Vk::getImageViewType(const ImageDimensions& dimension, const UInt32& layers)
 {
 	switch (dimension)
 	{
@@ -862,7 +862,7 @@ VkImageViewType LiteFX::Rendering::Backends::Vk::getImageViewType(const ImageDim
 	}
 }
 
-VkSampleCountFlagBits LiteFX::Rendering::Backends::Vk::getSamples(const MultiSamplingLevel& samples)
+constexpr VkSampleCountFlagBits LiteFX::Rendering::Backends::Vk::getSamples(const MultiSamplingLevel& samples)
 {
 	switch (samples)
 	{
@@ -885,7 +885,7 @@ VkSampleCountFlagBits LiteFX::Rendering::Backends::Vk::getSamples(const MultiSam
 	}
 }
 
-VkCompareOp LiteFX::Rendering::Backends::Vk::getCompareOp(const CompareOperation& compareOp)
+constexpr VkCompareOp LiteFX::Rendering::Backends::Vk::getCompareOp(const CompareOperation& compareOp)
 {
 	switch (compareOp) {
 	case CompareOperation::Never: return VkCompareOp::VK_COMPARE_OP_NEVER;
@@ -900,7 +900,7 @@ VkCompareOp LiteFX::Rendering::Backends::Vk::getCompareOp(const CompareOperation
 	}
 }
 
-VkStencilOp LiteFX::Rendering::Backends::Vk::getStencilOp(const StencilOperation& stencilOp)
+constexpr VkStencilOp LiteFX::Rendering::Backends::Vk::getStencilOp(const StencilOperation& stencilOp)
 {
 	switch (stencilOp) {
 	case StencilOperation::Keep: return VkStencilOp::VK_STENCIL_OP_KEEP;
@@ -915,7 +915,7 @@ VkStencilOp LiteFX::Rendering::Backends::Vk::getStencilOp(const StencilOperation
 	}
 }
 
-VkBlendFactor LITEFX_VULKAN_API LiteFX::Rendering::Backends::Vk::getBlendFactor(const BlendFactor& blendFactor)
+constexpr VkBlendFactor LITEFX_VULKAN_API LiteFX::Rendering::Backends::Vk::getBlendFactor(const BlendFactor& blendFactor)
 {
 	switch (blendFactor) {
 	case BlendFactor::Zero: return VkBlendFactor::VK_BLEND_FACTOR_ZERO;
@@ -941,7 +941,7 @@ VkBlendFactor LITEFX_VULKAN_API LiteFX::Rendering::Backends::Vk::getBlendFactor(
 	}
 }
 
-VkBlendOp LITEFX_VULKAN_API LiteFX::Rendering::Backends::Vk::getBlendOperation(const BlendOperation& blendOperation)
+constexpr VkBlendOp LITEFX_VULKAN_API LiteFX::Rendering::Backends::Vk::getBlendOperation(const BlendOperation& blendOperation)
 {
 	switch (blendOperation) {
 	case BlendOperation::Add: return VkBlendOp::VK_BLEND_OP_ADD;
@@ -953,7 +953,7 @@ VkBlendOp LITEFX_VULKAN_API LiteFX::Rendering::Backends::Vk::getBlendOperation(c
 	}
 }
 
-VkPipelineStageFlags LITEFX_VULKAN_API LiteFX::Rendering::Backends::Vk::getPipelineStage(const PipelineStage& pipelineStage)
+constexpr VkPipelineStageFlags LITEFX_VULKAN_API LiteFX::Rendering::Backends::Vk::getPipelineStage(const PipelineStage& pipelineStage)
 {
 	if (pipelineStage == PipelineStage::None)
 		return VK_PIPELINE_STAGE_NONE;
@@ -1000,7 +1000,7 @@ VkPipelineStageFlags LITEFX_VULKAN_API LiteFX::Rendering::Backends::Vk::getPipel
 	return sync;
 }
 
-VkAccessFlags LITEFX_VULKAN_API LiteFX::Rendering::Backends::Vk::getResourceAccess(const ResourceAccess& resourceAccess)
+constexpr VkAccessFlags LITEFX_VULKAN_API LiteFX::Rendering::Backends::Vk::getResourceAccess(const ResourceAccess& resourceAccess)
 {
 	if (resourceAccess == ResourceAccess::None)
 		return VK_ACCESS_NONE;
@@ -1052,7 +1052,7 @@ VkAccessFlags LITEFX_VULKAN_API LiteFX::Rendering::Backends::Vk::getResourceAcce
 	return access;
 }
 
-VkImageLayout LITEFX_VULKAN_API LiteFX::Rendering::Backends::Vk::getImageLayout(const ImageLayout& imageLayout)
+constexpr VkImageLayout LITEFX_VULKAN_API LiteFX::Rendering::Backends::Vk::getImageLayout(const ImageLayout& imageLayout)
 {
 	switch (imageLayout) {
 	case ImageLayout::Common: return VK_IMAGE_LAYOUT_GENERAL;

--- a/src/Backends/Vulkan/src/convert.cpp
+++ b/src/Backends/Vulkan/src/convert.cpp
@@ -744,7 +744,7 @@ constexpr PrimitiveTopology LiteFX::Rendering::Backends::Vk::getPrimitiveTopolog
 	}
 }
 
-constexpr VkPrimitiveTopology LiteFX::Rendering::Backends::Vk::getPrimitiveTopology(const PrimitiveTopology& topology)
+constexpr VkPrimitiveTopology LiteFX::Rendering::Backends::Vk::getPrimitiveTopology(PrimitiveTopology topology)
 {
 	switch (topology)
 	{

--- a/src/Backends/Vulkan/src/descriptor_layout.cpp
+++ b/src/Backends/Vulkan/src/descriptor_layout.cpp
@@ -18,7 +18,7 @@ private:
     UniquePtr<IVulkanSampler> m_staticSampler;
 
 public:
-    VulkanDescriptorLayoutImpl(VulkanDescriptorLayout* parent, const DescriptorType& type, const UInt32& binding, const size_t& elementSize, const UInt32& descriptors) :
+    VulkanDescriptorLayoutImpl(VulkanDescriptorLayout* parent, DescriptorType type, const UInt32& binding, const size_t& elementSize, const UInt32& descriptors) :
         base(parent), m_descriptorType(type), m_binding(binding), m_elementSize(elementSize), m_descriptors(descriptors)
     {
         switch (m_descriptorType)
@@ -56,7 +56,7 @@ public:
 // Shared interface.
 // ------------------------------------------------------------------------------------------------
 
-VulkanDescriptorLayout::VulkanDescriptorLayout(const DescriptorType& type, const UInt32& binding, const size_t& elementSize, const UInt32& descriptors) :
+VulkanDescriptorLayout::VulkanDescriptorLayout(DescriptorType type, const UInt32& binding, const size_t& elementSize, const UInt32& descriptors) :
     m_impl(makePimpl<VulkanDescriptorLayoutImpl>(this, type, binding, elementSize, descriptors))
 {
 }
@@ -83,12 +83,12 @@ const UInt32& VulkanDescriptorLayout::descriptors() const noexcept
     return m_impl->m_descriptors;
 }
 
-const BufferType& VulkanDescriptorLayout::type() const noexcept
+BufferType VulkanDescriptorLayout::type() const noexcept
 {
     return m_impl->m_bufferType;
 }
 
-const DescriptorType& VulkanDescriptorLayout::descriptorType() const noexcept
+DescriptorType VulkanDescriptorLayout::descriptorType() const noexcept
 {
     return m_impl->m_descriptorType;
 }

--- a/src/Backends/Vulkan/src/descriptor_layout.cpp
+++ b/src/Backends/Vulkan/src/descriptor_layout.cpp
@@ -18,7 +18,7 @@ private:
     UniquePtr<IVulkanSampler> m_staticSampler;
 
 public:
-    VulkanDescriptorLayoutImpl(VulkanDescriptorLayout* parent, DescriptorType type, const UInt32& binding, const size_t& elementSize, const UInt32& descriptors) :
+    VulkanDescriptorLayoutImpl(VulkanDescriptorLayout* parent, DescriptorType type, UInt32 binding, size_t elementSize, UInt32 descriptors) :
         base(parent), m_descriptorType(type), m_binding(binding), m_elementSize(elementSize), m_descriptors(descriptors)
     {
         switch (m_descriptorType)
@@ -42,7 +42,7 @@ public:
         }
     }
 
-    VulkanDescriptorLayoutImpl(VulkanDescriptorLayout* parent, UniquePtr<IVulkanSampler>&& staticSampler, const UInt32& binding) :
+    VulkanDescriptorLayoutImpl(VulkanDescriptorLayout* parent, UniquePtr<IVulkanSampler>&& staticSampler, UInt32 binding) :
         VulkanDescriptorLayoutImpl(parent, DescriptorType::Sampler, binding, 0, 1)
     {
         if (staticSampler == nullptr)
@@ -56,12 +56,12 @@ public:
 // Shared interface.
 // ------------------------------------------------------------------------------------------------
 
-VulkanDescriptorLayout::VulkanDescriptorLayout(DescriptorType type, const UInt32& binding, const size_t& elementSize, const UInt32& descriptors) :
+VulkanDescriptorLayout::VulkanDescriptorLayout(DescriptorType type, UInt32 binding, size_t elementSize, UInt32 descriptors) :
     m_impl(makePimpl<VulkanDescriptorLayoutImpl>(this, type, binding, elementSize, descriptors))
 {
 }
 
-VulkanDescriptorLayout::VulkanDescriptorLayout(UniquePtr<IVulkanSampler>&& staticSampler, const UInt32& binding) :
+VulkanDescriptorLayout::VulkanDescriptorLayout(UniquePtr<IVulkanSampler>&& staticSampler, UInt32 binding) :
     m_impl(makePimpl<VulkanDescriptorLayoutImpl>(this, std::move(staticSampler), binding))
 {
 }
@@ -73,12 +73,12 @@ size_t VulkanDescriptorLayout::elementSize() const noexcept
     return m_impl->m_elementSize;
 }
 
-const UInt32& VulkanDescriptorLayout::binding() const noexcept
+UInt32 VulkanDescriptorLayout::binding() const noexcept
 {
     return m_impl->m_binding;
 }
 
-const UInt32& VulkanDescriptorLayout::descriptors() const noexcept
+UInt32 VulkanDescriptorLayout::descriptors() const noexcept
 {
     return m_impl->m_descriptors;
 }

--- a/src/Backends/Vulkan/src/descriptor_set.cpp
+++ b/src/Backends/Vulkan/src/descriptor_set.cpp
@@ -48,7 +48,7 @@ const VulkanDescriptorSetLayout& VulkanDescriptorSet::layout() const noexcept
     return m_impl->m_layout;
 }
 
-void VulkanDescriptorSet::update(const UInt32& binding, const IVulkanBuffer& buffer, const UInt32& bufferElement, const UInt32& elements, const UInt32& firstDescriptor) const
+void VulkanDescriptorSet::update(UInt32 binding, const IVulkanBuffer& buffer, UInt32 bufferElement, UInt32 elements, UInt32 firstDescriptor) const
 {
     VkWriteDescriptorSet descriptorWrite{ };
     descriptorWrite.sType = VK_STRUCTURE_TYPE_WRITE_DESCRIPTOR_SET;
@@ -157,7 +157,7 @@ void VulkanDescriptorSet::update(const UInt32& binding, const IVulkanBuffer& buf
     ::vkUpdateDescriptorSets(m_impl->m_layout.device().handle(), 1, &descriptorWrite, 0, nullptr);
 }
 
-void VulkanDescriptorSet::update(const UInt32& binding, const IVulkanImage& texture, const UInt32& descriptor, const UInt32& firstLevel, const UInt32& levels, const UInt32& firstLayer, const UInt32& layers) const
+void VulkanDescriptorSet::update(UInt32 binding, const IVulkanImage& texture, UInt32 descriptor, UInt32 firstLevel, UInt32 levels, UInt32 firstLayer, UInt32 layers) const
 {
     VkDescriptorImageInfo imageInfo{ };
     VkWriteDescriptorSet descriptorWrite{ };
@@ -230,7 +230,7 @@ void VulkanDescriptorSet::update(const UInt32& binding, const IVulkanImage& text
     ::vkUpdateDescriptorSets(m_impl->m_layout.device().handle(), 1, &descriptorWrite, 0, nullptr);
 }
 
-void VulkanDescriptorSet::update(const UInt32& binding, const IVulkanSampler& sampler, const UInt32& descriptor) const
+void VulkanDescriptorSet::update(UInt32 binding, const IVulkanSampler& sampler, UInt32 descriptor) const
 {
     const auto& layout = m_impl->m_layout.descriptor(binding);
 
@@ -252,7 +252,7 @@ void VulkanDescriptorSet::update(const UInt32& binding, const IVulkanSampler& sa
     ::vkUpdateDescriptorSets(m_impl->m_layout.device().handle(), 1, &descriptorWrite, 0, nullptr);
 }
 
-void VulkanDescriptorSet::attach(const UInt32& binding, const IVulkanImage& image) const
+void VulkanDescriptorSet::attach(UInt32 binding, const IVulkanImage& image) const
 {
     const auto& layout = m_impl->m_layout.descriptor(binding);
 

--- a/src/Backends/Vulkan/src/descriptor_set_layout.cpp
+++ b/src/Backends/Vulkan/src/descriptor_set_layout.cpp
@@ -45,7 +45,7 @@ private:
     Dictionary<const VkDescriptorSet*, const VkDescriptorPool*> m_descriptorSetSources;
 
 public:
-    VulkanDescriptorSetLayoutImpl(VulkanDescriptorSetLayout* parent, const VulkanDevice& device, Enumerable<UniquePtr<VulkanDescriptorLayout>>&& descriptorLayouts, const UInt32& space, const ShaderStage& stages) :
+    VulkanDescriptorSetLayoutImpl(VulkanDescriptorSetLayout* parent, const VulkanDevice& device, Enumerable<UniquePtr<VulkanDescriptorLayout>>&& descriptorLayouts, const UInt32& space, ShaderStage stages) :
         base(parent), m_device(device), m_space(space), m_stages(stages), m_poolSize(0)
     {
         m_descriptorLayouts = descriptorLayouts | std::views::as_rvalue | std::ranges::to<std::vector>();
@@ -233,7 +233,7 @@ public:
 // Shared interface.
 // ------------------------------------------------------------------------------------------------
 
-VulkanDescriptorSetLayout::VulkanDescriptorSetLayout(const VulkanDevice& device, Enumerable<UniquePtr<VulkanDescriptorLayout>>&& descriptorLayouts, const UInt32& space, const ShaderStage& stages, const UInt32& poolSize, const UInt32& maxUnboundedArraySize) :
+VulkanDescriptorSetLayout::VulkanDescriptorSetLayout(const VulkanDevice& device, Enumerable<UniquePtr<VulkanDescriptorLayout>>&& descriptorLayouts, const UInt32& space, ShaderStage stages, const UInt32& poolSize, const UInt32& maxUnboundedArraySize) :
     m_impl(makePimpl<VulkanDescriptorSetLayoutImpl>(this, device, std::move(descriptorLayouts), space, stages)), Resource<VkDescriptorSetLayout>(VK_NULL_HANDLE)
 {
     this->handle() = m_impl->initialize(poolSize, maxUnboundedArraySize);
@@ -274,7 +274,7 @@ const UInt32& VulkanDescriptorSetLayout::space() const noexcept
     return m_impl->m_space;
 }
 
-const ShaderStage& VulkanDescriptorSetLayout::shaderStages() const noexcept
+ShaderStage VulkanDescriptorSetLayout::shaderStages() const noexcept
 {
     return m_impl->m_stages;
 }

--- a/src/Backends/Vulkan/src/descriptor_set_layout.cpp
+++ b/src/Backends/Vulkan/src/descriptor_set_layout.cpp
@@ -45,7 +45,7 @@ private:
     Dictionary<const VkDescriptorSet*, const VkDescriptorPool*> m_descriptorSetSources;
 
 public:
-    VulkanDescriptorSetLayoutImpl(VulkanDescriptorSetLayout* parent, const VulkanDevice& device, Enumerable<UniquePtr<VulkanDescriptorLayout>>&& descriptorLayouts, const UInt32& space, ShaderStage stages) :
+    VulkanDescriptorSetLayoutImpl(VulkanDescriptorSetLayout* parent, const VulkanDevice& device, Enumerable<UniquePtr<VulkanDescriptorLayout>>&& descriptorLayouts, UInt32 space, ShaderStage stages) :
         base(parent), m_device(device), m_space(space), m_stages(stages), m_poolSize(0)
     {
         m_descriptorLayouts = descriptorLayouts | std::views::as_rvalue | std::ranges::to<std::vector>();
@@ -188,7 +188,7 @@ public:
         m_descriptorPools.push_back(descriptorPool);
     }
 
-    VkDescriptorSet tryAllocate(const UInt32& descriptors)
+    VkDescriptorSet tryAllocate(UInt32 descriptors)
     {
         VkDescriptorSetVariableDescriptorCountAllocateInfo variableCountInfo;
         VkDescriptorSetAllocateInfo descriptorSetInfo = {
@@ -233,7 +233,7 @@ public:
 // Shared interface.
 // ------------------------------------------------------------------------------------------------
 
-VulkanDescriptorSetLayout::VulkanDescriptorSetLayout(const VulkanDevice& device, Enumerable<UniquePtr<VulkanDescriptorLayout>>&& descriptorLayouts, const UInt32& space, ShaderStage stages, const UInt32& poolSize, const UInt32& maxUnboundedArraySize) :
+VulkanDescriptorSetLayout::VulkanDescriptorSetLayout(const VulkanDevice& device, Enumerable<UniquePtr<VulkanDescriptorLayout>>&& descriptorLayouts, UInt32 space, ShaderStage stages, UInt32 poolSize, UInt32 maxUnboundedArraySize) :
     m_impl(makePimpl<VulkanDescriptorSetLayoutImpl>(this, device, std::move(descriptorLayouts), space, stages)), Resource<VkDescriptorSetLayout>(VK_NULL_HANDLE)
 {
     this->handle() = m_impl->initialize(poolSize, maxUnboundedArraySize);
@@ -261,7 +261,7 @@ Enumerable<const VulkanDescriptorLayout*> VulkanDescriptorSetLayout::descriptors
     return m_impl->m_descriptorLayouts | std::views::transform([](const UniquePtr<VulkanDescriptorLayout>& layout) { return layout.get(); });
 }
 
-const VulkanDescriptorLayout& VulkanDescriptorSetLayout::descriptor(const UInt32& binding) const
+const VulkanDescriptorLayout& VulkanDescriptorSetLayout::descriptor(UInt32 binding) const
 {
     if (auto match = std::ranges::find_if(m_impl->m_descriptorLayouts, [&binding](const UniquePtr<VulkanDescriptorLayout>& layout) { return layout->binding() == binding; }); match != m_impl->m_descriptorLayouts.end())
         return *match->get();
@@ -269,7 +269,7 @@ const VulkanDescriptorLayout& VulkanDescriptorSetLayout::descriptor(const UInt32
     throw ArgumentOutOfRangeException("No layout has been provided for the binding {0}.", binding);
 }
 
-const UInt32& VulkanDescriptorSetLayout::space() const noexcept
+UInt32 VulkanDescriptorSetLayout::space() const noexcept
 {
     return m_impl->m_space;
 }
@@ -319,7 +319,7 @@ UniquePtr<VulkanDescriptorSet> VulkanDescriptorSetLayout::allocate(const Enumera
     return this->allocate(0, bindings);
 }
 
-UniquePtr<VulkanDescriptorSet> VulkanDescriptorSetLayout::allocate(const UInt32& descriptors, const Enumerable<DescriptorBinding>& bindings) const
+UniquePtr<VulkanDescriptorSet> VulkanDescriptorSetLayout::allocate(UInt32 descriptors, const Enumerable<DescriptorBinding>& bindings) const
 {
     std::lock_guard<std::mutex> lock(m_impl->m_mutex);
 
@@ -347,17 +347,17 @@ UniquePtr<VulkanDescriptorSet> VulkanDescriptorSetLayout::allocate(const UInt32&
     return descriptorSet;
 }
 
-Enumerable<UniquePtr<VulkanDescriptorSet>> VulkanDescriptorSetLayout::allocateMultiple(const UInt32& descriptorSets, const Enumerable<Enumerable<DescriptorBinding>>& bindings) const
+Enumerable<UniquePtr<VulkanDescriptorSet>> VulkanDescriptorSetLayout::allocateMultiple(UInt32 descriptorSets, const Enumerable<Enumerable<DescriptorBinding>>& bindings) const
 {
     return this->allocateMultiple(descriptorSets, 0, bindings);
 }
 
-Enumerable<UniquePtr<VulkanDescriptorSet>> VulkanDescriptorSetLayout::allocateMultiple(const UInt32& descriptorSets, std::function<Enumerable<DescriptorBinding>(const UInt32&)> bindingFactory) const
+Enumerable<UniquePtr<VulkanDescriptorSet>> VulkanDescriptorSetLayout::allocateMultiple(UInt32 descriptorSets, std::function<Enumerable<DescriptorBinding>(UInt32)> bindingFactory) const
 {
     return this->allocateMultiple(descriptorSets, 0, bindingFactory);
 }
 
-Enumerable<UniquePtr<VulkanDescriptorSet>> VulkanDescriptorSetLayout::allocateMultiple(const UInt32& count, const UInt32& descriptors, const Enumerable<Enumerable<DescriptorBinding>>& bindings) const
+Enumerable<UniquePtr<VulkanDescriptorSet>> VulkanDescriptorSetLayout::allocateMultiple(UInt32 count, UInt32 descriptors, const Enumerable<Enumerable<DescriptorBinding>>& bindings) const
 {
     return [this, descriptors, &bindings, &count]() -> std::generator<UniquePtr<VulkanDescriptorSet>> {
         for (auto& binding : bindings)
@@ -368,7 +368,7 @@ Enumerable<UniquePtr<VulkanDescriptorSet>> VulkanDescriptorSetLayout::allocateMu
     }() | std::views::as_rvalue;
 }
 
-Enumerable<UniquePtr<VulkanDescriptorSet>> VulkanDescriptorSetLayout::allocateMultiple(const UInt32& count, const UInt32& descriptors, std::function<Enumerable<DescriptorBinding>(const UInt32&)> bindingFactory) const
+Enumerable<UniquePtr<VulkanDescriptorSet>> VulkanDescriptorSetLayout::allocateMultiple(UInt32 count, UInt32 descriptors, std::function<Enumerable<DescriptorBinding>(UInt32)> bindingFactory) const
 {
     return [this, descriptors, &bindingFactory, &count]() -> std::generator<UniquePtr<VulkanDescriptorSet>> {
         for (int i = 0; i < count; ++i)
@@ -411,7 +411,7 @@ void VulkanDescriptorSetLayout::free(const VulkanDescriptorSet& descriptorSet) c
     }
 }
 
-const UInt32& VulkanDescriptorSetLayout::poolSize() const noexcept
+UInt32 VulkanDescriptorSetLayout::poolSize() const noexcept
 {
     return m_impl->m_poolSize;
 }

--- a/src/Backends/Vulkan/src/device.cpp
+++ b/src/Backends/Vulkan/src/device.cpp
@@ -19,14 +19,14 @@ private:
 		QueueType m_type;
 
 	public:
-		const QueueType& type() const noexcept { return m_type; }
+		QueueType type() const noexcept { return m_type; }
 		const UInt32& total() const noexcept { return m_queueCount; }
 		const UInt32 active() const noexcept { return static_cast<UInt32>(m_queues.size()); }
 		const UInt32& id() const noexcept { return m_id; }
 		const Array<UniquePtr<VulkanQueue>>& queues() const noexcept { return m_queues; }
 
 	public:
-		QueueFamily(const UInt32& id, const UInt32& queueCount, const QueueType& type) :
+		QueueFamily(const UInt32& id, const UInt32& queueCount, QueueType type) :
 			m_id(id), m_queueCount(queueCount), m_type(type) { 
 		}
 		QueueFamily(const QueueFamily& _other) = delete;
@@ -41,7 +41,7 @@ private:
 		}
 
 	public:
-		VulkanQueue* createQueue(const VulkanDevice& device, const QueuePriority& priority) {
+		VulkanQueue* createQueue(const VulkanDevice& device, QueuePriority priority) {
 			if (this->active() >= this->total())
 			{
 				LITEFX_ERROR(VULKAN_LOG, "Unable to create another queue for family {0}, since all {1} queues are already created.", m_id, m_queueCount);
@@ -281,7 +281,7 @@ public:
 		m_factory = makeUnique<VulkanGraphicsFactory>(*m_parent);
 	}
 
-	void createSwapChain(const Format& format, const Size2d& frameBufferSize, const UInt32& frameBuffers)
+	void createSwapChain(Format format, const Size2d& frameBufferSize, const UInt32& frameBuffers)
 	{
 		m_swapChain = makeUnique<VulkanSwapChain>(*m_parent, format, frameBufferSize, frameBuffers);
 	}
@@ -295,7 +295,7 @@ public:
 	}
 
 public:
-	VulkanQueue* createQueue(const QueueType& type, const QueuePriority& priority)
+	VulkanQueue* createQueue(QueueType type, QueuePriority priority)
 	{
 		// If a transfer queue is requested, look up only dedicated transfer queues. If none is available, fallbacks need to be handled manually. Every queue implicitly handles transfer.
 		auto match = type == QueueType::Transfer ?
@@ -305,7 +305,7 @@ public:
 		return match == m_families.end() ? nullptr : match->createQueue(*m_parent, priority);
 	}
 
-	VulkanQueue* createQueue(const QueueType& type, const QueuePriority& priority, const VkSurfaceKHR& surface)
+	VulkanQueue* createQueue(QueueType type, QueuePriority priority, const VkSurfaceKHR& surface)
 	{
 		if (auto match = std::ranges::find_if(m_families, [&](const auto& family) {
 				if (!LITEFX_FLAG_IS_SET(family.type(), type))
@@ -331,7 +331,7 @@ VulkanDevice::VulkanDevice(const VulkanBackend& backend, const VulkanGraphicsAda
 {
 }
 
-VulkanDevice::VulkanDevice(const VulkanBackend& /*backend*/, const VulkanGraphicsAdapter& adapter, UniquePtr<VulkanSurface>&& surface, const Format& format, const Size2d& frameBufferSize, const UInt32& frameBuffers, Span<String> extensions) :
+VulkanDevice::VulkanDevice(const VulkanBackend& /*backend*/, const VulkanGraphicsAdapter& adapter, UniquePtr<VulkanSurface>&& surface, Format format, const Size2d& frameBufferSize, const UInt32& frameBuffers, Span<String> extensions) :
 	Resource<VkDevice>(nullptr), m_impl(makePimpl<VulkanDeviceImpl>(this, adapter, std::move(surface), extensions))
 {
 	LITEFX_DEBUG(VULKAN_LOG, "Creating Vulkan device {{ Surface: {0}, Adapter: {1}, Extensions: {2} }}...", fmt::ptr(reinterpret_cast<const void*>(m_impl->m_surface.get())), adapter.deviceId(), Join(this->enabledExtensions(), ", "));
@@ -392,12 +392,12 @@ VulkanSwapChain& VulkanDevice::swapChain() noexcept
 }
 
 #if defined(BUILD_DEFINE_BUILDERS)
-VulkanRenderPassBuilder VulkanDevice::buildRenderPass(const MultiSamplingLevel& samples, const UInt32& commandBuffers) const
+VulkanRenderPassBuilder VulkanDevice::buildRenderPass(MultiSamplingLevel samples, const UInt32& commandBuffers) const
 {
 	return VulkanRenderPassBuilder(*this, commandBuffers, samples);
 }
 
-VulkanRenderPassBuilder VulkanDevice::buildRenderPass(const String& name, const MultiSamplingLevel& samples, const UInt32& commandBuffers) const
+VulkanRenderPassBuilder VulkanDevice::buildRenderPass(const String& name, MultiSamplingLevel samples, const UInt32& commandBuffers) const
 {
 	return VulkanRenderPassBuilder(*this, commandBuffers, samples, name);
 }
@@ -483,12 +483,12 @@ const VulkanQueue& VulkanDevice::computeQueue() const noexcept
 	return *m_impl->m_computeQueue;
 }
 
-UniquePtr<VulkanBarrier> VulkanDevice::makeBarrier(const PipelineStage& syncBefore, const PipelineStage& syncAfter) const noexcept
+UniquePtr<VulkanBarrier> VulkanDevice::makeBarrier(PipelineStage syncBefore, PipelineStage syncAfter) const noexcept
 {
 	return makeUnique<VulkanBarrier>(syncBefore, syncAfter);
 }
 
-MultiSamplingLevel VulkanDevice::maximumMultiSamplingLevel(const Format& format) const noexcept
+MultiSamplingLevel VulkanDevice::maximumMultiSamplingLevel(Format format) const noexcept
 {
 	auto limits = m_impl->m_adapter.limits();
 	VkSampleCountFlags sampleCounts = limits.framebufferColorSampleCounts;

--- a/src/Backends/Vulkan/src/device.cpp
+++ b/src/Backends/Vulkan/src/device.cpp
@@ -20,13 +20,13 @@ private:
 
 	public:
 		QueueType type() const noexcept { return m_type; }
-		const UInt32& total() const noexcept { return m_queueCount; }
+		UInt32 total() const noexcept { return m_queueCount; }
 		const UInt32 active() const noexcept { return static_cast<UInt32>(m_queues.size()); }
-		const UInt32& id() const noexcept { return m_id; }
+		UInt32 id() const noexcept { return m_id; }
 		const Array<UniquePtr<VulkanQueue>>& queues() const noexcept { return m_queues; }
 
 	public:
-		QueueFamily(const UInt32& id, const UInt32& queueCount, QueueType type) :
+		QueueFamily(UInt32 id, UInt32 queueCount, QueueType type) :
 			m_id(id), m_queueCount(queueCount), m_type(type) { 
 		}
 		QueueFamily(const QueueFamily& _other) = delete;
@@ -281,7 +281,7 @@ public:
 		m_factory = makeUnique<VulkanGraphicsFactory>(*m_parent);
 	}
 
-	void createSwapChain(Format format, const Size2d& frameBufferSize, const UInt32& frameBuffers)
+	void createSwapChain(Format format, const Size2d& frameBufferSize, UInt32 frameBuffers)
 	{
 		m_swapChain = makeUnique<VulkanSwapChain>(*m_parent, format, frameBufferSize, frameBuffers);
 	}
@@ -331,7 +331,7 @@ VulkanDevice::VulkanDevice(const VulkanBackend& backend, const VulkanGraphicsAda
 {
 }
 
-VulkanDevice::VulkanDevice(const VulkanBackend& /*backend*/, const VulkanGraphicsAdapter& adapter, UniquePtr<VulkanSurface>&& surface, Format format, const Size2d& frameBufferSize, const UInt32& frameBuffers, Span<String> extensions) :
+VulkanDevice::VulkanDevice(const VulkanBackend& /*backend*/, const VulkanGraphicsAdapter& adapter, UniquePtr<VulkanSurface>&& surface, Format format, const Size2d& frameBufferSize, UInt32 frameBuffers, Span<String> extensions) :
 	Resource<VkDevice>(nullptr), m_impl(makePimpl<VulkanDeviceImpl>(this, adapter, std::move(surface), extensions))
 {
 	LITEFX_DEBUG(VULKAN_LOG, "Creating Vulkan device {{ Surface: {0}, Adapter: {1}, Extensions: {2} }}...", fmt::ptr(reinterpret_cast<const void*>(m_impl->m_surface.get())), adapter.deviceId(), Join(this->enabledExtensions(), ", "));
@@ -392,12 +392,12 @@ VulkanSwapChain& VulkanDevice::swapChain() noexcept
 }
 
 #if defined(BUILD_DEFINE_BUILDERS)
-VulkanRenderPassBuilder VulkanDevice::buildRenderPass(MultiSamplingLevel samples, const UInt32& commandBuffers) const
+VulkanRenderPassBuilder VulkanDevice::buildRenderPass(MultiSamplingLevel samples, UInt32 commandBuffers) const
 {
 	return VulkanRenderPassBuilder(*this, commandBuffers, samples);
 }
 
-VulkanRenderPassBuilder VulkanDevice::buildRenderPass(const String& name, MultiSamplingLevel samples, const UInt32& commandBuffers) const
+VulkanRenderPassBuilder VulkanDevice::buildRenderPass(const String& name, MultiSamplingLevel samples, UInt32 commandBuffers) const
 {
 	return VulkanRenderPassBuilder(*this, commandBuffers, samples, name);
 }

--- a/src/Backends/Vulkan/src/factory.cpp
+++ b/src/Backends/Vulkan/src/factory.cpp
@@ -47,12 +47,12 @@ VulkanGraphicsFactory::VulkanGraphicsFactory(const VulkanDevice& device) :
 
 VulkanGraphicsFactory::~VulkanGraphicsFactory() noexcept = default;
 
-UniquePtr<IVulkanBuffer> VulkanGraphicsFactory::createBuffer(const BufferType& type, const BufferUsage& usage, const size_t& elementSize, const UInt32& elements, const bool& allowWrite) const
+UniquePtr<IVulkanBuffer> VulkanGraphicsFactory::createBuffer(BufferType type, BufferUsage usage, const size_t& elementSize, const UInt32& elements, const bool& allowWrite) const
 {
 	return this->createBuffer("", type, usage, elementSize, elements, allowWrite);
 }
 
-UniquePtr<IVulkanBuffer> VulkanGraphicsFactory::createBuffer(const String& name, const BufferType& type, const BufferUsage& usage, const size_t& elementSize, const UInt32& elements, const bool& allowWrite) const
+UniquePtr<IVulkanBuffer> VulkanGraphicsFactory::createBuffer(const String& name, BufferType type, BufferUsage usage, const size_t& elementSize, const UInt32& elements, const bool& allowWrite) const
 {
 	VkBufferCreateInfo bufferInfo = { VK_STRUCTURE_TYPE_BUFFER_CREATE_INFO };
 	VkBufferUsageFlags usageFlags = {};
@@ -142,12 +142,12 @@ UniquePtr<IVulkanBuffer> VulkanGraphicsFactory::createBuffer(const String& name,
 	return buffer;
 }
 
-UniquePtr<IVulkanVertexBuffer> VulkanGraphicsFactory::createVertexBuffer(const VulkanVertexBufferLayout& layout, const BufferUsage& usage, const UInt32& elements) const
+UniquePtr<IVulkanVertexBuffer> VulkanGraphicsFactory::createVertexBuffer(const VulkanVertexBufferLayout& layout, BufferUsage usage, const UInt32& elements) const
 {
 	return this->createVertexBuffer("", layout, usage, elements);
 }
 
-UniquePtr<IVulkanVertexBuffer> VulkanGraphicsFactory::createVertexBuffer(const String& name, const VulkanVertexBufferLayout& layout, const BufferUsage& usage, const UInt32& elements) const
+UniquePtr<IVulkanVertexBuffer> VulkanGraphicsFactory::createVertexBuffer(const String& name, const VulkanVertexBufferLayout& layout, BufferUsage usage, const UInt32& elements) const
 {
 	VkBufferCreateInfo bufferInfo = { VK_STRUCTURE_TYPE_BUFFER_CREATE_INFO };
 	bufferInfo.size = layout.elementSize() * elements;
@@ -205,12 +205,12 @@ UniquePtr<IVulkanVertexBuffer> VulkanGraphicsFactory::createVertexBuffer(const S
 	return buffer;
 }
 
-UniquePtr<IVulkanIndexBuffer> VulkanGraphicsFactory::createIndexBuffer(const VulkanIndexBufferLayout& layout, const BufferUsage& usage, const UInt32& elements) const
+UniquePtr<IVulkanIndexBuffer> VulkanGraphicsFactory::createIndexBuffer(const VulkanIndexBufferLayout& layout, BufferUsage usage, const UInt32& elements) const
 {
 	return this->createIndexBuffer("", layout, usage, elements);
 }
 
-UniquePtr<IVulkanIndexBuffer> VulkanGraphicsFactory::createIndexBuffer(const String& name, const VulkanIndexBufferLayout& layout, const BufferUsage& usage, const UInt32& elements) const
+UniquePtr<IVulkanIndexBuffer> VulkanGraphicsFactory::createIndexBuffer(const String& name, const VulkanIndexBufferLayout& layout, BufferUsage usage, const UInt32& elements) const
 {
 	VkBufferCreateInfo bufferInfo = { VK_STRUCTURE_TYPE_BUFFER_CREATE_INFO };
 	bufferInfo.size = layout.elementSize() * elements;
@@ -268,12 +268,12 @@ UniquePtr<IVulkanIndexBuffer> VulkanGraphicsFactory::createIndexBuffer(const Str
 	return buffer;
 }
 
-UniquePtr<IVulkanImage> VulkanGraphicsFactory::createAttachment(const Format& format, const Size2d& size, const MultiSamplingLevel& samples) const
+UniquePtr<IVulkanImage> VulkanGraphicsFactory::createAttachment(Format format, const Size2d& size, MultiSamplingLevel samples) const
 {
 	return this->createAttachment("", format, size, samples);
 }
 
-UniquePtr<IVulkanImage> VulkanGraphicsFactory::createAttachment(const String& name, const Format& format, const Size2d& size, const MultiSamplingLevel& samples) const
+UniquePtr<IVulkanImage> VulkanGraphicsFactory::createAttachment(const String& name, Format format, const Size2d& size, MultiSamplingLevel samples) const
 {
 	auto width = std::max<UInt32>(1, size.width());
 	auto height = std::max<UInt32>(1, size.height());
@@ -315,12 +315,12 @@ UniquePtr<IVulkanImage> VulkanGraphicsFactory::createAttachment(const String& na
 	return image;
 }
 
-UniquePtr<IVulkanImage> VulkanGraphicsFactory::createTexture(const Format& format, const Size3d& size, const ImageDimensions& dimension, const UInt32& levels, const UInt32& layers, const MultiSamplingLevel& samples, const bool& allowWrite) const
+UniquePtr<IVulkanImage> VulkanGraphicsFactory::createTexture(Format format, const Size3d& size, ImageDimensions dimension, const UInt32& levels, const UInt32& layers, MultiSamplingLevel samples, const bool& allowWrite) const
 {
 	return this->createTexture("", format, size, dimension, levels, layers, samples, allowWrite);
 }
 
-UniquePtr<IVulkanImage> VulkanGraphicsFactory::createTexture(const String& name, const Format& format, const Size3d& size, const ImageDimensions& dimension, const UInt32& levels, const UInt32& layers, const MultiSamplingLevel& samples, const bool& allowWrite) const
+UniquePtr<IVulkanImage> VulkanGraphicsFactory::createTexture(const String& name, Format format, const Size3d& size, ImageDimensions dimension, const UInt32& levels, const UInt32& layers, MultiSamplingLevel samples, const bool& allowWrite) const
 {
 	if (dimension == ImageDimensions::CUBE && layers != 6) [[unlikely]]
 		throw ArgumentOutOfRangeException("A cube map must be defined with 6 layers, but only {0} are provided.", layers);
@@ -374,7 +374,7 @@ UniquePtr<IVulkanImage> VulkanGraphicsFactory::createTexture(const String& name,
 	return image;
 }
 
-Enumerable<UniquePtr<IVulkanImage>> VulkanGraphicsFactory::createTextures(const UInt32& elements, const Format& format, const Size3d& size, const ImageDimensions& dimension, const UInt32& levels, const UInt32& layers, const MultiSamplingLevel& samples, const bool& allowWrite) const
+Enumerable<UniquePtr<IVulkanImage>> VulkanGraphicsFactory::createTextures(const UInt32& elements, Format format, const Size3d& size, ImageDimensions dimension, const UInt32& levels, const UInt32& layers, MultiSamplingLevel samples, const bool& allowWrite) const
 {
 	return [&, this]() -> std::generator<UniquePtr<IVulkanImage>> {
 		for (UInt32 i = 0; i < elements; ++i)
@@ -382,12 +382,12 @@ Enumerable<UniquePtr<IVulkanImage>> VulkanGraphicsFactory::createTextures(const 
 	}() | std::views::as_rvalue;
 }
 
-UniquePtr<IVulkanSampler> VulkanGraphicsFactory::createSampler(const FilterMode& magFilter, const FilterMode& minFilter, const BorderMode& borderU, const BorderMode& borderV, const BorderMode& borderW, const MipMapMode& mipMapMode, const Float& mipMapBias, const Float& maxLod, const Float& minLod, const Float& anisotropy) const
+UniquePtr<IVulkanSampler> VulkanGraphicsFactory::createSampler(FilterMode magFilter, FilterMode minFilter, BorderMode borderU, BorderMode borderV, BorderMode borderW, MipMapMode mipMapMode, const Float& mipMapBias, const Float& maxLod, const Float& minLod, const Float& anisotropy) const
 {
 	return makeUnique<VulkanSampler>(m_impl->m_device, magFilter, minFilter, borderU, borderV, borderW, mipMapMode, mipMapBias, minLod, maxLod, anisotropy);
 }
 
-UniquePtr<IVulkanSampler> VulkanGraphicsFactory::createSampler(const String& name, const FilterMode& magFilter, const FilterMode& minFilter, const BorderMode& borderU, const BorderMode& borderV, const BorderMode& borderW, const MipMapMode& mipMapMode, const Float& mipMapBias, const Float& maxLod, const Float& minLod, const Float& anisotropy) const
+UniquePtr<IVulkanSampler> VulkanGraphicsFactory::createSampler(const String& name, FilterMode magFilter, FilterMode minFilter, BorderMode borderU, BorderMode borderV, BorderMode borderW, MipMapMode mipMapMode, const Float& mipMapBias, const Float& maxLod, const Float& minLod, const Float& anisotropy) const
 {
 	auto sampler = makeUnique<VulkanSampler>(m_impl->m_device, magFilter, minFilter, borderU, borderV, borderW, mipMapMode, mipMapBias, minLod, maxLod, anisotropy, name);
 
@@ -399,7 +399,7 @@ UniquePtr<IVulkanSampler> VulkanGraphicsFactory::createSampler(const String& nam
 	return sampler;
 }
 
-Enumerable<UniquePtr<IVulkanSampler>> VulkanGraphicsFactory::createSamplers(const UInt32& elements, const FilterMode& magFilter, const FilterMode& minFilter, const BorderMode& borderU, const BorderMode& borderV, const BorderMode& borderW, const MipMapMode& mipMapMode, const Float& mipMapBias, const Float& maxLod, const Float& minLod, const Float& anisotropy) const
+Enumerable<UniquePtr<IVulkanSampler>> VulkanGraphicsFactory::createSamplers(const UInt32& elements, FilterMode magFilter, FilterMode minFilter, BorderMode borderU, BorderMode borderV, BorderMode borderW, MipMapMode mipMapMode, const Float& mipMapBias, const Float& maxLod, const Float& minLod, const Float& anisotropy) const
 {
 	return [&, this]() -> std::generator<UniquePtr<IVulkanSampler>> {
 		for (UInt32 i = 0; i < elements; ++i)

--- a/src/Backends/Vulkan/src/factory.cpp
+++ b/src/Backends/Vulkan/src/factory.cpp
@@ -47,12 +47,12 @@ VulkanGraphicsFactory::VulkanGraphicsFactory(const VulkanDevice& device) :
 
 VulkanGraphicsFactory::~VulkanGraphicsFactory() noexcept = default;
 
-UniquePtr<IVulkanBuffer> VulkanGraphicsFactory::createBuffer(BufferType type, BufferUsage usage, const size_t& elementSize, const UInt32& elements, const bool& allowWrite) const
+UniquePtr<IVulkanBuffer> VulkanGraphicsFactory::createBuffer(BufferType type, BufferUsage usage, size_t elementSize, UInt32 elements, bool allowWrite) const
 {
 	return this->createBuffer("", type, usage, elementSize, elements, allowWrite);
 }
 
-UniquePtr<IVulkanBuffer> VulkanGraphicsFactory::createBuffer(const String& name, BufferType type, BufferUsage usage, const size_t& elementSize, const UInt32& elements, const bool& allowWrite) const
+UniquePtr<IVulkanBuffer> VulkanGraphicsFactory::createBuffer(const String& name, BufferType type, BufferUsage usage, size_t elementSize, UInt32 elements, bool allowWrite) const
 {
 	VkBufferCreateInfo bufferInfo = { VK_STRUCTURE_TYPE_BUFFER_CREATE_INFO };
 	VkBufferUsageFlags usageFlags = {};
@@ -142,12 +142,12 @@ UniquePtr<IVulkanBuffer> VulkanGraphicsFactory::createBuffer(const String& name,
 	return buffer;
 }
 
-UniquePtr<IVulkanVertexBuffer> VulkanGraphicsFactory::createVertexBuffer(const VulkanVertexBufferLayout& layout, BufferUsage usage, const UInt32& elements) const
+UniquePtr<IVulkanVertexBuffer> VulkanGraphicsFactory::createVertexBuffer(const VulkanVertexBufferLayout& layout, BufferUsage usage, UInt32 elements) const
 {
 	return this->createVertexBuffer("", layout, usage, elements);
 }
 
-UniquePtr<IVulkanVertexBuffer> VulkanGraphicsFactory::createVertexBuffer(const String& name, const VulkanVertexBufferLayout& layout, BufferUsage usage, const UInt32& elements) const
+UniquePtr<IVulkanVertexBuffer> VulkanGraphicsFactory::createVertexBuffer(const String& name, const VulkanVertexBufferLayout& layout, BufferUsage usage, UInt32 elements) const
 {
 	VkBufferCreateInfo bufferInfo = { VK_STRUCTURE_TYPE_BUFFER_CREATE_INFO };
 	bufferInfo.size = layout.elementSize() * elements;
@@ -205,12 +205,12 @@ UniquePtr<IVulkanVertexBuffer> VulkanGraphicsFactory::createVertexBuffer(const S
 	return buffer;
 }
 
-UniquePtr<IVulkanIndexBuffer> VulkanGraphicsFactory::createIndexBuffer(const VulkanIndexBufferLayout& layout, BufferUsage usage, const UInt32& elements) const
+UniquePtr<IVulkanIndexBuffer> VulkanGraphicsFactory::createIndexBuffer(const VulkanIndexBufferLayout& layout, BufferUsage usage, UInt32 elements) const
 {
 	return this->createIndexBuffer("", layout, usage, elements);
 }
 
-UniquePtr<IVulkanIndexBuffer> VulkanGraphicsFactory::createIndexBuffer(const String& name, const VulkanIndexBufferLayout& layout, BufferUsage usage, const UInt32& elements) const
+UniquePtr<IVulkanIndexBuffer> VulkanGraphicsFactory::createIndexBuffer(const String& name, const VulkanIndexBufferLayout& layout, BufferUsage usage, UInt32 elements) const
 {
 	VkBufferCreateInfo bufferInfo = { VK_STRUCTURE_TYPE_BUFFER_CREATE_INFO };
 	bufferInfo.size = layout.elementSize() * elements;
@@ -315,12 +315,12 @@ UniquePtr<IVulkanImage> VulkanGraphicsFactory::createAttachment(const String& na
 	return image;
 }
 
-UniquePtr<IVulkanImage> VulkanGraphicsFactory::createTexture(Format format, const Size3d& size, ImageDimensions dimension, const UInt32& levels, const UInt32& layers, MultiSamplingLevel samples, const bool& allowWrite) const
+UniquePtr<IVulkanImage> VulkanGraphicsFactory::createTexture(Format format, const Size3d& size, ImageDimensions dimension, UInt32 levels, UInt32 layers, MultiSamplingLevel samples, bool allowWrite) const
 {
 	return this->createTexture("", format, size, dimension, levels, layers, samples, allowWrite);
 }
 
-UniquePtr<IVulkanImage> VulkanGraphicsFactory::createTexture(const String& name, Format format, const Size3d& size, ImageDimensions dimension, const UInt32& levels, const UInt32& layers, MultiSamplingLevel samples, const bool& allowWrite) const
+UniquePtr<IVulkanImage> VulkanGraphicsFactory::createTexture(const String& name, Format format, const Size3d& size, ImageDimensions dimension, UInt32 levels, UInt32 layers, MultiSamplingLevel samples, bool allowWrite) const
 {
 	if (dimension == ImageDimensions::CUBE && layers != 6) [[unlikely]]
 		throw ArgumentOutOfRangeException("A cube map must be defined with 6 layers, but only {0} are provided.", layers);
@@ -374,7 +374,7 @@ UniquePtr<IVulkanImage> VulkanGraphicsFactory::createTexture(const String& name,
 	return image;
 }
 
-Enumerable<UniquePtr<IVulkanImage>> VulkanGraphicsFactory::createTextures(const UInt32& elements, Format format, const Size3d& size, ImageDimensions dimension, const UInt32& levels, const UInt32& layers, MultiSamplingLevel samples, const bool& allowWrite) const
+Enumerable<UniquePtr<IVulkanImage>> VulkanGraphicsFactory::createTextures(UInt32 elements, Format format, const Size3d& size, ImageDimensions dimension, UInt32 levels, UInt32 layers, MultiSamplingLevel samples, bool allowWrite) const
 {
 	return [&, this]() -> std::generator<UniquePtr<IVulkanImage>> {
 		for (UInt32 i = 0; i < elements; ++i)
@@ -382,12 +382,12 @@ Enumerable<UniquePtr<IVulkanImage>> VulkanGraphicsFactory::createTextures(const 
 	}() | std::views::as_rvalue;
 }
 
-UniquePtr<IVulkanSampler> VulkanGraphicsFactory::createSampler(FilterMode magFilter, FilterMode minFilter, BorderMode borderU, BorderMode borderV, BorderMode borderW, MipMapMode mipMapMode, const Float& mipMapBias, const Float& maxLod, const Float& minLod, const Float& anisotropy) const
+UniquePtr<IVulkanSampler> VulkanGraphicsFactory::createSampler(FilterMode magFilter, FilterMode minFilter, BorderMode borderU, BorderMode borderV, BorderMode borderW, MipMapMode mipMapMode, Float mipMapBias, Float maxLod, Float minLod, Float anisotropy) const
 {
 	return makeUnique<VulkanSampler>(m_impl->m_device, magFilter, minFilter, borderU, borderV, borderW, mipMapMode, mipMapBias, minLod, maxLod, anisotropy);
 }
 
-UniquePtr<IVulkanSampler> VulkanGraphicsFactory::createSampler(const String& name, FilterMode magFilter, FilterMode minFilter, BorderMode borderU, BorderMode borderV, BorderMode borderW, MipMapMode mipMapMode, const Float& mipMapBias, const Float& maxLod, const Float& minLod, const Float& anisotropy) const
+UniquePtr<IVulkanSampler> VulkanGraphicsFactory::createSampler(const String& name, FilterMode magFilter, FilterMode minFilter, BorderMode borderU, BorderMode borderV, BorderMode borderW, MipMapMode mipMapMode, Float mipMapBias, Float maxLod, Float minLod, Float anisotropy) const
 {
 	auto sampler = makeUnique<VulkanSampler>(m_impl->m_device, magFilter, minFilter, borderU, borderV, borderW, mipMapMode, mipMapBias, minLod, maxLod, anisotropy, name);
 
@@ -399,7 +399,7 @@ UniquePtr<IVulkanSampler> VulkanGraphicsFactory::createSampler(const String& nam
 	return sampler;
 }
 
-Enumerable<UniquePtr<IVulkanSampler>> VulkanGraphicsFactory::createSamplers(const UInt32& elements, FilterMode magFilter, FilterMode minFilter, BorderMode borderU, BorderMode borderV, BorderMode borderW, MipMapMode mipMapMode, const Float& mipMapBias, const Float& maxLod, const Float& minLod, const Float& anisotropy) const
+Enumerable<UniquePtr<IVulkanSampler>> VulkanGraphicsFactory::createSamplers(UInt32 elements, FilterMode magFilter, FilterMode minFilter, BorderMode borderU, BorderMode borderV, BorderMode borderW, MipMapMode mipMapMode, Float mipMapBias, Float maxLod, Float minLod, Float anisotropy) const
 {
 	return [&, this]() -> std::generator<UniquePtr<IVulkanSampler>> {
 		for (UInt32 i = 0; i < elements; ++i)

--- a/src/Backends/Vulkan/src/frame_buffer.cpp
+++ b/src/Backends/Vulkan/src/frame_buffer.cpp
@@ -21,7 +21,7 @@ private:
     UInt64 m_lastFence{ 0 };
 
 public:
-    VulkanFrameBufferImpl(VulkanFrameBuffer* parent, const VulkanRenderPass& renderPass, const UInt32& bufferIndex, const Size2d& renderArea, const UInt32& commandBuffers) :
+    VulkanFrameBufferImpl(VulkanFrameBuffer* parent, const VulkanRenderPass& renderPass, UInt32 bufferIndex, const Size2d& renderArea, UInt32 commandBuffers) :
         base(parent), m_bufferIndex(bufferIndex), m_size(renderArea), m_renderPass(renderPass)
 	{
         const auto& device = m_renderPass.device();
@@ -121,7 +121,7 @@ public:
 // Shared interface.
 // ------------------------------------------------------------------------------------------------
 
-VulkanFrameBuffer::VulkanFrameBuffer(const VulkanRenderPass& renderPass, const UInt32& bufferIndex, const Size2d& renderArea, const UInt32& commandBuffers) :
+VulkanFrameBuffer::VulkanFrameBuffer(const VulkanRenderPass& renderPass, UInt32 bufferIndex, const Size2d& renderArea, UInt32 commandBuffers) :
 	m_impl(makePimpl<VulkanFrameBufferImpl>(this, renderPass, bufferIndex, renderArea, commandBuffers)), Resource<VkFramebuffer>(VK_NULL_HANDLE)
 {
     this->handle() = m_impl->initialize();
@@ -142,7 +142,7 @@ UInt64& VulkanFrameBuffer::lastFence() const noexcept
     return m_impl->m_lastFence;
 }
 
-const UInt32& VulkanFrameBuffer::bufferIndex() const noexcept
+UInt32 VulkanFrameBuffer::bufferIndex() const noexcept
 {
     return m_impl->m_bufferIndex;
 }
@@ -162,7 +162,7 @@ size_t VulkanFrameBuffer::getHeight() const noexcept
 	return m_impl->m_size.height();
 }
 
-SharedPtr<const VulkanCommandBuffer> VulkanFrameBuffer::commandBuffer(const UInt32& index) const
+SharedPtr<const VulkanCommandBuffer> VulkanFrameBuffer::commandBuffer(UInt32 index) const
 {
     if (index >= static_cast<UInt32>(m_impl->m_commandBuffers.size())) [[unlikely]]
         throw ArgumentOutOfRangeException("No command buffer with index {1} is stored in the frame buffer. The frame buffer only contains {0} command buffers.", m_impl->m_commandBuffers.size(), index);
@@ -180,7 +180,7 @@ Enumerable<const IVulkanImage*> VulkanFrameBuffer::images() const noexcept
     return m_impl->m_renderTargetViews;
 }
 
-const IVulkanImage& VulkanFrameBuffer::image(const UInt32& location) const
+const IVulkanImage& VulkanFrameBuffer::image(UInt32 location) const
 {
     if (location >= m_impl->m_renderTargetViews.size())
         throw ArgumentOutOfRangeException("No render target is mapped to location {0}.", location);

--- a/src/Backends/Vulkan/src/image.cpp
+++ b/src/Backends/Vulkan/src/image.cpp
@@ -27,7 +27,7 @@ private:
 	const VulkanDevice& m_device;
 
 public:
-	VulkanImageImpl(VulkanImage* parent, const VulkanDevice& device, const Size3d& extent, const Format& format, const ImageDimensions& dimensions, const UInt32& levels, const UInt32& layers, const MultiSamplingLevel& samples, const bool& writable, const ImageLayout& initialLayout, VmaAllocator allocator, VmaAllocation allocation) :
+	VulkanImageImpl(VulkanImage* parent, const VulkanDevice& device, const Size3d& extent, Format format, ImageDimensions dimensions, const UInt32& levels, const UInt32& layers, MultiSamplingLevel samples, const bool& writable, ImageLayout initialLayout, VmaAllocator allocator, VmaAllocation allocation) :
 		base(parent), m_device(device), m_allocator(allocator), m_allocationInfo(allocation), m_extent(extent), m_format(format), m_dimensions(dimensions), m_levels(levels), m_layers(layers), m_writable(writable), m_samples(samples)
 	{	
 		VkImageViewCreateInfo createInfo = {
@@ -91,7 +91,7 @@ public:
 // Image Base shared interface.
 // ------------------------------------------------------------------------------------------------
 
-VulkanImage::VulkanImage(const VulkanDevice& device, VkImage image, const Size3d& extent, const Format& format, const ImageDimensions& dimensions, const UInt32& levels, const UInt32& layers, const MultiSamplingLevel& samples, const bool& writable, const ImageLayout& initialLayout, VmaAllocator allocator, VmaAllocation allocation, const String& name) :
+VulkanImage::VulkanImage(const VulkanDevice& device, VkImage image, const Size3d& extent, Format format, ImageDimensions dimensions, const UInt32& levels, const UInt32& layers, MultiSamplingLevel samples, const bool& writable, ImageLayout initialLayout, VmaAllocator allocator, VmaAllocation allocation, const String& name) :
 	m_impl(makePimpl<VulkanImageImpl>(this, device, extent, format, dimensions, levels, layers, samples, writable, initialLayout, allocator, allocation)), Resource<VkImage>(image)
 {
 	if (!name.empty())
@@ -158,7 +158,7 @@ const bool& VulkanImage::writable() const noexcept
 	return m_impl->m_writable;
 }
 
-const ImageLayout& VulkanImage::layout(const UInt32& subresource) const
+ImageLayout VulkanImage::layout(const UInt32& subresource) const
 {
 	if (subresource >= m_impl->m_layouts.size()) [[unlikely]]
 		throw ArgumentOutOfRangeException("The sub-resource with the provided index {0} does not exist.", subresource);
@@ -208,12 +208,12 @@ Size3d VulkanImage::extent(const UInt32& level) const noexcept
 	return size;
 }
 
-const Format& VulkanImage::format() const noexcept
+Format VulkanImage::format() const noexcept
 {
 	return m_impl->m_format;
 }
 
-const ImageDimensions& VulkanImage::dimensions() const noexcept
+ImageDimensions VulkanImage::dimensions() const noexcept
 {
 	return m_impl->m_dimensions;
 }
@@ -233,7 +233,7 @@ const UInt32& VulkanImage::planes() const noexcept
 	return m_impl->m_planes;
 }
 
-const MultiSamplingLevel& VulkanImage::samples() const noexcept
+MultiSamplingLevel VulkanImage::samples() const noexcept
 {
 	return m_impl->m_samples;
 }
@@ -339,12 +339,12 @@ VkImageView& VulkanImage::imageView(const UInt32& plane)
 	return m_impl->m_views[plane];
 }
 
-UniquePtr<VulkanImage> VulkanImage::allocate(const VulkanDevice& device, const Size3d& extent, const Format& format, const ImageDimensions& dimensions, const UInt32& levels, const UInt32& layers, const MultiSamplingLevel& samples, const bool& writable, const ImageLayout& initialLayout, VmaAllocator& allocator, const VkImageCreateInfo& createInfo, const VmaAllocationCreateInfo& allocationInfo, VmaAllocationInfo* allocationResult)
+UniquePtr<VulkanImage> VulkanImage::allocate(const VulkanDevice& device, const Size3d& extent, Format format, ImageDimensions dimensions, const UInt32& levels, const UInt32& layers, MultiSamplingLevel samples, const bool& writable, ImageLayout initialLayout, VmaAllocator& allocator, const VkImageCreateInfo& createInfo, const VmaAllocationCreateInfo& allocationInfo, VmaAllocationInfo* allocationResult)
 {
 	return VulkanImage::allocate("", device, extent, format, dimensions, levels, layers, samples, writable, initialLayout, allocator, createInfo, allocationInfo, allocationResult);
 }
 
-UniquePtr<VulkanImage> VulkanImage::allocate(const String& name, const VulkanDevice& device, const Size3d& extent, const Format& format, const ImageDimensions& dimensions, const UInt32& levels, const UInt32& layers, const MultiSamplingLevel& samples, const bool& writable, const ImageLayout& initialLayout, VmaAllocator& allocator, const VkImageCreateInfo& createInfo, const VmaAllocationCreateInfo& allocationInfo, VmaAllocationInfo* allocationResult)
+UniquePtr<VulkanImage> VulkanImage::allocate(const String& name, const VulkanDevice& device, const Size3d& extent, Format format, ImageDimensions dimensions, const UInt32& levels, const UInt32& layers, MultiSamplingLevel samples, const bool& writable, ImageLayout initialLayout, VmaAllocator& allocator, const VkImageCreateInfo& createInfo, const VmaAllocationCreateInfo& allocationInfo, VmaAllocationInfo* allocationResult)
 {
 	VkImage image;
 	VmaAllocation allocation;
@@ -373,13 +373,13 @@ private:
 	const VulkanDevice& m_device;
 
 public:
-	VulkanSamplerImpl(VulkanSampler* parent, const VulkanDevice& device, const FilterMode& magFilter, const FilterMode& minFilter, const BorderMode& borderU, const BorderMode& borderV, const BorderMode& borderW, const MipMapMode& mipMapMode, const Float& mipMapBias, const Float& minLod, const Float& maxLod, const Float& anisotropy) :
+	VulkanSamplerImpl(VulkanSampler* parent, const VulkanDevice& device, FilterMode magFilter, FilterMode minFilter, BorderMode borderU, BorderMode borderV, BorderMode borderW, MipMapMode mipMapMode, const Float& mipMapBias, const Float& minLod, const Float& maxLod, const Float& anisotropy) :
 		base(parent), m_device(device), m_magFilter(magFilter), m_minFilter(minFilter), m_borderU(borderU), m_borderV(borderV), m_borderW(borderW), m_mipMapMode(mipMapMode), m_mipMapBias(mipMapBias), m_minLod(minLod), m_maxLod(maxLod), m_anisotropy(anisotropy)
 	{
 	}
 
 private:
-	VkFilter getFilterMode(const FilterMode& mode)
+	VkFilter getFilterMode(FilterMode mode)
 	{
 		switch (mode)
 		{
@@ -389,7 +389,7 @@ private:
 		}
 	}
 
-	VkSamplerMipmapMode getMipMapMode(const MipMapMode& mode)
+	VkSamplerMipmapMode getMipMapMode(MipMapMode mode)
 	{
 		switch (mode)
 		{
@@ -399,7 +399,7 @@ private:
 		}
 	}
 
-	VkSamplerAddressMode getBorderMode(const BorderMode& mode)
+	VkSamplerAddressMode getBorderMode(BorderMode mode)
 	{
 		switch (mode)
 		{
@@ -444,7 +444,7 @@ public:
 // Sampler shared interface.
 // ------------------------------------------------------------------------------------------------
 
-VulkanSampler::VulkanSampler(const VulkanDevice& device, const FilterMode& magFilter, const FilterMode& minFilter, const BorderMode& borderU, const BorderMode& borderV, const BorderMode& borderW, const MipMapMode& mipMapMode, const Float& mipMapBias, const Float& minLod, const Float& maxLod, const Float& anisotropy, const String& name) :
+VulkanSampler::VulkanSampler(const VulkanDevice& device, FilterMode magFilter, FilterMode minFilter, BorderMode borderU, BorderMode borderV, BorderMode borderW, MipMapMode mipMapMode, const Float& mipMapBias, const Float& minLod, const Float& maxLod, const Float& anisotropy, const String& name) :
 	Resource<VkSampler>(VK_NULL_HANDLE), m_impl(makePimpl<VulkanSamplerImpl>(this, device, magFilter, minFilter, borderU, borderV, borderW, mipMapMode, mipMapBias, minLod, maxLod, anisotropy))
 {
 	this->handle() = m_impl->initialize();
@@ -458,27 +458,27 @@ VulkanSampler::~VulkanSampler() noexcept
 	::vkDestroySampler(m_impl->m_device.handle(), this->handle(), nullptr);
 }
 
-const FilterMode& VulkanSampler::getMinifyingFilter() const noexcept
+FilterMode VulkanSampler::getMinifyingFilter() const noexcept
 {
 	return m_impl->m_minFilter;
 }
 
-const FilterMode& VulkanSampler::getMagnifyingFilter() const noexcept
+FilterMode VulkanSampler::getMagnifyingFilter() const noexcept
 {
 	return m_impl->m_magFilter;
 }
 
-const BorderMode& VulkanSampler::getBorderModeU() const noexcept
+BorderMode VulkanSampler::getBorderModeU() const noexcept
 {
 	return m_impl->m_borderU;
 }
 
-const BorderMode& VulkanSampler::getBorderModeV() const noexcept
+BorderMode VulkanSampler::getBorderModeV() const noexcept
 {
 	return m_impl->m_borderV;
 }
 
-const BorderMode& VulkanSampler::getBorderModeW() const noexcept
+BorderMode VulkanSampler::getBorderModeW() const noexcept
 {
 	return m_impl->m_borderW;
 }
@@ -488,7 +488,7 @@ const Float& VulkanSampler::getAnisotropy() const noexcept
 	return m_impl->m_anisotropy;
 }
 
-const MipMapMode& VulkanSampler::getMipMapMode() const noexcept
+MipMapMode VulkanSampler::getMipMapMode() const noexcept
 {
 	return m_impl->m_mipMapMode;
 }

--- a/src/Backends/Vulkan/src/image.cpp
+++ b/src/Backends/Vulkan/src/image.cpp
@@ -27,7 +27,7 @@ private:
 	const VulkanDevice& m_device;
 
 public:
-	VulkanImageImpl(VulkanImage* parent, const VulkanDevice& device, const Size3d& extent, Format format, ImageDimensions dimensions, const UInt32& levels, const UInt32& layers, MultiSamplingLevel samples, const bool& writable, ImageLayout initialLayout, VmaAllocator allocator, VmaAllocation allocation) :
+	VulkanImageImpl(VulkanImage* parent, const VulkanDevice& device, const Size3d& extent, Format format, ImageDimensions dimensions, UInt32 levels, UInt32 layers, MultiSamplingLevel samples, bool writable, ImageLayout initialLayout, VmaAllocator allocator, VmaAllocation allocation) :
 		base(parent), m_device(device), m_allocator(allocator), m_allocationInfo(allocation), m_extent(extent), m_format(format), m_dimensions(dimensions), m_levels(levels), m_layers(layers), m_writable(writable), m_samples(samples)
 	{	
 		VkImageViewCreateInfo createInfo = {
@@ -91,7 +91,7 @@ public:
 // Image Base shared interface.
 // ------------------------------------------------------------------------------------------------
 
-VulkanImage::VulkanImage(const VulkanDevice& device, VkImage image, const Size3d& extent, Format format, ImageDimensions dimensions, const UInt32& levels, const UInt32& layers, MultiSamplingLevel samples, const bool& writable, ImageLayout initialLayout, VmaAllocator allocator, VmaAllocation allocation, const String& name) :
+VulkanImage::VulkanImage(const VulkanDevice& device, VkImage image, const Size3d& extent, Format format, ImageDimensions dimensions, UInt32 levels, UInt32 layers, MultiSamplingLevel samples, bool writable, ImageLayout initialLayout, VmaAllocator allocator, VmaAllocation allocation, const String& name) :
 	m_impl(makePimpl<VulkanImageImpl>(this, device, extent, format, dimensions, levels, layers, samples, writable, initialLayout, allocator, allocation)), Resource<VkImage>(image)
 {
 	if (!name.empty())
@@ -110,7 +110,7 @@ VulkanImage::~VulkanImage() noexcept
 	}
 }
 
-const UInt32& VulkanImage::elements() const noexcept
+UInt32 VulkanImage::elements() const noexcept
 {
 	return m_impl->m_elements;
 }
@@ -153,12 +153,12 @@ size_t VulkanImage::alignedElementSize() const noexcept
 	return this->elementSize();
 }
 
-const bool& VulkanImage::writable() const noexcept
+bool VulkanImage::writable() const noexcept
 {
 	return m_impl->m_writable;
 }
 
-ImageLayout VulkanImage::layout(const UInt32& subresource) const
+ImageLayout VulkanImage::layout(UInt32 subresource) const
 {
 	if (subresource >= m_impl->m_layouts.size()) [[unlikely]]
 		throw ArgumentOutOfRangeException("The sub-resource with the provided index {0} does not exist.", subresource);
@@ -166,7 +166,7 @@ ImageLayout VulkanImage::layout(const UInt32& subresource) const
 	return m_impl->m_layouts[subresource];
 }
 
-ImageLayout& VulkanImage::layout(const UInt32& subresource)
+ImageLayout& VulkanImage::layout(UInt32 subresource)
 {
 	if (subresource >= m_impl->m_layouts.size()) [[unlikely]]
 		throw ArgumentOutOfRangeException("The sub-resource with the provided index {0} does not exist.", subresource);
@@ -174,7 +174,7 @@ ImageLayout& VulkanImage::layout(const UInt32& subresource)
 	return m_impl->m_layouts[subresource];
 }
 
-size_t VulkanImage::size(const UInt32& level) const noexcept
+size_t VulkanImage::size(UInt32 level) const noexcept
 {
 	if (level >= m_impl->m_levels)
 		return 0;
@@ -191,7 +191,7 @@ size_t VulkanImage::size(const UInt32& level) const noexcept
 	}
 }
 
-Size3d VulkanImage::extent(const UInt32& level) const noexcept
+Size3d VulkanImage::extent(UInt32 level) const noexcept
 {
 	if (level >= m_impl->m_levels)
 		return Size3d{ 0, 0, 0 };
@@ -218,17 +218,17 @@ ImageDimensions VulkanImage::dimensions() const noexcept
 	return m_impl->m_dimensions;
 }
 
-const UInt32& VulkanImage::levels() const noexcept
+UInt32 VulkanImage::levels() const noexcept
 {
 	return m_impl->m_levels;
 }
 
-const UInt32& VulkanImage::layers() const noexcept
+UInt32 VulkanImage::layers() const noexcept
 {
 	return m_impl->m_layers;
 }
 
-const UInt32& VulkanImage::planes() const noexcept
+UInt32 VulkanImage::planes() const noexcept
 {
 	return m_impl->m_planes;
 }
@@ -273,7 +273,7 @@ VkImageAspectFlags VulkanImage::aspectMask() const noexcept
 	}
 }
 
-VkImageAspectFlags VulkanImage::aspectMask(const UInt32& plane) const 
+VkImageAspectFlags VulkanImage::aspectMask(UInt32 plane) const 
 {
 	if (::hasDepth(m_impl->m_format) && ::hasStencil(m_impl->m_format))
 	{
@@ -313,7 +313,7 @@ VkImageAspectFlags VulkanImage::aspectMask(const UInt32& plane) const
 	}
 }
 
-const VkImageView& VulkanImage::imageView(const UInt32& plane) const
+const VkImageView& VulkanImage::imageView(UInt32 plane) const
 {
 	if (plane >= m_impl->m_views.size()) [[unlikely]]
 		throw ArgumentOutOfRangeException("The image does not have a plane {0}.", plane);
@@ -331,7 +331,7 @@ VmaAllocation& VulkanImage::allocationInfo() const noexcept
 	return m_impl->m_allocationInfo;
 }
 
-VkImageView& VulkanImage::imageView(const UInt32& plane)
+VkImageView& VulkanImage::imageView(UInt32 plane)
 {
 	if (plane >= m_impl->m_views.size()) [[unlikely]]
 		throw ArgumentOutOfRangeException("The image does not have a plane {0}.", plane);
@@ -339,12 +339,12 @@ VkImageView& VulkanImage::imageView(const UInt32& plane)
 	return m_impl->m_views[plane];
 }
 
-UniquePtr<VulkanImage> VulkanImage::allocate(const VulkanDevice& device, const Size3d& extent, Format format, ImageDimensions dimensions, const UInt32& levels, const UInt32& layers, MultiSamplingLevel samples, const bool& writable, ImageLayout initialLayout, VmaAllocator& allocator, const VkImageCreateInfo& createInfo, const VmaAllocationCreateInfo& allocationInfo, VmaAllocationInfo* allocationResult)
+UniquePtr<VulkanImage> VulkanImage::allocate(const VulkanDevice& device, const Size3d& extent, Format format, ImageDimensions dimensions, UInt32 levels, UInt32 layers, MultiSamplingLevel samples, bool writable, ImageLayout initialLayout, VmaAllocator& allocator, const VkImageCreateInfo& createInfo, const VmaAllocationCreateInfo& allocationInfo, VmaAllocationInfo* allocationResult)
 {
 	return VulkanImage::allocate("", device, extent, format, dimensions, levels, layers, samples, writable, initialLayout, allocator, createInfo, allocationInfo, allocationResult);
 }
 
-UniquePtr<VulkanImage> VulkanImage::allocate(const String& name, const VulkanDevice& device, const Size3d& extent, Format format, ImageDimensions dimensions, const UInt32& levels, const UInt32& layers, MultiSamplingLevel samples, const bool& writable, ImageLayout initialLayout, VmaAllocator& allocator, const VkImageCreateInfo& createInfo, const VmaAllocationCreateInfo& allocationInfo, VmaAllocationInfo* allocationResult)
+UniquePtr<VulkanImage> VulkanImage::allocate(const String& name, const VulkanDevice& device, const Size3d& extent, Format format, ImageDimensions dimensions, UInt32 levels, UInt32 layers, MultiSamplingLevel samples, bool writable, ImageLayout initialLayout, VmaAllocator& allocator, const VkImageCreateInfo& createInfo, const VmaAllocationCreateInfo& allocationInfo, VmaAllocationInfo* allocationResult)
 {
 	VkImage image;
 	VmaAllocation allocation;
@@ -373,7 +373,7 @@ private:
 	const VulkanDevice& m_device;
 
 public:
-	VulkanSamplerImpl(VulkanSampler* parent, const VulkanDevice& device, FilterMode magFilter, FilterMode minFilter, BorderMode borderU, BorderMode borderV, BorderMode borderW, MipMapMode mipMapMode, const Float& mipMapBias, const Float& minLod, const Float& maxLod, const Float& anisotropy) :
+	VulkanSamplerImpl(VulkanSampler* parent, const VulkanDevice& device, FilterMode magFilter, FilterMode minFilter, BorderMode borderU, BorderMode borderV, BorderMode borderW, MipMapMode mipMapMode, Float mipMapBias, Float minLod, Float maxLod, Float anisotropy) :
 		base(parent), m_device(device), m_magFilter(magFilter), m_minFilter(minFilter), m_borderU(borderU), m_borderV(borderV), m_borderW(borderW), m_mipMapMode(mipMapMode), m_mipMapBias(mipMapBias), m_minLod(minLod), m_maxLod(maxLod), m_anisotropy(anisotropy)
 	{
 	}
@@ -444,7 +444,7 @@ public:
 // Sampler shared interface.
 // ------------------------------------------------------------------------------------------------
 
-VulkanSampler::VulkanSampler(const VulkanDevice& device, FilterMode magFilter, FilterMode minFilter, BorderMode borderU, BorderMode borderV, BorderMode borderW, MipMapMode mipMapMode, const Float& mipMapBias, const Float& minLod, const Float& maxLod, const Float& anisotropy, const String& name) :
+VulkanSampler::VulkanSampler(const VulkanDevice& device, FilterMode magFilter, FilterMode minFilter, BorderMode borderU, BorderMode borderV, BorderMode borderW, MipMapMode mipMapMode, Float mipMapBias, Float minLod, Float maxLod, Float anisotropy, const String& name) :
 	Resource<VkSampler>(VK_NULL_HANDLE), m_impl(makePimpl<VulkanSamplerImpl>(this, device, magFilter, minFilter, borderU, borderV, borderW, mipMapMode, mipMapBias, minLod, maxLod, anisotropy))
 {
 	this->handle() = m_impl->initialize();
@@ -483,7 +483,7 @@ BorderMode VulkanSampler::getBorderModeW() const noexcept
 	return m_impl->m_borderW;
 }
 
-const Float& VulkanSampler::getAnisotropy() const noexcept
+Float VulkanSampler::getAnisotropy() const noexcept
 {
 	return m_impl->m_anisotropy;
 }
@@ -493,17 +493,17 @@ MipMapMode VulkanSampler::getMipMapMode() const noexcept
 	return m_impl->m_mipMapMode;
 }
 
-const Float& VulkanSampler::getMipMapBias() const noexcept
+Float VulkanSampler::getMipMapBias() const noexcept
 {
 	return m_impl->m_mipMapBias;
 }
 
-const Float& VulkanSampler::getMaxLOD() const noexcept
+Float VulkanSampler::getMaxLOD() const noexcept
 {
 	return m_impl->m_maxLod;
 }
 
-const Float& VulkanSampler::getMinLOD() const noexcept
+Float VulkanSampler::getMinLOD() const noexcept
 {
 	return m_impl->m_minLod;
 }

--- a/src/Backends/Vulkan/src/image.h
+++ b/src/Backends/Vulkan/src/image.h
@@ -14,7 +14,7 @@ namespace LiteFX::Rendering::Backends {
 		LITEFX_IMPLEMENTATION(VulkanImageImpl);
 
 	public:
-		explicit VulkanImage(const VulkanDevice& device, VkImage image, const Size3d& extent, Format format, ImageDimensions dimensions, const UInt32& levels, const UInt32& layers, MultiSamplingLevel samples, const bool& writable, ImageLayout initialLayout, VmaAllocator allocator = nullptr, VmaAllocation allocation = nullptr, const String& name = "");
+		explicit VulkanImage(const VulkanDevice& device, VkImage image, const Size3d& extent, Format format, ImageDimensions dimensions, UInt32 levels, UInt32 layers, MultiSamplingLevel samples, bool writable, ImageLayout initialLayout, VmaAllocator allocator = nullptr, VmaAllocation allocation = nullptr, const String& name = "");
 		VulkanImage(VulkanImage&&) = delete;
 		VulkanImage(const VulkanImage&) = delete;
 		virtual ~VulkanImage() noexcept;
@@ -22,7 +22,7 @@ namespace LiteFX::Rendering::Backends {
 		// IDeviceMemory interface.
 	public:
 		/// <inheritdoc />
-		virtual const UInt32& elements() const noexcept override;
+		virtual UInt32 elements() const noexcept override;
 
 		/// <inheritdoc />
 		virtual size_t size() const noexcept override;
@@ -37,21 +37,21 @@ namespace LiteFX::Rendering::Backends {
 		virtual size_t alignedElementSize() const noexcept override;
 
 		/// <inheritdoc />
-		virtual const bool& writable() const noexcept override;
+		virtual bool writable() const noexcept override;
 
 		/// <inheritdoc />
-		virtual ImageLayout layout(const UInt32& subresource = 0) const override;
+		virtual ImageLayout layout(UInt32 subresource = 0) const override;
 
 		/// <inheritdoc />
-		virtual ImageLayout& layout(const UInt32& subresource = 0) override;
+		virtual ImageLayout& layout(UInt32 subresource = 0) override;
 
 		// IImage interface.
 	public:
 		/// <inheritdoc />
-		virtual size_t size(const UInt32& level) const noexcept override;
+		virtual size_t size(UInt32 level) const noexcept override;
 
 		/// <inheritdoc />
-		virtual Size3d extent(const UInt32& level = 0) const noexcept override;
+		virtual Size3d extent(UInt32 level = 0) const noexcept override;
 
 		/// <inheritdoc />
 		virtual Format format() const noexcept override;
@@ -60,13 +60,13 @@ namespace LiteFX::Rendering::Backends {
 		virtual ImageDimensions dimensions() const noexcept override;
 
 		/// <inheritdoc />
-		virtual const UInt32& levels() const noexcept override;
+		virtual UInt32 levels() const noexcept override;
 
 		/// <inheritdoc />
-		virtual const UInt32& layers() const noexcept override;
+		virtual UInt32 layers() const noexcept override;
 
 		/// <inheritdoc />
-		virtual const UInt32& planes() const noexcept override;
+		virtual UInt32 planes() const noexcept override;
 
 		/// <inheritdoc />
 		virtual MultiSamplingLevel samples() const noexcept override;
@@ -74,17 +74,17 @@ namespace LiteFX::Rendering::Backends {
 		// IVulkanImage interface.
 	public:
 		virtual VkImageAspectFlags aspectMask() const noexcept override;
-		virtual VkImageAspectFlags aspectMask(const UInt32& plane) const override;
-		virtual const VkImageView& imageView(const UInt32& plane = 0) const override;
+		virtual VkImageAspectFlags aspectMask(UInt32 plane) const override;
+		virtual const VkImageView& imageView(UInt32 plane = 0) const override;
 
 	protected:
 		virtual VmaAllocator& allocator() const noexcept;
 		virtual VmaAllocation& allocationInfo() const noexcept;
-		virtual VkImageView& imageView(const UInt32& plane = 0);
+		virtual VkImageView& imageView(UInt32 plane = 0);
 
 	public:
-		static UniquePtr<VulkanImage> allocate(const VulkanDevice& device, const Size3d& extent, Format format, ImageDimensions dimensions, const UInt32& levels, const UInt32& layers, MultiSamplingLevel samples, const bool& writable, ImageLayout initialLayout, VmaAllocator& allocator, const VkImageCreateInfo& createInfo, const VmaAllocationCreateInfo& allocationInfo, VmaAllocationInfo* allocationResult = nullptr);
-		static UniquePtr<VulkanImage> allocate(const String& name, const VulkanDevice& device, const Size3d& extent, Format format, ImageDimensions dimensions, const UInt32& levels, const UInt32& layers, MultiSamplingLevel samples, const bool& writable, ImageLayout initialLayout, VmaAllocator& allocator, const VkImageCreateInfo& createInfo, const VmaAllocationCreateInfo& allocationInfo, VmaAllocationInfo* allocationResult = nullptr);
+		static UniquePtr<VulkanImage> allocate(const VulkanDevice& device, const Size3d& extent, Format format, ImageDimensions dimensions, UInt32 levels, UInt32 layers, MultiSamplingLevel samples, bool writable, ImageLayout initialLayout, VmaAllocator& allocator, const VkImageCreateInfo& createInfo, const VmaAllocationCreateInfo& allocationInfo, VmaAllocationInfo* allocationResult = nullptr);
+		static UniquePtr<VulkanImage> allocate(const String& name, const VulkanDevice& device, const Size3d& extent, Format format, ImageDimensions dimensions, UInt32 levels, UInt32 layers, MultiSamplingLevel samples, bool writable, ImageLayout initialLayout, VmaAllocator& allocator, const VkImageCreateInfo& createInfo, const VmaAllocationCreateInfo& allocationInfo, VmaAllocationInfo* allocationResult = nullptr);
 	};
 
 	/// <summary>
@@ -108,7 +108,7 @@ namespace LiteFX::Rendering::Backends {
 		/// <param name="maxLod"></param>
 		/// <param name="minLod"></param>
 		/// <param name="anisotropy"></param>
-		explicit VulkanSampler(const VulkanDevice& device, FilterMode magFilter = FilterMode::Nearest, FilterMode minFilter = FilterMode::Nearest, BorderMode borderU = BorderMode::Repeat, BorderMode borderV = BorderMode::Repeat, BorderMode borderW = BorderMode::Repeat, MipMapMode mipMapMode = MipMapMode::Nearest, const Float& mipMapBias = 0.f, const Float& minLod = 0.f, const Float& maxLod = std::numeric_limits<Float>::max(), const Float& anisotropy = 0.f, const String& name = "");
+		explicit VulkanSampler(const VulkanDevice& device, FilterMode magFilter = FilterMode::Nearest, FilterMode minFilter = FilterMode::Nearest, BorderMode borderU = BorderMode::Repeat, BorderMode borderV = BorderMode::Repeat, BorderMode borderW = BorderMode::Repeat, MipMapMode mipMapMode = MipMapMode::Nearest, Float mipMapBias = 0.f, Float minLod = 0.f, Float maxLod = std::numeric_limits<Float>::max(), Float anisotropy = 0.f, const String& name = "");
 		VulkanSampler(VulkanSampler&&) = delete;
 		VulkanSampler(const VulkanSampler&) = delete;
 		virtual ~VulkanSampler() noexcept;
@@ -131,18 +131,18 @@ namespace LiteFX::Rendering::Backends {
 		virtual BorderMode getBorderModeW() const noexcept override;
 
 		/// <inheritdoc />
-		virtual const Float& getAnisotropy() const noexcept override;
+		virtual Float getAnisotropy() const noexcept override;
 
 		/// <inheritdoc />
 		virtual MipMapMode getMipMapMode() const noexcept override;
 
 		/// <inheritdoc />
-		virtual const Float& getMipMapBias() const noexcept override;
+		virtual Float getMipMapBias() const noexcept override;
 
 		/// <inheritdoc />
-		virtual const Float& getMaxLOD() const noexcept override;
+		virtual Float getMaxLOD() const noexcept override;
 
 		/// <inheritdoc />
-		virtual const Float& getMinLOD() const noexcept override;
+		virtual Float getMinLOD() const noexcept override;
 	};
 }

--- a/src/Backends/Vulkan/src/image.h
+++ b/src/Backends/Vulkan/src/image.h
@@ -14,7 +14,7 @@ namespace LiteFX::Rendering::Backends {
 		LITEFX_IMPLEMENTATION(VulkanImageImpl);
 
 	public:
-		explicit VulkanImage(const VulkanDevice& device, VkImage image, const Size3d& extent, const Format& format, const ImageDimensions& dimensions, const UInt32& levels, const UInt32& layers, const MultiSamplingLevel& samples, const bool& writable, const ImageLayout& initialLayout, VmaAllocator allocator = nullptr, VmaAllocation allocation = nullptr, const String& name = "");
+		explicit VulkanImage(const VulkanDevice& device, VkImage image, const Size3d& extent, Format format, ImageDimensions dimensions, const UInt32& levels, const UInt32& layers, MultiSamplingLevel samples, const bool& writable, ImageLayout initialLayout, VmaAllocator allocator = nullptr, VmaAllocation allocation = nullptr, const String& name = "");
 		VulkanImage(VulkanImage&&) = delete;
 		VulkanImage(const VulkanImage&) = delete;
 		virtual ~VulkanImage() noexcept;
@@ -40,7 +40,7 @@ namespace LiteFX::Rendering::Backends {
 		virtual const bool& writable() const noexcept override;
 
 		/// <inheritdoc />
-		virtual const ImageLayout& layout(const UInt32& subresource = 0) const override;
+		virtual ImageLayout layout(const UInt32& subresource = 0) const override;
 
 		/// <inheritdoc />
 		virtual ImageLayout& layout(const UInt32& subresource = 0) override;
@@ -54,10 +54,10 @@ namespace LiteFX::Rendering::Backends {
 		virtual Size3d extent(const UInt32& level = 0) const noexcept override;
 
 		/// <inheritdoc />
-		virtual const Format& format() const noexcept override;
+		virtual Format format() const noexcept override;
 
 		/// <inheritdoc />
-		virtual const ImageDimensions& dimensions() const noexcept override;
+		virtual ImageDimensions dimensions() const noexcept override;
 
 		/// <inheritdoc />
 		virtual const UInt32& levels() const noexcept override;
@@ -69,7 +69,7 @@ namespace LiteFX::Rendering::Backends {
 		virtual const UInt32& planes() const noexcept override;
 
 		/// <inheritdoc />
-		virtual const MultiSamplingLevel& samples() const noexcept override;
+		virtual MultiSamplingLevel samples() const noexcept override;
 
 		// IVulkanImage interface.
 	public:
@@ -83,8 +83,8 @@ namespace LiteFX::Rendering::Backends {
 		virtual VkImageView& imageView(const UInt32& plane = 0);
 
 	public:
-		static UniquePtr<VulkanImage> allocate(const VulkanDevice& device, const Size3d& extent, const Format& format, const ImageDimensions& dimensions, const UInt32& levels, const UInt32& layers, const MultiSamplingLevel& samples, const bool& writable, const ImageLayout& initialLayout, VmaAllocator& allocator, const VkImageCreateInfo& createInfo, const VmaAllocationCreateInfo& allocationInfo, VmaAllocationInfo* allocationResult = nullptr);
-		static UniquePtr<VulkanImage> allocate(const String& name, const VulkanDevice& device, const Size3d& extent, const Format& format, const ImageDimensions& dimensions, const UInt32& levels, const UInt32& layers, const MultiSamplingLevel& samples, const bool& writable, const ImageLayout& initialLayout, VmaAllocator& allocator, const VkImageCreateInfo& createInfo, const VmaAllocationCreateInfo& allocationInfo, VmaAllocationInfo* allocationResult = nullptr);
+		static UniquePtr<VulkanImage> allocate(const VulkanDevice& device, const Size3d& extent, Format format, ImageDimensions dimensions, const UInt32& levels, const UInt32& layers, MultiSamplingLevel samples, const bool& writable, ImageLayout initialLayout, VmaAllocator& allocator, const VkImageCreateInfo& createInfo, const VmaAllocationCreateInfo& allocationInfo, VmaAllocationInfo* allocationResult = nullptr);
+		static UniquePtr<VulkanImage> allocate(const String& name, const VulkanDevice& device, const Size3d& extent, Format format, ImageDimensions dimensions, const UInt32& levels, const UInt32& layers, MultiSamplingLevel samples, const bool& writable, ImageLayout initialLayout, VmaAllocator& allocator, const VkImageCreateInfo& createInfo, const VmaAllocationCreateInfo& allocationInfo, VmaAllocationInfo* allocationResult = nullptr);
 	};
 
 	/// <summary>
@@ -108,7 +108,7 @@ namespace LiteFX::Rendering::Backends {
 		/// <param name="maxLod"></param>
 		/// <param name="minLod"></param>
 		/// <param name="anisotropy"></param>
-		explicit VulkanSampler(const VulkanDevice& device, const FilterMode& magFilter = FilterMode::Nearest, const FilterMode& minFilter = FilterMode::Nearest, const BorderMode& borderU = BorderMode::Repeat, const BorderMode& borderV = BorderMode::Repeat, const BorderMode& borderW = BorderMode::Repeat, const MipMapMode& mipMapMode = MipMapMode::Nearest, const Float& mipMapBias = 0.f, const Float& minLod = 0.f, const Float& maxLod = std::numeric_limits<Float>::max(), const Float& anisotropy = 0.f, const String& name = "");
+		explicit VulkanSampler(const VulkanDevice& device, FilterMode magFilter = FilterMode::Nearest, FilterMode minFilter = FilterMode::Nearest, BorderMode borderU = BorderMode::Repeat, BorderMode borderV = BorderMode::Repeat, BorderMode borderW = BorderMode::Repeat, MipMapMode mipMapMode = MipMapMode::Nearest, const Float& mipMapBias = 0.f, const Float& minLod = 0.f, const Float& maxLod = std::numeric_limits<Float>::max(), const Float& anisotropy = 0.f, const String& name = "");
 		VulkanSampler(VulkanSampler&&) = delete;
 		VulkanSampler(const VulkanSampler&) = delete;
 		virtual ~VulkanSampler() noexcept;
@@ -116,25 +116,25 @@ namespace LiteFX::Rendering::Backends {
 		// ISampler interface.
 	public:
 		/// <inheritdoc />
-		virtual const FilterMode& getMinifyingFilter() const noexcept override;
+		virtual FilterMode getMinifyingFilter() const noexcept override;
 
 		/// <inheritdoc />
-		virtual const FilterMode& getMagnifyingFilter() const noexcept override;
+		virtual FilterMode getMagnifyingFilter() const noexcept override;
 
 		/// <inheritdoc />
-		virtual const BorderMode& getBorderModeU() const noexcept override;
+		virtual BorderMode getBorderModeU() const noexcept override;
 
 		/// <inheritdoc />
-		virtual const BorderMode& getBorderModeV() const noexcept override;
+		virtual BorderMode getBorderModeV() const noexcept override;
 
 		/// <inheritdoc />
-		virtual const BorderMode& getBorderModeW() const noexcept override;
+		virtual BorderMode getBorderModeW() const noexcept override;
 
 		/// <inheritdoc />
 		virtual const Float& getAnisotropy() const noexcept override;
 
 		/// <inheritdoc />
-		virtual const MipMapMode& getMipMapMode() const noexcept override;
+		virtual MipMapMode getMipMapMode() const noexcept override;
 
 		/// <inheritdoc />
 		virtual const Float& getMipMapBias() const noexcept override;

--- a/src/Backends/Vulkan/src/image.h
+++ b/src/Backends/Vulkan/src/image.h
@@ -22,60 +22,60 @@ namespace LiteFX::Rendering::Backends {
 		// IDeviceMemory interface.
 	public:
 		/// <inheritdoc />
-		virtual UInt32 elements() const noexcept override;
+		UInt32 elements() const noexcept override;
 
 		/// <inheritdoc />
-		virtual size_t size() const noexcept override;
+		size_t size() const noexcept override;
 
 		/// <inheritdoc />
-		virtual size_t elementSize() const noexcept override;
+		size_t elementSize() const noexcept override;
 
 		/// <inheritdoc />
-		virtual size_t elementAlignment() const noexcept override;
+		size_t elementAlignment() const noexcept override;
 
 		/// <inheritdoc />
-		virtual size_t alignedElementSize() const noexcept override;
+		size_t alignedElementSize() const noexcept override;
 
 		/// <inheritdoc />
-		virtual bool writable() const noexcept override;
+		bool writable() const noexcept override;
 
 		/// <inheritdoc />
-		virtual ImageLayout layout(UInt32 subresource = 0) const override;
+		ImageLayout layout(UInt32 subresource = 0) const override;
 
 		/// <inheritdoc />
-		virtual ImageLayout& layout(UInt32 subresource = 0) override;
+		ImageLayout& layout(UInt32 subresource = 0) override;
 
 		// IImage interface.
 	public:
 		/// <inheritdoc />
-		virtual size_t size(UInt32 level) const noexcept override;
+		size_t size(UInt32 level) const noexcept override;
 
 		/// <inheritdoc />
-		virtual Size3d extent(UInt32 level = 0) const noexcept override;
+		Size3d extent(UInt32 level = 0) const noexcept override;
 
 		/// <inheritdoc />
-		virtual Format format() const noexcept override;
+		Format format() const noexcept override;
 
 		/// <inheritdoc />
-		virtual ImageDimensions dimensions() const noexcept override;
+		ImageDimensions dimensions() const noexcept override;
 
 		/// <inheritdoc />
-		virtual UInt32 levels() const noexcept override;
+		UInt32 levels() const noexcept override;
 
 		/// <inheritdoc />
-		virtual UInt32 layers() const noexcept override;
+		UInt32 layers() const noexcept override;
 
 		/// <inheritdoc />
-		virtual UInt32 planes() const noexcept override;
+		UInt32 planes() const noexcept override;
 
 		/// <inheritdoc />
-		virtual MultiSamplingLevel samples() const noexcept override;
+		MultiSamplingLevel samples() const noexcept override;
 
 		// IVulkanImage interface.
 	public:
-		virtual VkImageAspectFlags aspectMask() const noexcept override;
-		virtual VkImageAspectFlags aspectMask(UInt32 plane) const override;
-		virtual const VkImageView& imageView(UInt32 plane = 0) const override;
+		VkImageAspectFlags aspectMask() const noexcept override;
+		VkImageAspectFlags aspectMask(UInt32 plane) const override;
+		const VkImageView& imageView(UInt32 plane = 0) const override;
 
 	protected:
 		virtual VmaAllocator& allocator() const noexcept;
@@ -116,33 +116,33 @@ namespace LiteFX::Rendering::Backends {
 		// ISampler interface.
 	public:
 		/// <inheritdoc />
-		virtual FilterMode getMinifyingFilter() const noexcept override;
+		FilterMode getMinifyingFilter() const noexcept override;
 
 		/// <inheritdoc />
-		virtual FilterMode getMagnifyingFilter() const noexcept override;
+		FilterMode getMagnifyingFilter() const noexcept override;
 
 		/// <inheritdoc />
-		virtual BorderMode getBorderModeU() const noexcept override;
+		BorderMode getBorderModeU() const noexcept override;
 
 		/// <inheritdoc />
-		virtual BorderMode getBorderModeV() const noexcept override;
+		BorderMode getBorderModeV() const noexcept override;
 
 		/// <inheritdoc />
-		virtual BorderMode getBorderModeW() const noexcept override;
+		BorderMode getBorderModeW() const noexcept override;
 
 		/// <inheritdoc />
-		virtual Float getAnisotropy() const noexcept override;
+		Float getAnisotropy() const noexcept override;
 
 		/// <inheritdoc />
-		virtual MipMapMode getMipMapMode() const noexcept override;
+		MipMapMode getMipMapMode() const noexcept override;
 
 		/// <inheritdoc />
-		virtual Float getMipMapBias() const noexcept override;
+		Float getMipMapBias() const noexcept override;
 
 		/// <inheritdoc />
-		virtual Float getMaxLOD() const noexcept override;
+		Float getMaxLOD() const noexcept override;
 
 		/// <inheritdoc />
-		virtual Float getMinLOD() const noexcept override;
+		Float getMinLOD() const noexcept override;
 	};
 }

--- a/src/Backends/Vulkan/src/index_buffer_layout.cpp
+++ b/src/Backends/Vulkan/src/index_buffer_layout.cpp
@@ -38,7 +38,7 @@ size_t VulkanIndexBufferLayout::elementSize() const noexcept
     return static_cast<UInt32>(m_impl->m_indexType) >> 3;
 }
 
-const UInt32& VulkanIndexBufferLayout::binding() const noexcept
+UInt32 VulkanIndexBufferLayout::binding() const noexcept
 {
     return m_impl->m_binding;
 }

--- a/src/Backends/Vulkan/src/index_buffer_layout.cpp
+++ b/src/Backends/Vulkan/src/index_buffer_layout.cpp
@@ -16,7 +16,7 @@ private:
     BufferType m_bufferType{ BufferType::Index };
 
 public:
-    VulkanIndexBufferLayoutImpl(VulkanIndexBufferLayout* parent, const IndexType& type) : 
+    VulkanIndexBufferLayoutImpl(VulkanIndexBufferLayout* parent, IndexType type) : 
         base(parent), m_indexType(type)
     {
     }
@@ -26,7 +26,7 @@ public:
 // Shared interface.
 // ------------------------------------------------------------------------------------------------
 
-VulkanIndexBufferLayout::VulkanIndexBufferLayout(const IndexType& type) :
+VulkanIndexBufferLayout::VulkanIndexBufferLayout(IndexType type) :
     m_impl(makePimpl<VulkanIndexBufferLayoutImpl>(this, type))
 {
 }
@@ -43,12 +43,12 @@ const UInt32& VulkanIndexBufferLayout::binding() const noexcept
     return m_impl->m_binding;
 }
 
-const BufferType& VulkanIndexBufferLayout::type() const noexcept
+BufferType VulkanIndexBufferLayout::type() const noexcept
 {
     return m_impl->m_bufferType;
 }
 
-const IndexType& VulkanIndexBufferLayout::indexType() const noexcept
+IndexType VulkanIndexBufferLayout::indexType() const noexcept
 {
     return m_impl->m_indexType;
 }

--- a/src/Backends/Vulkan/src/input_assembler.cpp
+++ b/src/Backends/Vulkan/src/input_assembler.cpp
@@ -23,7 +23,7 @@ public:
     }
 
 public:
-    void initialize(Enumerable<UniquePtr<VulkanVertexBufferLayout>>&& vertexBufferLayouts, UniquePtr<VulkanIndexBufferLayout>&& indexBufferLayout, const PrimitiveTopology& primitiveTopology)
+    void initialize(Enumerable<UniquePtr<VulkanVertexBufferLayout>>&& vertexBufferLayouts, UniquePtr<VulkanIndexBufferLayout>&& indexBufferLayout, PrimitiveTopology primitiveTopology)
     {
         m_primitiveTopology = primitiveTopology;
 
@@ -49,7 +49,7 @@ public:
 // Shared interface.
 // ------------------------------------------------------------------------------------------------
 
-VulkanInputAssembler::VulkanInputAssembler(Enumerable<UniquePtr<VulkanVertexBufferLayout>>&& vertexBufferLayouts, UniquePtr<VulkanIndexBufferLayout>&& indexBufferLayout, const PrimitiveTopology& primitiveTopology) :
+VulkanInputAssembler::VulkanInputAssembler(Enumerable<UniquePtr<VulkanVertexBufferLayout>>&& vertexBufferLayouts, UniquePtr<VulkanIndexBufferLayout>&& indexBufferLayout, PrimitiveTopology primitiveTopology) :
     m_impl(makePimpl<VulkanInputAssemblerImpl>(this))
 {
     m_impl->initialize(std::move(vertexBufferLayouts), std::move(indexBufferLayout), primitiveTopology);
@@ -80,7 +80,7 @@ const VulkanIndexBufferLayout& VulkanInputAssembler::indexBufferLayout() const
     return *m_impl->m_indexBufferLayout;
 }
 
-const PrimitiveTopology& VulkanInputAssembler::topology() const noexcept
+PrimitiveTopology VulkanInputAssembler::topology() const noexcept
 {
     return m_impl->m_primitiveTopology;
 }

--- a/src/Backends/Vulkan/src/input_assembler.cpp
+++ b/src/Backends/Vulkan/src/input_assembler.cpp
@@ -67,7 +67,7 @@ Enumerable<const VulkanVertexBufferLayout*> VulkanInputAssembler::vertexBufferLa
     return m_impl->m_vertexBufferLayouts | std::views::transform([](const auto& pair) { return pair.second.get(); });
 }
 
-const VulkanVertexBufferLayout& VulkanInputAssembler::vertexBufferLayout(const UInt32& binding) const
+const VulkanVertexBufferLayout& VulkanInputAssembler::vertexBufferLayout(UInt32 binding) const
 {
     [[likely]] if (m_impl->m_vertexBufferLayouts.contains(binding))
         return *m_impl->m_vertexBufferLayouts[binding];

--- a/src/Backends/Vulkan/src/input_attachment_mapping.cpp
+++ b/src/Backends/Vulkan/src/input_attachment_mapping.cpp
@@ -16,7 +16,7 @@ private:
     UInt32 m_location;
 
 public:
-    VulkanInputAttachmentMappingImpl(VulkanInputAttachmentMapping* parent, const VulkanRenderPass* renderPass, const RenderTarget& renderTarget, const UInt32& location) :
+    VulkanInputAttachmentMappingImpl(VulkanInputAttachmentMapping* parent, const VulkanRenderPass* renderPass, const RenderTarget& renderTarget, UInt32 location) :
         base(parent), m_renderPass(renderPass), m_location(location), m_renderTarget(renderTarget)
     {
     }
@@ -31,7 +31,7 @@ VulkanInputAttachmentMapping::VulkanInputAttachmentMapping() noexcept :
 {
 }
 
-VulkanInputAttachmentMapping::VulkanInputAttachmentMapping(const VulkanRenderPass& renderPass, const RenderTarget& renderTarget, const UInt32& location) :
+VulkanInputAttachmentMapping::VulkanInputAttachmentMapping(const VulkanRenderPass& renderPass, const RenderTarget& renderTarget, UInt32 location) :
     m_impl(makePimpl<VulkanInputAttachmentMappingImpl>(this, &renderPass, renderTarget, location))
 {
 }
@@ -71,7 +71,7 @@ const VulkanRenderPass* VulkanInputAttachmentMapping::inputAttachmentSource() co
     return m_impl->m_renderPass;
 }
 
-const UInt32& VulkanInputAttachmentMapping::location() const noexcept
+UInt32 VulkanInputAttachmentMapping::location() const noexcept
 {
     return m_impl->m_location;
 }

--- a/src/Backends/Vulkan/src/pipeline_layout.cpp
+++ b/src/Backends/Vulkan/src/pipeline_layout.cpp
@@ -91,7 +91,7 @@ const VulkanDevice& VulkanPipelineLayout::device() const noexcept
     return m_impl->m_device;
 }
 
-const VulkanDescriptorSetLayout& VulkanPipelineLayout::descriptorSet(const UInt32& space) const
+const VulkanDescriptorSetLayout& VulkanPipelineLayout::descriptorSet(UInt32 space) const
 {
     if (auto match = std::ranges::find_if(m_impl->m_descriptorSetLayouts, [&space](const UniquePtr<VulkanDescriptorSetLayout>& layout) { return layout->space() == space; }); match != m_impl->m_descriptorSetLayouts.end())
         return *match->get();

--- a/src/Backends/Vulkan/src/push_constants_layout.cpp
+++ b/src/Backends/Vulkan/src/push_constants_layout.cpp
@@ -19,7 +19,7 @@ private:
     UInt32 m_size;
 
 public:
-    VulkanPushConstantsLayoutImpl(VulkanPushConstantsLayout* parent, const UInt32& size) :
+    VulkanPushConstantsLayoutImpl(VulkanPushConstantsLayout* parent, UInt32 size) :
         base(parent), m_size(size)
     {
         // Align the size to 4 bytes.
@@ -48,13 +48,13 @@ private:
 // Shared interface.
 // ------------------------------------------------------------------------------------------------
 
-VulkanPushConstantsLayout::VulkanPushConstantsLayout(Enumerable<UniquePtr<VulkanPushConstantsRange>>&& ranges, const UInt32& size) :
+VulkanPushConstantsLayout::VulkanPushConstantsLayout(Enumerable<UniquePtr<VulkanPushConstantsRange>>&& ranges, UInt32 size) :
     m_impl(makePimpl<VulkanPushConstantsLayoutImpl>(this, size))
 {
     m_impl->setRanges(std::move(ranges));
 }
 
-VulkanPushConstantsLayout::VulkanPushConstantsLayout(const UInt32& size) :
+VulkanPushConstantsLayout::VulkanPushConstantsLayout(UInt32 size) :
     m_impl(makePimpl<VulkanPushConstantsLayoutImpl>(this, size))
 {
 }
@@ -77,7 +77,7 @@ void VulkanPushConstantsLayout::pipelineLayout(const VulkanPipelineLayout& pipel
         throw RuntimeException("The push constant layout has already been initialized from another pipeline layout.");
 }
 
-const UInt32& VulkanPushConstantsLayout::size() const noexcept
+UInt32 VulkanPushConstantsLayout::size() const noexcept
 {
     return m_impl->m_size;
 }

--- a/src/Backends/Vulkan/src/push_constants_layout.cpp
+++ b/src/Backends/Vulkan/src/push_constants_layout.cpp
@@ -82,7 +82,7 @@ const UInt32& VulkanPushConstantsLayout::size() const noexcept
     return m_impl->m_size;
 }
 
-const VulkanPushConstantsRange& VulkanPushConstantsLayout::range(const ShaderStage& stage) const
+const VulkanPushConstantsRange& VulkanPushConstantsLayout::range(ShaderStage stage) const
 {
     if (!(std::to_underlying(stage) && !(std::to_underlying(stage) & (std::to_underlying(stage) - 1))))
         throw ArgumentOutOfRangeException("The stage mask must only contain one shader stage.");

--- a/src/Backends/Vulkan/src/push_constants_range.cpp
+++ b/src/Backends/Vulkan/src/push_constants_range.cpp
@@ -15,7 +15,7 @@ private:
     UInt32 m_offset, m_size, m_space, m_binding;
 
 public:
-    VulkanPushConstantsRangeImpl(VulkanPushConstantsRange* parent, ShaderStage shaderStage, const UInt32& offset, const UInt32& size, const UInt32& space, const UInt32& binding) :
+    VulkanPushConstantsRangeImpl(VulkanPushConstantsRange* parent, ShaderStage shaderStage, UInt32 offset, UInt32 size, UInt32 space, UInt32 binding) :
         base(parent), m_stage(shaderStage), m_offset(offset), m_size(size), m_space(space), m_binding(binding)
     {
         if (offset % 4 != 0)
@@ -33,29 +33,29 @@ public:
 // Shared interface.
 // ------------------------------------------------------------------------------------------------
 
-VulkanPushConstantsRange::VulkanPushConstantsRange(ShaderStage shaderStage, const UInt32& offset, const UInt32& size, const UInt32& space, const UInt32& binding) :
+VulkanPushConstantsRange::VulkanPushConstantsRange(ShaderStage shaderStage, UInt32 offset, UInt32 size, UInt32 space, UInt32 binding) :
     m_impl(makePimpl<VulkanPushConstantsRangeImpl>(this, shaderStage, offset, size, space, binding))
 {
 }
 
 VulkanPushConstantsRange::~VulkanPushConstantsRange() noexcept = default;
 
-const UInt32& VulkanPushConstantsRange::space() const noexcept
+UInt32 VulkanPushConstantsRange::space() const noexcept
 {
     return m_impl->m_space;
 }
 
-const UInt32& VulkanPushConstantsRange::binding() const noexcept
+UInt32 VulkanPushConstantsRange::binding() const noexcept
 {
     return m_impl->m_binding;
 }
 
-const UInt32& VulkanPushConstantsRange::offset() const noexcept
+UInt32 VulkanPushConstantsRange::offset() const noexcept
 {
     return m_impl->m_offset;
 }
 
-const UInt32& VulkanPushConstantsRange::size() const noexcept
+UInt32 VulkanPushConstantsRange::size() const noexcept
 {
     return m_impl->m_size;
 }

--- a/src/Backends/Vulkan/src/push_constants_range.cpp
+++ b/src/Backends/Vulkan/src/push_constants_range.cpp
@@ -15,7 +15,7 @@ private:
     UInt32 m_offset, m_size, m_space, m_binding;
 
 public:
-    VulkanPushConstantsRangeImpl(VulkanPushConstantsRange* parent, const ShaderStage& shaderStage, const UInt32& offset, const UInt32& size, const UInt32& space, const UInt32& binding) :
+    VulkanPushConstantsRangeImpl(VulkanPushConstantsRange* parent, ShaderStage shaderStage, const UInt32& offset, const UInt32& size, const UInt32& space, const UInt32& binding) :
         base(parent), m_stage(shaderStage), m_offset(offset), m_size(size), m_space(space), m_binding(binding)
     {
         if (offset % 4 != 0)
@@ -33,7 +33,7 @@ public:
 // Shared interface.
 // ------------------------------------------------------------------------------------------------
 
-VulkanPushConstantsRange::VulkanPushConstantsRange(const ShaderStage& shaderStage, const UInt32& offset, const UInt32& size, const UInt32& space, const UInt32& binding) :
+VulkanPushConstantsRange::VulkanPushConstantsRange(ShaderStage shaderStage, const UInt32& offset, const UInt32& size, const UInt32& space, const UInt32& binding) :
     m_impl(makePimpl<VulkanPushConstantsRangeImpl>(this, shaderStage, offset, size, space, binding))
 {
 }
@@ -60,7 +60,7 @@ const UInt32& VulkanPushConstantsRange::size() const noexcept
     return m_impl->m_size;
 }
 
-const ShaderStage& VulkanPushConstantsRange::stage() const noexcept
+ShaderStage VulkanPushConstantsRange::stage() const noexcept
 {
     return m_impl->m_stage;
 }

--- a/src/Backends/Vulkan/src/queue.cpp
+++ b/src/Backends/Vulkan/src/queue.cpp
@@ -28,7 +28,7 @@ private:
 	Array<Tuple<UInt64, SharedPtr<const VulkanCommandBuffer>>> m_submittedCommandBuffers;
 
 public:
-	VulkanQueueImpl(VulkanQueue* parent, const VulkanDevice& device, const QueueType& type, const QueuePriority& priority, const UInt32& familyId, const UInt32& queueId) :
+	VulkanQueueImpl(VulkanQueue* parent, const VulkanDevice& device, QueueType type, QueuePriority priority, const UInt32& familyId, const UInt32& queueId) :
 		base(parent), m_type(type), m_priority(priority), m_familyId(familyId), m_queueId(queueId), m_bound(false), m_device(device)
 	{
 	}
@@ -98,7 +98,7 @@ public:
 // Shared interface.
 // ------------------------------------------------------------------------------------------------
 
-VulkanQueue::VulkanQueue(const VulkanDevice& device, const QueueType& type, const QueuePriority& priority, const UInt32& familyId, const UInt32& queueId) :
+VulkanQueue::VulkanQueue(const VulkanDevice& device, QueueType type, QueuePriority priority, const UInt32& familyId, const UInt32& queueId) :
 	Resource<VkQueue>(nullptr), m_impl(makePimpl<VulkanQueueImpl>(this, device, type, priority, familyId, queueId))
 {
 }
@@ -135,7 +135,7 @@ bool VulkanQueue::isBound() const noexcept
 	return m_impl->m_bound;
 }
 
-const QueueType& VulkanQueue::type() const noexcept
+QueueType VulkanQueue::type() const noexcept
 {
 	return m_impl->m_type;
 }
@@ -169,7 +169,7 @@ void VulkanQueue::SetDebugMarker(const String& label, const Vectors::ByteVector3
 }
 #endif
 
-const QueuePriority& VulkanQueue::priority() const noexcept
+QueuePriority VulkanQueue::priority() const noexcept
 {
 	return m_impl->m_priority;
 }

--- a/src/Backends/Vulkan/src/queue.cpp
+++ b/src/Backends/Vulkan/src/queue.cpp
@@ -28,7 +28,7 @@ private:
 	Array<Tuple<UInt64, SharedPtr<const VulkanCommandBuffer>>> m_submittedCommandBuffers;
 
 public:
-	VulkanQueueImpl(VulkanQueue* parent, const VulkanDevice& device, QueueType type, QueuePriority priority, const UInt32& familyId, const UInt32& queueId) :
+	VulkanQueueImpl(VulkanQueue* parent, const VulkanDevice& device, QueueType type, QueuePriority priority, UInt32 familyId, UInt32 queueId) :
 		base(parent), m_type(type), m_priority(priority), m_familyId(familyId), m_queueId(queueId), m_bound(false), m_device(device)
 	{
 	}
@@ -98,7 +98,7 @@ public:
 // Shared interface.
 // ------------------------------------------------------------------------------------------------
 
-VulkanQueue::VulkanQueue(const VulkanDevice& device, QueueType type, QueuePriority priority, const UInt32& familyId, const UInt32& queueId) :
+VulkanQueue::VulkanQueue(const VulkanDevice& device, QueueType type, QueuePriority priority, UInt32 familyId, UInt32 queueId) :
 	Resource<VkQueue>(nullptr), m_impl(makePimpl<VulkanQueueImpl>(this, device, type, priority, familyId, queueId))
 {
 }
@@ -115,12 +115,12 @@ const VkCommandPool& VulkanQueue::commandPool() const noexcept
 	return m_impl->m_commandPool;
 }
 
-const UInt32& VulkanQueue::familyId() const noexcept
+UInt32 VulkanQueue::familyId() const noexcept
 {
 	return m_impl->m_familyId;
 }
 
-const UInt32& VulkanQueue::queueId() const noexcept
+UInt32 VulkanQueue::queueId() const noexcept
 {
 	return m_impl->m_queueId;
 }
@@ -186,7 +186,7 @@ void VulkanQueue::release()
 	this->released(this, { });
 }
 
-SharedPtr<VulkanCommandBuffer> VulkanQueue::createCommandBuffer(const bool& beginRecording, const bool& secondary) const
+SharedPtr<VulkanCommandBuffer> VulkanQueue::createCommandBuffer(bool beginRecording, bool secondary) const
 {
 	return makeShared<VulkanCommandBuffer>(*this, beginRecording, !secondary);
 }
@@ -325,7 +325,7 @@ UInt64 VulkanQueue::submit(const Enumerable<SharedPtr<const VulkanCommandBuffer>
 	return fence;
 }
 
-void VulkanQueue::waitFor(const UInt64& fence) const noexcept
+void VulkanQueue::waitFor(UInt64 fence) const noexcept
 {
 	UInt64 completedValue{ 0 };
 	//raiseIfFailed<RuntimeException>(::vkGetSemaphoreCounterValue(this->getDevice()->handle(), m_impl->m_timelineSemaphore, &completedValue), "Unable to query current queue timeline semaphore value.");

--- a/src/Backends/Vulkan/src/rasterizer.cpp
+++ b/src/Backends/Vulkan/src/rasterizer.cpp
@@ -7,7 +7,7 @@ using namespace LiteFX::Rendering::Backends;
 // Shared interface.
 // ------------------------------------------------------------------------------------------------
 
-VulkanRasterizer::VulkanRasterizer(PolygonMode polygonMode, CullMode cullMode, CullOrder cullOrder, const Float& lineWidth, const DepthStencilState& depthStencilState) noexcept :
+VulkanRasterizer::VulkanRasterizer(PolygonMode polygonMode, CullMode cullMode, CullOrder cullOrder, Float lineWidth, const DepthStencilState& depthStencilState) noexcept :
     Rasterizer(polygonMode, cullMode, cullOrder, lineWidth, depthStencilState)
 {
 }
@@ -19,7 +19,7 @@ VulkanRasterizer::VulkanRasterizer() noexcept :
 
 VulkanRasterizer::~VulkanRasterizer() noexcept = default;
 
-void VulkanRasterizer::updateLineWidth(const Float& lineWidth) noexcept
+void VulkanRasterizer::updateLineWidth(Float lineWidth) noexcept
 {
     this->lineWidth() = lineWidth;
 }

--- a/src/Backends/Vulkan/src/rasterizer.cpp
+++ b/src/Backends/Vulkan/src/rasterizer.cpp
@@ -7,7 +7,7 @@ using namespace LiteFX::Rendering::Backends;
 // Shared interface.
 // ------------------------------------------------------------------------------------------------
 
-VulkanRasterizer::VulkanRasterizer(const PolygonMode& polygonMode, const CullMode& cullMode, const CullOrder& cullOrder, const Float& lineWidth, const DepthStencilState& depthStencilState) noexcept :
+VulkanRasterizer::VulkanRasterizer(PolygonMode polygonMode, CullMode cullMode, CullOrder cullOrder, const Float& lineWidth, const DepthStencilState& depthStencilState) noexcept :
     Rasterizer(polygonMode, cullMode, cullOrder, lineWidth, depthStencilState)
 {
 }

--- a/src/Backends/Vulkan/src/render_pass.cpp
+++ b/src/Backends/Vulkan/src/render_pass.cpp
@@ -26,7 +26,7 @@ private:
     const VulkanDevice& m_device;
 
 public:
-    VulkanRenderPassImpl(VulkanRenderPass* parent, const VulkanDevice& device, Span<RenderTarget> renderTargets, const MultiSamplingLevel& samples, Span<VulkanInputAttachmentMapping> inputAttachments) :
+    VulkanRenderPassImpl(VulkanRenderPass* parent, const VulkanDevice& device, Span<RenderTarget> renderTargets, MultiSamplingLevel samples, Span<VulkanInputAttachmentMapping> inputAttachments) :
         base(parent), m_samples(samples), m_device(device)
     {
         this->mapRenderTargets(renderTargets);
@@ -292,14 +292,14 @@ public:
 // Interface.
 // ------------------------------------------------------------------------------------------------
 
-VulkanRenderPass::VulkanRenderPass(const VulkanDevice& device, Span<RenderTarget> renderTargets, const UInt32& commandBuffers, const MultiSamplingLevel& samples, Span<VulkanInputAttachmentMapping> inputAttachments) :
+VulkanRenderPass::VulkanRenderPass(const VulkanDevice& device, Span<RenderTarget> renderTargets, const UInt32& commandBuffers, MultiSamplingLevel samples, Span<VulkanInputAttachmentMapping> inputAttachments) :
     m_impl(makePimpl<VulkanRenderPassImpl>(this, device, renderTargets, samples, inputAttachments)), Resource<VkRenderPass>(VK_NULL_HANDLE)
 {
     this->handle() = m_impl->initialize();
     m_impl->initializeFrameBuffers(commandBuffers);
 }
 
-VulkanRenderPass::VulkanRenderPass(const VulkanDevice& device, const String& name, Span<RenderTarget> renderTargets, const UInt32& commandBuffers, const MultiSamplingLevel& samples, Span<VulkanInputAttachmentMapping> inputAttachments) :
+VulkanRenderPass::VulkanRenderPass(const VulkanDevice& device, const String& name, Span<RenderTarget> renderTargets, const UInt32& commandBuffers, MultiSamplingLevel samples, Span<VulkanInputAttachmentMapping> inputAttachments) :
     VulkanRenderPass(device, renderTargets, commandBuffers, samples, inputAttachments)
 {
     if (!name.empty())
@@ -372,7 +372,7 @@ Span<const VulkanInputAttachmentMapping> VulkanRenderPass::inputAttachments() co
     return m_impl->m_inputAttachments;
 }
 
-const MultiSamplingLevel& VulkanRenderPass::multiSamplingLevel() const noexcept
+MultiSamplingLevel VulkanRenderPass::multiSamplingLevel() const noexcept
 {
     return m_impl->m_samples;
 }
@@ -464,7 +464,7 @@ void VulkanRenderPass::resizeFrameBuffers(const Size2d& renderArea)
     std::ranges::for_each(m_impl->m_frameBuffers, [&](UniquePtr<VulkanFrameBuffer>& frameBuffer) { frameBuffer->resize(renderArea); });
 }
 
-void VulkanRenderPass::changeMultiSamplingLevel(const MultiSamplingLevel& samples)
+void VulkanRenderPass::changeMultiSamplingLevel(MultiSamplingLevel samples)
 {
     // Check if we're currently running.
     if (m_impl->m_activeFrameBuffer != nullptr)

--- a/src/Backends/Vulkan/src/render_pass.cpp
+++ b/src/Backends/Vulkan/src/render_pass.cpp
@@ -244,7 +244,7 @@ public:
         return renderPass;
     }
 
-    void initializeFrameBuffers(const UInt32& commandBuffers)
+    void initializeFrameBuffers(UInt32 commandBuffers)
     {
         // Initialize the frame buffers.
         this->m_frameBuffers.resize(this->m_device.swapChain().buffers());
@@ -292,14 +292,14 @@ public:
 // Interface.
 // ------------------------------------------------------------------------------------------------
 
-VulkanRenderPass::VulkanRenderPass(const VulkanDevice& device, Span<RenderTarget> renderTargets, const UInt32& commandBuffers, MultiSamplingLevel samples, Span<VulkanInputAttachmentMapping> inputAttachments) :
+VulkanRenderPass::VulkanRenderPass(const VulkanDevice& device, Span<RenderTarget> renderTargets, UInt32 commandBuffers, MultiSamplingLevel samples, Span<VulkanInputAttachmentMapping> inputAttachments) :
     m_impl(makePimpl<VulkanRenderPassImpl>(this, device, renderTargets, samples, inputAttachments)), Resource<VkRenderPass>(VK_NULL_HANDLE)
 {
     this->handle() = m_impl->initialize();
     m_impl->initializeFrameBuffers(commandBuffers);
 }
 
-VulkanRenderPass::VulkanRenderPass(const VulkanDevice& device, const String& name, Span<RenderTarget> renderTargets, const UInt32& commandBuffers, MultiSamplingLevel samples, Span<VulkanInputAttachmentMapping> inputAttachments) :
+VulkanRenderPass::VulkanRenderPass(const VulkanDevice& device, const String& name, Span<RenderTarget> renderTargets, UInt32 commandBuffers, MultiSamplingLevel samples, Span<VulkanInputAttachmentMapping> inputAttachments) :
     VulkanRenderPass(device, renderTargets, commandBuffers, samples, inputAttachments)
 {
     if (!name.empty())
@@ -318,7 +318,7 @@ VulkanRenderPass::~VulkanRenderPass() noexcept
     ::vkDestroyRenderPass(m_impl->m_device.handle(), this->handle(), nullptr);
 }
 
-const VulkanFrameBuffer& VulkanRenderPass::frameBuffer(const UInt32& buffer) const
+const VulkanFrameBuffer& VulkanRenderPass::frameBuffer(UInt32 buffer) const
 {
     if (buffer >= m_impl->m_frameBuffers.size()) [[unlikely]]
         throw ArgumentOutOfRangeException("The buffer {0} does not exist in this render pass. The render pass only contains {1} frame buffers.", buffer, m_impl->m_frameBuffers.size());
@@ -349,7 +349,7 @@ Enumerable<const VulkanRenderPipeline*> VulkanRenderPass::pipelines() const noex
     return m_impl->m_pipelines | std::views::transform([](const UniquePtr<VulkanRenderPipeline>& pipeline) { return pipeline.get(); });
 }
 
-const RenderTarget& VulkanRenderPass::renderTarget(const UInt32& location) const
+const RenderTarget& VulkanRenderPass::renderTarget(UInt32 location) const
 {
     if (auto match = std::ranges::find_if(m_impl->m_renderTargets, [&location](const RenderTarget& renderTarget) { return renderTarget.location() == location; }); match != m_impl->m_renderTargets.end())
         return *match;
@@ -377,7 +377,7 @@ MultiSamplingLevel VulkanRenderPass::multiSamplingLevel() const noexcept
     return m_impl->m_samples;
 }
 
-void VulkanRenderPass::begin(const UInt32& buffer)
+void VulkanRenderPass::begin(UInt32 buffer)
 {
     // Only begin, if we are currently not running.
     if (m_impl->m_activeFrameBuffer != nullptr)

--- a/src/Backends/Vulkan/src/render_pipeline.cpp
+++ b/src/Backends/Vulkan/src/render_pipeline.cpp
@@ -21,7 +21,7 @@ private:
 	const VulkanRenderPass& m_renderPass;
 
 public:
-	VulkanRenderPipelineImpl(VulkanRenderPipeline* parent, const VulkanRenderPass& renderPass, const bool& alphaToCoverage, SharedPtr<VulkanPipelineLayout> layout, SharedPtr<VulkanShaderProgram> shaderProgram, SharedPtr<VulkanInputAssembler> inputAssembler, SharedPtr<VulkanRasterizer> rasterizer) :
+	VulkanRenderPipelineImpl(VulkanRenderPipeline* parent, const VulkanRenderPass& renderPass, bool alphaToCoverage, SharedPtr<VulkanPipelineLayout> layout, SharedPtr<VulkanShaderProgram> shaderProgram, SharedPtr<VulkanInputAssembler> inputAssembler, SharedPtr<VulkanRasterizer> rasterizer) :
 		base(parent), m_renderPass(renderPass), m_alphaToCoverage(alphaToCoverage), m_layout(layout), m_program(shaderProgram), m_inputAssembler(inputAssembler), m_rasterizer(rasterizer)
 	{
 	}
@@ -230,7 +230,7 @@ public:
 // Interface.
 // ------------------------------------------------------------------------------------------------
 
-VulkanRenderPipeline::VulkanRenderPipeline(const VulkanRenderPass& renderPass, SharedPtr<VulkanShaderProgram> shaderProgram, SharedPtr<VulkanPipelineLayout> layout, SharedPtr<VulkanInputAssembler> inputAssembler, SharedPtr<VulkanRasterizer> rasterizer, const bool& enableAlphaToCoverage, const String& name) :
+VulkanRenderPipeline::VulkanRenderPipeline(const VulkanRenderPass& renderPass, SharedPtr<VulkanShaderProgram> shaderProgram, SharedPtr<VulkanPipelineLayout> layout, SharedPtr<VulkanInputAssembler> inputAssembler, SharedPtr<VulkanRasterizer> rasterizer, bool enableAlphaToCoverage, const String& name) :
 	m_impl(makePimpl<VulkanRenderPipelineImpl>(this, renderPass, enableAlphaToCoverage, layout, shaderProgram, inputAssembler, rasterizer)), VulkanPipelineState(VK_NULL_HANDLE)
 {
 	this->handle() = m_impl->initialize();
@@ -271,7 +271,7 @@ SharedPtr<VulkanRasterizer> VulkanRenderPipeline::rasterizer() const noexcept
 	return m_impl->m_rasterizer;
 }
 
-const bool& VulkanRenderPipeline::alphaToCoverage() const noexcept
+bool VulkanRenderPipeline::alphaToCoverage() const noexcept
 {
 	return m_impl->m_alphaToCoverage;
 }

--- a/src/Backends/Vulkan/src/shader_module.cpp
+++ b/src/Backends/Vulkan/src/shader_module.cpp
@@ -17,7 +17,7 @@ private:
 	const VulkanDevice& m_device;
 
 public:
-	VulkanShaderModuleImpl(VulkanShaderModule* parent, const VulkanDevice& device, const ShaderStage& type, const String& fileName, const String& entryPoint) :
+	VulkanShaderModuleImpl(VulkanShaderModule* parent, const VulkanDevice& device, ShaderStage type, const String& fileName, const String& entryPoint) :
 		base(parent), m_device(device), m_fileName(fileName), m_entryPoint(entryPoint), m_type(type) 
 	{
 	}
@@ -73,13 +73,13 @@ public:
 // Interface.
 // ------------------------------------------------------------------------------------------------
 
-VulkanShaderModule::VulkanShaderModule(const VulkanDevice& device, const ShaderStage& type, const String& fileName, const String& entryPoint) :
+VulkanShaderModule::VulkanShaderModule(const VulkanDevice& device, ShaderStage type, const String& fileName, const String& entryPoint) :
 	Resource<VkShaderModule>(VK_NULL_HANDLE), m_impl(makePimpl<VulkanShaderModuleImpl>(this, device, type, fileName, entryPoint))
 {
 	this->handle() = m_impl->initialize();
 }
 
-VulkanShaderModule::VulkanShaderModule(const VulkanDevice& device, const ShaderStage& type, std::istream& stream, const String& name, const String& entryPoint) :
+VulkanShaderModule::VulkanShaderModule(const VulkanDevice& device, ShaderStage type, std::istream& stream, const String& name, const String& entryPoint) :
 	Resource<VkShaderModule>(VK_NULL_HANDLE), m_impl(makePimpl<VulkanShaderModuleImpl>(this, device, type, name, entryPoint))
 {
 	this->handle() = m_impl->initialize(stream);
@@ -90,7 +90,7 @@ VulkanShaderModule::~VulkanShaderModule() noexcept
 	::vkDestroyShaderModule(m_impl->m_device.handle(), this->handle(), nullptr);
 }
 
-const ShaderStage& VulkanShaderModule::type() const noexcept
+ShaderStage VulkanShaderModule::type() const noexcept
 {
 	return m_impl->m_type;
 }

--- a/src/Backends/Vulkan/src/swapchain.cpp
+++ b/src/Backends/Vulkan/src/swapchain.cpp
@@ -50,7 +50,7 @@ public:
 	}
 
 public:
-	void initialize(const Format& format, const Size2d& renderArea, const UInt32& buffers)
+	void initialize(Format format, const Size2d& renderArea, const UInt32& buffers)
 	{
 		if (format == Format::Other || format == Format::None)
 			throw InvalidArgumentException("The provided surface format it not a valid value.");
@@ -62,7 +62,7 @@ public:
 		auto surfaceFormats = this->getSurfaceFormats(adapter, surface);
 		Format selectedFormat{ Format::None };
 		
-		if (auto match = std::ranges::find_if(surfaceFormats, [format](const Format& surfaceFormat) { return surfaceFormat == format; }); match != surfaceFormats.end()) [[likely]]
+		if (auto match = std::ranges::find_if(surfaceFormats, [format](Format surfaceFormat) { return surfaceFormat == format; }); match != surfaceFormats.end()) [[likely]]
 			selectedFormat = *match;
 		else
 			throw InvalidArgumentException("The requested format is not supported by this device.");
@@ -174,7 +174,7 @@ public:
 		m_timestamps.resize(timingEvents.size());
 	}
 
-	void reset(const Format& format, const Size2d& renderArea, const UInt32& buffers)
+	void reset(Format format, const Size2d& renderArea, const UInt32& buffers)
 	{
 		// Cleanup and re-initialize.
 		this->cleanup();
@@ -265,7 +265,7 @@ public:
 		return availableFormats | std::views::transform([](const VkSurfaceFormatKHR& format) { return Vk::getFormat(format.format); }) | std::ranges::to<Array<Format>>();
 	}
 
-	VkColorSpaceKHR findColorSpace(const VkPhysicalDevice adapter, const VkSurfaceKHR surface, const Format& format) const noexcept
+	VkColorSpaceKHR findColorSpace(const VkPhysicalDevice adapter, const VkSurfaceKHR surface, Format format) const noexcept
 	{
 		uint32_t formats;
 		::vkGetPhysicalDeviceSurfaceFormatsKHR(adapter, surface, &formats, nullptr);
@@ -363,7 +363,7 @@ public:
 	}
 
 public:
-	void initialize(const Format& format, const Size2d& renderArea, const UInt32& buffers)
+	void initialize(Format format, const Size2d& renderArea, const UInt32& buffers)
 	{
 		if (format == Format::Other || format == Format::None)
 			throw InvalidArgumentException("The provided surface format it not a valid value.");
@@ -372,7 +372,7 @@ public:
 		auto surfaceFormats = this->getSurfaceFormats(m_device.adapter().handle(), m_device.surface().handle());
 		Format selectedFormat{ Format::None };
 
-		if (auto match = std::ranges::find_if(surfaceFormats, [format](const Format& surfaceFormat) { return surfaceFormat == format; }); match != surfaceFormats.end()) [[likely]]
+		if (auto match = std::ranges::find_if(surfaceFormats, [format](Format surfaceFormat) { return surfaceFormat == format; }); match != surfaceFormats.end()) [[likely]]
 			selectedFormat = *match;
 		else
 			throw InvalidArgumentException("The requested format is not supported by this device.");
@@ -485,7 +485,7 @@ public:
 			LITEFX_WARNING(VULKAN_LOG, "Unable disable keyboard control sequence for full-screen switching.");
 	}
 
-	void reset(const Format& format, const Size2d& renderArea, const UInt32& buffers)
+	void reset(Format format, const Size2d& renderArea, const UInt32& buffers)
 	{
 		// Release the image memory of the previously allocated images.
 		std::ranges::for_each(m_presentImages, [this](const auto& image) { ::vkDestroyImage(m_device.handle(), std::as_const(*image).handle(), nullptr); });
@@ -494,7 +494,7 @@ public:
 		auto surfaceFormats = this->getSurfaceFormats(m_device.adapter().handle(), m_device.surface().handle());
 		Format selectedFormat{ Format::None };
 
-		if (auto match = std::ranges::find_if(surfaceFormats, [format](const Format& surfaceFormat) { return surfaceFormat == format; }); match != surfaceFormats.end()) [[likely]]
+		if (auto match = std::ranges::find_if(surfaceFormats, [format](Format surfaceFormat) { return surfaceFormat == format; }); match != surfaceFormats.end()) [[likely]]
 			selectedFormat = *match;
 		else
 			throw InvalidArgumentException("The requested format is not supported by this device.");
@@ -534,7 +534,7 @@ public:
 			this->resetQueryPools(m_timingEvents);
 	}
 
-	void createImages(const Format& format, const Size2d& renderArea, const UInt32& buffers)
+	void createImages(Format format, const Size2d& renderArea, const UInt32& buffers)
 	{	
 		// Acquire the swap chain images.
 		m_presentImages.resize(buffers);
@@ -771,7 +771,7 @@ public:
 		return availableFormats | std::views::transform([](const VkSurfaceFormatKHR& format) { return Vk::getFormat(format.format); });
 	}
 
-	VkColorSpaceKHR findColorSpace(const VkPhysicalDevice adapter, const VkSurfaceKHR surface, const Format& format) const noexcept
+	VkColorSpaceKHR findColorSpace(const VkPhysicalDevice adapter, const VkSurfaceKHR surface, Format format) const noexcept
 	{
 		uint32_t formats;
 		::vkGetPhysicalDeviceSurfaceFormatsKHR(adapter, surface, &formats, nullptr);
@@ -824,7 +824,7 @@ private:
 // Shared interface.
 // ------------------------------------------------------------------------------------------------
 
-VulkanSwapChain::VulkanSwapChain(const VulkanDevice& device, const Format& surfaceFormat, const Size2d& renderArea, const UInt32& buffers) :
+VulkanSwapChain::VulkanSwapChain(const VulkanDevice& device, Format surfaceFormat, const Size2d& renderArea, const UInt32& buffers) :
 	m_impl(makePimpl<VulkanSwapChainImpl>(this, device))
 {
 	m_impl->initialize(surfaceFormat, renderArea, buffers);
@@ -883,7 +883,7 @@ UInt32 VulkanSwapChain::resolveQueryId(SharedPtr<const TimingEvent> timingEvent)
 	throw InvalidArgumentException("The timing event is not registered on the swap chain.");
 }
 
-const Format& VulkanSwapChain::surfaceFormat() const noexcept
+Format VulkanSwapChain::surfaceFormat() const noexcept
 {
 	return m_impl->m_format;
 }
@@ -936,7 +936,7 @@ void VulkanSwapChain::addTimingEvent(SharedPtr<TimingEvent> timingEvent)
 	m_impl->resetQueryPools(events);
 }
 
-void VulkanSwapChain::reset(const Format& surfaceFormat, const Size2d& renderArea, const UInt32& buffers)
+void VulkanSwapChain::reset(Format surfaceFormat, const Size2d& renderArea, const UInt32& buffers)
 {
 	m_impl->reset(surfaceFormat, renderArea, buffers);
 	this->reseted(this, { surfaceFormat, renderArea, buffers });

--- a/src/Backends/Vulkan/src/swapchain.cpp
+++ b/src/Backends/Vulkan/src/swapchain.cpp
@@ -50,7 +50,7 @@ public:
 	}
 
 public:
-	void initialize(Format format, const Size2d& renderArea, const UInt32& buffers)
+	void initialize(Format format, const Size2d& renderArea, UInt32 buffers)
 	{
 		if (format == Format::Other || format == Format::None)
 			throw InvalidArgumentException("The provided surface format it not a valid value.");
@@ -174,7 +174,7 @@ public:
 		m_timestamps.resize(timingEvents.size());
 	}
 
-	void reset(Format format, const Size2d& renderArea, const UInt32& buffers)
+	void reset(Format format, const Size2d& renderArea, UInt32 buffers)
 	{
 		// Cleanup and re-initialize.
 		this->cleanup();
@@ -363,7 +363,7 @@ public:
 	}
 
 public:
-	void initialize(Format format, const Size2d& renderArea, const UInt32& buffers)
+	void initialize(Format format, const Size2d& renderArea, UInt32 buffers)
 	{
 		if (format == Format::Other || format == Format::None)
 			throw InvalidArgumentException("The provided surface format it not a valid value.");
@@ -485,7 +485,7 @@ public:
 			LITEFX_WARNING(VULKAN_LOG, "Unable disable keyboard control sequence for full-screen switching.");
 	}
 
-	void reset(Format format, const Size2d& renderArea, const UInt32& buffers)
+	void reset(Format format, const Size2d& renderArea, UInt32 buffers)
 	{
 		// Release the image memory of the previously allocated images.
 		std::ranges::for_each(m_presentImages, [this](const auto& image) { ::vkDestroyImage(m_device.handle(), std::as_const(*image).handle(), nullptr); });
@@ -534,7 +534,7 @@ public:
 			this->resetQueryPools(m_timingEvents);
 	}
 
-	void createImages(Format format, const Size2d& renderArea, const UInt32& buffers)
+	void createImages(Format format, const Size2d& renderArea, UInt32 buffers)
 	{	
 		// Acquire the swap chain images.
 		m_presentImages.resize(buffers);
@@ -824,7 +824,7 @@ private:
 // Shared interface.
 // ------------------------------------------------------------------------------------------------
 
-VulkanSwapChain::VulkanSwapChain(const VulkanDevice& device, Format surfaceFormat, const Size2d& renderArea, const UInt32& buffers) :
+VulkanSwapChain::VulkanSwapChain(const VulkanDevice& device, Format surfaceFormat, const Size2d& renderArea, UInt32 buffers) :
 	m_impl(makePimpl<VulkanSwapChainImpl>(this, device))
 {
 	m_impl->initialize(surfaceFormat, renderArea, buffers);
@@ -847,7 +847,7 @@ Enumerable<SharedPtr<TimingEvent>> VulkanSwapChain::timingEvents() const noexcep
 	return m_impl->m_timingEvents;
 }
 
-SharedPtr<TimingEvent> VulkanSwapChain::timingEvent(const UInt32& queryId) const
+SharedPtr<TimingEvent> VulkanSwapChain::timingEvent(UInt32 queryId) const
 {
 	if (queryId >= m_impl->m_timingEvents.size())
 		throw ArgumentOutOfRangeException("No timing event has been registered for query ID {0}.", queryId);
@@ -888,7 +888,7 @@ Format VulkanSwapChain::surfaceFormat() const noexcept
 	return m_impl->m_format;
 }
 
-const UInt32& VulkanSwapChain::buffers() const noexcept
+UInt32 VulkanSwapChain::buffers() const noexcept
 {
 	return m_impl->m_buffers;
 }
@@ -898,7 +898,7 @@ const Size2d& VulkanSwapChain::renderArea() const noexcept
 	return m_impl->m_renderArea;
 }
 
-const IVulkanImage* VulkanSwapChain::image(const UInt32& backBuffer) const
+const IVulkanImage* VulkanSwapChain::image(UInt32 backBuffer) const
 {
 	if (backBuffer >= m_impl->m_presentImages.size()) [[unlikely]]
 		throw ArgumentOutOfRangeException("The back buffer must be a valid index.");
@@ -936,7 +936,7 @@ void VulkanSwapChain::addTimingEvent(SharedPtr<TimingEvent> timingEvent)
 	m_impl->resetQueryPools(events);
 }
 
-void VulkanSwapChain::reset(Format surfaceFormat, const Size2d& renderArea, const UInt32& buffers)
+void VulkanSwapChain::reset(Format surfaceFormat, const Size2d& renderArea, UInt32 buffers)
 {
 	m_impl->reset(surfaceFormat, renderArea, buffers);
 	this->reseted(this, { surfaceFormat, renderArea, buffers });

--- a/src/Backends/Vulkan/src/vertex_buffer_layout.cpp
+++ b/src/Backends/Vulkan/src/vertex_buffer_layout.cpp
@@ -19,7 +19,7 @@ private:
     BufferType m_bufferType{ BufferType::Vertex };
 
 public:
-    VulkanVertexBufferLayoutImpl(VulkanVertexBufferLayout* parent, const size_t& vertexSize, const UInt32& binding) : 
+    VulkanVertexBufferLayoutImpl(VulkanVertexBufferLayout* parent, size_t vertexSize, UInt32 binding) : 
         base(parent), m_vertexSize(vertexSize), m_binding(binding) 
     {
     }
@@ -29,7 +29,7 @@ public:
 // Shared interface.
 // ------------------------------------------------------------------------------------------------
 
-VulkanVertexBufferLayout::VulkanVertexBufferLayout(const size_t& vertexSize, const UInt32& binding) :
+VulkanVertexBufferLayout::VulkanVertexBufferLayout(size_t vertexSize, UInt32 binding) :
     m_impl(makePimpl<VulkanVertexBufferLayoutImpl>(this, vertexSize, binding))
 {
 }
@@ -41,7 +41,7 @@ size_t VulkanVertexBufferLayout::elementSize() const noexcept
     return m_impl->m_vertexSize;
 }
 
-const UInt32& VulkanVertexBufferLayout::binding() const noexcept
+UInt32 VulkanVertexBufferLayout::binding() const noexcept
 {
     return m_impl->m_binding;
 }

--- a/src/Backends/Vulkan/src/vertex_buffer_layout.cpp
+++ b/src/Backends/Vulkan/src/vertex_buffer_layout.cpp
@@ -46,7 +46,7 @@ const UInt32& VulkanVertexBufferLayout::binding() const noexcept
     return m_impl->m_binding;
 }
 
-const BufferType& VulkanVertexBufferLayout::type() const noexcept
+BufferType VulkanVertexBufferLayout::type() const noexcept
 {
     return m_impl->m_bufferType;
 }

--- a/src/Logging/include/litefx/logging.hpp
+++ b/src/Logging/include/litefx/logging.hpp
@@ -66,16 +66,16 @@ namespace LiteFX::Logging {
 
     public:
         /// <inheritdoc />
-        virtual LogLevel getLevel() const override;
+        LogLevel getLevel() const override;
 
         /// <inheritdoc />
-        virtual String getName() const override;
+        String getName() const override;
 
         /// <inheritdoc />
-        virtual String getPattern() const override;
+        String getPattern() const override;
 
     protected:
-        virtual spdlog::sink_ptr get() const override;
+        spdlog::sink_ptr get() const override;
     };
 
     class LITEFX_LOGGING_API RollingFileSink : public ISink {
@@ -89,13 +89,13 @@ namespace LiteFX::Logging {
 
     public:
         /// <inheritdoc />
-        virtual LogLevel getLevel() const override;
+        LogLevel getLevel() const override;
 
         /// <inheritdoc />
-        virtual String getName() const override;
+        String getName() const override;
 
         /// <inheritdoc />
-        virtual String getPattern() const override;
+        String getPattern() const override;
 
         virtual String getFileName() const;
 
@@ -104,7 +104,7 @@ namespace LiteFX::Logging {
         virtual int getMaxFiles() const;
 
     protected:
-        virtual spdlog::sink_ptr get() const override;
+        spdlog::sink_ptr get() const override;
     };
 
     class LITEFX_LOGGING_API Log {

--- a/src/Logging/include/litefx/logging.hpp
+++ b/src/Logging/include/litefx/logging.hpp
@@ -59,7 +59,7 @@ namespace LiteFX::Logging {
         LITEFX_IMPLEMENTATION(ConsoleSinkImpl);
 
     public:
-        ConsoleSink(const LogLevel& level = LogLevel::Info, const String& pattern = "%+");
+        ConsoleSink(LogLevel level = LogLevel::Info, const String& pattern = "%+");
         ConsoleSink(const ConsoleSink&) = delete;
         ConsoleSink(ConsoleSink&&) = delete;
         virtual ~ConsoleSink() noexcept;
@@ -82,7 +82,7 @@ namespace LiteFX::Logging {
         LITEFX_IMPLEMENTATION(RollingFileSinkImpl);
 
     public:
-        RollingFileSink(const String& fileName, const LogLevel& level = LogLevel::Info, const String& pattern = "%+", const bool& truncate = false, const int& maxFiles = 0);
+        RollingFileSink(const String& fileName, LogLevel level = LogLevel::Info, const String& pattern = "%+", bool truncate = false, int maxFiles = 0);
         RollingFileSink(const RollingFileSink&) = delete;
         RollingFileSink(RollingFileSink&&) = delete;
         virtual ~RollingFileSink() noexcept;
@@ -123,11 +123,11 @@ namespace LiteFX::Logging {
         virtual inline const String& getName() const noexcept;
 
     protected:
-        virtual void log(const LogLevel& level, StringView message);
+        virtual void log(LogLevel level, StringView message);
 
     public:
         template<typename ...TArgs>
-        inline void log(const LogLevel& level, StringView format, TArgs&&... args) {
+        inline void log(LogLevel level, StringView format, TArgs&&... args) {
             this->log(level, fmt::format(fmt::runtime(format), std::forward<TArgs>(args)...));
         }
 

--- a/src/Logging/src/console.cpp
+++ b/src/Logging/src/console.cpp
@@ -17,7 +17,7 @@ private:
     SharedPtr<spdlog::sinks::ansicolor_stdout_sink_mt> m_sink;
 
 public:
-    ConsoleSinkImpl(ConsoleSink* parent, const LogLevel& level, const String& pattern) : 
+    ConsoleSinkImpl(ConsoleSink* parent, LogLevel level, const String& pattern) : 
         base(parent), m_pattern(pattern), m_level(level), m_sink(makeShared<spdlog::sinks::ansicolor_stdout_sink_mt>()) 
     { 
         m_sink->set_level(static_cast<spdlog::level::level_enum>(level));
@@ -29,7 +29,7 @@ public:
 // Shared interface.
 // ------------------------------------------------------------------------------------------------
 
-ConsoleSink::ConsoleSink(const LogLevel& level, const String& pattern) :
+ConsoleSink::ConsoleSink(LogLevel level, const String& pattern) :
     m_impl(makePimpl<ConsoleSinkImpl>(this, level, pattern))
 {
 }

--- a/src/Logging/src/logger.cpp
+++ b/src/Logging/src/logger.cpp
@@ -35,7 +35,7 @@ const String& Log::getName() const noexcept
     return m_impl->m_name;
 }
 
-void Log::log(const LogLevel& level, StringView message)
+void Log::log(LogLevel level, StringView message)
 {
     auto logger = spdlog::get(this->getName());
     assert(logger != nullptr);

--- a/src/Logging/src/rolling_file.cpp
+++ b/src/Logging/src/rolling_file.cpp
@@ -20,7 +20,7 @@ private:
     SharedPtr<spdlog::sinks::daily_file_sink_mt> m_sink;
 
 public:
-    RollingFileSinkImpl(RollingFileSink* parent, const LogLevel& level, const String& fileName, const String& pattern, bool truncate, int maxFiles) :
+    RollingFileSinkImpl(RollingFileSink* parent, LogLevel level, const String& fileName, const String& pattern, bool truncate, int maxFiles) :
         base(parent), m_pattern(pattern), m_level(level), m_fileName(fileName), m_truncate(truncate), m_maxFiles(maxFiles), 
         m_sink(makeShared<spdlog::sinks::daily_file_sink_mt>(fileName, 23, 59, truncate, maxFiles)) 
     {
@@ -33,7 +33,7 @@ public:
 // Shared interface.
 // ------------------------------------------------------------------------------------------------
 
-RollingFileSink::RollingFileSink(const String& fileName, const LogLevel& level, const String& pattern, const bool& truncate, const int& maxFiles) :
+RollingFileSink::RollingFileSink(const String& fileName, LogLevel level, const String& pattern, bool truncate, int maxFiles) :
     m_impl(makePimpl<RollingFileSinkImpl>(this, level, fileName, pattern, truncate, maxFiles))
 {
 }

--- a/src/Math/include/litefx/math.hpp
+++ b/src/Math/include/litefx/math.hpp
@@ -80,7 +80,7 @@ namespace LiteFX::Math {
 	class LITEFX_MATH_API Vector1f : public Vector<Float, 1> {
 	public:
 		Vector1f() noexcept;
-		Vector1f(const Float& v) noexcept;
+		Vector1f(Float v) noexcept;
 		Vector1f(const Vector1f&) noexcept;
 		Vector1f(const Vector<Float, 1>&) noexcept;
 		Vector1f(Vector1f&&) noexcept;
@@ -93,8 +93,8 @@ namespace LiteFX::Math {
 		inline Vector1f& operator=(const Enumerable<Float>& _other) noexcept;
 		inline Vector1f& operator=(const Vector1f& _other) noexcept;
 		inline Vector1f& operator=(Vector1f&& _other) noexcept;
-		inline const Float& operator[](const unsigned int& i) const noexcept;
-		inline Float& operator[](const unsigned int& i) noexcept;
+		inline Float operator[](UInt32 i) const noexcept;
+		inline Float& operator[](UInt32 i) noexcept;
 		inline operator Enumerable<Float>() noexcept;
 
 #if defined(BUILD_WITH_GLM)
@@ -115,7 +115,7 @@ namespace LiteFX::Math {
 	class LITEFX_MATH_API Vector1u : public Vector<UInt32, 1> {
 	public:
 		Vector1u() noexcept;
-		Vector1u(const UInt32& v) noexcept;
+		Vector1u(UInt32 v) noexcept;
 		Vector1u(const Vector1u&) noexcept;
 		Vector1u(const Vector<UInt32, 1>&) noexcept;
 		Vector1u(Vector1u&&) noexcept;
@@ -129,8 +129,8 @@ namespace LiteFX::Math {
 		inline Vector1u& operator=(const Enumerable<UInt32>& _other) noexcept;
 		inline Vector1u& operator=(const Vector1u& _other) noexcept;
 		inline Vector1u& operator=(Vector1u&& _other) noexcept;
-		inline const UInt32& operator[](const unsigned int& i) const noexcept;
-		inline UInt32& operator[](const unsigned int& i) noexcept;
+		inline UInt32 operator[](UInt32 i) const noexcept;
+		inline UInt32& operator[](UInt32 i) noexcept;
 		inline operator Enumerable<UInt32>() noexcept;
 
 #if defined(BUILD_WITH_GLM)
@@ -151,8 +151,8 @@ namespace LiteFX::Math {
 	class LITEFX_MATH_API Vector2f : public Vector<Float, 2> {
 	public:
 		Vector2f() noexcept;
-		Vector2f(const Float& v) noexcept;
-		Vector2f(const Float& x, const Float& y) noexcept;
+		Vector2f(Float v) noexcept;
+		Vector2f(Float x, Float y) noexcept;
 		Vector2f(const Vector2f&) noexcept;
 		Vector2f(const Vector<Float, 2>&) noexcept;
 		Vector2f(Vector2f&&) noexcept;
@@ -165,8 +165,8 @@ namespace LiteFX::Math {
 		inline Vector2f& operator=(const Enumerable<Float>& _other) noexcept;
 		inline Vector2f& operator=(const Vector2f& _other) noexcept;
 		inline Vector2f& operator=(Vector2f&& _other) noexcept;
-		inline const Float& operator[](const unsigned int& i) const noexcept;
-		inline Float& operator[](const unsigned int& i) noexcept;
+		inline Float operator[](UInt32 i) const noexcept;
+		inline Float& operator[](UInt32 i) noexcept;
 		inline operator Enumerable<Float>() noexcept;
 
 #if defined(BUILD_WITH_GLM)
@@ -190,8 +190,8 @@ namespace LiteFX::Math {
 	class LITEFX_MATH_API Vector2u : public Vector<UInt32, 2> {
 	public:
 		Vector2u() noexcept;
-		Vector2u(const UInt32& v) noexcept;
-		Vector2u(const UInt32& x, const UInt32& y) noexcept;
+		Vector2u(UInt32 v) noexcept;
+		Vector2u(UInt32 x, UInt32 y) noexcept;
 		Vector2u(const Vector2u&) noexcept;
 		Vector2u(const Vector<UInt32, 2>&) noexcept;
 		Vector2u(Vector2u&&) noexcept;
@@ -204,8 +204,8 @@ namespace LiteFX::Math {
 		inline Vector2u& operator=(const Enumerable<UInt32>& _other) noexcept;
 		inline Vector2u& operator=(const Vector2u& _other) noexcept;
 		inline Vector2u& operator=(Vector2u&& _other) noexcept;
-		inline const UInt32& operator[](const unsigned int& i) const noexcept;
-		inline UInt32& operator[](const unsigned int& i) noexcept;
+		inline UInt32 operator[](UInt32 i) const noexcept;
+		inline UInt32& operator[](UInt32 i) noexcept;
 		inline operator Enumerable<UInt32>() noexcept;
 
 #if defined(BUILD_WITH_GLM)
@@ -229,8 +229,8 @@ namespace LiteFX::Math {
 	class LITEFX_MATH_API Vector2i : public Vector<Int32, 2> {
 	public:
 		Vector2i() noexcept;
-		Vector2i(const Int32& v) noexcept;
-		Vector2i(const Int32& x, const Int32& y) noexcept;
+		Vector2i(Int32 v) noexcept;
+		Vector2i(Int32 x, Int32 y) noexcept;
 		Vector2i(const Vector2i&) noexcept;
 		Vector2i(const Vector<Int32, 2>&) noexcept;
 		Vector2i(Vector2i&&) noexcept;
@@ -243,8 +243,8 @@ namespace LiteFX::Math {
 		inline Vector2i& operator=(const Enumerable<Int32>& _other) noexcept;
 		inline Vector2i& operator=(const Vector2i& _other) noexcept;
 		inline Vector2i& operator=(Vector2i&& _other) noexcept;
-		inline const Int32& operator[](const unsigned int& i) const noexcept;
-		inline Int32& operator[](const unsigned int& i) noexcept;
+		inline Int32 operator[](UInt32 i) const noexcept;
+		inline Int32& operator[](UInt32 i) noexcept;
 		inline operator Enumerable<Int32>() noexcept;
 
 #if defined(BUILD_WITH_GLM)
@@ -268,8 +268,8 @@ namespace LiteFX::Math {
 	class LITEFX_MATH_API Vector3f : public Vector<Float, 3> {
 	public:
 		Vector3f() noexcept;
-		Vector3f(const Float& v) noexcept;
-		Vector3f(const Float& x, const Float& y, const Float& z) noexcept;
+		Vector3f(Float v) noexcept;
+		Vector3f(Float x, Float y, Float z) noexcept;
 		Vector3f(const Vector3f&) noexcept;
 		Vector3f(const Vector<Float, 3>&) noexcept;
 		Vector3f(Vector3f&&) noexcept;
@@ -282,8 +282,8 @@ namespace LiteFX::Math {
 		inline Vector3f& operator=(const Enumerable<Float>& _other) noexcept;
 		inline Vector3f& operator=(const Vector3f& _other) noexcept;
 		inline Vector3f& operator=(Vector3f&& _other) noexcept;
-		inline const Float& operator[](const unsigned int& i) const noexcept;
-		inline Float& operator[](const unsigned int& i) noexcept;
+		inline Float operator[](UInt32 i) const noexcept;
+		inline Float& operator[](UInt32 i) noexcept;
 		inline operator Enumerable<Float>() noexcept;
 
 #if defined(BUILD_WITH_GLM)
@@ -307,8 +307,8 @@ namespace LiteFX::Math {
 	class LITEFX_MATH_API Vector3u : public Vector<UInt32, 3> {
 	public:
 		Vector3u() noexcept;
-		Vector3u(const UInt32& v) noexcept;
-		Vector3u(const UInt32& x, const UInt32& y, const UInt32& z) noexcept;
+		Vector3u(UInt32 v) noexcept;
+		Vector3u(UInt32 x, UInt32 y, UInt32 z) noexcept;
 		Vector3u(const Vector3u&) noexcept;
 		Vector3u(const Vector<UInt32, 3>&) noexcept;
 		Vector3u(Vector3u&&) noexcept;
@@ -321,8 +321,8 @@ namespace LiteFX::Math {
 		inline Vector3u& operator=(const Enumerable<UInt32>& _other) noexcept;
 		inline Vector3u& operator=(const Vector3u& _other) noexcept;
 		inline Vector3u& operator=(Vector3u&& _other) noexcept;
-		inline const UInt32& operator[](const unsigned int& i) const noexcept;
-		inline UInt32& operator[](const unsigned int& i) noexcept;
+		inline UInt32 operator[](UInt32 i) const noexcept;
+		inline UInt32& operator[](UInt32 i) noexcept;
 		inline operator Enumerable<UInt32>() noexcept;
 
 #if defined(BUILD_WITH_GLM)
@@ -346,8 +346,8 @@ namespace LiteFX::Math {
 	class LITEFX_MATH_API Vector3i : public Vector<Int32, 3> {
 	public:
 		Vector3i() noexcept;
-		Vector3i(const Int32& v) noexcept;
-		Vector3i(const Int32& x, const Int32& y, const Int32& z) noexcept;
+		Vector3i(Int32 v) noexcept;
+		Vector3i(Int32 x, Int32 y, Int32 z) noexcept;
 		Vector3i(const Vector3i&) noexcept;
 		Vector3i(const Vector<Int32, 3>&) noexcept;
 		Vector3i(Vector3i&&) noexcept;
@@ -360,8 +360,8 @@ namespace LiteFX::Math {
 		inline Vector3i& operator=(const Enumerable<Int32>& _other) noexcept;
 		inline Vector3i& operator=(const Vector3i& _other) noexcept;
 		inline Vector3i& operator=(Vector3i&& _other) noexcept;
-		inline const Int32& operator[](const unsigned int& i) const noexcept;
-		inline Int32& operator[](const unsigned int& i) noexcept;
+		inline Int32 operator[](UInt32 i) const noexcept;
+		inline Int32& operator[](UInt32 i) noexcept;
 		inline operator Enumerable<Int32>() noexcept;
 
 #if defined(BUILD_WITH_GLM)
@@ -385,8 +385,8 @@ namespace LiteFX::Math {
 	class LITEFX_MATH_API Vector4f : public Vector<Float, 4> {
 	public:
 		Vector4f() noexcept;
-		Vector4f(const Float& v) noexcept;
-		Vector4f(const Float& x, const Float& y, const Float& z, const Float& w) noexcept;
+		Vector4f(Float v) noexcept;
+		Vector4f(Float x, Float y, Float z, Float w) noexcept;
 		Vector4f(const Vector4f&) noexcept;
 		Vector4f(const Vector<Float, 4>&) noexcept;
 		Vector4f(Vector4f&&) noexcept;
@@ -399,8 +399,8 @@ namespace LiteFX::Math {
 		inline Vector4f& operator=(const Enumerable<Float>& _other) noexcept;
 		inline Vector4f& operator=(const Vector4f& _other) noexcept;
 		inline Vector4f& operator=(Vector4f&& _other) noexcept;
-		inline const Float& operator[](const unsigned int& i) const noexcept;
-		inline Float& operator[](const unsigned int& i) noexcept;
+		inline Float operator[](UInt32 i) const noexcept;
+		inline Float& operator[](UInt32 i) noexcept;
 		inline operator Enumerable<Float>() noexcept;
 
 #if defined(BUILD_WITH_GLM)
@@ -424,8 +424,8 @@ namespace LiteFX::Math {
 	class LITEFX_MATH_API Vector4u : public Vector<UInt32, 4> {
 	public:
 		Vector4u() noexcept;
-		Vector4u(const UInt32& v) noexcept;
-		Vector4u(const UInt32& x, const UInt32& y, const UInt32& z, const UInt32& w) noexcept;
+		Vector4u(UInt32 v) noexcept;
+		Vector4u(UInt32 x, UInt32 y, UInt32 z, UInt32 w) noexcept;
 		Vector4u(const Vector4u&) noexcept;
 		Vector4u(const Vector<UInt32, 4>&) noexcept;
 		Vector4u(Vector4u&&) noexcept;
@@ -438,8 +438,8 @@ namespace LiteFX::Math {
 		inline Vector4u& operator=(const Enumerable<UInt32>& _other) noexcept;
 		inline Vector4u& operator=(const Vector4u& _other) noexcept;
 		inline Vector4u& operator=(Vector4u&& _other) noexcept;
-		inline const UInt32& operator[](const unsigned int& i) const noexcept;
-		inline UInt32& operator[](const unsigned int& i) noexcept;
+		inline UInt32 operator[](UInt32 i) const noexcept;
+		inline UInt32& operator[](UInt32 i) noexcept;
 		inline operator Enumerable<UInt32>() noexcept;
 
 #if defined(BUILD_WITH_GLM)
@@ -463,8 +463,8 @@ namespace LiteFX::Math {
 	class LITEFX_MATH_API Vector4i : public Vector<Int32, 4> {
 	public:
 		Vector4i() noexcept;
-		Vector4i(const Int32& v) noexcept;
-		Vector4i(const Int32& x, const Int32& y, const Int32& z, const Int32& w) noexcept;
+		Vector4i(Int32 v) noexcept;
+		Vector4i(Int32 x, Int32 y, Int32 z, Int32 w) noexcept;
 		Vector4i(const Vector4i&) noexcept;
 		Vector4i(const Vector<Int32, 4>&) noexcept;
 		Vector4i(Vector4i&&) noexcept;
@@ -477,8 +477,8 @@ namespace LiteFX::Math {
 		inline Vector4i& operator=(const Enumerable<Int32>& _other) noexcept;
 		inline Vector4i& operator=(const Vector4i& _other) noexcept;
 		inline Vector4i& operator=(Vector4i&& _other) noexcept;
-		inline const Int32& operator[](const unsigned int& i) const noexcept;
-		inline Int32& operator[](const unsigned int& i) noexcept;
+		inline Int32 operator[](UInt32 i) const noexcept;
+		inline Int32& operator[](UInt32 i) noexcept;
 		inline operator Enumerable<Int32>() noexcept;
 
 #if defined(BUILD_WITH_GLM)
@@ -544,8 +544,8 @@ namespace LiteFX::Math {
 	class LITEFX_MATH_API Size4d : public Vector<size_t, 4> {
 	public:
 		Size4d() noexcept;
-		Size4d(const size_t& v) noexcept;
-		Size4d(const size_t& w, const size_t& h, const size_t& d, const size_t& a) noexcept;
+		Size4d(size_t v) noexcept;
+		Size4d(size_t w, size_t h, size_t d, size_t a) noexcept;
 		Size4d(const Size4d&) noexcept;
 		Size4d(Size4d&&) noexcept;
 		//virtual ~Size4d() noexcept = default;
@@ -553,31 +553,31 @@ namespace LiteFX::Math {
 	public:
 		inline Size4d& operator=(const Size4d& _other) noexcept;
 		inline Size4d& operator=(Size4d&& _other) noexcept;
-		inline Size4d operator/(const size_t& s) noexcept;
-		inline Size4d& operator/=(const size_t& s) noexcept;
-		inline Size4d operator*(const size_t& s) noexcept;
-		inline Size4d& operator*=(const size_t& s) noexcept;
+		inline Size4d operator/(size_t s) noexcept;
+		inline Size4d& operator/=(size_t s) noexcept;
+		inline Size4d operator*(size_t s) noexcept;
+		inline Size4d& operator*=(size_t s) noexcept;
 		inline Size4d operator+(const Size4d& s) noexcept;
 		inline Size4d& operator+=(const Size4d& s) noexcept;
 		inline Size4d operator-(const Size4d& s) noexcept;
 		inline Size4d& operator-=(const Size4d& s) noexcept;
 
 	public:
-		inline const size_t& width() const noexcept;
+		inline size_t width() const noexcept;
 		inline size_t& width() noexcept;
-		inline const size_t& height() const noexcept;
+		inline size_t height() const noexcept;
 		inline size_t& height() noexcept;
-		inline const size_t& depth() const noexcept;
+		inline size_t depth() const noexcept;
 		inline size_t& depth() noexcept;
-		inline const size_t& alpha() const noexcept;
+		inline size_t alpha() const noexcept;
 		inline size_t& alpha() noexcept;
 	};
 
 	class LITEFX_MATH_API Size3d : public Vector<size_t, 3> {
 	public:
 		Size3d() noexcept;
-		Size3d(const size_t& v) noexcept;
-		Size3d(const size_t& w, const size_t& h, const size_t& d) noexcept;
+		Size3d(size_t v) noexcept;
+		Size3d(size_t w, size_t h, size_t d) noexcept;
 		Size3d(const Size3d&) noexcept;
 		Size3d(Size3d&&) noexcept;
 		//virtual ~Size3d() noexcept = default;
@@ -586,29 +586,29 @@ namespace LiteFX::Math {
 		inline Size3d& operator=(const Size3d& _other) noexcept;
 		inline Size3d& operator=(Size3d&& _other) noexcept;
 		inline operator Size4d() const noexcept;
-		inline Size3d operator/(const size_t& s) noexcept;
-		inline Size3d& operator/=(const size_t& s) noexcept;
-		inline Size3d operator*(const size_t& s) noexcept;
-		inline Size3d& operator*=(const size_t& s) noexcept;
+		inline Size3d operator/(size_t s) noexcept;
+		inline Size3d& operator/=(size_t s) noexcept;
+		inline Size3d operator*(size_t s) noexcept;
+		inline Size3d& operator*=(size_t s) noexcept;
 		inline Size3d operator+(const Size3d& s) noexcept;
 		inline Size3d& operator+=(const Size3d& s) noexcept;
 		inline Size3d operator-(const Size3d& s) noexcept;
 		inline Size3d& operator-=(const Size3d& s) noexcept;
 
 	public:
-		inline const size_t& width() const noexcept;
+		inline size_t width() const noexcept;
 		inline size_t& width() noexcept;
-		inline const size_t& height() const noexcept;
+		inline size_t height() const noexcept;
 		inline size_t& height() noexcept;
-		inline const size_t& depth() const noexcept;
+		inline size_t depth() const noexcept;
 		inline size_t& depth() noexcept;
 	};
 
 	class LITEFX_MATH_API Size2d : public Vector<size_t, 2> {
 	public:
 		Size2d() noexcept;
-		Size2d(const size_t& v) noexcept;
-		Size2d(const size_t& w, const size_t& h) noexcept;
+		Size2d(size_t v) noexcept;
+		Size2d(size_t w, size_t h) noexcept;
 		Size2d(const Size2d&) noexcept;
 		Size2d(Size2d&&) noexcept;
 		//virtual ~Size2d() noexcept = default;
@@ -618,19 +618,19 @@ namespace LiteFX::Math {
 		inline Size2d& operator=(Size2d&& _other) noexcept;
 		inline operator Size3d() const noexcept;
 		inline operator Size4d() const noexcept;
-		inline Size2d operator/(const size_t& s) noexcept;
-		inline Size2d& operator/=(const size_t& s) noexcept;
-		inline Size2d operator*(const size_t& s) noexcept;
-		inline Size2d& operator*=(const size_t& s) noexcept;
+		inline Size2d operator/(size_t s) noexcept;
+		inline Size2d& operator/=(size_t s) noexcept;
+		inline Size2d operator*(size_t s) noexcept;
+		inline Size2d& operator*=(size_t s) noexcept;
 		inline Size2d operator+(const Size2d& s) noexcept;
 		inline Size2d& operator+=(const Size2d& s) noexcept;
 		inline Size2d operator-(const Size2d& s) noexcept;
 		inline Size2d& operator-=(const Size2d& s) noexcept;
 
 	public:
-		inline const size_t& width() const noexcept;
+		inline size_t width() const noexcept;
 		inline size_t& width() noexcept;
-		inline const size_t& height() const noexcept;
+		inline size_t height() const noexcept;
 		inline size_t& height() noexcept;
 	};
 #pragma endregion
@@ -639,8 +639,8 @@ namespace LiteFX::Math {
 	class LITEFX_MATH_API Rect : public Vector<size_t, 4> {
 	public:
 		Rect() noexcept;
-		Rect(const Vector<size_t, 2>& pos, const size_t& w, const size_t& h) noexcept;
-		Rect(const size_t& x, const size_t& y, const size_t& w, const size_t& h) noexcept;
+		Rect(const Vector<size_t, 2>& pos, size_t w, size_t h) noexcept;
+		Rect(size_t x, size_t y, size_t w, size_t h) noexcept;
 		Rect(const Rect&) noexcept;
 		Rect(Rect&&) noexcept;
 		//virtual ~Rect() noexcept = default;
@@ -652,17 +652,17 @@ namespace LiteFX::Math {
 	public:
 		inline Vector<size_t, 2> position() const noexcept;
 		inline Size2d extent() const noexcept;
-		inline const size_t& width() const noexcept;
+		inline size_t width() const noexcept;
 		inline size_t& width() noexcept;
-		inline const size_t& height() const noexcept;
+		inline size_t height() const noexcept;
 		inline size_t& height() noexcept;
 	};
 
 	class LITEFX_MATH_API RectI : public Vector<Int32, 4> {
 	public:
 		RectI() noexcept;
-		RectI(const Vector<Int32, 2>& pos, const Int32& w, const Int32& h) noexcept;
-		RectI(const Int32& x, const Int32& y, const Int32& w, const Int32& h) noexcept;
+		RectI(const Vector<Int32, 2>& pos, Int32 w, Int32 h) noexcept;
+		RectI(Int32 x, Int32 y, Int32 w, Int32 h) noexcept;
 		RectI(const RectI&) noexcept;
 		RectI(RectI&&) noexcept;
 		//virtual ~RectI() noexcept = default;
@@ -674,17 +674,17 @@ namespace LiteFX::Math {
 	public:
 		inline Vector<Int32, 2> position() const noexcept;
 		inline Size2d extent() const noexcept;
-		inline const Int32& width() const noexcept;
+		inline Int32 width() const noexcept;
 		inline Int32& width() noexcept;
-		inline const Int32& height() const noexcept;
+		inline Int32 height() const noexcept;
 		inline Int32& height() noexcept;
 	};
 
 	class LITEFX_MATH_API RectF : public Vector<Float, 4> {
 	public:
 		RectF() noexcept;
-		RectF(const Vector<Float, 2>& pos, const Float& w, const Float& h) noexcept;
-		RectF(const Float& x, const Float& y, const Float& w, const Float& h) noexcept;
+		RectF(const Vector<Float, 2>& pos, Float w, Float h) noexcept;
+		RectF(Float x, Float y, Float w, Float h) noexcept;
 		RectF(const RectF&) noexcept;
 		RectF(RectF&&) noexcept;
 		//virtual ~RectF() noexcept = default;
@@ -696,9 +696,9 @@ namespace LiteFX::Math {
 	public:
 		inline Vector<Float, 2> position() const noexcept;
 		inline Size2d extent() const noexcept;
-		inline const Float& width() const noexcept;
+		inline Float width() const noexcept;
 		inline Float& width() noexcept;
-		inline const Float& height() const noexcept;
+		inline Float height() const noexcept;
 		inline Float& height() noexcept;
 	};
 #pragma endregion

--- a/src/Math/include/litefx/vector.hpp
+++ b/src/Math/include/litefx/vector.hpp
@@ -19,7 +19,7 @@ namespace LiteFX::Math {
 	public:
 		Vector() noexcept = default;
 
-		Vector(const T& val) noexcept {
+		Vector(T val) noexcept {
 			std::fill(std::begin(m_elements), std::end(m_elements), val);
 		}
 
@@ -56,13 +56,13 @@ namespace LiteFX::Math {
 			return *this;
 		}
 
-		inline const T& operator[](const unsigned int& i) const noexcept {
+		inline T operator[](unsigned int i) const noexcept {
 			assert(i < DIM);
 
 			return m_elements[i];
 		}
 
-		inline T& operator[](const unsigned int& i) noexcept {
+		inline T& operator[](unsigned int i) noexcept {
 			assert(i < DIM);
 
 			return m_elements[i];
@@ -85,7 +85,7 @@ namespace LiteFX::Math {
 			return vec_size;
 		}
 
-		inline const scalar_type& x() const noexcept requires (DIM > 0) {
+		inline scalar_type x() const noexcept requires (DIM > 0) {
 			return m_elements[0];
 		}
 
@@ -93,7 +93,7 @@ namespace LiteFX::Math {
 			return m_elements[0];
 		}
 
-		inline const scalar_type& y() const noexcept requires (DIM > 1) {
+		inline scalar_type y() const noexcept requires (DIM > 1) {
 			return m_elements[1];
 		}
 
@@ -101,7 +101,7 @@ namespace LiteFX::Math {
 			return m_elements[1];
 		}
 
-		inline const scalar_type& z() const noexcept requires (DIM > 2) {
+		inline scalar_type z() const noexcept requires (DIM > 2) {
 			return m_elements[2];
 		}
 
@@ -109,7 +109,7 @@ namespace LiteFX::Math {
 			return m_elements[2];
 		}
 
-		inline const scalar_type& w() const noexcept requires (DIM > 3) {
+		inline scalar_type w() const noexcept requires (DIM > 3) {
 			return m_elements[3];
 		}
 

--- a/src/Math/src/rect.cpp
+++ b/src/Math/src/rect.cpp
@@ -10,14 +10,14 @@ Rect::Rect() noexcept : Vector<scalar_type, vec_size>() {}
 Rect::Rect(const Rect& _other) noexcept : Vector<scalar_type, vec_size>(static_cast<Vector<scalar_type, vec_size>>(_other)) {}
 Rect::Rect(Rect&& _other) noexcept : Vector<scalar_type, vec_size>(std::move(static_cast<Vector<scalar_type, vec_size>>(_other))) {}
 
-Rect::Rect(const Vector<size_t, 2>& pos, const size_t& w, const size_t& h) noexcept : Vector<scalar_type, vec_size>() {
+Rect::Rect(const Vector<size_t, 2>& pos, size_t w, size_t h) noexcept : Vector<scalar_type, vec_size>() {
 	this->x() = pos.x();
 	this->y() = pos.y();
 	this->z() = w;
 	this->w() = h;
 }
 
-Rect::Rect(const size_t& x, const size_t& y, const size_t& w, const size_t& h) noexcept : Vector<scalar_type, vec_size>() {
+Rect::Rect(size_t x, size_t y, size_t w, size_t h) noexcept : Vector<scalar_type, vec_size>() {
 	this->x() = x;
 	this->y() = y;
 	this->z() = w;
@@ -45,7 +45,7 @@ Size2d Rect::extent() const noexcept {
 	return Size2d(this->z(), this->w());
 }
 
-const size_t& Rect::width() const noexcept {
+size_t Rect::width() const noexcept {
 	return this->z();
 }
 
@@ -53,7 +53,7 @@ size_t& Rect::width() noexcept {
 	return this->z();
 }
 
-const size_t& Rect::height() const noexcept {
+size_t Rect::height() const noexcept {
 	return this->w();
 }
 
@@ -69,14 +69,14 @@ RectI::RectI() noexcept : Vector<scalar_type, vec_size>() {}
 RectI::RectI(const RectI& _other) noexcept : Vector<scalar_type, vec_size>(static_cast<Vector<scalar_type, vec_size>>(_other)) {}
 RectI::RectI(RectI&& _other) noexcept : Vector<scalar_type, vec_size>(std::move(static_cast<Vector<scalar_type, vec_size>>(_other))) {}
 
-RectI::RectI(const Vector<Int32, 2>& pos, const Int32& w, const Int32& h) noexcept : Vector<scalar_type, vec_size>() {
+RectI::RectI(const Vector<Int32, 2>& pos, Int32 w, Int32 h) noexcept : Vector<scalar_type, vec_size>() {
 	this->x() = pos.x();
 	this->y() = pos.y();
 	this->z() = w;
 	this->w() = h;
 }
 
-RectI::RectI(const Int32& x, const Int32& y, const Int32& w, const Int32& h) noexcept : Vector<scalar_type, vec_size>() {
+RectI::RectI(Int32 x, Int32 y, Int32 w, Int32 h) noexcept : Vector<scalar_type, vec_size>() {
 	this->x() = x;
 	this->y() = y;
 	this->z() = w;
@@ -101,7 +101,7 @@ Size2d RectI::extent() const noexcept {
 	return Size2d(this->z(), this->w());
 }
 
-const Int32& RectI::width() const noexcept {
+Int32 RectI::width() const noexcept {
 	return this->z();
 }
 
@@ -109,7 +109,7 @@ Int32& RectI::width() noexcept {
 	return this->z();
 }
 
-const Int32& RectI::height() const noexcept {
+Int32 RectI::height() const noexcept {
 	return this->w();
 }
 
@@ -125,14 +125,14 @@ RectF::RectF() noexcept : Vector<scalar_type, vec_size>() {}
 RectF::RectF(const RectF& _other) noexcept : Vector<scalar_type, vec_size>(static_cast<Vector<scalar_type, vec_size>>(_other)) {}
 RectF::RectF(RectF&& _other) noexcept : Vector<scalar_type, vec_size>(std::move(static_cast<Vector<scalar_type, vec_size>>(_other))) {}
 
-RectF::RectF(const Vector<Float, 2>& pos, const Float& w, const Float& h) noexcept : Vector<scalar_type, vec_size>() {
+RectF::RectF(const Vector<Float, 2>& pos, Float w, Float h) noexcept : Vector<scalar_type, vec_size>() {
 	this->x() = pos.x();
 	this->y() = pos.y();
 	this->z() = w;
 	this->w() = h;
 }
 
-RectF::RectF(const Float& x, const Float& y, const Float& w, const Float& h) noexcept : Vector<scalar_type, vec_size>() {
+RectF::RectF(Float x, Float y, Float w, Float h) noexcept : Vector<scalar_type, vec_size>() {
 	this->x() = x;
 	this->y() = y;
 	this->z() = w;
@@ -157,7 +157,7 @@ Size2d RectF::extent() const noexcept {
 	return Size2d(this->z(), this->w());
 }
 
-const Float& RectF::width() const noexcept {
+Float RectF::width() const noexcept {
 	return this->z();
 }
 
@@ -165,7 +165,7 @@ Float& RectF::width() noexcept {
 	return this->z();
 }
 
-const Float& RectF::height() const noexcept {
+Float RectF::height() const noexcept {
 	return this->w();
 }
 

--- a/src/Math/src/size.cpp
+++ b/src/Math/src/size.cpp
@@ -7,8 +7,8 @@ using namespace LiteFX::Math;
 // ------------------------------------------------------------------------------------------------
 
 Size2d::Size2d() noexcept : Vector<scalar_type, vec_size>() {}
-Size2d::Size2d(const size_t& v) noexcept : Vector<scalar_type, vec_size>(v) {}
-Size2d::Size2d(const size_t& w, const size_t& h) noexcept : Vector<scalar_type, vec_size>() {
+Size2d::Size2d(size_t v) noexcept : Vector<scalar_type, vec_size>(v) {}
+Size2d::Size2d(size_t w, size_t h) noexcept : Vector<scalar_type, vec_size>() {
     this->x() = w;
     this->y() = h;
 }
@@ -28,18 +28,18 @@ Size2d& Size2d::operator=(Size2d&& _other) noexcept {
 
 Size2d::operator Size3d() const noexcept { return Size3d{ this->width(), this->height(), 1 }; }
 Size2d::operator Size4d() const noexcept { return Size4d{ this->width(), this->height(), 1, 1 }; }
-Size2d Size2d::operator/(const size_t& s) noexcept { return Size2d{ this->width() / s, this->height() / s }; }
-Size2d& Size2d::operator/=(const size_t& s) noexcept { this->width() /= s; this->height() /= s; return *this; }
-Size2d Size2d::operator*(const size_t& s) noexcept { return Size2d{ this->width() * s, this->height() * s }; }
-Size2d& Size2d::operator*=(const size_t& s) noexcept { this->width() *= s; this->height() *= s; return *this; }
+Size2d Size2d::operator/(size_t s) noexcept { return Size2d{ this->width() / s, this->height() / s }; }
+Size2d& Size2d::operator/=(size_t s) noexcept { this->width() /= s; this->height() /= s; return *this; }
+Size2d Size2d::operator*(size_t s) noexcept { return Size2d{ this->width() * s, this->height() * s }; }
+Size2d& Size2d::operator*=(size_t s) noexcept { this->width() *= s; this->height() *= s; return *this; }
 Size2d Size2d::operator+(const Size2d& s) noexcept { return Size2d{ this->width() + s.width(), this->height() + s.height() }; }
 Size2d& Size2d::operator+=(const Size2d& s) noexcept { this->width() += s.width(); this->height() += s.height(); return *this; }
 Size2d Size2d::operator-(const Size2d& s) noexcept { return Size2d{ this->width() - s.width(), this->height() - s.height() }; }
 Size2d& Size2d::operator-=(const Size2d& s) noexcept { this->width() -= s.width(); this->height() -= s.height(); return *this; }
 
-const size_t& Size2d::width() const noexcept{ return this->x(); }
+size_t Size2d::width() const noexcept{ return this->x(); }
 size_t& Size2d::width() noexcept { return this->x(); }
-const size_t& Size2d::height() const noexcept { return this->y(); }
+size_t Size2d::height() const noexcept { return this->y(); }
 size_t& Size2d::height() noexcept { return this->y(); }
 
 // ------------------------------------------------------------------------------------------------
@@ -47,8 +47,8 @@ size_t& Size2d::height() noexcept { return this->y(); }
 // ------------------------------------------------------------------------------------------------
 
 Size3d::Size3d() noexcept : Vector<scalar_type, vec_size>() {}
-Size3d::Size3d(const size_t& v) noexcept : Vector<scalar_type, vec_size>(v) {}
-Size3d::Size3d(const size_t& w, const size_t& h, const size_t& d) noexcept : Vector<scalar_type, vec_size>() {
+Size3d::Size3d(size_t v) noexcept : Vector<scalar_type, vec_size>(v) {}
+Size3d::Size3d(size_t w, size_t h, size_t d) noexcept : Vector<scalar_type, vec_size>() {
     this->x() = w;
     this->y() = h;
     this->z() = d;
@@ -68,19 +68,19 @@ Size3d& Size3d::operator=(Size3d&& _other) noexcept {
 }
 
 Size3d::operator Size4d() const noexcept { return Size4d{ this->width(), this->height(), this->depth(), 1 }; }
-Size3d Size3d::operator/(const size_t& s) noexcept { return Size3d{ this->width() / s, this->height() / s, this->depth() / s }; }
-Size3d& Size3d::operator/=(const size_t& s) noexcept { this->width() /= s; this->height() /= s; this->depth() /= s; return *this; }
-Size3d Size3d::operator*(const size_t& s) noexcept { return Size3d{ this->width() * s, this->height() * s, this->depth() * s }; }
-Size3d& Size3d::operator*=(const size_t& s) noexcept { this->width() *= s; this->height() *= s; this->depth() *= s; return *this; }
+Size3d Size3d::operator/(size_t s) noexcept { return Size3d{ this->width() / s, this->height() / s, this->depth() / s }; }
+Size3d& Size3d::operator/=(size_t s) noexcept { this->width() /= s; this->height() /= s; this->depth() /= s; return *this; }
+Size3d Size3d::operator*(size_t s) noexcept { return Size3d{ this->width() * s, this->height() * s, this->depth() * s }; }
+Size3d& Size3d::operator*=(size_t s) noexcept { this->width() *= s; this->height() *= s; this->depth() *= s; return *this; }
 Size3d Size3d::operator+(const Size3d& s) noexcept { return Size3d{ this->width() + s.width(), this->height() + s.height(), this->depth() + s.depth() }; }
 Size3d& Size3d::operator+=(const Size3d& s) noexcept { this->width() += s.width(); this->height() += s.height(); this->depth() += s.depth() ; return *this; }
 Size3d Size3d::operator-(const Size3d& s) noexcept { return Size3d{ this->width() - s.width(), this->height() - s.height(), this->depth() - s.depth() }; }
 Size3d& Size3d::operator-=(const Size3d& s) noexcept { this->width() -= s.width(); this->height() -= s.height(); this->depth() -= s.depth(); return *this; }
-const size_t& Size3d::width() const noexcept { return this->x(); }
+size_t Size3d::width() const noexcept { return this->x(); }
 size_t& Size3d::width() noexcept { return this->x(); }
-const size_t& Size3d::height() const noexcept { return this->y(); }
+size_t Size3d::height() const noexcept { return this->y(); }
 size_t& Size3d::height() noexcept { return this->y(); }
-const size_t& Size3d::depth() const noexcept { return this->z(); }
+size_t Size3d::depth() const noexcept { return this->z(); }
 size_t& Size3d::depth() noexcept { return this->z(); }
 
 // ------------------------------------------------------------------------------------------------
@@ -88,8 +88,8 @@ size_t& Size3d::depth() noexcept { return this->z(); }
 // ------------------------------------------------------------------------------------------------
 
 Size4d::Size4d() noexcept : Vector<scalar_type, vec_size>() {}
-Size4d::Size4d(const size_t& v) noexcept : Vector<scalar_type, vec_size>(v) {}
-Size4d::Size4d(const size_t& w, const size_t& h, const size_t& d, const size_t& a) noexcept : Vector<scalar_type, vec_size>() {
+Size4d::Size4d(size_t v) noexcept : Vector<scalar_type, vec_size>(v) {}
+Size4d::Size4d(size_t w, size_t h, size_t d, size_t a) noexcept : Vector<scalar_type, vec_size>() {
     this->x() = w;
     this->y() = h;
     this->z() = d;
@@ -109,20 +109,20 @@ Size4d& Size4d::operator=(Size4d&& _other) noexcept {
     return *this;
 }
 
-Size4d Size4d::operator/(const size_t& s) noexcept { return Size4d{ this->width() / s, this->height() / s, this->depth() / s, this->alpha() / s }; }
-Size4d& Size4d::operator/=(const size_t& s) noexcept { this->width() /= s; this->height() /= s; this->depth() /= s; this->alpha() /= s; return *this; }
-Size4d Size4d::operator*(const size_t& s) noexcept { return Size4d{ this->width() * s, this->height() * s, this->depth() * s, this->alpha() * s }; }
-Size4d& Size4d::operator*=(const size_t& s) noexcept { this->width() *= s; this->height() *= s; this->depth() *= s; this->alpha() *= s; return *this; }
+Size4d Size4d::operator/(size_t s) noexcept { return Size4d{ this->width() / s, this->height() / s, this->depth() / s, this->alpha() / s }; }
+Size4d& Size4d::operator/=(size_t s) noexcept { this->width() /= s; this->height() /= s; this->depth() /= s; this->alpha() /= s; return *this; }
+Size4d Size4d::operator*(size_t s) noexcept { return Size4d{ this->width() * s, this->height() * s, this->depth() * s, this->alpha() * s }; }
+Size4d& Size4d::operator*=(size_t s) noexcept { this->width() *= s; this->height() *= s; this->depth() *= s; this->alpha() *= s; return *this; }
 Size4d Size4d::operator+(const Size4d& s) noexcept { return Size4d{ this->width() + s.width(), this->height() + s.height(), this->depth() + s.depth(), this->alpha() + s.alpha() }; }
 Size4d& Size4d::operator+=(const Size4d& s) noexcept { this->width() += s.width(); this->height() += s.height(); this->depth() += s.depth(); this->alpha() += s.alpha(); return *this; }
 Size4d Size4d::operator-(const Size4d& s) noexcept { return Size4d{ this->width() - s.width(), this->height() - s.height(), this->depth() - s.depth(), this->alpha() - s.alpha() }; }
 Size4d& Size4d::operator-=(const Size4d& s) noexcept { this->width() -= s.width(); this->height() -= s.height(); this->depth() -= s.depth(); this->alpha() -= s.alpha(); return *this; }
 
-const size_t& Size4d::width() const noexcept { return this->x(); }
+size_t Size4d::width() const noexcept { return this->x(); }
 size_t& Size4d::width() noexcept { return this->x(); }
-const size_t& Size4d::height() const noexcept { return this->y(); }
+size_t Size4d::height() const noexcept { return this->y(); }
 size_t& Size4d::height() noexcept { return this->y(); }
-const size_t& Size4d::depth() const noexcept { return this->z(); }
+size_t Size4d::depth() const noexcept { return this->z(); }
 size_t& Size4d::depth() noexcept { return this->z(); }
-const size_t& Size4d::alpha() const noexcept { return this->w(); }
+size_t Size4d::alpha() const noexcept { return this->w(); }
 size_t& Size4d::alpha() noexcept { return this->w(); }

--- a/src/Math/src/vector.cpp
+++ b/src/Math/src/vector.cpp
@@ -7,7 +7,7 @@ using namespace LiteFX::Math;
 // ------------------------------------------------------------------------------------------------
 
 Vector1f::Vector1f() noexcept : Vector<Float, 1>() { }
-Vector1f::Vector1f(const Float& v) noexcept : Vector<Float, 1>(v) { }
+Vector1f::Vector1f(Float v) noexcept : Vector<Float, 1>(v) { }
 Vector1f::Vector1f(const Vector1f& _v) noexcept : Vector<Float, 1>(_v) { }
 Vector1f::Vector1f(const Vector<Float, 1>& _v) noexcept : Vector<Float, 1>(_v) { }
 Vector1f::Vector1f(Vector1f&& _v) noexcept : Vector<Float, 1>(_v) { }
@@ -36,11 +36,11 @@ Vector1f& Vector1f::operator=(Vector1f&& _other) noexcept {
     return this->operator=(std::move(static_cast<Vector<scalar_type, vec_size>>(_other)));
 }
 
-const Float& Vector1f::operator[](const unsigned int& i) const noexcept {
+Float Vector1f::operator[](UInt32 i) const noexcept {
     return Vector<Float, 1>::operator[](i);
 }
 
-Float& Vector1f::operator[](const unsigned int& i) noexcept {
+Float& Vector1f::operator[](UInt32 i) noexcept {
     return Vector<Float, 1>::operator[](i);
 }
 
@@ -81,7 +81,7 @@ Vector1f::operator DirectX::XMVECTOR() const noexcept {
 // ------------------------------------------------------------------------------------------------
 
 Vector1u::Vector1u() noexcept : Vector<UInt32, 1>() { }
-Vector1u::Vector1u(const UInt32& v) noexcept : Vector<UInt32, 1>(v) { }
+Vector1u::Vector1u(UInt32 v) noexcept : Vector<UInt32, 1>(v) { }
 Vector1u::Vector1u(const Vector1u& _v) noexcept : Vector<UInt32, 1>(_v) { }
 Vector1u::Vector1u(const Vector<UInt32, 1>& _v) noexcept : Vector<UInt32, 1>(_v) { }
 Vector1u::Vector1u(Vector1u&& _v) noexcept : Vector<UInt32, 1>(_v) { }
@@ -113,11 +113,11 @@ Vector1u& Vector1u::operator=(Vector1u&& _other) noexcept {
     return this->operator=(std::move(static_cast<Vector<scalar_type, vec_size>>(_other)));
 }
 
-const UInt32& Vector1u::operator[](const unsigned int& i) const noexcept {
+UInt32 Vector1u::operator[](UInt32 i) const noexcept {
     return Vector<UInt32, 1>::operator[](i);
 }
 
-UInt32& Vector1u::operator[](const unsigned int& i) noexcept {
+UInt32& Vector1u::operator[](UInt32 i) noexcept {
     return Vector<UInt32, 1>::operator[](i);
 }
 
@@ -158,8 +158,8 @@ Vector1u::operator DirectX::XMVECTOR() const noexcept {
 // ------------------------------------------------------------------------------------------------
 
 Vector2f::Vector2f() noexcept : Vector<Float, 2>() { }
-Vector2f::Vector2f(const Float& v) noexcept : Vector<Float, 2>(v) { }
-Vector2f::Vector2f(const Float& x, const Float& y) noexcept : Vector<Float, 2>() { 
+Vector2f::Vector2f(Float v) noexcept : Vector<Float, 2>(v) { }
+Vector2f::Vector2f(Float x, Float y) noexcept : Vector<Float, 2>() { 
     this->x() = x;
     this->y() = y;
 }
@@ -192,11 +192,11 @@ Vector2f& Vector2f::operator=(Vector2f&& _other) noexcept {
     return this->operator=(std::move(static_cast<Vector<scalar_type, vec_size>>(_other)));
 }
 
-const Float& Vector2f::operator[](const unsigned int& i) const noexcept {
+Float Vector2f::operator[](UInt32 i) const noexcept {
     return Vector<Float, 2>::operator[](i);
 }
 
-Float& Vector2f::operator[](const unsigned int& i) noexcept {
+Float& Vector2f::operator[](UInt32 i) noexcept {
     return Vector<Float, 2>::operator[](i);
 }
 
@@ -260,8 +260,8 @@ Vector2f::operator DirectX::XMFLOAT2() const noexcept {
 // ------------------------------------------------------------------------------------------------
 
 Vector2u::Vector2u() noexcept : Vector<UInt32, 2>() { }
-Vector2u::Vector2u(const UInt32& v) noexcept : Vector<UInt32, 2>(v) { }
-Vector2u::Vector2u(const UInt32& x, const UInt32& y) noexcept : Vector<UInt32, 2>() {
+Vector2u::Vector2u(UInt32 v) noexcept : Vector<UInt32, 2>(v) { }
+Vector2u::Vector2u(UInt32 x, UInt32 y) noexcept : Vector<UInt32, 2>() {
     this->x() = x;
     this->y() = y;
 }
@@ -294,11 +294,11 @@ Vector2u& Vector2u::operator=(Vector2u&& _other) noexcept {
     return this->operator=(std::move(static_cast<Vector<scalar_type, vec_size>>(_other)));
 }
 
-const UInt32& Vector2u::operator[](const unsigned int& i) const noexcept {
+UInt32 Vector2u::operator[](UInt32 i) const noexcept {
     return Vector<UInt32, 2>::operator[](i);
 }
 
-UInt32& Vector2u::operator[](const unsigned int& i) noexcept {
+UInt32& Vector2u::operator[](UInt32 i) noexcept {
     return Vector<UInt32, 2>::operator[](i);
 }
 
@@ -362,8 +362,8 @@ Vector2u::operator DirectX::XMUINT2() const noexcept {
 // ------------------------------------------------------------------------------------------------
 
 Vector2i::Vector2i() noexcept : Vector<Int32, 2>() { }
-Vector2i::Vector2i(const Int32& v) noexcept : Vector<Int32, 2>(v) { }
-Vector2i::Vector2i(const Int32& x, const Int32& y) noexcept : Vector<Int32, 2>() {
+Vector2i::Vector2i(Int32 v) noexcept : Vector<Int32, 2>(v) { }
+Vector2i::Vector2i(Int32 x, Int32 y) noexcept : Vector<Int32, 2>() {
     this->x() = x;
     this->y() = y;
 }
@@ -396,11 +396,11 @@ Vector2i& Vector2i::operator=(Vector2i&& _other) noexcept {
     return this->operator=(std::move(static_cast<Vector<scalar_type, vec_size>>(_other)));
 }
 
-const Int32& Vector2i::operator[](const unsigned int& i) const noexcept {
+Int32 Vector2i::operator[](UInt32 i) const noexcept {
     return Vector<Int32, 2>::operator[](i);
 }
 
-Int32& Vector2i::operator[](const unsigned int& i) noexcept {
+Int32& Vector2i::operator[](UInt32 i) noexcept {
     return Vector<Int32, 2>::operator[](i);
 }
 
@@ -464,8 +464,8 @@ Vector2i::operator DirectX::XMINT2() const noexcept {
 // ------------------------------------------------------------------------------------------------
 
 Vector3f::Vector3f() noexcept : Vector<Float, 3>() { }
-Vector3f::Vector3f(const Float& v) noexcept : Vector<Float, 3>(v) { }
-Vector3f::Vector3f(const Float& x, const Float& y, const Float& z) noexcept : Vector<Float, 3>() {
+Vector3f::Vector3f(Float v) noexcept : Vector<Float, 3>(v) { }
+Vector3f::Vector3f(Float x, Float y, Float z) noexcept : Vector<Float, 3>() {
     this->x() = x;
     this->y() = y;
     this->z() = z;
@@ -499,11 +499,11 @@ Vector3f& Vector3f::operator=(Vector3f&& _other) noexcept {
     return this->operator=(std::move(static_cast<Vector<scalar_type, vec_size>>(_other)));
 }
 
-const Float& Vector3f::operator[](const unsigned int& i) const noexcept {
+Float Vector3f::operator[](UInt32 i) const noexcept {
     return Vector<Float, 3>::operator[](i);
 }
 
-Float& Vector3f::operator[](const unsigned int& i) noexcept {
+Float& Vector3f::operator[](UInt32 i) noexcept {
     return Vector<Float, 3>::operator[](i);
 }
 
@@ -571,8 +571,8 @@ Vector3f::operator DirectX::XMFLOAT3() const noexcept {
 // ------------------------------------------------------------------------------------------------
 
 Vector3u::Vector3u() noexcept : Vector<UInt32, 3>() { }
-Vector3u::Vector3u(const UInt32& v) noexcept : Vector<UInt32, 3>(v) { }
-Vector3u::Vector3u(const UInt32& x, const UInt32& y, const UInt32& z) noexcept : Vector<UInt32, 3>() {
+Vector3u::Vector3u(UInt32 v) noexcept : Vector<UInt32, 3>(v) { }
+Vector3u::Vector3u(UInt32 x, UInt32 y, UInt32 z) noexcept : Vector<UInt32, 3>() {
     this->x() = x;
     this->y() = y;
     this->z() = z;
@@ -606,11 +606,11 @@ Vector3u& Vector3u::operator=(Vector3u&& _other) noexcept {
     return this->operator=(std::move(static_cast<Vector<scalar_type, vec_size>>(_other)));
 }
 
-const UInt32& Vector3u::operator[](const unsigned int& i) const noexcept {
+UInt32 Vector3u::operator[](UInt32 i) const noexcept {
     return Vector<UInt32, 3>::operator[](i);
 }
 
-UInt32& Vector3u::operator[](const unsigned int& i) noexcept {
+UInt32& Vector3u::operator[](UInt32 i) noexcept {
     return Vector<UInt32, 3>::operator[](i);
 }
 
@@ -678,8 +678,8 @@ Vector3u::operator DirectX::XMUINT3() const noexcept {
 // ------------------------------------------------------------------------------------------------
 
 Vector3i::Vector3i() noexcept : Vector<Int32, 3>() { }
-Vector3i::Vector3i(const Int32& v) noexcept : Vector<Int32, 3>(v) { }
-Vector3i::Vector3i(const Int32& x, const Int32& y, const Int32& z) noexcept : Vector<Int32, 3>() {
+Vector3i::Vector3i(Int32 v) noexcept : Vector<Int32, 3>(v) { }
+Vector3i::Vector3i(Int32 x, Int32 y, Int32 z) noexcept : Vector<Int32, 3>() {
     this->x() = x;
     this->y() = y;
     this->z() = z;
@@ -713,11 +713,11 @@ Vector3i& Vector3i::operator=(Vector3i&& _other) noexcept {
     return this->operator=(std::move(static_cast<Vector<scalar_type, vec_size>>(_other)));
 }
 
-const Int32& Vector3i::operator[](const unsigned int& i) const noexcept {
+Int32 Vector3i::operator[](UInt32 i) const noexcept {
     return Vector<Int32, 3>::operator[](i);
 }
 
-Int32& Vector3i::operator[](const unsigned int& i) noexcept {
+Int32& Vector3i::operator[](UInt32 i) noexcept {
     return Vector<Int32, 3>::operator[](i);
 }
 
@@ -785,8 +785,8 @@ Vector3i::operator DirectX::XMINT3() const noexcept {
 // ------------------------------------------------------------------------------------------------
 
 Vector4f::Vector4f() noexcept : Vector<Float, 4>() { }
-Vector4f::Vector4f(const Float& v) noexcept : Vector<Float, 4>(v) { }
-Vector4f::Vector4f(const Float& x, const Float& y, const Float& z, const Float& w) noexcept : Vector<Float, 4>() {
+Vector4f::Vector4f(Float v) noexcept : Vector<Float, 4>(v) { }
+Vector4f::Vector4f(Float x, Float y, Float z, Float w) noexcept : Vector<Float, 4>() {
     this->x() = x;
     this->y() = y;
     this->z() = z;
@@ -821,11 +821,11 @@ Vector4f& Vector4f::operator=(Vector4f&& _other) noexcept {
     return this->operator=(std::move(static_cast<Vector<scalar_type, vec_size>>(_other)));
 }
 
-const Float& Vector4f::operator[](const unsigned int& i) const noexcept {
+Float Vector4f::operator[](UInt32 i) const noexcept {
     return Vector<Float, 4>::operator[](i);
 }
 
-Float& Vector4f::operator[](const unsigned int& i) noexcept {
+Float& Vector4f::operator[](UInt32 i) noexcept {
     return Vector<Float, 4>::operator[](i);
 }
 
@@ -897,8 +897,8 @@ Vector4f::operator DirectX::XMFLOAT4() const noexcept {
 // ------------------------------------------------------------------------------------------------
 
 Vector4u::Vector4u() noexcept : Vector<UInt32, 4>() { }
-Vector4u::Vector4u(const UInt32& v) noexcept : Vector<UInt32, 4>(v) { }
-Vector4u::Vector4u(const UInt32& x, const UInt32& y, const UInt32& z, const UInt32& w) noexcept : Vector<UInt32, 4>() {
+Vector4u::Vector4u(UInt32 v) noexcept : Vector<UInt32, 4>(v) { }
+Vector4u::Vector4u(UInt32 x, UInt32 y, UInt32 z, UInt32 w) noexcept : Vector<UInt32, 4>() {
     this->x() = x;
     this->y() = y;
     this->z() = z;
@@ -933,11 +933,11 @@ Vector4u& Vector4u::operator=(Vector4u&& _other) noexcept {
     return this->operator=(std::move(static_cast<Vector<scalar_type, vec_size>>(_other)));
 }
 
-const UInt32& Vector4u::operator[](const unsigned int& i) const noexcept {
+UInt32 Vector4u::operator[](UInt32 i) const noexcept {
     return Vector<UInt32, 4>::operator[](i);
 }
 
-UInt32& Vector4u::operator[](const unsigned int& i) noexcept {
+UInt32& Vector4u::operator[](UInt32 i) noexcept {
     return Vector<UInt32, 4>::operator[](i);
 }
 
@@ -1009,8 +1009,8 @@ Vector4u::operator DirectX::XMUINT4() const noexcept {
 // ------------------------------------------------------------------------------------------------
 
 Vector4i::Vector4i() noexcept : Vector<Int32, 4>() { }
-Vector4i::Vector4i(const Int32& v) noexcept : Vector<Int32, 4>(v) { }
-Vector4i::Vector4i(const Int32& x, const Int32& y, const Int32& z, const Int32& w) noexcept : Vector<Int32, 4>() {
+Vector4i::Vector4i(Int32 v) noexcept : Vector<Int32, 4>(v) { }
+Vector4i::Vector4i(Int32 x, Int32 y, Int32 z, Int32 w) noexcept : Vector<Int32, 4>() {
     this->x() = x;
     this->y() = y;
     this->z() = z;
@@ -1045,11 +1045,11 @@ Vector4i& Vector4i::operator=(Vector4i&& _other) noexcept {
     return this->operator=(std::move(static_cast<Vector<scalar_type, vec_size>>(_other)));
 }
 
-const Int32& Vector4i::operator[](const unsigned int& i) const noexcept {
+Int32 Vector4i::operator[](UInt32 i) const noexcept {
     return Vector<Int32, 4>::operator[](i);
 }
 
-Int32& Vector4i::operator[](const unsigned int& i) noexcept {
+Int32& Vector4i::operator[](UInt32 i) noexcept {
     return Vector<Int32, 4>::operator[](i);
 }
 

--- a/src/Rendering/include/litefx/rendering.hpp
+++ b/src/Rendering/include/litefx/rendering.hpp
@@ -44,27 +44,27 @@ namespace LiteFX::Rendering {
         constexpr inline virtual void transition(image_type& image, UInt32 level, UInt32 levels, UInt32 layer, UInt32 layers, UInt32 plane, ResourceAccess accessBefore, ResourceAccess accessAfter, ImageLayout fromLayout, ImageLayout toLayout) = 0;
 
     private:
-        constexpr inline virtual void doTransition(IBuffer& buffer, ResourceAccess accessBefore, ResourceAccess accessAfter) override {
+        constexpr inline void doTransition(IBuffer& buffer, ResourceAccess accessBefore, ResourceAccess accessAfter) override {
             this->transition(dynamic_cast<buffer_type&>(buffer), accessBefore, accessAfter);
         }
 
-        constexpr inline virtual void doTransition(IBuffer& buffer, UInt32 element, ResourceAccess accessBefore, ResourceAccess accessAfter) override {
+        constexpr inline void doTransition(IBuffer& buffer, UInt32 element, ResourceAccess accessBefore, ResourceAccess accessAfter) override {
             this->transition(dynamic_cast<buffer_type&>(buffer), element, accessBefore, accessAfter);
         }
 
-        constexpr inline virtual void doTransition(IImage& image, ResourceAccess accessBefore, ResourceAccess accessAfter, ImageLayout layout) override {
+        constexpr inline void doTransition(IImage& image, ResourceAccess accessBefore, ResourceAccess accessAfter, ImageLayout layout) override {
             this->transition(dynamic_cast<image_type&>(image), accessBefore, accessAfter, layout);
         }
 
-        constexpr inline virtual void doTransition(IImage& image, ResourceAccess accessBefore, ResourceAccess accessAfter, ImageLayout fromLayout, ImageLayout toLayout) override {
+        constexpr inline void doTransition(IImage& image, ResourceAccess accessBefore, ResourceAccess accessAfter, ImageLayout fromLayout, ImageLayout toLayout) override {
             this->transition(dynamic_cast<image_type&>(image), accessBefore, accessAfter, fromLayout, toLayout);
         }
 
-        constexpr inline virtual void doTransition(IImage& image, UInt32 level, UInt32 levels, UInt32 layer, UInt32 layers, UInt32 plane, ResourceAccess accessBefore, ResourceAccess accessAfter, ImageLayout layout) override {
+        constexpr inline void doTransition(IImage& image, UInt32 level, UInt32 levels, UInt32 layer, UInt32 layers, UInt32 plane, ResourceAccess accessBefore, ResourceAccess accessAfter, ImageLayout layout) override {
             this->transition(dynamic_cast<image_type&>(image), level, levels, layer, layers, plane, accessBefore, accessAfter, layout);
         }
 
-        constexpr inline virtual void doTransition(IImage& image, UInt32 level, UInt32 levels, UInt32 layer, UInt32 layers, UInt32 plane, ResourceAccess accessBefore, ResourceAccess accessAfter, ImageLayout fromLayout, ImageLayout toLayout) override {
+        constexpr inline void doTransition(IImage& image, UInt32 level, UInt32 levels, UInt32 layer, UInt32 layers, UInt32 plane, ResourceAccess accessBefore, ResourceAccess accessAfter, ImageLayout fromLayout, ImageLayout toLayout) override {
             this->transition(dynamic_cast<image_type&>(image), level, levels, layer, layers, plane, accessBefore, accessAfter, fromLayout, toLayout);
         }
     };
@@ -164,19 +164,19 @@ namespace LiteFX::Rendering {
         virtual void attach(UInt32 binding, const image_type& image) const = 0;
 
     private:
-        virtual void doUpdate(UInt32 binding, const IBuffer& buffer, UInt32 bufferElement, UInt32 elements, UInt32 firstDescriptor) const override {
+        void doUpdate(UInt32 binding, const IBuffer& buffer, UInt32 bufferElement, UInt32 elements, UInt32 firstDescriptor) const override {
             this->update(binding, dynamic_cast<const buffer_type&>(buffer), bufferElement, elements, firstDescriptor);
         }
 
-        virtual void doUpdate(UInt32 binding, const IImage& texture, UInt32 descriptor, UInt32 firstLevel, UInt32 levels, UInt32 firstLayer, UInt32 layers) const  override {
+        void doUpdate(UInt32 binding, const IImage& texture, UInt32 descriptor, UInt32 firstLevel, UInt32 levels, UInt32 firstLayer, UInt32 layers) const  override {
             this->update(binding, dynamic_cast<const image_type&>(texture), descriptor, firstLevel, levels, firstLayer, layers);
         }
 
-        virtual void doUpdate(UInt32 binding, const ISampler& sampler, UInt32 descriptor) const  override {
+        void doUpdate(UInt32 binding, const ISampler& sampler, UInt32 descriptor) const  override {
             this->update(binding, dynamic_cast<const sampler_type&>(sampler), descriptor);
         }
 
-        virtual void doAttach(UInt32 binding, const IImage& image) const  override {
+        void doAttach(UInt32 binding, const IImage& image) const  override {
             this->attach(binding, dynamic_cast<const image_type&>(image));
         }
     };
@@ -235,23 +235,23 @@ namespace LiteFX::Rendering {
         virtual void free(const descriptor_set_type& descriptorSet) const noexcept = 0;
 
     private:
-        virtual Enumerable<const IDescriptorLayout*> getDescriptors() const noexcept override {
+        Enumerable<const IDescriptorLayout*> getDescriptors() const noexcept override {
             return this->descriptors();
         }
 
-        virtual UniquePtr<IDescriptorSet> getDescriptorSet(UInt32 descriptors, const Enumerable<DescriptorBinding>& bindings = { }) const override {
+        UniquePtr<IDescriptorSet> getDescriptorSet(UInt32 descriptors, const Enumerable<DescriptorBinding>& bindings = { }) const override {
             return this->allocate(descriptors, bindings);
         }
 
-        virtual Enumerable<UniquePtr<IDescriptorSet>> getDescriptorSets(UInt32 descriptorSets, UInt32 descriptors, const Enumerable<Enumerable<DescriptorBinding>>& bindings = { }) const override {
+        Enumerable<UniquePtr<IDescriptorSet>> getDescriptorSets(UInt32 descriptorSets, UInt32 descriptors, const Enumerable<Enumerable<DescriptorBinding>>& bindings = { }) const override {
             return this->allocateMultiple(descriptorSets, descriptors, bindings) | std::views::as_rvalue;
         }
 
-        virtual Enumerable<UniquePtr<IDescriptorSet>> getDescriptorSets(UInt32 descriptorSets, UInt32 descriptors, std::function<Enumerable<DescriptorBinding>(UInt32)> bindingFactory) const override {
+        Enumerable<UniquePtr<IDescriptorSet>> getDescriptorSets(UInt32 descriptorSets, UInt32 descriptors, std::function<Enumerable<DescriptorBinding>(UInt32)> bindingFactory) const override {
             return this->allocateMultiple(descriptorSets, descriptors, bindingFactory) | std::views::as_rvalue;
         }
 
-        virtual void releaseDescriptorSet(const IDescriptorSet& descriptorSet) const noexcept override {
+        void releaseDescriptorSet(const IDescriptorSet& descriptorSet) const noexcept override {
             this->releaseDescriptorSet(dynamic_cast<const descriptor_set_type&>(descriptorSet));
         }
     };
@@ -293,7 +293,7 @@ namespace LiteFX::Rendering {
         virtual Enumerable<const push_constants_range_type*> ranges() const noexcept = 0;
 
     private:
-        virtual Enumerable<const IPushConstantsRange*> getRanges() const noexcept override {
+        Enumerable<const IPushConstantsRange*> getRanges() const noexcept override {
             return this->ranges();
         }
     };
@@ -349,7 +349,7 @@ namespace LiteFX::Rendering {
         virtual const push_constants_layout_type* pushConstants() const noexcept = 0;
 
     private:
-        virtual Enumerable<const IDescriptorSetLayout*> getDescriptorSets() const noexcept override {
+        Enumerable<const IDescriptorSetLayout*> getDescriptorSets() const noexcept override {
             return this->descriptorSets();
         }
     };
@@ -417,7 +417,7 @@ namespace LiteFX::Rendering {
         virtual const index_buffer_layout_type& indexBufferLayout() const = 0;
 
     private:
-        virtual Enumerable<const IVertexBufferLayout*> getVertexBufferLayouts() const noexcept override {
+        Enumerable<const IVertexBufferLayout*> getVertexBufferLayouts() const noexcept override {
             return this->vertexBufferLayouts();
         }
     };
@@ -448,11 +448,11 @@ namespace LiteFX::Rendering {
         virtual SharedPtr<const pipeline_layout_type> layout() const noexcept = 0;
 
     private:
-        virtual SharedPtr<const IShaderProgram> getProgram() const noexcept override {
+        SharedPtr<const IShaderProgram> getProgram() const noexcept override {
             return std::static_pointer_cast<const IShaderProgram>(this->program());
         }
 
-        virtual SharedPtr<const IPipelineLayout> getLayout() const noexcept override {
+        SharedPtr<const IPipelineLayout> getLayout() const noexcept override {
             return std::static_pointer_cast<const IPipelineLayout>(this->layout());
         }
     };
@@ -571,83 +571,83 @@ namespace LiteFX::Rendering {
         virtual void execute(Enumerable<SharedPtr<const command_buffer_type>> commandBuffers) const = 0;
 
     private:
-        virtual void cmdBarrier(const IBarrier& barrier) const noexcept override { 
+        void cmdBarrier(const IBarrier& barrier) const noexcept override { 
             this->barrier(dynamic_cast<const barrier_type&>(barrier));
         }
 
-        virtual void cmdGenerateMipMaps(IImage& image) noexcept override { 
+        void cmdGenerateMipMaps(IImage& image) noexcept override { 
             this->generateMipMaps(dynamic_cast<image_type&>(image));
         }
 
-        virtual void cmdTransfer(IBuffer& source, IBuffer& target, UInt32 sourceElement, UInt32 targetElement, UInt32 elements) const override { 
+        void cmdTransfer(IBuffer& source, IBuffer& target, UInt32 sourceElement, UInt32 targetElement, UInt32 elements) const override { 
             this->transfer(dynamic_cast<buffer_type&>(source), dynamic_cast<buffer_type&>(target), sourceElement, targetElement, elements);
         }
         
-        virtual void cmdTransfer(IBuffer& source, IImage& target, UInt32 sourceElement, UInt32 firstSubresource, UInt32 elements) const override { 
+        void cmdTransfer(IBuffer& source, IImage& target, UInt32 sourceElement, UInt32 firstSubresource, UInt32 elements) const override { 
             this->transfer(dynamic_cast<buffer_type&>(source), dynamic_cast<image_type&>(target), sourceElement, firstSubresource, elements);
         }
         
-        virtual void cmdTransfer(IImage& source, IImage& target, UInt32 sourceSubresource, UInt32 targetSubresource, UInt32 subresources) const override {
+        void cmdTransfer(IImage& source, IImage& target, UInt32 sourceSubresource, UInt32 targetSubresource, UInt32 subresources) const override {
             this->transfer(dynamic_cast<image_type&>(source), dynamic_cast<image_type&>(target), sourceSubresource, targetSubresource, subresources);
         }
 
-        virtual void cmdTransfer(IImage& source, IBuffer& target, UInt32 firstSubresource, UInt32 targetElement, UInt32 subresources) const override {
+        void cmdTransfer(IImage& source, IBuffer& target, UInt32 firstSubresource, UInt32 targetElement, UInt32 subresources) const override {
             this->transfer(dynamic_cast<image_type&>(source), dynamic_cast<buffer_type&>(target), firstSubresource, targetElement, subresources);
         }
 
-        virtual void cmdTransfer(SharedPtr<IBuffer> source, IBuffer& target, UInt32 sourceElement, UInt32 targetElement, UInt32 elements) const override {
+        void cmdTransfer(SharedPtr<IBuffer> source, IBuffer& target, UInt32 sourceElement, UInt32 targetElement, UInt32 elements) const override {
             this->transfer(std::dynamic_pointer_cast<buffer_type>(source), dynamic_cast<buffer_type&>(target), sourceElement, targetElement, elements);
         }
         
-        virtual void cmdTransfer(SharedPtr<IBuffer> source, IImage& target, UInt32 sourceElement, UInt32 firstSubresource, UInt32 elements) const override {
+        void cmdTransfer(SharedPtr<IBuffer> source, IImage& target, UInt32 sourceElement, UInt32 firstSubresource, UInt32 elements) const override {
             this->transfer(std::dynamic_pointer_cast<buffer_type>(source), dynamic_cast<image_type&>(target), sourceElement, firstSubresource, elements);
         }
         
-        virtual void cmdTransfer(SharedPtr<IImage> source, IImage& target, UInt32 sourceSubresource, UInt32 targetSubresource, UInt32 subresources) const override {
+        void cmdTransfer(SharedPtr<IImage> source, IImage& target, UInt32 sourceSubresource, UInt32 targetSubresource, UInt32 subresources) const override {
             this->transfer(std::dynamic_pointer_cast<image_type>(source), dynamic_cast<image_type&>(target), sourceSubresource, targetSubresource, subresources);
         }
         
-        virtual void cmdTransfer(SharedPtr<IImage> source, IBuffer& target, UInt32 firstSubresource, UInt32 targetElement, UInt32 subresources) const override {
+        void cmdTransfer(SharedPtr<IImage> source, IBuffer& target, UInt32 firstSubresource, UInt32 targetElement, UInt32 subresources) const override {
             this->transfer(std::dynamic_pointer_cast<image_type>(source), dynamic_cast<buffer_type&>(target), firstSubresource, targetElement, subresources);
         }
 
-        virtual void cmdUse(const IPipeline& pipeline) const noexcept override { 
+        void cmdUse(const IPipeline& pipeline) const noexcept override { 
             this->use(dynamic_cast<const pipeline_type&>(pipeline));
         }
 
-        virtual void cmdBind(const IDescriptorSet& descriptorSet, const IPipeline& pipeline) const noexcept override { 
+        void cmdBind(const IDescriptorSet& descriptorSet, const IPipeline& pipeline) const noexcept override { 
             this->bind(dynamic_cast<const descriptor_set_type&>(descriptorSet), dynamic_cast<const pipeline_type&>(pipeline));
         }
         
-        virtual void cmdBind(const IVertexBuffer& buffer) const noexcept override { 
+        void cmdBind(const IVertexBuffer& buffer) const noexcept override { 
             this->bind(dynamic_cast<const vertex_buffer_type&>(buffer));
         }
 
-        virtual void cmdBind(const IIndexBuffer& buffer) const noexcept override { 
+        void cmdBind(const IIndexBuffer& buffer) const noexcept override { 
             this->bind(dynamic_cast<const index_buffer_type&>(buffer));
         }
         
-        virtual void cmdPushConstants(const IPushConstantsLayout& layout, const void* const memory) const noexcept override { 
+        void cmdPushConstants(const IPushConstantsLayout& layout, const void* const memory) const noexcept override { 
             this->pushConstants(dynamic_cast<const push_constants_layout_type&>(layout), memory);
         }
         
-        virtual void cmdDraw(const IVertexBuffer& vertexBuffer, UInt32 instances, UInt32 firstVertex, UInt32 firstInstance) const override { 
+        void cmdDraw(const IVertexBuffer& vertexBuffer, UInt32 instances, UInt32 firstVertex, UInt32 firstInstance) const override { 
             this->draw(dynamic_cast<const vertex_buffer_type&>(vertexBuffer), instances, firstVertex, firstInstance);
         }
         
-        virtual void cmdDrawIndexed(const IIndexBuffer& indexBuffer, UInt32 instances, UInt32 firstIndex, Int32 vertexOffset, UInt32 firstInstance) const override { 
+        void cmdDrawIndexed(const IIndexBuffer& indexBuffer, UInt32 instances, UInt32 firstIndex, Int32 vertexOffset, UInt32 firstInstance) const override { 
             this->drawIndexed(dynamic_cast<const index_buffer_type&>(indexBuffer), instances, firstIndex, vertexOffset, firstInstance);
         }
         
-        virtual void cmdDrawIndexed(const IVertexBuffer& vertexBuffer, const IIndexBuffer& indexBuffer, UInt32 instances, UInt32 firstIndex, Int32 vertexOffset, UInt32 firstInstance) const override { 
+        void cmdDrawIndexed(const IVertexBuffer& vertexBuffer, const IIndexBuffer& indexBuffer, UInt32 instances, UInt32 firstIndex, Int32 vertexOffset, UInt32 firstInstance) const override { 
             this->drawIndexed(dynamic_cast<const vertex_buffer_type&>(vertexBuffer), dynamic_cast<const index_buffer_type&>(indexBuffer), instances, firstIndex, vertexOffset, firstInstance);
         }
 
-        virtual void cmdExecute(SharedPtr<const ICommandBuffer> commandBuffer) const override {
+        void cmdExecute(SharedPtr<const ICommandBuffer> commandBuffer) const override {
             this->execute(std::dynamic_pointer_cast<const command_buffer_type>(commandBuffer));
         }
         
-        virtual void cmdExecute(Enumerable<SharedPtr<const ICommandBuffer>> commandBuffers) const override {
+        void cmdExecute(Enumerable<SharedPtr<const ICommandBuffer>> commandBuffers) const override {
             return this->execute(commandBuffers | std::views::transform([](auto buffer) { return std::dynamic_pointer_cast<const command_buffer_type>(buffer); }));
         }
 
@@ -680,11 +680,11 @@ namespace LiteFX::Rendering {
         virtual SharedPtr<rasterizer_type> rasterizer() const noexcept = 0;
 
     private:
-        virtual SharedPtr<IInputAssembler> getInputAssembler() const noexcept override {
+        SharedPtr<IInputAssembler> getInputAssembler() const noexcept override {
             return this->inputAssembler();
         }
 
-        virtual SharedPtr<IRasterizer> getRasterizer() const noexcept override {
+        SharedPtr<IRasterizer> getRasterizer() const noexcept override {
             return this->rasterizer();
         }
     };
@@ -730,15 +730,15 @@ namespace LiteFX::Rendering {
         virtual const image_type& image(UInt32 location) const = 0;
 
     private:
-        virtual SharedPtr<const ICommandBuffer> getCommandBuffer(UInt32 index) const noexcept override {
+        SharedPtr<const ICommandBuffer> getCommandBuffer(UInt32 index) const noexcept override {
             return this->commandBuffer(index);
         }
 
-        virtual Enumerable<SharedPtr<const ICommandBuffer>> getCommandBuffers() const noexcept override {
+        Enumerable<SharedPtr<const ICommandBuffer>> getCommandBuffers() const noexcept override {
             return this->commandBuffers();
         }
 
-        virtual Enumerable<const IImage*> getImages() const noexcept override {
+        Enumerable<const IImage*> getImages() const noexcept override {
             return this->images();
         }
     };
@@ -852,15 +852,15 @@ namespace LiteFX::Rendering {
         virtual void updateAttachments(const descriptor_set_type& descriptorSet) const = 0;
 
     private:
-        virtual Enumerable<const IFrameBuffer*> getFrameBuffers() const noexcept override {
+        Enumerable<const IFrameBuffer*> getFrameBuffers() const noexcept override {
             return this->frameBuffers();
         }
 
-        virtual Enumerable<const IRenderPipeline*> getPipelines() const noexcept override {
+        Enumerable<const IRenderPipeline*> getPipelines() const noexcept override {
             return this->pipelines();
         }
 
-        virtual void setAttachments(const IDescriptorSet& descriptorSet) const override {
+        void setAttachments(const IDescriptorSet& descriptorSet) const override {
             this->updateAttachments(dynamic_cast<const descriptor_set_type&>(descriptorSet));
         }
     };
@@ -891,12 +891,12 @@ namespace LiteFX::Rendering {
         virtual void present(const frame_buffer_type& frameBuffer) const = 0;
 
         /// <inheritdoc />
-        virtual void present(const IFrameBuffer& frameBuffer) const override {
+        void present(const IFrameBuffer& frameBuffer) const override {
             this->present(dynamic_cast<const frame_buffer_type&>(frameBuffer));
         }
 
     private:
-        virtual Enumerable<const IImage*> getImages() const noexcept override {
+        Enumerable<const IImage*> getImages() const noexcept override {
             return this->images();
         }
     };
@@ -937,15 +937,15 @@ namespace LiteFX::Rendering {
         virtual UInt64 submit(const Enumerable<SharedPtr<const command_buffer_type>>& commandBuffers) const = 0;
 
     private:
-        virtual SharedPtr<ICommandBuffer> getCommandBuffer(bool beginRecording, bool secondary) const override {
+        SharedPtr<ICommandBuffer> getCommandBuffer(bool beginRecording, bool secondary) const override {
             return this->createCommandBuffer(beginRecording, secondary);
         }
 
-        virtual UInt64 submitCommandBuffer(SharedPtr<const ICommandBuffer> commandBuffer) const override {
+        UInt64 submitCommandBuffer(SharedPtr<const ICommandBuffer> commandBuffer) const override {
             return this->submit(std::dynamic_pointer_cast<const command_buffer_type>(commandBuffer));
         }
 
-        virtual UInt64 submitCommandBuffers(const Enumerable<SharedPtr<const ICommandBuffer>>& commandBuffers) const override {
+        UInt64 submitCommandBuffers(const Enumerable<SharedPtr<const ICommandBuffer>>& commandBuffers) const override {
             return this->submit(commandBuffers | std::views::transform([](auto buffer) { return std::dynamic_pointer_cast<const command_buffer_type>(buffer); }) | std::ranges::to<Enumerable<SharedPtr<const command_buffer_type>>>());
         }
     };
@@ -1033,59 +1033,59 @@ namespace LiteFX::Rendering {
         virtual Enumerable<UniquePtr<TSampler>> createSamplers(UInt32 elements, FilterMode magFilter = FilterMode::Nearest, FilterMode minFilter = FilterMode::Nearest, BorderMode borderU = BorderMode::Repeat, BorderMode borderV = BorderMode::Repeat, BorderMode borderW = BorderMode::Repeat, MipMapMode mipMapMode = MipMapMode::Nearest, Float mipMapBias = 0.f, Float maxLod = std::numeric_limits<Float>::max(), Float minLod = 0.f, Float anisotropy = 0.f) const = 0;
 
     private:
-        virtual UniquePtr<IBuffer> getBuffer(BufferType type, BufferUsage usage, size_t elementSize, UInt32 elements, bool allowWrite) const override { 
+        UniquePtr<IBuffer> getBuffer(BufferType type, BufferUsage usage, size_t elementSize, UInt32 elements, bool allowWrite) const override { 
             return this->createBuffer(type, usage, elementSize, elements, allowWrite);
         }
 
-        virtual UniquePtr<IBuffer> getBuffer(const String& name, BufferType type, BufferUsage usage, size_t elementSize, UInt32 elements, bool allowWrite) const override {
+        UniquePtr<IBuffer> getBuffer(const String& name, BufferType type, BufferUsage usage, size_t elementSize, UInt32 elements, bool allowWrite) const override {
             return this->createBuffer(name, type, usage, elementSize, elements, allowWrite);
         }
 
-        virtual UniquePtr<IVertexBuffer> getVertexBuffer(const IVertexBufferLayout& layout, BufferUsage usage, UInt32 elements) const override { 
+        UniquePtr<IVertexBuffer> getVertexBuffer(const IVertexBufferLayout& layout, BufferUsage usage, UInt32 elements) const override { 
             return this->createVertexBuffer(dynamic_cast<const vertex_buffer_layout_type&>(layout), usage, elements);
         }
 
-        virtual UniquePtr<IVertexBuffer> getVertexBuffer(const String& name, const IVertexBufferLayout& layout, BufferUsage usage, UInt32 elements) const override {
+        UniquePtr<IVertexBuffer> getVertexBuffer(const String& name, const IVertexBufferLayout& layout, BufferUsage usage, UInt32 elements) const override {
             return this->createVertexBuffer(name, dynamic_cast<const vertex_buffer_layout_type&>(layout), usage, elements);
         }
         
-        virtual UniquePtr<IIndexBuffer> getIndexBuffer(const IIndexBufferLayout& layout, BufferUsage usage, UInt32 elements) const override {
+        UniquePtr<IIndexBuffer> getIndexBuffer(const IIndexBufferLayout& layout, BufferUsage usage, UInt32 elements) const override {
             return this->createIndexBuffer(dynamic_cast<const index_buffer_layout_type&>(layout), usage, elements);
         }
 
-        virtual UniquePtr<IIndexBuffer> getIndexBuffer(const String& name, const IIndexBufferLayout& layout, BufferUsage usage, UInt32 elements) const override {
+        UniquePtr<IIndexBuffer> getIndexBuffer(const String& name, const IIndexBufferLayout& layout, BufferUsage usage, UInt32 elements) const override {
             return this->createIndexBuffer(name, dynamic_cast<const index_buffer_layout_type&>(layout), usage, elements);
         }
 
-        virtual UniquePtr<IImage> getAttachment(Format format, const Size2d& size, MultiSamplingLevel samples) const override { 
+        UniquePtr<IImage> getAttachment(Format format, const Size2d& size, MultiSamplingLevel samples) const override { 
             return this->createAttachment(format, size, samples);
         }
 
-        virtual UniquePtr<IImage> getAttachment(const String& name, Format format, const Size2d& size, MultiSamplingLevel samples) const override {
+        UniquePtr<IImage> getAttachment(const String& name, Format format, const Size2d& size, MultiSamplingLevel samples) const override {
             return this->createAttachment(name, format, size, samples);
         }
         
-        virtual UniquePtr<IImage> getTexture(Format format, const Size3d& size, ImageDimensions dimension, UInt32 levels, UInt32 layers, MultiSamplingLevel samples, bool allowWrite) const override { 
+        UniquePtr<IImage> getTexture(Format format, const Size3d& size, ImageDimensions dimension, UInt32 levels, UInt32 layers, MultiSamplingLevel samples, bool allowWrite) const override { 
             return this->createTexture(format, size, dimension, levels, layers, samples, allowWrite);
         }
 
-        virtual UniquePtr<IImage> getTexture(const String& name, Format format, const Size3d& size, ImageDimensions dimension, UInt32 levels, UInt32 layers, MultiSamplingLevel samples, bool allowWrite) const override {
+        UniquePtr<IImage> getTexture(const String& name, Format format, const Size3d& size, ImageDimensions dimension, UInt32 levels, UInt32 layers, MultiSamplingLevel samples, bool allowWrite) const override {
             return this->createTexture(name, format, size, dimension, levels, layers, samples, allowWrite);
         }
 
-        virtual Enumerable<UniquePtr<IImage>> getTextures(UInt32 elements, Format format, const Size3d& size, ImageDimensions dimension, UInt32 layers, UInt32 levels, MultiSamplingLevel samples, bool allowWrite) const override {
+        Enumerable<UniquePtr<IImage>> getTextures(UInt32 elements, Format format, const Size3d& size, ImageDimensions dimension, UInt32 layers, UInt32 levels, MultiSamplingLevel samples, bool allowWrite) const override {
             return this->getTextures(elements, format, size, dimension, layers, levels, samples, allowWrite) | std::views::as_rvalue;
         }
         
-        virtual UniquePtr<ISampler> getSampler(FilterMode magFilter, FilterMode minFilter, BorderMode borderU, BorderMode borderV, BorderMode borderW, MipMapMode mipMapMode, Float mipMapBias, Float maxLod, Float minLod, Float anisotropy) const override { 
+        UniquePtr<ISampler> getSampler(FilterMode magFilter, FilterMode minFilter, BorderMode borderU, BorderMode borderV, BorderMode borderW, MipMapMode mipMapMode, Float mipMapBias, Float maxLod, Float minLod, Float anisotropy) const override { 
             return this->createSampler(magFilter, minFilter, borderU, borderV, borderW, mipMapMode, mipMapBias, maxLod, minLod, anisotropy);
         }
 
-        virtual UniquePtr<ISampler> getSampler(const String& name, FilterMode magFilter, FilterMode minFilter, BorderMode borderU, BorderMode borderV, BorderMode borderW, MipMapMode mipMapMode, Float mipMapBias, Float maxLod, Float minLod, Float anisotropy) const override {
+        UniquePtr<ISampler> getSampler(const String& name, FilterMode magFilter, FilterMode minFilter, BorderMode borderU, BorderMode borderV, BorderMode borderW, MipMapMode mipMapMode, Float mipMapBias, Float maxLod, Float minLod, Float anisotropy) const override {
             return this->createSampler(name, magFilter, minFilter, borderU, borderV, borderW, mipMapMode, mipMapBias, maxLod, minLod, anisotropy);
         }
         
-        virtual Enumerable<UniquePtr<ISampler>> getSamplers(UInt32 elements, FilterMode magFilter, FilterMode minFilter, BorderMode borderU, BorderMode borderV, BorderMode borderW, MipMapMode mipMapMode, Float mipMapBias, Float maxLod, Float minLod, Float anisotropy) const override {
+        Enumerable<UniquePtr<ISampler>> getSamplers(UInt32 elements, FilterMode magFilter, FilterMode minFilter, BorderMode borderU, BorderMode borderV, BorderMode borderW, MipMapMode mipMapMode, Float mipMapBias, Float maxLod, Float minLod, Float anisotropy) const override {
             return this->createSamplers(elements, magFilter, minFilter, borderU, borderV, borderW, mipMapMode, mipMapBias, maxLod, minLod, anisotropy) | std::views::as_rvalue;
         }
     };
@@ -1175,7 +1175,7 @@ namespace LiteFX::Rendering {
         [[nodiscard]] virtual UniquePtr<barrier_type> makeBarrier(PipelineStage syncBefore, PipelineStage syncAfter) const noexcept = 0;
 
     private:
-        virtual UniquePtr<IBarrier> getNewBarrier(PipelineStage syncBefore, PipelineStage syncAfter) const noexcept override {
+        UniquePtr<IBarrier> getNewBarrier(PipelineStage syncBefore, PipelineStage syncAfter) const noexcept override {
             return this->makeBarrier(syncBefore, syncAfter);
         }
 
@@ -1342,7 +1342,7 @@ namespace LiteFX::Rendering {
 
         // IRenderBackend interface
     private:
-        virtual Enumerable<const IGraphicsAdapter*> getAdapters() const override {
+        Enumerable<const IGraphicsAdapter*> getAdapters() const override {
             return this->listAdapters();
         }
     };

--- a/src/Rendering/include/litefx/rendering.hpp
+++ b/src/Rendering/include/litefx/rendering.hpp
@@ -26,45 +26,45 @@ namespace LiteFX::Rendering {
 
     public:
         /// <inheritdoc />
-        constexpr inline virtual void transition(buffer_type& buffer, const ResourceAccess& accessBefore, const ResourceAccess& accessAfter) = 0;
+        constexpr inline virtual void transition(buffer_type& buffer, ResourceAccess accessBefore, ResourceAccess accessAfter) = 0;
 
         /// <inheritdoc />
-        constexpr inline virtual void transition(buffer_type& buffer, const UInt32& element, const ResourceAccess& accessBefore, const ResourceAccess& accessAfter) = 0;
+        constexpr inline virtual void transition(buffer_type& buffer, const UInt32& element, ResourceAccess accessBefore, ResourceAccess accessAfter) = 0;
 
         /// <inheritdoc />
-        constexpr inline virtual void transition(image_type& image, const ResourceAccess& accessBefore, const ResourceAccess& accessAfter, const ImageLayout& layout) = 0;
+        constexpr inline virtual void transition(image_type& image, ResourceAccess accessBefore, ResourceAccess accessAfter, ImageLayout layout) = 0;
 
         /// <inheritdoc />
-        constexpr inline virtual void transition(image_type& image, const ResourceAccess& accessBefore, const ResourceAccess& accessAfter, const ImageLayout& fromLayout, const ImageLayout& toLayout) = 0;
+        constexpr inline virtual void transition(image_type& image, ResourceAccess accessBefore, ResourceAccess accessAfter, ImageLayout fromLayout, ImageLayout toLayout) = 0;
 
         /// <inheritdoc />
-        constexpr inline virtual void transition(image_type& image, const UInt32& level, const UInt32& levels, const UInt32& layer, const UInt32& layers, const UInt32& plane, const ResourceAccess& accessBefore, const ResourceAccess& accessAfter, const ImageLayout& layout) = 0;
+        constexpr inline virtual void transition(image_type& image, const UInt32& level, const UInt32& levels, const UInt32& layer, const UInt32& layers, const UInt32& plane, ResourceAccess accessBefore, ResourceAccess accessAfter, ImageLayout layout) = 0;
 
         /// <inheritdoc />
-        constexpr inline virtual void transition(image_type& image, const UInt32& level, const UInt32& levels, const UInt32& layer, const UInt32& layers, const UInt32& plane, const ResourceAccess& accessBefore, const ResourceAccess& accessAfter, const ImageLayout& fromLayout, const ImageLayout& toLayout) = 0;
+        constexpr inline virtual void transition(image_type& image, const UInt32& level, const UInt32& levels, const UInt32& layer, const UInt32& layers, const UInt32& plane, ResourceAccess accessBefore, ResourceAccess accessAfter, ImageLayout fromLayout, ImageLayout toLayout) = 0;
 
     private:
-        constexpr inline virtual void doTransition(IBuffer& buffer, const ResourceAccess& accessBefore, const ResourceAccess& accessAfter) override {
+        constexpr inline virtual void doTransition(IBuffer& buffer, ResourceAccess accessBefore, ResourceAccess accessAfter) override {
             this->transition(dynamic_cast<buffer_type&>(buffer), accessBefore, accessAfter);
         }
 
-        constexpr inline virtual void doTransition(IBuffer& buffer, const UInt32& element, const ResourceAccess& accessBefore, const ResourceAccess& accessAfter) override {
+        constexpr inline virtual void doTransition(IBuffer& buffer, const UInt32& element, ResourceAccess accessBefore, ResourceAccess accessAfter) override {
             this->transition(dynamic_cast<buffer_type&>(buffer), element, accessBefore, accessAfter);
         }
 
-        constexpr inline virtual void doTransition(IImage& image, const ResourceAccess& accessBefore, const ResourceAccess& accessAfter, const ImageLayout& layout) override {
+        constexpr inline virtual void doTransition(IImage& image, ResourceAccess accessBefore, ResourceAccess accessAfter, ImageLayout layout) override {
             this->transition(dynamic_cast<image_type&>(image), accessBefore, accessAfter, layout);
         }
 
-        constexpr inline virtual void doTransition(IImage& image, const ResourceAccess& accessBefore, const ResourceAccess& accessAfter, const ImageLayout& fromLayout, const ImageLayout& toLayout) override {
+        constexpr inline virtual void doTransition(IImage& image, ResourceAccess accessBefore, ResourceAccess accessAfter, ImageLayout fromLayout, ImageLayout toLayout) override {
             this->transition(dynamic_cast<image_type&>(image), accessBefore, accessAfter, fromLayout, toLayout);
         }
 
-        constexpr inline virtual void doTransition(IImage& image, const UInt32& level, const UInt32& levels, const UInt32& layer, const UInt32& layers, const UInt32& plane, const ResourceAccess& accessBefore, const ResourceAccess& accessAfter, const ImageLayout& layout) override {
+        constexpr inline virtual void doTransition(IImage& image, const UInt32& level, const UInt32& levels, const UInt32& layer, const UInt32& layers, const UInt32& plane, ResourceAccess accessBefore, ResourceAccess accessAfter, ImageLayout layout) override {
             this->transition(dynamic_cast<image_type&>(image), level, levels, layer, layers, plane, accessBefore, accessAfter, layout);
         }
 
-        constexpr inline virtual void doTransition(IImage& image, const UInt32& level, const UInt32& levels, const UInt32& layer, const UInt32& layers, const UInt32& plane, const ResourceAccess& accessBefore, const ResourceAccess& accessAfter, const ImageLayout& fromLayout, const ImageLayout& toLayout) override {
+        constexpr inline virtual void doTransition(IImage& image, const UInt32& level, const UInt32& levels, const UInt32& layer, const UInt32& layers, const UInt32& plane, ResourceAccess accessBefore, ResourceAccess accessAfter, ImageLayout fromLayout, ImageLayout toLayout) override {
             this->transition(dynamic_cast<image_type&>(image), level, levels, layer, layers, plane, accessBefore, accessAfter, fromLayout, toLayout);
         }
     };
@@ -991,101 +991,101 @@ namespace LiteFX::Rendering {
 
     public:
         /// <inheritdoc />
-        virtual UniquePtr<TBuffer> createBuffer(const BufferType& type, const BufferUsage& usage, const size_t& elementSize, const UInt32& elements = 1, const bool& allowWrite = false) const = 0;
+        virtual UniquePtr<TBuffer> createBuffer(BufferType type, BufferUsage usage, const size_t& elementSize, const UInt32& elements = 1, const bool& allowWrite = false) const = 0;
         
         /// <inheritdoc />
-        virtual UniquePtr<TBuffer> createBuffer(const String& name, const BufferType& type, const BufferUsage& usage, const size_t& elementSize, const UInt32& elements = 1, const bool& allowWrite = false) const = 0;
+        virtual UniquePtr<TBuffer> createBuffer(const String& name, BufferType type, BufferUsage usage, const size_t& elementSize, const UInt32& elements = 1, const bool& allowWrite = false) const = 0;
 
         /// <inheritdoc />
-        virtual UniquePtr<TVertexBuffer> createVertexBuffer(const vertex_buffer_layout_type& layout, const BufferUsage& usage, const UInt32& elements = 1) const = 0;
+        virtual UniquePtr<TVertexBuffer> createVertexBuffer(const vertex_buffer_layout_type& layout, BufferUsage usage, const UInt32& elements = 1) const = 0;
 
         /// <inheritdoc />
-        virtual UniquePtr<TVertexBuffer> createVertexBuffer(const String& name, const vertex_buffer_layout_type& layout, const BufferUsage& usage, const UInt32& elements = 1) const = 0;
+        virtual UniquePtr<TVertexBuffer> createVertexBuffer(const String& name, const vertex_buffer_layout_type& layout, BufferUsage usage, const UInt32& elements = 1) const = 0;
 
         /// <inheritdoc />
-        virtual UniquePtr<TIndexBuffer> createIndexBuffer(const index_buffer_layout_type& layout, const BufferUsage& usage, const UInt32& elements) const = 0;
+        virtual UniquePtr<TIndexBuffer> createIndexBuffer(const index_buffer_layout_type& layout, BufferUsage usage, const UInt32& elements) const = 0;
 
         /// <inheritdoc />
-        virtual UniquePtr<TIndexBuffer> createIndexBuffer(const String& name, const index_buffer_layout_type& layout, const BufferUsage& usage, const UInt32& elements) const = 0;
+        virtual UniquePtr<TIndexBuffer> createIndexBuffer(const String& name, const index_buffer_layout_type& layout, BufferUsage usage, const UInt32& elements) const = 0;
 
         /// <inheritdoc />
-        virtual UniquePtr<TImage> createAttachment(const Format& format, const Size2d& size, const MultiSamplingLevel& samples = MultiSamplingLevel::x1) const = 0;
+        virtual UniquePtr<TImage> createAttachment(Format format, const Size2d& size, MultiSamplingLevel samples = MultiSamplingLevel::x1) const = 0;
 
         /// <inheritdoc />
-        virtual UniquePtr<TImage> createAttachment(const String& name, const Format& format, const Size2d& size, const MultiSamplingLevel& samples = MultiSamplingLevel::x1) const = 0;
+        virtual UniquePtr<TImage> createAttachment(const String& name, Format format, const Size2d& size, MultiSamplingLevel samples = MultiSamplingLevel::x1) const = 0;
 
         /// <inheritdoc />
-        virtual UniquePtr<TImage> createTexture(const Format& format, const Size3d& size, const ImageDimensions& dimension = ImageDimensions::DIM_2, const UInt32& levels = 1, const UInt32& layers = 1, const MultiSamplingLevel& samples = MultiSamplingLevel::x1, const bool& allowWrite = false) const = 0;
+        virtual UniquePtr<TImage> createTexture(Format format, const Size3d& size, ImageDimensions dimension = ImageDimensions::DIM_2, const UInt32& levels = 1, const UInt32& layers = 1, MultiSamplingLevel samples = MultiSamplingLevel::x1, const bool& allowWrite = false) const = 0;
 
         /// <inheritdoc />
-        virtual UniquePtr<TImage> createTexture(const String& name, const Format& format, const Size3d& size, const ImageDimensions& dimension = ImageDimensions::DIM_2, const UInt32& levels = 1, const UInt32& layers = 1, const MultiSamplingLevel& samples = MultiSamplingLevel::x1, const bool& allowWrite = false) const = 0;
+        virtual UniquePtr<TImage> createTexture(const String& name, Format format, const Size3d& size, ImageDimensions dimension = ImageDimensions::DIM_2, const UInt32& levels = 1, const UInt32& layers = 1, MultiSamplingLevel samples = MultiSamplingLevel::x1, const bool& allowWrite = false) const = 0;
 
         /// <inheritdoc />
-        virtual Enumerable<UniquePtr<TImage>> createTextures(const UInt32& elements, const Format& format, const Size3d& size, const ImageDimensions& dimension = ImageDimensions::DIM_2, const UInt32 & layers = 1, const UInt32& levels = 1, const MultiSamplingLevel& samples = MultiSamplingLevel::x1, const bool& allowWrite = false) const = 0;
+        virtual Enumerable<UniquePtr<TImage>> createTextures(const UInt32& elements, Format format, const Size3d& size, ImageDimensions dimension = ImageDimensions::DIM_2, const UInt32 & layers = 1, const UInt32& levels = 1, MultiSamplingLevel samples = MultiSamplingLevel::x1, const bool& allowWrite = false) const = 0;
 
         /// <inheritdoc />
-        virtual UniquePtr<TSampler> createSampler(const FilterMode& magFilter = FilterMode::Nearest, const FilterMode& minFilter = FilterMode::Nearest, const BorderMode& borderU = BorderMode::Repeat, const BorderMode& borderV = BorderMode::Repeat, const BorderMode& borderW = BorderMode::Repeat, const MipMapMode& mipMapMode = MipMapMode::Nearest, const Float& mipMapBias = 0.f, const Float& maxLod = std::numeric_limits<Float>::max(), const Float& minLod = 0.f, const Float& anisotropy = 0.f) const = 0;
+        virtual UniquePtr<TSampler> createSampler(FilterMode magFilter = FilterMode::Nearest, FilterMode minFilter = FilterMode::Nearest, BorderMode borderU = BorderMode::Repeat, BorderMode borderV = BorderMode::Repeat, BorderMode borderW = BorderMode::Repeat, MipMapMode mipMapMode = MipMapMode::Nearest, const Float& mipMapBias = 0.f, const Float& maxLod = std::numeric_limits<Float>::max(), const Float& minLod = 0.f, const Float& anisotropy = 0.f) const = 0;
 
         /// <inheritdoc />
-        virtual UniquePtr<TSampler> createSampler(const String& name, const FilterMode& magFilter = FilterMode::Nearest, const FilterMode& minFilter = FilterMode::Nearest, const BorderMode& borderU = BorderMode::Repeat, const BorderMode& borderV = BorderMode::Repeat, const BorderMode& borderW = BorderMode::Repeat, const MipMapMode& mipMapMode = MipMapMode::Nearest, const Float& mipMapBias = 0.f, const Float& maxLod = std::numeric_limits<Float>::max(), const Float& minLod = 0.f, const Float& anisotropy = 0.f) const = 0;
+        virtual UniquePtr<TSampler> createSampler(const String& name, FilterMode magFilter = FilterMode::Nearest, FilterMode minFilter = FilterMode::Nearest, BorderMode borderU = BorderMode::Repeat, BorderMode borderV = BorderMode::Repeat, BorderMode borderW = BorderMode::Repeat, MipMapMode mipMapMode = MipMapMode::Nearest, const Float& mipMapBias = 0.f, const Float& maxLod = std::numeric_limits<Float>::max(), const Float& minLod = 0.f, const Float& anisotropy = 0.f) const = 0;
 
         /// <inheritdoc />
-        virtual Enumerable<UniquePtr<TSampler>> createSamplers(const UInt32& elements, const FilterMode& magFilter = FilterMode::Nearest, const FilterMode& minFilter = FilterMode::Nearest, const BorderMode& borderU = BorderMode::Repeat, const BorderMode& borderV = BorderMode::Repeat, const BorderMode& borderW = BorderMode::Repeat, const MipMapMode& mipMapMode = MipMapMode::Nearest, const Float& mipMapBias = 0.f, const Float& maxLod = std::numeric_limits<Float>::max(), const Float& minLod = 0.f, const Float& anisotropy = 0.f) const = 0;
+        virtual Enumerable<UniquePtr<TSampler>> createSamplers(const UInt32& elements, FilterMode magFilter = FilterMode::Nearest, FilterMode minFilter = FilterMode::Nearest, BorderMode borderU = BorderMode::Repeat, BorderMode borderV = BorderMode::Repeat, BorderMode borderW = BorderMode::Repeat, MipMapMode mipMapMode = MipMapMode::Nearest, const Float& mipMapBias = 0.f, const Float& maxLod = std::numeric_limits<Float>::max(), const Float& minLod = 0.f, const Float& anisotropy = 0.f) const = 0;
 
     private:
-        virtual UniquePtr<IBuffer> getBuffer(const BufferType& type, const BufferUsage& usage, const size_t& elementSize, const UInt32& elements, const bool& allowWrite) const override { 
+        virtual UniquePtr<IBuffer> getBuffer(BufferType type, BufferUsage usage, const size_t& elementSize, const UInt32& elements, const bool& allowWrite) const override { 
             return this->createBuffer(type, usage, elementSize, elements, allowWrite);
         }
 
-        virtual UniquePtr<IBuffer> getBuffer(const String& name, const BufferType& type, const BufferUsage& usage, const size_t& elementSize, const UInt32& elements, const bool& allowWrite) const override {
+        virtual UniquePtr<IBuffer> getBuffer(const String& name, BufferType type, BufferUsage usage, const size_t& elementSize, const UInt32& elements, const bool& allowWrite) const override {
             return this->createBuffer(name, type, usage, elementSize, elements, allowWrite);
         }
 
-        virtual UniquePtr<IVertexBuffer> getVertexBuffer(const IVertexBufferLayout& layout, const BufferUsage& usage, const UInt32& elements) const override { 
+        virtual UniquePtr<IVertexBuffer> getVertexBuffer(const IVertexBufferLayout& layout, BufferUsage usage, const UInt32& elements) const override { 
             return this->createVertexBuffer(dynamic_cast<const vertex_buffer_layout_type&>(layout), usage, elements);
         }
 
-        virtual UniquePtr<IVertexBuffer> getVertexBuffer(const String& name, const IVertexBufferLayout& layout, const BufferUsage& usage, const UInt32& elements) const override {
+        virtual UniquePtr<IVertexBuffer> getVertexBuffer(const String& name, const IVertexBufferLayout& layout, BufferUsage usage, const UInt32& elements) const override {
             return this->createVertexBuffer(name, dynamic_cast<const vertex_buffer_layout_type&>(layout), usage, elements);
         }
         
-        virtual UniquePtr<IIndexBuffer> getIndexBuffer(const IIndexBufferLayout& layout, const BufferUsage& usage, const UInt32& elements) const override {
+        virtual UniquePtr<IIndexBuffer> getIndexBuffer(const IIndexBufferLayout& layout, BufferUsage usage, const UInt32& elements) const override {
             return this->createIndexBuffer(dynamic_cast<const index_buffer_layout_type&>(layout), usage, elements);
         }
 
-        virtual UniquePtr<IIndexBuffer> getIndexBuffer(const String& name, const IIndexBufferLayout& layout, const BufferUsage& usage, const UInt32& elements) const override {
+        virtual UniquePtr<IIndexBuffer> getIndexBuffer(const String& name, const IIndexBufferLayout& layout, BufferUsage usage, const UInt32& elements) const override {
             return this->createIndexBuffer(name, dynamic_cast<const index_buffer_layout_type&>(layout), usage, elements);
         }
 
-        virtual UniquePtr<IImage> getAttachment(const Format& format, const Size2d& size, const MultiSamplingLevel& samples) const override { 
+        virtual UniquePtr<IImage> getAttachment(Format format, const Size2d& size, MultiSamplingLevel samples) const override { 
             return this->createAttachment(format, size, samples);
         }
 
-        virtual UniquePtr<IImage> getAttachment(const String& name, const Format& format, const Size2d& size, const MultiSamplingLevel& samples) const override {
+        virtual UniquePtr<IImage> getAttachment(const String& name, Format format, const Size2d& size, MultiSamplingLevel samples) const override {
             return this->createAttachment(name, format, size, samples);
         }
         
-        virtual UniquePtr<IImage> getTexture(const Format& format, const Size3d& size, const ImageDimensions& dimension, const UInt32& levels, const UInt32& layers, const MultiSamplingLevel& samples, const bool& allowWrite) const override { 
+        virtual UniquePtr<IImage> getTexture(Format format, const Size3d& size, ImageDimensions dimension, const UInt32& levels, const UInt32& layers, MultiSamplingLevel samples, const bool& allowWrite) const override { 
             return this->createTexture(format, size, dimension, levels, layers, samples, allowWrite);
         }
 
-        virtual UniquePtr<IImage> getTexture(const String& name, const Format& format, const Size3d& size, const ImageDimensions& dimension, const UInt32& levels, const UInt32& layers, const MultiSamplingLevel& samples, const bool& allowWrite) const override {
+        virtual UniquePtr<IImage> getTexture(const String& name, Format format, const Size3d& size, ImageDimensions dimension, const UInt32& levels, const UInt32& layers, MultiSamplingLevel samples, const bool& allowWrite) const override {
             return this->createTexture(name, format, size, dimension, levels, layers, samples, allowWrite);
         }
 
-        virtual Enumerable<UniquePtr<IImage>> getTextures(const UInt32& elements, const Format& format, const Size3d& size, const ImageDimensions& dimension, const UInt32& layers, const UInt32& levels, const MultiSamplingLevel& samples, const bool& allowWrite) const override {
+        virtual Enumerable<UniquePtr<IImage>> getTextures(const UInt32& elements, Format format, const Size3d& size, ImageDimensions dimension, const UInt32& layers, const UInt32& levels, MultiSamplingLevel samples, const bool& allowWrite) const override {
             return this->getTextures(elements, format, size, dimension, layers, levels, samples, allowWrite) | std::views::as_rvalue;
         }
         
-        virtual UniquePtr<ISampler> getSampler(const FilterMode& magFilter, const FilterMode& minFilter, const BorderMode& borderU, const BorderMode& borderV, const BorderMode& borderW, const MipMapMode& mipMapMode, const Float& mipMapBias, const Float& maxLod, const Float& minLod, const Float& anisotropy) const override { 
+        virtual UniquePtr<ISampler> getSampler(FilterMode magFilter, FilterMode minFilter, BorderMode borderU, BorderMode borderV, BorderMode borderW, MipMapMode mipMapMode, const Float& mipMapBias, const Float& maxLod, const Float& minLod, const Float& anisotropy) const override { 
             return this->createSampler(magFilter, minFilter, borderU, borderV, borderW, mipMapMode, mipMapBias, maxLod, minLod, anisotropy);
         }
 
-        virtual UniquePtr<ISampler> getSampler(const String& name, const FilterMode& magFilter, const FilterMode& minFilter, const BorderMode& borderU, const BorderMode& borderV, const BorderMode& borderW, const MipMapMode& mipMapMode, const Float& mipMapBias, const Float& maxLod, const Float& minLod, const Float& anisotropy) const override {
+        virtual UniquePtr<ISampler> getSampler(const String& name, FilterMode magFilter, FilterMode minFilter, BorderMode borderU, BorderMode borderV, BorderMode borderW, MipMapMode mipMapMode, const Float& mipMapBias, const Float& maxLod, const Float& minLod, const Float& anisotropy) const override {
             return this->createSampler(name, magFilter, minFilter, borderU, borderV, borderW, mipMapMode, mipMapBias, maxLod, minLod, anisotropy);
         }
         
-        virtual Enumerable<UniquePtr<ISampler>> getSamplers(const UInt32& elements, const FilterMode& magFilter, const FilterMode& minFilter, const BorderMode& borderU, const BorderMode& borderV, const BorderMode& borderW, const MipMapMode& mipMapMode, const Float& mipMapBias, const Float& maxLod, const Float& minLod, const Float& anisotropy) const override {
+        virtual Enumerable<UniquePtr<ISampler>> getSamplers(const UInt32& elements, FilterMode magFilter, FilterMode minFilter, BorderMode borderU, BorderMode borderV, BorderMode borderW, MipMapMode mipMapMode, const Float& mipMapBias, const Float& maxLod, const Float& minLod, const Float& anisotropy) const override {
             return this->createSamplers(elements, magFilter, minFilter, borderU, borderV, borderW, mipMapMode, mipMapBias, maxLod, minLod, anisotropy) | std::views::as_rvalue;
         }
     };
@@ -1172,10 +1172,10 @@ namespace LiteFX::Rendering {
         virtual const command_queue_type& computeQueue() const noexcept = 0;
 
         /// <inheritdoc />
-        [[nodiscard]] virtual UniquePtr<barrier_type> makeBarrier(const PipelineStage& syncBefore, const PipelineStage& syncAfter) const noexcept = 0;
+        [[nodiscard]] virtual UniquePtr<barrier_type> makeBarrier(PipelineStage syncBefore, PipelineStage syncAfter) const noexcept = 0;
 
     private:
-        virtual UniquePtr<IBarrier> getNewBarrier(const PipelineStage& syncBefore, const PipelineStage& syncAfter) const noexcept override {
+        virtual UniquePtr<IBarrier> getNewBarrier(PipelineStage syncBefore, PipelineStage syncAfter) const noexcept override {
             return this->makeBarrier(syncBefore, syncAfter);
         }
 
@@ -1196,7 +1196,7 @@ namespace LiteFX::Rendering {
         /// <param name="samples">The number of samples, the render targets of the render pass should be sampled with.</param>
         /// <param name="commandBuffers">The number of command buffers in each frame buffer.</param>
         /// <returns>An instance of a builder that is used to create a new render pass.</returns>
-        [[nodiscard]] virtual render_pass_builder_type buildRenderPass(const MultiSamplingLevel& samples = MultiSamplingLevel::x1, const UInt32& commandBuffers = 1) const = 0;
+        [[nodiscard]] virtual render_pass_builder_type buildRenderPass(MultiSamplingLevel samples = MultiSamplingLevel::x1, const UInt32& commandBuffers = 1) const = 0;
 
         /// <summary>
         /// Returns a builder for a <see cref="RenderPass" />.
@@ -1205,7 +1205,7 @@ namespace LiteFX::Rendering {
         /// <param name="samples">The number of samples, the render targets of the render pass should be sampled with.</param>
         /// <param name="commandBuffers">The number of command buffers in each frame buffer.</param>
         /// <returns>An instance of a builder that is used to create a new render pass.</returns>
-        [[nodiscard]] virtual render_pass_builder_type buildRenderPass(const String& name, const MultiSamplingLevel& samples = MultiSamplingLevel::x1, const UInt32& commandBuffers = 1) const = 0;
+        [[nodiscard]] virtual render_pass_builder_type buildRenderPass(const String& name, MultiSamplingLevel samples = MultiSamplingLevel::x1, const UInt32& commandBuffers = 1) const = 0;
 
         /// <summary>
         /// Returns a builder for a <see cref="ComputePipeline" />.

--- a/src/Rendering/include/litefx/rendering.hpp
+++ b/src/Rendering/include/litefx/rendering.hpp
@@ -29,7 +29,7 @@ namespace LiteFX::Rendering {
         constexpr inline virtual void transition(buffer_type& buffer, ResourceAccess accessBefore, ResourceAccess accessAfter) = 0;
 
         /// <inheritdoc />
-        constexpr inline virtual void transition(buffer_type& buffer, const UInt32& element, ResourceAccess accessBefore, ResourceAccess accessAfter) = 0;
+        constexpr inline virtual void transition(buffer_type& buffer, UInt32 element, ResourceAccess accessBefore, ResourceAccess accessAfter) = 0;
 
         /// <inheritdoc />
         constexpr inline virtual void transition(image_type& image, ResourceAccess accessBefore, ResourceAccess accessAfter, ImageLayout layout) = 0;
@@ -38,17 +38,17 @@ namespace LiteFX::Rendering {
         constexpr inline virtual void transition(image_type& image, ResourceAccess accessBefore, ResourceAccess accessAfter, ImageLayout fromLayout, ImageLayout toLayout) = 0;
 
         /// <inheritdoc />
-        constexpr inline virtual void transition(image_type& image, const UInt32& level, const UInt32& levels, const UInt32& layer, const UInt32& layers, const UInt32& plane, ResourceAccess accessBefore, ResourceAccess accessAfter, ImageLayout layout) = 0;
+        constexpr inline virtual void transition(image_type& image, UInt32 level, UInt32 levels, UInt32 layer, UInt32 layers, UInt32 plane, ResourceAccess accessBefore, ResourceAccess accessAfter, ImageLayout layout) = 0;
 
         /// <inheritdoc />
-        constexpr inline virtual void transition(image_type& image, const UInt32& level, const UInt32& levels, const UInt32& layer, const UInt32& layers, const UInt32& plane, ResourceAccess accessBefore, ResourceAccess accessAfter, ImageLayout fromLayout, ImageLayout toLayout) = 0;
+        constexpr inline virtual void transition(image_type& image, UInt32 level, UInt32 levels, UInt32 layer, UInt32 layers, UInt32 plane, ResourceAccess accessBefore, ResourceAccess accessAfter, ImageLayout fromLayout, ImageLayout toLayout) = 0;
 
     private:
         constexpr inline virtual void doTransition(IBuffer& buffer, ResourceAccess accessBefore, ResourceAccess accessAfter) override {
             this->transition(dynamic_cast<buffer_type&>(buffer), accessBefore, accessAfter);
         }
 
-        constexpr inline virtual void doTransition(IBuffer& buffer, const UInt32& element, ResourceAccess accessBefore, ResourceAccess accessAfter) override {
+        constexpr inline virtual void doTransition(IBuffer& buffer, UInt32 element, ResourceAccess accessBefore, ResourceAccess accessAfter) override {
             this->transition(dynamic_cast<buffer_type&>(buffer), element, accessBefore, accessAfter);
         }
 
@@ -60,11 +60,11 @@ namespace LiteFX::Rendering {
             this->transition(dynamic_cast<image_type&>(image), accessBefore, accessAfter, fromLayout, toLayout);
         }
 
-        constexpr inline virtual void doTransition(IImage& image, const UInt32& level, const UInt32& levels, const UInt32& layer, const UInt32& layers, const UInt32& plane, ResourceAccess accessBefore, ResourceAccess accessAfter, ImageLayout layout) override {
+        constexpr inline virtual void doTransition(IImage& image, UInt32 level, UInt32 levels, UInt32 layer, UInt32 layers, UInt32 plane, ResourceAccess accessBefore, ResourceAccess accessAfter, ImageLayout layout) override {
             this->transition(dynamic_cast<image_type&>(image), level, levels, layer, layers, plane, accessBefore, accessAfter, layout);
         }
 
-        constexpr inline virtual void doTransition(IImage& image, const UInt32& level, const UInt32& levels, const UInt32& layer, const UInt32& layers, const UInt32& plane, ResourceAccess accessBefore, ResourceAccess accessAfter, ImageLayout fromLayout, ImageLayout toLayout) override {
+        constexpr inline virtual void doTransition(IImage& image, UInt32 level, UInt32 levels, UInt32 layer, UInt32 layers, UInt32 plane, ResourceAccess accessBefore, ResourceAccess accessAfter, ImageLayout fromLayout, ImageLayout toLayout) override {
             this->transition(dynamic_cast<image_type&>(image), level, levels, layer, layers, plane, accessBefore, accessAfter, fromLayout, toLayout);
         }
     };
@@ -152,31 +152,31 @@ namespace LiteFX::Rendering {
 
     public:
         /// <inheritdoc />
-        virtual void update(const UInt32& binding, const buffer_type& buffer, const UInt32& bufferElement = 0, const UInt32& elements = 0, const UInt32& firstDescriptor = 0) const = 0;
+        virtual void update(UInt32 binding, const buffer_type& buffer, UInt32 bufferElement = 0, UInt32 elements = 0, UInt32 firstDescriptor = 0) const = 0;
 
         /// <inheritdoc />
-        virtual void update(const UInt32& binding, const image_type& texture, const UInt32& descriptor = 0, const UInt32& firstLevel = 0, const UInt32& levels = 0, const UInt32& firstLayer = 0, const UInt32& layers = 0) const = 0;
+        virtual void update(UInt32 binding, const image_type& texture, UInt32 descriptor = 0, UInt32 firstLevel = 0, UInt32 levels = 0, UInt32 firstLayer = 0, UInt32 layers = 0) const = 0;
 
         /// <inheritdoc />
-        virtual void update(const UInt32& binding, const sampler_type& sampler, const UInt32& descriptor = 0) const = 0;
+        virtual void update(UInt32 binding, const sampler_type& sampler, UInt32 descriptor = 0) const = 0;
 
         /// <inheritdoc />
-        virtual void attach(const UInt32& binding, const image_type& image) const = 0;
+        virtual void attach(UInt32 binding, const image_type& image) const = 0;
 
     private:
-        virtual void doUpdate(const UInt32& binding, const IBuffer& buffer, const UInt32& bufferElement, const UInt32& elements, const UInt32& firstDescriptor) const override {
+        virtual void doUpdate(UInt32 binding, const IBuffer& buffer, UInt32 bufferElement, UInt32 elements, UInt32 firstDescriptor) const override {
             this->update(binding, dynamic_cast<const buffer_type&>(buffer), bufferElement, elements, firstDescriptor);
         }
 
-        virtual void doUpdate(const UInt32& binding, const IImage& texture, const UInt32& descriptor, const UInt32& firstLevel, const UInt32& levels, const UInt32& firstLayer, const UInt32& layers) const  override {
+        virtual void doUpdate(UInt32 binding, const IImage& texture, UInt32 descriptor, UInt32 firstLevel, UInt32 levels, UInt32 firstLayer, UInt32 layers) const  override {
             this->update(binding, dynamic_cast<const image_type&>(texture), descriptor, firstLevel, levels, firstLayer, layers);
         }
 
-        virtual void doUpdate(const UInt32& binding, const ISampler& sampler, const UInt32& descriptor) const  override {
+        virtual void doUpdate(UInt32 binding, const ISampler& sampler, UInt32 descriptor) const  override {
             this->update(binding, dynamic_cast<const sampler_type&>(sampler), descriptor);
         }
 
-        virtual void doAttach(const UInt32& binding, const IImage& image) const  override {
+        virtual void doAttach(UInt32 binding, const IImage& image) const  override {
             this->attach(binding, dynamic_cast<const image_type&>(image));
         }
     };
@@ -211,25 +211,25 @@ namespace LiteFX::Rendering {
         virtual Enumerable<const descriptor_layout_type*> descriptors() const noexcept = 0;
 
         /// <inheritdoc />
-        virtual const descriptor_layout_type& descriptor(const UInt32& binding) const = 0;
+        virtual const descriptor_layout_type& descriptor(UInt32 binding) const = 0;
 
         /// <inheritdoc />
         virtual UniquePtr<descriptor_set_type> allocate(const Enumerable<DescriptorBinding>& bindings = { }) const = 0;
 
         /// <inheritdoc />
-        virtual UniquePtr<descriptor_set_type> allocate(const UInt32& descriptors, const Enumerable<DescriptorBinding>& bindings = { }) const = 0;
+        virtual UniquePtr<descriptor_set_type> allocate(UInt32 descriptors, const Enumerable<DescriptorBinding>& bindings = { }) const = 0;
 
         /// <inheritdoc />
-        virtual Enumerable<UniquePtr<descriptor_set_type>> allocateMultiple(const UInt32& descriptorSets, const Enumerable<Enumerable<DescriptorBinding>>& bindings = { }) const = 0;
+        virtual Enumerable<UniquePtr<descriptor_set_type>> allocateMultiple(UInt32 descriptorSets, const Enumerable<Enumerable<DescriptorBinding>>& bindings = { }) const = 0;
 
         /// <inheritdoc />
-        virtual Enumerable<UniquePtr<descriptor_set_type>> allocateMultiple(const UInt32& descriptorSets, std::function<Enumerable<DescriptorBinding>(const UInt32&)> bindingFactory) const = 0;
+        virtual Enumerable<UniquePtr<descriptor_set_type>> allocateMultiple(UInt32 descriptorSets, std::function<Enumerable<DescriptorBinding>(UInt32)> bindingFactory) const = 0;
 
         /// <inheritdoc />
-        virtual Enumerable<UniquePtr<descriptor_set_type>> allocateMultiple(const UInt32& descriptorSets, const UInt32& descriptors, const Enumerable<Enumerable<DescriptorBinding>>& bindings = { }) const = 0;
+        virtual Enumerable<UniquePtr<descriptor_set_type>> allocateMultiple(UInt32 descriptorSets, UInt32 descriptors, const Enumerable<Enumerable<DescriptorBinding>>& bindings = { }) const = 0;
 
         /// <inheritdoc />
-        virtual Enumerable<UniquePtr<descriptor_set_type>> allocateMultiple(const UInt32& descriptorSets, const UInt32& descriptors, std::function<Enumerable<DescriptorBinding>(const UInt32&)> bindingFactory) const = 0;
+        virtual Enumerable<UniquePtr<descriptor_set_type>> allocateMultiple(UInt32 descriptorSets, UInt32 descriptors, std::function<Enumerable<DescriptorBinding>(UInt32)> bindingFactory) const = 0;
 
         /// <inheritdoc />
         virtual void free(const descriptor_set_type& descriptorSet) const noexcept = 0;
@@ -239,15 +239,15 @@ namespace LiteFX::Rendering {
             return this->descriptors();
         }
 
-        virtual UniquePtr<IDescriptorSet> getDescriptorSet(const UInt32& descriptors, const Enumerable<DescriptorBinding>& bindings = { }) const override {
+        virtual UniquePtr<IDescriptorSet> getDescriptorSet(UInt32 descriptors, const Enumerable<DescriptorBinding>& bindings = { }) const override {
             return this->allocate(descriptors, bindings);
         }
 
-        virtual Enumerable<UniquePtr<IDescriptorSet>> getDescriptorSets(const UInt32& descriptorSets, const UInt32& descriptors, const Enumerable<Enumerable<DescriptorBinding>>& bindings = { }) const override {
+        virtual Enumerable<UniquePtr<IDescriptorSet>> getDescriptorSets(UInt32 descriptorSets, UInt32 descriptors, const Enumerable<Enumerable<DescriptorBinding>>& bindings = { }) const override {
             return this->allocateMultiple(descriptorSets, descriptors, bindings) | std::views::as_rvalue;
         }
 
-        virtual Enumerable<UniquePtr<IDescriptorSet>> getDescriptorSets(const UInt32& descriptorSets, const UInt32& descriptors, std::function<Enumerable<DescriptorBinding>(const UInt32&)> bindingFactory) const override {
+        virtual Enumerable<UniquePtr<IDescriptorSet>> getDescriptorSets(UInt32 descriptorSets, UInt32 descriptors, std::function<Enumerable<DescriptorBinding>(UInt32)> bindingFactory) const override {
             return this->allocateMultiple(descriptorSets, descriptors, bindingFactory) | std::views::as_rvalue;
         }
 
@@ -340,7 +340,7 @@ namespace LiteFX::Rendering {
 
     public:
         /// <inheritdoc />
-        virtual const descriptor_set_layout_type& descriptorSet(const UInt32& space) const = 0;
+        virtual const descriptor_set_layout_type& descriptorSet(UInt32 space) const = 0;
 
         /// <inheritdoc />
         virtual Enumerable<const descriptor_set_layout_type*> descriptorSets() const noexcept = 0;
@@ -411,7 +411,7 @@ namespace LiteFX::Rendering {
         virtual Enumerable<const vertex_buffer_layout_type*> vertexBufferLayouts() const noexcept = 0;
 
         /// <inheritdoc />
-        virtual const vertex_buffer_layout_type& vertexBufferLayout(const UInt32& binding) const = 0;
+        virtual const vertex_buffer_layout_type& vertexBufferLayout(UInt32 binding) const = 0;
 
         /// <inheritdoc />
         virtual const index_buffer_layout_type& indexBufferLayout() const = 0;
@@ -507,28 +507,28 @@ namespace LiteFX::Rendering {
         virtual void generateMipMaps(image_type& image) noexcept = 0;
 
         /// <inheritdoc />
-        virtual void transfer(buffer_type& source, buffer_type& target, const UInt32& sourceElement = 0, const UInt32& targetElement = 0, const UInt32& elements = 1) const = 0;
+        virtual void transfer(buffer_type& source, buffer_type& target, UInt32 sourceElement = 0, UInt32 targetElement = 0, UInt32 elements = 1) const = 0;
 
         /// <inheritdoc />
-        virtual void transfer(buffer_type& source, image_type& target, const UInt32& sourceElement = 0, const UInt32& firstSubresource = 0, const UInt32& elements = 1) const = 0;
+        virtual void transfer(buffer_type& source, image_type& target, UInt32 sourceElement = 0, UInt32 firstSubresource = 0, UInt32 elements = 1) const = 0;
 
         /// <inheritdoc />
-        virtual void transfer(image_type& source, image_type& target, const UInt32& sourceSubresource = 0, const UInt32& targetSubresource = 0, const UInt32& subresources = 1) const = 0;
+        virtual void transfer(image_type& source, image_type& target, UInt32 sourceSubresource = 0, UInt32 targetSubresource = 0, UInt32 subresources = 1) const = 0;
 
         /// <inheritdoc />
-        virtual void transfer(image_type& source, buffer_type& target, const UInt32& firstSubresource = 0, const UInt32& targetElement = 0, const UInt32& subresources = 1) const = 0;
+        virtual void transfer(image_type& source, buffer_type& target, UInt32 firstSubresource = 0, UInt32 targetElement = 0, UInt32 subresources = 1) const = 0;
 
         /// <inheritdoc />
-        virtual void transfer(SharedPtr<buffer_type> source, buffer_type& target, const UInt32& sourceElement = 0, const UInt32& targetElement = 0, const UInt32& elements = 1) const = 0;
+        virtual void transfer(SharedPtr<buffer_type> source, buffer_type& target, UInt32 sourceElement = 0, UInt32 targetElement = 0, UInt32 elements = 1) const = 0;
 
         /// <inheritdoc />
-        virtual void transfer(SharedPtr<buffer_type> source, image_type& target, const UInt32& sourceElement = 0, const UInt32& firstSubresource = 0, const UInt32& elements = 1) const = 0;
+        virtual void transfer(SharedPtr<buffer_type> source, image_type& target, UInt32 sourceElement = 0, UInt32 firstSubresource = 0, UInt32 elements = 1) const = 0;
 
         /// <inheritdoc />
-        virtual void transfer(SharedPtr<image_type> source, image_type& target, const UInt32& sourceSubresource = 0, const UInt32& targetSubresource = 0, const UInt32& subresources = 1) const = 0;
+        virtual void transfer(SharedPtr<image_type> source, image_type& target, UInt32 sourceSubresource = 0, UInt32 targetSubresource = 0, UInt32 subresources = 1) const = 0;
 
         /// <inheritdoc />
-        virtual void transfer(SharedPtr<image_type> source, buffer_type& target, const UInt32& firstSubresource = 0, const UInt32& targetElement = 0, const UInt32& subresources = 1) const = 0;
+        virtual void transfer(SharedPtr<image_type> source, buffer_type& target, UInt32 firstSubresource = 0, UInt32 targetElement = 0, UInt32 subresources = 1) const = 0;
 
         /// <inheritdoc />
         virtual void use(const pipeline_type& pipeline) const noexcept = 0;
@@ -546,19 +546,19 @@ namespace LiteFX::Rendering {
         virtual void pushConstants(const push_constants_layout_type& layout, const void* const memory) const noexcept = 0;
 
         /// <inheritdoc />
-        virtual void draw(const vertex_buffer_type& vertexBuffer, const UInt32& instances = 1, const UInt32& firstVertex = 0, const UInt32& firstInstance = 0) const {
+        virtual void draw(const vertex_buffer_type& vertexBuffer, UInt32 instances = 1, UInt32 firstVertex = 0, UInt32 firstInstance = 0) const {
             this->bind(vertexBuffer);
             this->draw(vertexBuffer.elements(), instances, firstVertex, firstInstance);
         }
 
         /// <inheritdoc />
-        virtual void drawIndexed(const index_buffer_type& indexBuffer, const UInt32& instances = 1, const UInt32& firstIndex = 0, const Int32& vertexOffset = 0, const UInt32& firstInstance = 0) const {
+        virtual void drawIndexed(const index_buffer_type& indexBuffer, UInt32 instances = 1, UInt32 firstIndex = 0, Int32 vertexOffset = 0, UInt32 firstInstance = 0) const {
             this->bind(indexBuffer);
             this->drawIndexed(indexBuffer.elements(), instances, firstIndex, vertexOffset, firstInstance);
         }
 
         /// <inheritdoc />
-        virtual void drawIndexed(const vertex_buffer_type& vertexBuffer, const index_buffer_type& indexBuffer, const UInt32& instances = 1, const UInt32& firstIndex = 0, const Int32& vertexOffset = 0, const UInt32& firstInstance = 0) const {
+        virtual void drawIndexed(const vertex_buffer_type& vertexBuffer, const index_buffer_type& indexBuffer, UInt32 instances = 1, UInt32 firstIndex = 0, Int32 vertexOffset = 0, UInt32 firstInstance = 0) const {
             this->bind(vertexBuffer);
             this->bind(indexBuffer);
             this->drawIndexed(indexBuffer.elements(), instances, firstIndex, vertexOffset, firstInstance);
@@ -579,35 +579,35 @@ namespace LiteFX::Rendering {
             this->generateMipMaps(dynamic_cast<image_type&>(image));
         }
 
-        virtual void cmdTransfer(IBuffer& source, IBuffer& target, const UInt32& sourceElement, const UInt32& targetElement, const UInt32& elements) const override { 
+        virtual void cmdTransfer(IBuffer& source, IBuffer& target, UInt32 sourceElement, UInt32 targetElement, UInt32 elements) const override { 
             this->transfer(dynamic_cast<buffer_type&>(source), dynamic_cast<buffer_type&>(target), sourceElement, targetElement, elements);
         }
         
-        virtual void cmdTransfer(IBuffer& source, IImage& target, const UInt32& sourceElement, const UInt32& firstSubresource, const UInt32& elements) const override { 
+        virtual void cmdTransfer(IBuffer& source, IImage& target, UInt32 sourceElement, UInt32 firstSubresource, UInt32 elements) const override { 
             this->transfer(dynamic_cast<buffer_type&>(source), dynamic_cast<image_type&>(target), sourceElement, firstSubresource, elements);
         }
         
-        virtual void cmdTransfer(IImage& source, IImage& target, const UInt32& sourceSubresource, const UInt32& targetSubresource, const UInt32& subresources) const override {
+        virtual void cmdTransfer(IImage& source, IImage& target, UInt32 sourceSubresource, UInt32 targetSubresource, UInt32 subresources) const override {
             this->transfer(dynamic_cast<image_type&>(source), dynamic_cast<image_type&>(target), sourceSubresource, targetSubresource, subresources);
         }
 
-        virtual void cmdTransfer(IImage& source, IBuffer& target, const UInt32& firstSubresource, const UInt32& targetElement, const UInt32& subresources) const override {
+        virtual void cmdTransfer(IImage& source, IBuffer& target, UInt32 firstSubresource, UInt32 targetElement, UInt32 subresources) const override {
             this->transfer(dynamic_cast<image_type&>(source), dynamic_cast<buffer_type&>(target), firstSubresource, targetElement, subresources);
         }
 
-        virtual void cmdTransfer(SharedPtr<IBuffer> source, IBuffer& target, const UInt32& sourceElement, const UInt32& targetElement, const UInt32& elements) const override {
+        virtual void cmdTransfer(SharedPtr<IBuffer> source, IBuffer& target, UInt32 sourceElement, UInt32 targetElement, UInt32 elements) const override {
             this->transfer(std::dynamic_pointer_cast<buffer_type>(source), dynamic_cast<buffer_type&>(target), sourceElement, targetElement, elements);
         }
         
-        virtual void cmdTransfer(SharedPtr<IBuffer> source, IImage& target, const UInt32& sourceElement, const UInt32& firstSubresource, const UInt32& elements) const override {
+        virtual void cmdTransfer(SharedPtr<IBuffer> source, IImage& target, UInt32 sourceElement, UInt32 firstSubresource, UInt32 elements) const override {
             this->transfer(std::dynamic_pointer_cast<buffer_type>(source), dynamic_cast<image_type&>(target), sourceElement, firstSubresource, elements);
         }
         
-        virtual void cmdTransfer(SharedPtr<IImage> source, IImage& target, const UInt32& sourceSubresource, const UInt32& targetSubresource, const UInt32& subresources) const override {
+        virtual void cmdTransfer(SharedPtr<IImage> source, IImage& target, UInt32 sourceSubresource, UInt32 targetSubresource, UInt32 subresources) const override {
             this->transfer(std::dynamic_pointer_cast<image_type>(source), dynamic_cast<image_type&>(target), sourceSubresource, targetSubresource, subresources);
         }
         
-        virtual void cmdTransfer(SharedPtr<IImage> source, IBuffer& target, const UInt32& firstSubresource, const UInt32& targetElement, const UInt32& subresources) const override {
+        virtual void cmdTransfer(SharedPtr<IImage> source, IBuffer& target, UInt32 firstSubresource, UInt32 targetElement, UInt32 subresources) const override {
             this->transfer(std::dynamic_pointer_cast<image_type>(source), dynamic_cast<buffer_type&>(target), firstSubresource, targetElement, subresources);
         }
 
@@ -631,15 +631,15 @@ namespace LiteFX::Rendering {
             this->pushConstants(dynamic_cast<const push_constants_layout_type&>(layout), memory);
         }
         
-        virtual void cmdDraw(const IVertexBuffer& vertexBuffer, const UInt32& instances, const UInt32& firstVertex, const UInt32& firstInstance) const override { 
+        virtual void cmdDraw(const IVertexBuffer& vertexBuffer, UInt32 instances, UInt32 firstVertex, UInt32 firstInstance) const override { 
             this->draw(dynamic_cast<const vertex_buffer_type&>(vertexBuffer), instances, firstVertex, firstInstance);
         }
         
-        virtual void cmdDrawIndexed(const IIndexBuffer& indexBuffer, const UInt32& instances, const UInt32& firstIndex, const Int32& vertexOffset, const UInt32& firstInstance) const override { 
+        virtual void cmdDrawIndexed(const IIndexBuffer& indexBuffer, UInt32 instances, UInt32 firstIndex, Int32 vertexOffset, UInt32 firstInstance) const override { 
             this->drawIndexed(dynamic_cast<const index_buffer_type&>(indexBuffer), instances, firstIndex, vertexOffset, firstInstance);
         }
         
-        virtual void cmdDrawIndexed(const IVertexBuffer& vertexBuffer, const IIndexBuffer& indexBuffer, const UInt32& instances, const UInt32& firstIndex, const Int32& vertexOffset, const UInt32& firstInstance) const override { 
+        virtual void cmdDrawIndexed(const IVertexBuffer& vertexBuffer, const IIndexBuffer& indexBuffer, UInt32 instances, UInt32 firstIndex, Int32 vertexOffset, UInt32 firstInstance) const override { 
             this->drawIndexed(dynamic_cast<const vertex_buffer_type&>(vertexBuffer), dynamic_cast<const index_buffer_type&>(indexBuffer), instances, firstIndex, vertexOffset, firstInstance);
         }
 
@@ -721,16 +721,16 @@ namespace LiteFX::Rendering {
         virtual Enumerable<SharedPtr<const command_buffer_type>> commandBuffers() const noexcept = 0;
 
         /// <inheritdoc />
-        virtual SharedPtr<const command_buffer_type> commandBuffer(const UInt32& index) const = 0;
+        virtual SharedPtr<const command_buffer_type> commandBuffer(UInt32 index) const = 0;
 
         /// <inheritdoc />
         virtual Enumerable<const image_type*> images() const noexcept = 0;
 
         /// <inheritdoc />
-        virtual const image_type& image(const UInt32& location) const = 0;
+        virtual const image_type& image(UInt32 location) const = 0;
 
     private:
-        virtual SharedPtr<const ICommandBuffer> getCommandBuffer(const UInt32& index) const noexcept override {
+        virtual SharedPtr<const ICommandBuffer> getCommandBuffer(UInt32 index) const noexcept override {
             return this->commandBuffer(index);
         }
 
@@ -767,7 +767,7 @@ namespace LiteFX::Rendering {
         /// <param name="buffer">The index of a frame buffer within the source.</param>
         /// <returns>The frame buffer with the index provided in <paramref name="buffer" />.</returns>
         /// <exception cref="ArgumentOutOfRangeException">Thrown, if the <paramref name="buffer" /> does not map to a frame buffer within the source.</exception>
-        virtual const frame_buffer_type& frameBuffer(const UInt32& buffer) const = 0;
+        virtual const frame_buffer_type& frameBuffer(UInt32 buffer) const = 0;
     };
 
     /// <summary>
@@ -804,7 +804,7 @@ namespace LiteFX::Rendering {
         /// when it is initialized and will raise an exception, if a location is either not mapped or assigned multiple times.
         /// </remarks>
         /// <returns>The location of the input attachment, the render target will be bound to.</returns>
-        virtual const UInt32& location() const noexcept = 0;
+        virtual UInt32 location() const noexcept = 0;
     };
 
     /// <summary>
@@ -918,7 +918,7 @@ namespace LiteFX::Rendering {
 
     public:
         /// <inheritdoc />
-        virtual SharedPtr<command_buffer_type> createCommandBuffer(const bool& beginRecording = false, const bool& secondary = false) const = 0;
+        virtual SharedPtr<command_buffer_type> createCommandBuffer(bool beginRecording = false, bool secondary = false) const = 0;
 
         /// <inheritdoc />
         virtual UInt64 submit(SharedPtr<command_buffer_type> commandBuffer) const {
@@ -937,7 +937,7 @@ namespace LiteFX::Rendering {
         virtual UInt64 submit(const Enumerable<SharedPtr<const command_buffer_type>>& commandBuffers) const = 0;
 
     private:
-        virtual SharedPtr<ICommandBuffer> getCommandBuffer(const bool& beginRecording, const bool& secondary) const override {
+        virtual SharedPtr<ICommandBuffer> getCommandBuffer(bool beginRecording, bool secondary) const override {
             return this->createCommandBuffer(beginRecording, secondary);
         }
 
@@ -991,22 +991,22 @@ namespace LiteFX::Rendering {
 
     public:
         /// <inheritdoc />
-        virtual UniquePtr<TBuffer> createBuffer(BufferType type, BufferUsage usage, const size_t& elementSize, const UInt32& elements = 1, const bool& allowWrite = false) const = 0;
+        virtual UniquePtr<TBuffer> createBuffer(BufferType type, BufferUsage usage, size_t elementSize, UInt32 elements = 1, bool allowWrite = false) const = 0;
         
         /// <inheritdoc />
-        virtual UniquePtr<TBuffer> createBuffer(const String& name, BufferType type, BufferUsage usage, const size_t& elementSize, const UInt32& elements = 1, const bool& allowWrite = false) const = 0;
+        virtual UniquePtr<TBuffer> createBuffer(const String& name, BufferType type, BufferUsage usage, size_t elementSize, UInt32 elements = 1, bool allowWrite = false) const = 0;
 
         /// <inheritdoc />
-        virtual UniquePtr<TVertexBuffer> createVertexBuffer(const vertex_buffer_layout_type& layout, BufferUsage usage, const UInt32& elements = 1) const = 0;
+        virtual UniquePtr<TVertexBuffer> createVertexBuffer(const vertex_buffer_layout_type& layout, BufferUsage usage, UInt32 elements = 1) const = 0;
 
         /// <inheritdoc />
-        virtual UniquePtr<TVertexBuffer> createVertexBuffer(const String& name, const vertex_buffer_layout_type& layout, BufferUsage usage, const UInt32& elements = 1) const = 0;
+        virtual UniquePtr<TVertexBuffer> createVertexBuffer(const String& name, const vertex_buffer_layout_type& layout, BufferUsage usage, UInt32 elements = 1) const = 0;
 
         /// <inheritdoc />
-        virtual UniquePtr<TIndexBuffer> createIndexBuffer(const index_buffer_layout_type& layout, BufferUsage usage, const UInt32& elements) const = 0;
+        virtual UniquePtr<TIndexBuffer> createIndexBuffer(const index_buffer_layout_type& layout, BufferUsage usage, UInt32 elements) const = 0;
 
         /// <inheritdoc />
-        virtual UniquePtr<TIndexBuffer> createIndexBuffer(const String& name, const index_buffer_layout_type& layout, BufferUsage usage, const UInt32& elements) const = 0;
+        virtual UniquePtr<TIndexBuffer> createIndexBuffer(const String& name, const index_buffer_layout_type& layout, BufferUsage usage, UInt32 elements) const = 0;
 
         /// <inheritdoc />
         virtual UniquePtr<TImage> createAttachment(Format format, const Size2d& size, MultiSamplingLevel samples = MultiSamplingLevel::x1) const = 0;
@@ -1015,45 +1015,45 @@ namespace LiteFX::Rendering {
         virtual UniquePtr<TImage> createAttachment(const String& name, Format format, const Size2d& size, MultiSamplingLevel samples = MultiSamplingLevel::x1) const = 0;
 
         /// <inheritdoc />
-        virtual UniquePtr<TImage> createTexture(Format format, const Size3d& size, ImageDimensions dimension = ImageDimensions::DIM_2, const UInt32& levels = 1, const UInt32& layers = 1, MultiSamplingLevel samples = MultiSamplingLevel::x1, const bool& allowWrite = false) const = 0;
+        virtual UniquePtr<TImage> createTexture(Format format, const Size3d& size, ImageDimensions dimension = ImageDimensions::DIM_2, UInt32 levels = 1, UInt32 layers = 1, MultiSamplingLevel samples = MultiSamplingLevel::x1, bool allowWrite = false) const = 0;
 
         /// <inheritdoc />
-        virtual UniquePtr<TImage> createTexture(const String& name, Format format, const Size3d& size, ImageDimensions dimension = ImageDimensions::DIM_2, const UInt32& levels = 1, const UInt32& layers = 1, MultiSamplingLevel samples = MultiSamplingLevel::x1, const bool& allowWrite = false) const = 0;
+        virtual UniquePtr<TImage> createTexture(const String& name, Format format, const Size3d& size, ImageDimensions dimension = ImageDimensions::DIM_2, UInt32 levels = 1, UInt32 layers = 1, MultiSamplingLevel samples = MultiSamplingLevel::x1, bool allowWrite = false) const = 0;
 
         /// <inheritdoc />
-        virtual Enumerable<UniquePtr<TImage>> createTextures(const UInt32& elements, Format format, const Size3d& size, ImageDimensions dimension = ImageDimensions::DIM_2, const UInt32 & layers = 1, const UInt32& levels = 1, MultiSamplingLevel samples = MultiSamplingLevel::x1, const bool& allowWrite = false) const = 0;
+        virtual Enumerable<UniquePtr<TImage>> createTextures(UInt32 elements, Format format, const Size3d& size, ImageDimensions dimension = ImageDimensions::DIM_2, UInt32 layers = 1, UInt32 levels = 1, MultiSamplingLevel samples = MultiSamplingLevel::x1, bool allowWrite = false) const = 0;
 
         /// <inheritdoc />
-        virtual UniquePtr<TSampler> createSampler(FilterMode magFilter = FilterMode::Nearest, FilterMode minFilter = FilterMode::Nearest, BorderMode borderU = BorderMode::Repeat, BorderMode borderV = BorderMode::Repeat, BorderMode borderW = BorderMode::Repeat, MipMapMode mipMapMode = MipMapMode::Nearest, const Float& mipMapBias = 0.f, const Float& maxLod = std::numeric_limits<Float>::max(), const Float& minLod = 0.f, const Float& anisotropy = 0.f) const = 0;
+        virtual UniquePtr<TSampler> createSampler(FilterMode magFilter = FilterMode::Nearest, FilterMode minFilter = FilterMode::Nearest, BorderMode borderU = BorderMode::Repeat, BorderMode borderV = BorderMode::Repeat, BorderMode borderW = BorderMode::Repeat, MipMapMode mipMapMode = MipMapMode::Nearest, Float mipMapBias = 0.f, Float maxLod = std::numeric_limits<Float>::max(), Float minLod = 0.f, Float anisotropy = 0.f) const = 0;
 
         /// <inheritdoc />
-        virtual UniquePtr<TSampler> createSampler(const String& name, FilterMode magFilter = FilterMode::Nearest, FilterMode minFilter = FilterMode::Nearest, BorderMode borderU = BorderMode::Repeat, BorderMode borderV = BorderMode::Repeat, BorderMode borderW = BorderMode::Repeat, MipMapMode mipMapMode = MipMapMode::Nearest, const Float& mipMapBias = 0.f, const Float& maxLod = std::numeric_limits<Float>::max(), const Float& minLod = 0.f, const Float& anisotropy = 0.f) const = 0;
+        virtual UniquePtr<TSampler> createSampler(const String& name, FilterMode magFilter = FilterMode::Nearest, FilterMode minFilter = FilterMode::Nearest, BorderMode borderU = BorderMode::Repeat, BorderMode borderV = BorderMode::Repeat, BorderMode borderW = BorderMode::Repeat, MipMapMode mipMapMode = MipMapMode::Nearest, Float mipMapBias = 0.f, Float maxLod = std::numeric_limits<Float>::max(), Float minLod = 0.f, Float anisotropy = 0.f) const = 0;
 
         /// <inheritdoc />
-        virtual Enumerable<UniquePtr<TSampler>> createSamplers(const UInt32& elements, FilterMode magFilter = FilterMode::Nearest, FilterMode minFilter = FilterMode::Nearest, BorderMode borderU = BorderMode::Repeat, BorderMode borderV = BorderMode::Repeat, BorderMode borderW = BorderMode::Repeat, MipMapMode mipMapMode = MipMapMode::Nearest, const Float& mipMapBias = 0.f, const Float& maxLod = std::numeric_limits<Float>::max(), const Float& minLod = 0.f, const Float& anisotropy = 0.f) const = 0;
+        virtual Enumerable<UniquePtr<TSampler>> createSamplers(UInt32 elements, FilterMode magFilter = FilterMode::Nearest, FilterMode minFilter = FilterMode::Nearest, BorderMode borderU = BorderMode::Repeat, BorderMode borderV = BorderMode::Repeat, BorderMode borderW = BorderMode::Repeat, MipMapMode mipMapMode = MipMapMode::Nearest, Float mipMapBias = 0.f, Float maxLod = std::numeric_limits<Float>::max(), Float minLod = 0.f, Float anisotropy = 0.f) const = 0;
 
     private:
-        virtual UniquePtr<IBuffer> getBuffer(BufferType type, BufferUsage usage, const size_t& elementSize, const UInt32& elements, const bool& allowWrite) const override { 
+        virtual UniquePtr<IBuffer> getBuffer(BufferType type, BufferUsage usage, size_t elementSize, UInt32 elements, bool allowWrite) const override { 
             return this->createBuffer(type, usage, elementSize, elements, allowWrite);
         }
 
-        virtual UniquePtr<IBuffer> getBuffer(const String& name, BufferType type, BufferUsage usage, const size_t& elementSize, const UInt32& elements, const bool& allowWrite) const override {
+        virtual UniquePtr<IBuffer> getBuffer(const String& name, BufferType type, BufferUsage usage, size_t elementSize, UInt32 elements, bool allowWrite) const override {
             return this->createBuffer(name, type, usage, elementSize, elements, allowWrite);
         }
 
-        virtual UniquePtr<IVertexBuffer> getVertexBuffer(const IVertexBufferLayout& layout, BufferUsage usage, const UInt32& elements) const override { 
+        virtual UniquePtr<IVertexBuffer> getVertexBuffer(const IVertexBufferLayout& layout, BufferUsage usage, UInt32 elements) const override { 
             return this->createVertexBuffer(dynamic_cast<const vertex_buffer_layout_type&>(layout), usage, elements);
         }
 
-        virtual UniquePtr<IVertexBuffer> getVertexBuffer(const String& name, const IVertexBufferLayout& layout, BufferUsage usage, const UInt32& elements) const override {
+        virtual UniquePtr<IVertexBuffer> getVertexBuffer(const String& name, const IVertexBufferLayout& layout, BufferUsage usage, UInt32 elements) const override {
             return this->createVertexBuffer(name, dynamic_cast<const vertex_buffer_layout_type&>(layout), usage, elements);
         }
         
-        virtual UniquePtr<IIndexBuffer> getIndexBuffer(const IIndexBufferLayout& layout, BufferUsage usage, const UInt32& elements) const override {
+        virtual UniquePtr<IIndexBuffer> getIndexBuffer(const IIndexBufferLayout& layout, BufferUsage usage, UInt32 elements) const override {
             return this->createIndexBuffer(dynamic_cast<const index_buffer_layout_type&>(layout), usage, elements);
         }
 
-        virtual UniquePtr<IIndexBuffer> getIndexBuffer(const String& name, const IIndexBufferLayout& layout, BufferUsage usage, const UInt32& elements) const override {
+        virtual UniquePtr<IIndexBuffer> getIndexBuffer(const String& name, const IIndexBufferLayout& layout, BufferUsage usage, UInt32 elements) const override {
             return this->createIndexBuffer(name, dynamic_cast<const index_buffer_layout_type&>(layout), usage, elements);
         }
 
@@ -1065,27 +1065,27 @@ namespace LiteFX::Rendering {
             return this->createAttachment(name, format, size, samples);
         }
         
-        virtual UniquePtr<IImage> getTexture(Format format, const Size3d& size, ImageDimensions dimension, const UInt32& levels, const UInt32& layers, MultiSamplingLevel samples, const bool& allowWrite) const override { 
+        virtual UniquePtr<IImage> getTexture(Format format, const Size3d& size, ImageDimensions dimension, UInt32 levels, UInt32 layers, MultiSamplingLevel samples, bool allowWrite) const override { 
             return this->createTexture(format, size, dimension, levels, layers, samples, allowWrite);
         }
 
-        virtual UniquePtr<IImage> getTexture(const String& name, Format format, const Size3d& size, ImageDimensions dimension, const UInt32& levels, const UInt32& layers, MultiSamplingLevel samples, const bool& allowWrite) const override {
+        virtual UniquePtr<IImage> getTexture(const String& name, Format format, const Size3d& size, ImageDimensions dimension, UInt32 levels, UInt32 layers, MultiSamplingLevel samples, bool allowWrite) const override {
             return this->createTexture(name, format, size, dimension, levels, layers, samples, allowWrite);
         }
 
-        virtual Enumerable<UniquePtr<IImage>> getTextures(const UInt32& elements, Format format, const Size3d& size, ImageDimensions dimension, const UInt32& layers, const UInt32& levels, MultiSamplingLevel samples, const bool& allowWrite) const override {
+        virtual Enumerable<UniquePtr<IImage>> getTextures(UInt32 elements, Format format, const Size3d& size, ImageDimensions dimension, UInt32 layers, UInt32 levels, MultiSamplingLevel samples, bool allowWrite) const override {
             return this->getTextures(elements, format, size, dimension, layers, levels, samples, allowWrite) | std::views::as_rvalue;
         }
         
-        virtual UniquePtr<ISampler> getSampler(FilterMode magFilter, FilterMode minFilter, BorderMode borderU, BorderMode borderV, BorderMode borderW, MipMapMode mipMapMode, const Float& mipMapBias, const Float& maxLod, const Float& minLod, const Float& anisotropy) const override { 
+        virtual UniquePtr<ISampler> getSampler(FilterMode magFilter, FilterMode minFilter, BorderMode borderU, BorderMode borderV, BorderMode borderW, MipMapMode mipMapMode, Float mipMapBias, Float maxLod, Float minLod, Float anisotropy) const override { 
             return this->createSampler(magFilter, minFilter, borderU, borderV, borderW, mipMapMode, mipMapBias, maxLod, minLod, anisotropy);
         }
 
-        virtual UniquePtr<ISampler> getSampler(const String& name, FilterMode magFilter, FilterMode minFilter, BorderMode borderU, BorderMode borderV, BorderMode borderW, MipMapMode mipMapMode, const Float& mipMapBias, const Float& maxLod, const Float& minLod, const Float& anisotropy) const override {
+        virtual UniquePtr<ISampler> getSampler(const String& name, FilterMode magFilter, FilterMode minFilter, BorderMode borderU, BorderMode borderV, BorderMode borderW, MipMapMode mipMapMode, Float mipMapBias, Float maxLod, Float minLod, Float anisotropy) const override {
             return this->createSampler(name, magFilter, minFilter, borderU, borderV, borderW, mipMapMode, mipMapBias, maxLod, minLod, anisotropy);
         }
         
-        virtual Enumerable<UniquePtr<ISampler>> getSamplers(const UInt32& elements, FilterMode magFilter, FilterMode minFilter, BorderMode borderU, BorderMode borderV, BorderMode borderW, MipMapMode mipMapMode, const Float& mipMapBias, const Float& maxLod, const Float& minLod, const Float& anisotropy) const override {
+        virtual Enumerable<UniquePtr<ISampler>> getSamplers(UInt32 elements, FilterMode magFilter, FilterMode minFilter, BorderMode borderU, BorderMode borderV, BorderMode borderW, MipMapMode mipMapMode, Float mipMapBias, Float maxLod, Float minLod, Float anisotropy) const override {
             return this->createSamplers(elements, magFilter, minFilter, borderU, borderV, borderW, mipMapMode, mipMapBias, maxLod, minLod, anisotropy) | std::views::as_rvalue;
         }
     };
@@ -1196,7 +1196,7 @@ namespace LiteFX::Rendering {
         /// <param name="samples">The number of samples, the render targets of the render pass should be sampled with.</param>
         /// <param name="commandBuffers">The number of command buffers in each frame buffer.</param>
         /// <returns>An instance of a builder that is used to create a new render pass.</returns>
-        [[nodiscard]] virtual render_pass_builder_type buildRenderPass(MultiSamplingLevel samples = MultiSamplingLevel::x1, const UInt32& commandBuffers = 1) const = 0;
+        [[nodiscard]] virtual render_pass_builder_type buildRenderPass(MultiSamplingLevel samples = MultiSamplingLevel::x1, UInt32 commandBuffers = 1) const = 0;
 
         /// <summary>
         /// Returns a builder for a <see cref="RenderPass" />.
@@ -1205,7 +1205,7 @@ namespace LiteFX::Rendering {
         /// <param name="samples">The number of samples, the render targets of the render pass should be sampled with.</param>
         /// <param name="commandBuffers">The number of command buffers in each frame buffer.</param>
         /// <returns>An instance of a builder that is used to create a new render pass.</returns>
-        [[nodiscard]] virtual render_pass_builder_type buildRenderPass(const String& name, MultiSamplingLevel samples = MultiSamplingLevel::x1, const UInt32& commandBuffers = 1) const = 0;
+        [[nodiscard]] virtual render_pass_builder_type buildRenderPass(const String& name, MultiSamplingLevel samples = MultiSamplingLevel::x1, UInt32 commandBuffers = 1) const = 0;
 
         /// <summary>
         /// Returns a builder for a <see cref="ComputePipeline" />.

--- a/src/Rendering/include/litefx/rendering_api.hpp
+++ b/src/Rendering/include/litefx/rendering_api.hpp
@@ -1517,7 +1517,7 @@ namespace LiteFX::Rendering {
 
     public:
         /// <inheritdoc />
-        virtual const String& name() const noexcept override;
+        const String& name() const noexcept override;
     };
 
     /// <summary>
@@ -2078,31 +2078,31 @@ namespace LiteFX::Rendering {
 
     public:
         /// <inheritdoc />
-        virtual const String& name() const noexcept override;
+        const String& name() const noexcept override;
 
         /// <inheritdoc />
-        virtual UInt32 location() const noexcept override;
+        UInt32 location() const noexcept override;
 
         /// <inheritdoc />
-        virtual RenderTargetType type() const noexcept override;
+        RenderTargetType type() const noexcept override;
 
         /// <inheritdoc />
-        virtual Format format() const noexcept override;
+        Format format() const noexcept override;
 
         /// <inheritdoc />
-        virtual bool clearBuffer() const noexcept override;
+        bool clearBuffer() const noexcept override;
 
         /// <inheritdoc />
-        virtual bool clearStencil() const noexcept override;
+        bool clearStencil() const noexcept override;
 
         /// <inheritdoc />
-        virtual const Vector4f& clearValues() const noexcept override;
+        const Vector4f& clearValues() const noexcept override;
 
         /// <inheritdoc />
-        virtual bool isVolatile() const noexcept override;
+        bool isVolatile() const noexcept override;
 
         /// <inheritdoc />
-        virtual const BlendState& blendState() const noexcept override;
+        const BlendState& blendState() const noexcept override;
     };
 
     /// <summary>
@@ -2348,19 +2348,19 @@ namespace LiteFX::Rendering {
 
     public:
         /// <inheritdoc />
-        virtual PolygonMode polygonMode() const noexcept override;
+        PolygonMode polygonMode() const noexcept override;
 
         /// <inheritdoc />
-        virtual CullMode cullMode() const noexcept override;
+        CullMode cullMode() const noexcept override;
 
         /// <inheritdoc />
-        virtual CullOrder cullOrder() const noexcept override;
+        CullOrder cullOrder() const noexcept override;
 
         /// <inheritdoc />
-        virtual Float lineWidth() const noexcept override;
+        Float lineWidth() const noexcept override;
 
         /// <inheritdoc />
-        virtual const DepthStencilState& depthStencilState() const noexcept override;
+        const DepthStencilState& depthStencilState() const noexcept override;
 
     protected:
         virtual PolygonMode& polygonMode() noexcept;
@@ -2436,22 +2436,22 @@ namespace LiteFX::Rendering {
 
     public:
         /// <inheritdoc />
-        virtual RectF getRectangle() const noexcept override;
+        RectF getRectangle() const noexcept override;
 
         /// <inheritdoc />
-        virtual void setRectangle(const RectF& rectangle) noexcept override;
+        void setRectangle(const RectF& rectangle) noexcept override;
 
         /// <inheritdoc />
-        virtual Float getMinDepth() const noexcept override;
+        Float getMinDepth() const noexcept override;
 
         /// <inheritdoc />
-        virtual void setMinDepth(Float depth) const noexcept override;
+        void setMinDepth(Float depth) const noexcept override;
 
         /// <inheritdoc />
-        virtual Float getMaxDepth() const noexcept override;
+        Float getMaxDepth() const noexcept override;
 
         /// <inheritdoc />
-        virtual void setMaxDepth(Float depth) const noexcept override;
+        void setMaxDepth(Float depth) const noexcept override;
     };
 
     /// <summary>
@@ -2494,10 +2494,10 @@ namespace LiteFX::Rendering {
 
     public:
         /// <inheritdoc />
-        virtual RectF getRectangle() const noexcept override;
+        RectF getRectangle() const noexcept override;
 
         /// <inheritdoc />
-        virtual void setRectangle(const RectF& rectangle) noexcept override;
+        void setRectangle(const RectF& rectangle) noexcept override;
     };
 
     /// <summary>

--- a/src/Rendering/include/litefx/rendering_api.hpp
+++ b/src/Rendering/include/litefx/rendering_api.hpp
@@ -1970,7 +1970,7 @@ namespace LiteFX::Rendering {
         /// when it is initialized and will raise an exception, if a location is either not mapped or assigned multiple times.
         /// </remarks>
         /// <returns>The location of the render target output attachment within the fragment shader</returns>
-        virtual const UInt32& location() const noexcept = 0;
+        virtual UInt32 location() const noexcept = 0;
 
         /// <summary>
         /// Returns the type of the render target.
@@ -1991,7 +1991,7 @@ namespace LiteFX::Rendering {
         /// <returns><c>true</c>, if the render target should be cleared, when the render pass is started</returns>
         /// <seealso cref="clearStencil" />
         /// <seealso cref="clearValues" />
-        virtual const bool& clearBuffer() const noexcept = 0;
+        virtual bool clearBuffer() const noexcept = 0;
 
         /// <summary>
         /// Returns <c>true</c>, if the render target stencil should be cleared, when the render pass is started. If the <see cref="format" /> is does not contain a stencil channel,
@@ -2000,7 +2000,7 @@ namespace LiteFX::Rendering {
         /// <returns><c>true</c>, if the render target stencil should be cleared, when the render pass is started</returns>
         /// <seealso cref="clearStencil" />
         /// <seealso cref="clearValues" />
-        virtual const bool& clearStencil() const noexcept = 0;
+        virtual bool clearStencil() const noexcept = 0;
 
         /// <summary>
         /// Returns the value, the render target is cleared with, if <see cref="clearBuffer" /> either or <see cref="clearStencil" /> is specified.
@@ -2023,7 +2023,7 @@ namespace LiteFX::Rendering {
         /// the GPU memory again in the first place.
         /// </remarks>
         /// <returns><c>true</c>, if the target should not be made persistent for access after the render pass has finished.</returns>
-        virtual const bool& isVolatile() const noexcept = 0;
+        virtual bool isVolatile() const noexcept = 0;
 
         /// <summary>
         /// Returns the render targets blend state.
@@ -2053,7 +2053,7 @@ namespace LiteFX::Rendering {
         /// <param name="clearStencil"><c>true</c>, if the render target stencil should be cleared, when a render pass is started.</param>
         /// <param name="isVolatile"><c>true</c>, if the target should not be made persistent for access after the render pass has finished.</param>
         /// <param name="blendState">The render target blend state.</param>
-        explicit RenderTarget(const UInt32& location, RenderTargetType type, Format format, const bool& clearBuffer, const Vector4f& clearValues = { 0.f , 0.f, 0.f, 0.f }, const bool& clearStencil = true, const bool& isVolatile = false, const BlendState& blendState = {});
+        explicit RenderTarget(UInt32 location, RenderTargetType type, Format format, bool clearBuffer, const Vector4f& clearValues = { 0.f , 0.f, 0.f, 0.f }, bool clearStencil = true, bool isVolatile = false, const BlendState& blendState = {});
 
         /// <summary>
         /// Initializes the render target.
@@ -2067,7 +2067,7 @@ namespace LiteFX::Rendering {
         /// <param name="clearStencil"><c>true</c>, if the render target stencil should be cleared, when a render pass is started.</param>
         /// <param name="isVolatile"><c>true</c>, if the target should not be made persistent for access after the render pass has finished.</param>
         /// <param name="blendState">The render target blend state.</param>
-        explicit RenderTarget(const String& name, const UInt32& location, RenderTargetType type, Format format, const bool& clearBuffer, const Vector4f& clearValues = { 0.f , 0.f, 0.f, 0.f }, const bool& clearStencil = true, const bool& isVolatile = false, const BlendState& blendState = {});
+        explicit RenderTarget(const String& name, UInt32 location, RenderTargetType type, Format format, bool clearBuffer, const Vector4f& clearValues = { 0.f , 0.f, 0.f, 0.f }, bool clearStencil = true, bool isVolatile = false, const BlendState& blendState = {});
         RenderTarget(const RenderTarget&) noexcept;
         RenderTarget(RenderTarget&&) noexcept;
         virtual ~RenderTarget() noexcept;
@@ -2081,7 +2081,7 @@ namespace LiteFX::Rendering {
         virtual const String& name() const noexcept override;
 
         /// <inheritdoc />
-        virtual const UInt32& location() const noexcept override;
+        virtual UInt32 location() const noexcept override;
 
         /// <inheritdoc />
         virtual RenderTargetType type() const noexcept override;
@@ -2090,16 +2090,16 @@ namespace LiteFX::Rendering {
         virtual Format format() const noexcept override;
 
         /// <inheritdoc />
-        virtual const bool& clearBuffer() const noexcept override;
+        virtual bool clearBuffer() const noexcept override;
 
         /// <inheritdoc />
-        virtual const bool& clearStencil() const noexcept override;
+        virtual bool clearStencil() const noexcept override;
 
         /// <inheritdoc />
         virtual const Vector4f& clearValues() const noexcept override;
 
         /// <inheritdoc />
-        virtual const bool& isVolatile() const noexcept override;
+        virtual bool isVolatile() const noexcept override;
 
         /// <inheritdoc />
         virtual const BlendState& blendState() const noexcept override;
@@ -2317,7 +2317,7 @@ namespace LiteFX::Rendering {
         /// use a custom shader for it.
         /// </remarks>
         /// <returns>The line width of the rasterizer state.</returns>
-        virtual const Float& lineWidth() const noexcept = 0;
+        virtual Float lineWidth() const noexcept = 0;
 
         /// <summary>
         /// Returns the depth/stencil state of the rasterizer.
@@ -2341,7 +2341,7 @@ namespace LiteFX::Rendering {
         /// <param name="cullOrder">The cull order of the rasterizer state.</param>
         /// <param name="lineWidth">The line width of the rasterizer state.</param>
         /// <param name="depthStencilState">The rasterizer depth/stencil state.</param>
-        explicit Rasterizer(PolygonMode polygonMode, CullMode cullMode, CullOrder cullOrder, const Float& lineWidth = 1.f, const DepthStencilState& depthStencilState = {}) noexcept;
+        explicit Rasterizer(PolygonMode polygonMode, CullMode cullMode, CullOrder cullOrder, Float lineWidth = 1.f, const DepthStencilState& depthStencilState = {}) noexcept;
         Rasterizer(Rasterizer&&) noexcept;
         Rasterizer(const Rasterizer&) noexcept;
         virtual ~Rasterizer() noexcept;
@@ -2357,7 +2357,7 @@ namespace LiteFX::Rendering {
         virtual CullOrder cullOrder() const noexcept override;
 
         /// <inheritdoc />
-        virtual const Float& lineWidth() const noexcept override;
+        virtual Float lineWidth() const noexcept override;
 
         /// <inheritdoc />
         virtual const DepthStencilState& depthStencilState() const noexcept override;
@@ -2400,7 +2400,7 @@ namespace LiteFX::Rendering {
         /// Sets the minimum depth of the viewport.
         /// </summary>
         /// <param name="depth">The minimum depth of the viewport.</param>
-        virtual void setMinDepth(const float& depth) const noexcept = 0;
+        virtual void setMinDepth(Float depth) const noexcept = 0;
 
         /// <summary>
         /// Gets the maximum depth of the viewport.
@@ -2412,7 +2412,7 @@ namespace LiteFX::Rendering {
         /// Sets the maximum depth of the viewport.
         /// </summary>
         /// <param name="depth">The maximum depth of the viewport.</param>
-        virtual void setMaxDepth(const float& depth) const noexcept = 0;
+        virtual void setMaxDepth(Float depth) const noexcept = 0;
     };
 
     /// <summary>
@@ -2428,7 +2428,7 @@ namespace LiteFX::Rendering {
         /// <param name="clientRect">The rectangle that defines the dimensions of the viewport.</param>
         /// <param name="minDepth">The minimum depth of the viewport.</param>
         /// <param name="maxDepth">The maximum depth of the viewport.</param>
-        explicit Viewport(const RectF& clientRect = { }, const Float& minDepth = 0.f, const Float& maxDepth = 1.f);
+        explicit Viewport(const RectF& clientRect = { }, Float minDepth = 0.f, Float maxDepth = 1.f);
 
         Viewport(Viewport&&) noexcept = delete;
         Viewport(const Viewport&) noexcept = delete;
@@ -2445,13 +2445,13 @@ namespace LiteFX::Rendering {
         virtual Float getMinDepth() const noexcept override;
 
         /// <inheritdoc />
-        virtual void setMinDepth(const Float& depth) const noexcept override;
+        virtual void setMinDepth(Float depth) const noexcept override;
 
         /// <inheritdoc />
         virtual Float getMaxDepth() const noexcept override;
 
         /// <inheritdoc />
-        virtual void setMaxDepth(const Float& depth) const noexcept override;
+        virtual void setMaxDepth(Float depth) const noexcept override;
     };
 
     /// <summary>
@@ -2585,7 +2585,7 @@ namespace LiteFX::Rendering {
         /// <param name="format">The format of the buffer attribute.</param>
         /// <param name="semantic">The semantic of the buffer attribute.</param>
         /// <param name="semanticIndex">The semantic index of the buffer attribute.</param>
-        BufferAttribute(const UInt32& location, const UInt32& offset, BufferFormat format, AttributeSemantic semantic, const UInt32& semanticIndex = 0);
+        BufferAttribute(UInt32 location, UInt32 offset, BufferFormat format, AttributeSemantic semantic, UInt32 semanticIndex = 0);
         BufferAttribute(BufferAttribute&&) noexcept;
         BufferAttribute(const BufferAttribute&);
         virtual ~BufferAttribute() noexcept;
@@ -2598,7 +2598,7 @@ namespace LiteFX::Rendering {
         /// Locations can only be specified in Vulkan and are implicitly generated based on semantics for DirectX. However, it is a good practice to provide them anyway.
         /// </remarks>
         /// <returns>The location of the buffer attribute.</returns>
-        virtual const UInt32& location() const noexcept;
+        virtual UInt32 location() const noexcept;
 
         /// <summary>
         /// Returns the format of the buffer attribute.
@@ -2610,7 +2610,7 @@ namespace LiteFX::Rendering {
         /// Returns the offset of the buffer attribute.
         /// </summary>
         /// <returns>The offset of the buffer attribute.</returns>
-        virtual const UInt32& offset() const noexcept;
+        virtual UInt32 offset() const noexcept;
 
         /// <summary>
         /// Returns the semantic of the buffer attribute.
@@ -2630,7 +2630,7 @@ namespace LiteFX::Rendering {
         /// </remarks>
         /// <returns>The semantic index of the buffer attribute.</returns>
         /// <seealso cref="semantic" />
-        virtual const UInt32& semanticIndex() const noexcept;
+        virtual UInt32 semanticIndex() const noexcept;
     };
 
     /// <summary>
@@ -2657,7 +2657,7 @@ namespace LiteFX::Rendering {
         /// In GLSL, the binding point is identified by the <c>binding</c> keyword, whilst in HLSL the binding maps to a register.
         /// </remarks>
         /// <returns>The binding point, the buffer will be bound to.</returns>
-        virtual const UInt32& binding() const noexcept = 0;
+        virtual UInt32 binding() const noexcept = 0;
 
         /// <summary>
         /// Returns the buffer type of the buffer.
@@ -2741,7 +2741,7 @@ namespace LiteFX::Rendering {
         /// </remarks>
         /// <returns>The number of descriptors in the descriptor array, or `-1` if the array is unbounded.</returns>
         /// <seealso cref="IDescriptorLayout" />
-        virtual const UInt32& descriptors() const noexcept = 0;
+        virtual UInt32 descriptors() const noexcept = 0;
 
         /// <summary>
         /// If the descriptor describes a static sampler, this method returns the state of the sampler. Otherwise, it returns <c>nullptr</c>.
@@ -2769,7 +2769,7 @@ namespace LiteFX::Rendering {
         /// <param name="data">The address that marks the beginning of the data to map.</param>
         /// <param name="size">The number of bytes to map.</param>
         /// <param name="element">The array element to map the data to.</param>
-        virtual void map(const void* const data, const size_t& size, const UInt32& element = 0) = 0;
+        virtual void map(const void* const data, size_t size, UInt32 element = 0) = 0;
 
         /// <summary>
         /// Maps the memory blocks within <paramref name="data" /> to the internal memory of an array.
@@ -2777,7 +2777,7 @@ namespace LiteFX::Rendering {
         /// <param name="data">The data blocks to map.</param>
         /// <param name="size">The size of each data block within <paramref name="data" />.</param>
         /// <param name="firsElement">The first element of the array to map.</param>
-        virtual void map(Span<const void* const> data, const size_t& elementSize, const UInt32& firstElement = 0) = 0;
+        virtual void map(Span<const void* const> data, size_t elementSize, UInt32 firstElement = 0) = 0;
 
         /// <summary>
         /// Maps the memory at <paramref name="data" /> to the internal memory of this object.
@@ -2786,7 +2786,7 @@ namespace LiteFX::Rendering {
         /// <param name="size">The number of bytes to map.</param>
         /// <param name="element">The array element to map the data to.</param>
         /// <param name="write">If `true`, <paramref name="data" /> is copied into the internal memory. If `false` the internal memory is copied into <paramref name="data" />.</param>
-        virtual void map(void* data, const size_t& size, const UInt32& element = 0, bool write = true) = 0;
+        virtual void map(void* data, size_t size, UInt32 element = 0, bool write = true) = 0;
 
         /// <summary>
         /// Maps the memory blocks within <paramref name="data" /> to the internal memory of an array.
@@ -2795,7 +2795,7 @@ namespace LiteFX::Rendering {
         /// <param name="size">The size of each data block within <paramref name="data" />.</param>
         /// <param name="firsElement">The first element of the array to map.</param>
         /// <param name="write">If `true`, <paramref name="data" /> is copied into the internal memory. If `false` the internal memory is copied into <paramref name="data" />.</param>
-        virtual void map(Span<void*> data, const size_t& elementSize, const UInt32& firstElement = 0, bool write = true) = 0;
+        virtual void map(Span<void*> data, size_t elementSize, UInt32 firstElement = 0, bool write = true) = 0;
     };
 
     /// <summary>
@@ -2815,7 +2815,7 @@ namespace LiteFX::Rendering {
         /// </remarks>
         /// <returns>The number of array elements inside the memory chunk.</returns>
         /// <seealso cref="state" />
-        virtual const UInt32& elements() const noexcept = 0;
+        virtual UInt32 elements() const noexcept = 0;
 
         /// <summary>
         /// Gets the size (in bytes) of the aligned memory chunk.
@@ -2869,7 +2869,7 @@ namespace LiteFX::Rendering {
         /// If the resource is not writable, attempting to bind it to a writable descriptor will result in an exception.
         /// </remarks>
         /// <returns><c>true</c>, if the resource can be bound to a read/write descriptor.</returns>
-        virtual const bool& writable() const noexcept = 0;
+        virtual bool writable() const noexcept = 0;
     };
 
     /// <summary>
@@ -2904,7 +2904,7 @@ namespace LiteFX::Rendering {
         /// </remarks>
         /// <param name="level">The mip map level to return the size for.</param>
         /// <returns>The size (in bytes) of an image at a specified mip map level.</returns>
-        virtual size_t size(const UInt32& level) const noexcept = 0;
+        virtual size_t size(UInt32 level) const noexcept = 0;
 
         /// <summary>
         /// Gets the extent of the image at a certain mip-map level.
@@ -2915,7 +2915,7 @@ namespace LiteFX::Rendering {
         /// </remarks>
         /// <returns>The extent of the image at a certain mip-map level.</returns>
         /// <seealso cref="dimensions" />
-        virtual Size3d extent(const UInt32& level = 0) const noexcept = 0;
+        virtual Size3d extent(UInt32 level = 0) const noexcept = 0;
 
         /// <summary>
         /// Gets the internal format of the image.
@@ -2937,13 +2937,13 @@ namespace LiteFX::Rendering {
         /// Gets the number of mip-map levels of the image.
         /// </summary>
         /// <returns>The number of mip-map levels of the image.</returns>
-        virtual const UInt32& levels() const noexcept = 0;
+        virtual UInt32 levels() const noexcept = 0;
 
         /// <summary>
         /// Gets the number of layers (slices) of the image.
         /// </summary>
         /// <returns>The number of layers (slices) of the image.</returns>
-        virtual const UInt32& layers() const noexcept = 0;
+        virtual UInt32 layers() const noexcept = 0;
 
         /// <summary>
         /// Returns the number of planes of the image resource.
@@ -2953,7 +2953,7 @@ namespace LiteFX::Rendering {
         /// </remarks>
         /// <returns>The number of planes of the image resource.</returns>
         /// <seealso cref="format" />
-        virtual const UInt32& planes() const noexcept = 0;
+        virtual UInt32 planes() const noexcept = 0;
 
         /// <summary>
         /// Gets the number of samples of the texture.
@@ -2967,7 +2967,7 @@ namespace LiteFX::Rendering {
         /// <param name="subresource">The sub-resource ID for which to return the layout.</param>
         /// <returns>The current image layout.</returns>
         /// <seealso cref="subresourceId" />
-        virtual ImageLayout layout(const UInt32& subresource = 0) const = 0;
+        virtual ImageLayout layout(UInt32 subresource = 0) const = 0;
 
         // TODO: getSampler() for combined samplers?
 
@@ -2980,7 +2980,7 @@ namespace LiteFX::Rendering {
         /// <param name="plane">The plane of the sub-resource.</param>
         /// <returns>The sub-resource ID for the sub-resource.</returns>
         /// <seealso cref="resolveSubresource" />
-        inline virtual UInt32 subresourceId(const UInt32& level, const UInt32& layer, const UInt32& plane) const noexcept {
+        inline virtual UInt32 subresourceId(UInt32 level, UInt32 layer, UInt32 plane) const noexcept {
             return level + (layer * this->levels()) + (plane * this->levels() * this->layers());
         }
 
@@ -2992,7 +2992,7 @@ namespace LiteFX::Rendering {
         /// <param name="layer">The array layer of the sub-resource.</param>
         /// <param name="level">The mip-map level of the sub-resource.</param>
         /// <seealso cref="subresourceId" />
-        inline virtual void resolveSubresource(const UInt32& subresource, UInt32& plane, UInt32& layer, UInt32& level) const noexcept {
+        inline virtual void resolveSubresource(UInt32 subresource, UInt32& plane, UInt32& layer, UInt32& level) const noexcept {
             const auto levels = this->levels();
             const UInt32 resourcesPerPlane = levels * this->layers();
             plane = subresource / resourcesPerPlane;
@@ -3046,7 +3046,7 @@ namespace LiteFX::Rendering {
         /// Anisotropy will be disabled, if this value is set to <c>0.0</c>.
         /// </remarks>
         /// <returns>The anisotropy value used when sampling this texture.</returns>
-        virtual const Float& getAnisotropy() const noexcept = 0;
+        virtual Float getAnisotropy() const noexcept = 0;
 
         /// <summary>
         /// Gets the mip-map selection mode.
@@ -3058,19 +3058,19 @@ namespace LiteFX::Rendering {
         /// Gets the mip-map level of detail bias.
         /// </summary>
         /// <returns>The mip-map level of detail bias.</returns>
-        virtual const Float& getMipMapBias() const noexcept = 0;
+        virtual Float getMipMapBias() const noexcept = 0;
 
         /// <summary>
         /// Gets the maximum texture level of detail.
         /// </summary>
         /// <returns>The maximum texture level of detail.</returns>
-        virtual const Float& getMaxLOD() const noexcept = 0;
+        virtual Float getMaxLOD() const noexcept = 0;
 
         /// <summary>
         /// Gets the minimum texture level of detail.
         /// </summary>
         /// <returns>The minimum texture level of detail.</returns>
-        virtual const Float& getMinLOD() const noexcept = 0;
+        virtual Float getMinLOD() const noexcept = 0;
     };
 
     /// <summary>
@@ -3164,7 +3164,7 @@ namespace LiteFX::Rendering {
         /// <param name="element">The element of the resource to transition.</param>
         /// <param name="accessBefore">The access types previous commands have to finish.</param>
         /// <param name="accessAfter">The access types that subsequent commands continue with.</param>
-        constexpr inline void transition(IBuffer& buffer, const UInt32& element, ResourceAccess accessBefore, ResourceAccess accessAfter) {
+        constexpr inline void transition(IBuffer& buffer, UInt32 element, ResourceAccess accessBefore, ResourceAccess accessAfter) {
             this->doTransition(buffer, element, accessBefore, accessAfter);
         }
 
@@ -3195,7 +3195,7 @@ namespace LiteFX::Rendering {
         /// <param name="accessBefore">The access types previous commands have to finish.</param>
         /// <param name="accessAfter">The access types that subsequent commands continue with.</param>
         /// <param name="layout">The image layout to transition into.</param>
-        constexpr inline void transition(IImage& image, const UInt32& level, const UInt32& levels, const UInt32& layer, const UInt32& layers, const UInt32& plane, ResourceAccess accessBefore, ResourceAccess accessAfter, ImageLayout layout) {
+        constexpr inline void transition(IImage& image, UInt32 level, UInt32 levels, UInt32 layer, UInt32 layers, UInt32 plane, ResourceAccess accessBefore, ResourceAccess accessAfter, ImageLayout layout) {
             this->doTransition(image, level, levels, layer, layers, plane, accessBefore, accessAfter, layout);
         }
 
@@ -3236,17 +3236,17 @@ namespace LiteFX::Rendering {
         /// <param name="accessAfter">The access types that subsequent commands continue with.</param>
         /// <param name="fromLayout">The image layout to transition from.</param>
         /// <param name="toLayout">The image layout to transition into.</param>
-        constexpr inline void transition(IImage& image, const UInt32& level, const UInt32& levels, const UInt32& layer, const UInt32& layers, const UInt32& plane, ResourceAccess accessBefore, ResourceAccess accessAfter, ImageLayout fromLayout, ImageLayout toLayout) {
+        constexpr inline void transition(IImage& image, UInt32 level, UInt32 levels, UInt32 layer, UInt32 layers, UInt32 plane, ResourceAccess accessBefore, ResourceAccess accessAfter, ImageLayout fromLayout, ImageLayout toLayout) {
             this->doTransition(image, level, levels, layer, layers, plane, accessBefore, accessAfter, fromLayout, toLayout);
         }
 
     private:
         constexpr inline virtual void doTransition(IBuffer& buffer, ResourceAccess accessBefore, ResourceAccess accessAfter) = 0;
-        constexpr inline virtual void doTransition(IBuffer& buffer, const UInt32& element, ResourceAccess accessBefore, ResourceAccess accessAfter) = 0;
+        constexpr inline virtual void doTransition(IBuffer& buffer, UInt32 element, ResourceAccess accessBefore, ResourceAccess accessAfter) = 0;
         constexpr inline virtual void doTransition(IImage& image, ResourceAccess accessBefore, ResourceAccess accessAfter, ImageLayout layout) = 0;
         constexpr inline virtual void doTransition(IImage& image, ResourceAccess accessBefore, ResourceAccess accessAfter, ImageLayout fromLayout, ImageLayout toLayout) = 0;
-        constexpr inline virtual void doTransition(IImage& image, const UInt32& level, const UInt32& levels, const UInt32& layer, const UInt32& layers, const UInt32& plane, ResourceAccess accessBefore, ResourceAccess accessAfter, ImageLayout layout) = 0;
-        constexpr inline virtual void doTransition(IImage& image, const UInt32& level, const UInt32& levels, const UInt32& layer, const UInt32& layers, const UInt32& plane, ResourceAccess accessBefore, ResourceAccess accessAfter, ImageLayout fromLayout, ImageLayout toLayout) = 0;
+        constexpr inline virtual void doTransition(IImage& image, UInt32 level, UInt32 levels, UInt32 layer, UInt32 layers, UInt32 plane, ResourceAccess accessBefore, ResourceAccess accessAfter, ImageLayout layout) = 0;
+        constexpr inline virtual void doTransition(IImage& image, UInt32 level, UInt32 levels, UInt32 layer, UInt32 layers, UInt32 plane, ResourceAccess accessBefore, ResourceAccess accessAfter, ImageLayout fromLayout, ImageLayout toLayout) = 0;
     };
 
     /// <summary>
@@ -3265,7 +3265,7 @@ namespace LiteFX::Rendering {
         /// <param name="bufferElement">The index of the first element in the buffer to bind to the descriptor set.</param>
         /// <param name="elements">The number of elements from the buffer to bind to the descriptor set. A value of `0` binds all available elements, starting at <paramref name="bufferElement" />.</param>
         /// <param name="firstDescriptor">The index of the first descriptor in the descriptor array to update.</param>
-        void update(const UInt32& binding, const IBuffer& buffer, const UInt32& bufferElement = 0, const UInt32& elements = 0, const UInt32& firstDescriptor = 0) const {
+        void update(UInt32 binding, const IBuffer& buffer, UInt32 bufferElement = 0, UInt32 elements = 0, UInt32 firstDescriptor = 0) const {
             this->doUpdate(binding, buffer, bufferElement, elements, firstDescriptor);
         }
 
@@ -3290,7 +3290,7 @@ namespace LiteFX::Rendering {
         /// <param name="levels">The number of mip-map levels to bind. A value of `0` binds all available levels, starting at <paramref name="firstLevel" />.</param>
         /// <param name="firstLayer">The index of the first layer to bind.</param>
         /// <param name="layers">The number of layers to bind. A value of `0` binds all available layers, starting at <paramref name="firstLayer" />.</param>
-        void update(const UInt32& binding, const IImage& texture, const UInt32& descriptor = 0, const UInt32& firstLevel = 0, const UInt32& levels = 0, const UInt32& firstLayer = 0, const UInt32& layers = 0) const {
+        void update(UInt32 binding, const IImage& texture, UInt32 descriptor = 0, UInt32 firstLevel = 0, UInt32 levels = 0, UInt32 firstLayer = 0, UInt32 layers = 0) const {
             this->doUpdate(binding, texture, descriptor, firstLevel, levels, firstLayer, layers);
         }
 
@@ -3300,7 +3300,7 @@ namespace LiteFX::Rendering {
         /// <param name="binding">The sampler binding point.</param>
         /// <param name="sampler">The sampler to write to the descriptor set.</param>
         /// <param name="descriptor">The index of the descriptor in the descriptor array to bind the sampler to.</param>
-        void update(const UInt32& binding, const ISampler& sampler, const UInt32& descriptor = 0) const {
+        void update(UInt32 binding, const ISampler& sampler, UInt32 descriptor = 0) const {
             this->doUpdate(binding, sampler, descriptor);
         }
 
@@ -3309,15 +3309,15 @@ namespace LiteFX::Rendering {
         /// </summary>
         /// <param name="binding">The input attachment binding point.</param>
         /// <param name="image">The image to bind to the input attachment descriptor.</param>
-        void attach(const UInt32& binding, const IImage& image) const {
+        void attach(UInt32 binding, const IImage& image) const {
             this->doAttach(binding, image);
         }
 
     private:
-        virtual void doUpdate(const UInt32& binding, const IBuffer& buffer, const UInt32& bufferElement, const UInt32& elements, const UInt32& firstDescriptor) const = 0;
-        virtual void doUpdate(const UInt32& binding, const IImage& texture, const UInt32& descriptor, const UInt32& firstLevel, const UInt32& levels, const UInt32& firstLayer, const UInt32& layers) const = 0;
-        virtual void doUpdate(const UInt32& binding, const ISampler& sampler, const UInt32& descriptor) const = 0;
-        virtual void doAttach(const UInt32& binding, const IImage& image) const = 0;
+        virtual void doUpdate(UInt32 binding, const IBuffer& buffer, UInt32 bufferElement, UInt32 elements, UInt32 firstDescriptor) const = 0;
+        virtual void doUpdate(UInt32 binding, const IImage& texture, UInt32 descriptor, UInt32 firstLevel, UInt32 levels, UInt32 firstLayer, UInt32 layers) const = 0;
+        virtual void doUpdate(UInt32 binding, const ISampler& sampler, UInt32 descriptor) const = 0;
+        virtual void doAttach(UInt32 binding, const IImage& image) const = 0;
     };
 
     /// <summary>
@@ -3410,7 +3410,7 @@ namespace LiteFX::Rendering {
         /// </summary>
         /// <param name="binding">The binding point of the requested descriptor layout.</param>
         /// <returns>The descriptor layout for the descriptor bound to the binding point provided with <paramref name="binding" />.</returns>
-        virtual const IDescriptorLayout& descriptor(const UInt32& binding) const = 0;
+        virtual const IDescriptorLayout& descriptor(UInt32 binding) const = 0;
 
         /// <summary>
         /// Returns the space index of the descriptor set.
@@ -3419,7 +3419,7 @@ namespace LiteFX::Rendering {
         /// The descriptor set space maps to the space index in HLSL and the set index in GLSL.
         /// </remarks>
         /// <returns>The space index of the descriptor set.</returns>
-        virtual const UInt32& space() const noexcept = 0;
+        virtual UInt32 space() const noexcept = 0;
 
         /// <summary>
         /// Returns the shader stages, the descriptor set is used in.
@@ -3509,7 +3509,7 @@ namespace LiteFX::Rendering {
         /// <param name="bindings">Optional default bindings for descriptors in the descriptor set.</param>
         /// <returns>The instance of the descriptor set.</returns>
         /// <seealso cref="IDescriptorLayout" />
-        UniquePtr<IDescriptorSet> allocate(const UInt32& descriptors, const Enumerable<DescriptorBinding>& bindings = { }) const {
+        UniquePtr<IDescriptorSet> allocate(UInt32 descriptors, const Enumerable<DescriptorBinding>& bindings = { }) const {
             return this->getDescriptorSet(descriptors, bindings);
         }
 
@@ -3520,7 +3520,7 @@ namespace LiteFX::Rendering {
         /// <param name="bindings">Optional default bindings for descriptors in each descriptor set.</param>
         /// <returns>The array of descriptor set instances.</returns>
         /// <seealso cref="allocate" />
-        Enumerable<UniquePtr<IDescriptorSet>> allocateMultiple(const UInt32& descriptorSets, const Enumerable<Enumerable<DescriptorBinding>>& bindings = { }) const {
+        Enumerable<UniquePtr<IDescriptorSet>> allocateMultiple(UInt32 descriptorSets, const Enumerable<Enumerable<DescriptorBinding>>& bindings = { }) const {
             return this->allocateMultiple(descriptorSets, 0, bindings);
         }
 
@@ -3531,7 +3531,7 @@ namespace LiteFX::Rendering {
         /// <param name="bindingFactory">A factory function that is called for each descriptor set in order to provide the default bindings.</param>
         /// <returns>The array of descriptor set instances.</returns>
         /// <seealso cref="allocate" />
-        Enumerable<UniquePtr<IDescriptorSet>> allocateMultiple(const UInt32& descriptorSets, std::function<Enumerable<DescriptorBinding>(const UInt32&)> bindingFactory) const {
+        Enumerable<UniquePtr<IDescriptorSet>> allocateMultiple(UInt32 descriptorSets, std::function<Enumerable<DescriptorBinding>(UInt32)> bindingFactory) const {
             return this->allocateMultiple(descriptorSets, 0, bindingFactory);
         }
 
@@ -3543,7 +3543,7 @@ namespace LiteFX::Rendering {
         /// <param name="bindings">Optional default bindings for descriptors in each descriptor set.</param>
         /// <returns>The array of descriptor set instances.</returns>
         /// <seealso cref="allocate" />
-        Enumerable<UniquePtr<IDescriptorSet>> allocateMultiple(const UInt32& descriptorSets, const UInt32& descriptors, const Enumerable<Enumerable<DescriptorBinding>>& bindings = { }) const {
+        Enumerable<UniquePtr<IDescriptorSet>> allocateMultiple(UInt32 descriptorSets, UInt32 descriptors, const Enumerable<Enumerable<DescriptorBinding>>& bindings = { }) const {
             return this->getDescriptorSets(descriptorSets, descriptors, bindings);
         }
 
@@ -3555,7 +3555,7 @@ namespace LiteFX::Rendering {
         /// <param name="bindingFactory">A factory function that is called for each descriptor set in order to provide the default bindings.</param>
         /// <returns>The array of descriptor set instances.</returns>
         /// <seealso cref="allocate" />
-        Enumerable<UniquePtr<IDescriptorSet>> allocateMultiple(const UInt32& descriptorSets, const UInt32& descriptors, std::function<Enumerable<DescriptorBinding>(const UInt32&)> bindingFactory) const {
+        Enumerable<UniquePtr<IDescriptorSet>> allocateMultiple(UInt32 descriptorSets, UInt32 descriptors, std::function<Enumerable<DescriptorBinding>(UInt32)> bindingFactory) const {
             return this->getDescriptorSets(descriptorSets, descriptors, bindingFactory);
         }
 
@@ -3569,9 +3569,9 @@ namespace LiteFX::Rendering {
 
     private:
         virtual Enumerable<const IDescriptorLayout*> getDescriptors() const noexcept = 0;
-        virtual UniquePtr<IDescriptorSet> getDescriptorSet(const UInt32& descriptors, const Enumerable<DescriptorBinding>& bindings = { }) const = 0;
-        virtual Enumerable<UniquePtr<IDescriptorSet>> getDescriptorSets(const UInt32& descriptorSets, const UInt32& descriptors, const Enumerable<Enumerable<DescriptorBinding>>& bindings = { }) const = 0;
-        virtual Enumerable<UniquePtr<IDescriptorSet>> getDescriptorSets(const UInt32& descriptorSets, const UInt32& descriptors, std::function<Enumerable<DescriptorBinding>(const UInt32&)> bindingFactory) const = 0;
+        virtual UniquePtr<IDescriptorSet> getDescriptorSet(UInt32 descriptors, const Enumerable<DescriptorBinding>& bindings = { }) const = 0;
+        virtual Enumerable<UniquePtr<IDescriptorSet>> getDescriptorSets(UInt32 descriptorSets, UInt32 descriptors, const Enumerable<Enumerable<DescriptorBinding>>& bindings = { }) const = 0;
+        virtual Enumerable<UniquePtr<IDescriptorSet>> getDescriptorSets(UInt32 descriptorSets, UInt32 descriptors, std::function<Enumerable<DescriptorBinding>(UInt32)> bindingFactory) const = 0;
         virtual void releaseDescriptorSet(const IDescriptorSet& descriptorSet) const noexcept = 0;
     };
 
@@ -3587,27 +3587,27 @@ namespace LiteFX::Rendering {
         /// Returns the shader space the push constants can be accessed from.
         /// </summary>
         /// <returns>The shader space the push constants can be accessed from.</returns>
-        virtual const UInt32& space() const noexcept = 0;
+        virtual UInt32 space() const noexcept = 0;
 
         /// <summary>
         /// Returns the binding point or register, the push constants are made available at.
         /// </summary>
         /// <returns>The binding point or register, the push constants are made available at.</returns>
-        virtual const UInt32& binding() const noexcept = 0;
+        virtual UInt32 binding() const noexcept = 0;
 
         /// <summary>
         /// Returns the offset from the push constants backing memory block, the range starts at.
         /// </summary>
         /// <returns>The offset from the push constants backing memory block, the range starts at.</returns>
         /// <seealso cref="size" />
-        virtual const UInt32& offset() const noexcept = 0;
+        virtual UInt32 offset() const noexcept = 0;
 
         /// <summary>
         /// Returns the size (in bytes) of the range.
         /// </summary>
         /// <returns>The size (in bytes) of the range.</returns>
         /// <seealso cref="offset" />
-        virtual const UInt32& size() const noexcept = 0;
+        virtual UInt32 size() const noexcept = 0;
 
         /// <summary>
         /// Returns the shader stage(s), the range is accessible from.
@@ -3628,7 +3628,7 @@ namespace LiteFX::Rendering {
         /// Returns the size (in bytes) of the push constants backing memory.
         /// </summary>
         /// <returns>The size (in bytes) of the push constants backing memory.</returns>
-        virtual const UInt32& size() const noexcept = 0;
+        virtual UInt32 size() const noexcept = 0;
 
         /// <summary>
         /// Returns the push constant range associated with the shader stage provided in <paramref name="stage" />.
@@ -3716,7 +3716,7 @@ namespace LiteFX::Rendering {
         /// </summary>
         /// <param name="space">The space to request the descriptor set layout for.</param>
         /// <returns>The descriptor set layout for the descriptor set that is bound to the space provided by <paramref name="space" />.</returns>
-        virtual const IDescriptorSetLayout& descriptorSet(const UInt32& space) const = 0;
+        virtual const IDescriptorSetLayout& descriptorSet(UInt32 space) const = 0;
 
         /// <summary>
         /// Returns all descriptor set layouts, the pipeline has been initialized with.
@@ -3787,7 +3787,7 @@ namespace LiteFX::Rendering {
         /// </summary>
         /// <param name="binding">The binding point of the vertex buffer layout.</param>
         /// <returns>The vertex buffer layout for binding provided with <paramref name="binding" />.</returns>
-        virtual const IVertexBufferLayout& vertexBufferLayout(const UInt32& binding) const = 0;
+        virtual const IVertexBufferLayout& vertexBufferLayout(UInt32 binding) const = 0;
 
         /// <summary>
         /// Returns the index buffer layout.
@@ -3868,7 +3868,7 @@ namespace LiteFX::Rendering {
         /// Returns `true`, if the command buffer is a secondary command buffer, or `false` otherwise.
         /// </summary>
         /// <returns>`true`, if the command buffer is a secondary command buffer, or `false` otherwise.</returns>
-        virtual const bool& isSecondary() const noexcept = 0;
+        virtual bool isSecondary() const noexcept = 0;
 
     public:
         /// <summary>
@@ -3915,7 +3915,7 @@ namespace LiteFX::Rendering {
         /// <param name="elements">The number of elements to copy from the source buffer into the target buffer.</param>
         /// <exception cref="ArgumentOutOfRangeException">Thrown, if the number of either the source buffer or the target buffer has not enough elements for the specified <paramref name="elements" /> parameter.</exception>
         /// <seealso cref="IBarrier" />
-        void transfer(IBuffer& source, IBuffer& target, const UInt32& sourceElement = 0, const UInt32& targetElement = 0, const UInt32& elements = 1) const {
+        void transfer(IBuffer& source, IBuffer& target, UInt32 sourceElement = 0, UInt32 targetElement = 0, UInt32 elements = 1) const {
             this->cmdTransfer(source, target, sourceElement, targetElement, elements);
         }
         
@@ -3939,7 +3939,7 @@ namespace LiteFX::Rendering {
         /// <param name="targetElement">The index of the first element in the target buffer to copy to.</param>
         /// <param name="elements">The number of elements to copy from the source buffer into the target buffer.</param>
         /// <exception cref="ArgumentOutOfRangeException">Thrown, if the number of either the source buffer or the target buffer has not enough elements for the specified <paramref name="elements" /> parameter.</exception>
-        void transfer(SharedPtr<IBuffer> source, IBuffer& target, const UInt32& sourceElement = 0, const UInt32& targetElement = 0, const UInt32& elements = 1) const {
+        void transfer(SharedPtr<IBuffer> source, IBuffer& target, UInt32 sourceElement = 0, UInt32 targetElement = 0, UInt32 elements = 1) const {
             this->cmdTransfer(source, target, sourceElement, targetElement, elements);
         }
 
@@ -3978,7 +3978,7 @@ namespace LiteFX::Rendering {
         /// <param name="firstSubresource">The index of the first sub-resource of the target image to receive data.</param>
         /// <param name="elements">The number of elements to copy from the source buffer into the target image sub-resources.</param>
         /// <exception cref="ArgumentOutOfRangeException">Thrown, if the number of either the source buffer or the target buffer has not enough elements for the specified <paramref name="elements" /> parameter.</exception>
-        void transfer(IBuffer& source, IImage& target, const UInt32& sourceElement = 0, const UInt32& firstSubresource = 0, const UInt32& elements = 1) const {
+        void transfer(IBuffer& source, IImage& target, UInt32 sourceElement = 0, UInt32 firstSubresource = 0, UInt32 elements = 1) const {
             this->cmdTransfer(source, target, sourceElement, firstSubresource, elements);
         }
 
@@ -4024,7 +4024,7 @@ namespace LiteFX::Rendering {
         /// <param name="firstSubresource">The index of the first sub-resource of the target image to receive data.</param>
         /// <param name="elements">The number of elements to copy from the source buffer into the target image sub-resources.</param>
         /// <exception cref="ArgumentOutOfRangeException">Thrown, if the number of either the source buffer or the target buffer has not enough elements for the specified <paramref name="elements" /> parameter.</exception>
-        void transfer(SharedPtr<IBuffer> source, IImage& target, const UInt32& sourceElement = 0, const UInt32& firstSubresource = 0, const UInt32& elements = 1) const {
+        void transfer(SharedPtr<IBuffer> source, IImage& target, UInt32 sourceElement = 0, UInt32 firstSubresource = 0, UInt32 elements = 1) const {
             this->cmdTransfer(source, target, sourceElement, firstSubresource, elements);
         }
 
@@ -4041,7 +4041,7 @@ namespace LiteFX::Rendering {
         /// <param name="targetSubresource">The image of the first sub-resource in the target image to receive data.</param>
         /// <param name="subresources">The number of sub-resources to copy between the images.</param>
         /// <exception cref="ArgumentOutOfRangeException">Thrown, if the number of either the source buffer or the target buffer has not enough elements for the specified <paramref name="elements" /> parameter.</exception>
-        void transfer(IImage& source, IImage& target, const UInt32& sourceSubresource = 0, const UInt32& targetSubresource = 0, const UInt32& subresources = 1) const {
+        void transfer(IImage& source, IImage& target, UInt32 sourceSubresource = 0, UInt32 targetSubresource = 0, UInt32 subresources = 1) const {
             this->cmdTransfer(source, target, sourceSubresource, targetSubresource, subresources);
         }
 
@@ -4065,7 +4065,7 @@ namespace LiteFX::Rendering {
         /// <param name="targetSubresource">The image of the first sub-resource in the target image to receive data.</param>
         /// <param name="subresources">The number of sub-resources to copy between the images.</param>
         /// <exception cref="ArgumentOutOfRangeException">Thrown, if the number of either the source buffer or the target buffer has not enough elements for the specified <paramref name="elements" /> parameter.</exception>
-        void transfer(SharedPtr<IImage> source, IImage& target, const UInt32& sourceSubresource = 0, const UInt32& targetSubresource = 0, const UInt32& subresources = 1) const {
+        void transfer(SharedPtr<IImage> source, IImage& target, UInt32 sourceSubresource = 0, UInt32 targetSubresource = 0, UInt32 subresources = 1) const {
             this->cmdTransfer(source, target, sourceSubresource, targetSubresource, subresources);
         }
 
@@ -4104,7 +4104,7 @@ namespace LiteFX::Rendering {
         /// <param name="targetElement">The index of the first target element to receive data.</param>
         /// <param name="subresources">The number of sub-resources to copy.</param>
         /// <exception cref="ArgumentOutOfRangeException">Thrown, if the number of either the source buffer or the target buffer has not enough elements for the specified <paramref name="elements" /> parameter.</exception>
-        void transfer(IImage& source, IBuffer& target, const UInt32& firstSubresource = 0, const UInt32& targetElement = 0, const UInt32& subresources = 1) const {
+        void transfer(IImage& source, IBuffer& target, UInt32 firstSubresource = 0, UInt32 targetElement = 0, UInt32 subresources = 1) const {
             this->cmdTransfer(source, target, firstSubresource, targetElement, subresources);
         }
 
@@ -4150,7 +4150,7 @@ namespace LiteFX::Rendering {
         /// <param name="targetElement">The index of the first target element to receive data.</param>
         /// <param name="subresources">The number of sub-resources to copy.</param>
         /// <exception cref="ArgumentOutOfRangeException">Thrown, if the number of either the source buffer or the target buffer has not enough elements for the specified <paramref name="elements" /> parameter.</exception>
-        void transfer(SharedPtr<IImage> source, IBuffer& target, const UInt32& firstSubresource = 0, const UInt32& targetElement = 0, const UInt32& subresources = 1) const {
+        void transfer(SharedPtr<IImage> source, IBuffer& target, UInt32 firstSubresource = 0, UInt32 targetElement = 0, UInt32 subresources = 1) const {
             this->cmdTransfer(source, target, firstSubresource, targetElement, subresources);
         }
 
@@ -4213,7 +4213,7 @@ namespace LiteFX::Rendering {
         /// <param name="instances">The number of instances to draw.</param>
         /// <param name="firstVertex">The index of the first vertex to start drawing from.</param>
         /// <param name="firstInstance">The index of the first instance to draw.</param>
-        virtual void draw(const UInt32& vertices, const UInt32& instances = 1, const UInt32& firstVertex = 0, const UInt32& firstInstance = 0) const noexcept = 0;
+        virtual void draw(UInt32 vertices, UInt32 instances = 1, UInt32 firstVertex = 0, UInt32 firstInstance = 0) const noexcept = 0;
 
         /// <summary>
         /// Draws the currently bound vertex buffer with a set of indices from the currently bound index buffer.
@@ -4223,7 +4223,7 @@ namespace LiteFX::Rendering {
         /// <param name="firstIndex">The index of the first element of the index buffer to start drawing from.</param>
         /// <param name="vertexOffset">The offset added to each index to find the corresponding vertex.</param>
         /// <param name="firstInstance">The index of the first instance to draw.</param>
-        virtual void drawIndexed(const UInt32& indices, const UInt32& instances = 1, const UInt32& firstIndex = 0, const Int32& vertexOffset = 0, const UInt32& firstInstance = 0) const noexcept = 0;
+        virtual void drawIndexed(UInt32 indices, UInt32 instances = 1, UInt32 firstIndex = 0, Int32 vertexOffset = 0, UInt32 firstInstance = 0) const noexcept = 0;
 
         /// <summary>
         /// Pushes a block of memory into the push constants backing memory.
@@ -4244,7 +4244,7 @@ namespace LiteFX::Rendering {
         /// <param name="instances">The number of instances to draw.</param>
         /// <param name="firstVertex">The index of the first vertex to start drawing from.</param>
         /// <param name="firstInstance">The index of the first instance to draw.</param>
-        void draw(const IVertexBuffer& vertexBuffer, const UInt32& instances = 1, const UInt32& firstVertex = 0, const UInt32& firstInstance = 0) const {
+        void draw(const IVertexBuffer& vertexBuffer, UInt32 instances = 1, UInt32 firstVertex = 0, UInt32 firstInstance = 0) const {
             this->cmdDraw(vertexBuffer, instances, firstVertex, firstInstance);
         }
 
@@ -4259,7 +4259,7 @@ namespace LiteFX::Rendering {
         /// <param name="firstIndex">The index of the first element of the index buffer to start drawing from.</param>
         /// <param name="vertexOffset">The offset added to each index to find the corresponding vertex.</param>
         /// <param name="firstInstance">The index of the first instance to draw.</param>
-        void drawIndexed(const IIndexBuffer& indexBuffer, const UInt32& instances = 1, const UInt32& firstIndex = 0, const Int32& vertexOffset = 0, const UInt32& firstInstance = 0) const {
+        void drawIndexed(const IIndexBuffer& indexBuffer, UInt32 instances = 1, UInt32 firstIndex = 0, Int32 vertexOffset = 0, UInt32 firstInstance = 0) const {
             this->cmdDrawIndexed(indexBuffer, instances, firstIndex, vertexOffset, firstInstance);
         }
 
@@ -4275,7 +4275,7 @@ namespace LiteFX::Rendering {
         /// <param name="firstIndex">The index of the first element of the index buffer to start drawing from.</param>
         /// <param name="vertexOffset">The offset added to each index to find the corresponding vertex.</param>
         /// <param name="firstInstance">The index of the first instance to draw.</param>
-        void drawIndexed(const IVertexBuffer& vertexBuffer, const IIndexBuffer& indexBuffer, const UInt32& instances = 1, const UInt32& firstIndex = 0, const Int32& vertexOffset = 0, const UInt32& firstInstance = 0) const {
+        void drawIndexed(const IVertexBuffer& vertexBuffer, const IIndexBuffer& indexBuffer, UInt32 instances = 1, UInt32 firstIndex = 0, Int32 vertexOffset = 0, UInt32 firstInstance = 0) const {
             this->cmdDrawIndexed(vertexBuffer, indexBuffer, instances, firstIndex, vertexOffset, firstInstance);
         }
 
@@ -4317,7 +4317,7 @@ namespace LiteFX::Rendering {
         /// Sets the stencil reference for the subsequent draw calls.
         /// </summary>
         /// <param name="stencilRef">The stencil reference for the subsequent draw calls.</param>
-        virtual void setStencilRef(const UInt32& stencilRef) const noexcept = 0;
+        virtual void setStencilRef(UInt32 stencilRef) const noexcept = 0;
 
         /// <summary>
         /// Writes the current GPU time stamp value for the timing event.
@@ -4344,22 +4344,22 @@ namespace LiteFX::Rendering {
     private:
         virtual void cmdBarrier(const IBarrier& barrier) const noexcept = 0;
         virtual void cmdGenerateMipMaps(IImage& image) noexcept = 0;
-        virtual void cmdTransfer(IBuffer& source, IBuffer& target, const UInt32& sourceElement, const UInt32& targetElement, const UInt32& elements) const = 0;
-        virtual void cmdTransfer(IBuffer& source, IImage& target, const UInt32& sourceElement, const UInt32& firstSubresource, const UInt32& elements) const = 0;
-        virtual void cmdTransfer(IImage& source, IImage& target, const UInt32& sourceSubresource, const UInt32& targetSubresource, const UInt32& subresources) const = 0;
-        virtual void cmdTransfer(IImage& source, IBuffer& target, const UInt32& firstSubresource, const UInt32& targetElement, const UInt32& subresources) const = 0;
-        virtual void cmdTransfer(SharedPtr<IBuffer> source, IBuffer& target, const UInt32& sourceElement, const UInt32& targetElement, const UInt32& elements) const = 0;
-        virtual void cmdTransfer(SharedPtr<IBuffer> source, IImage& target, const UInt32& sourceElement, const UInt32& firstSubresource, const UInt32& elements) const = 0;
-        virtual void cmdTransfer(SharedPtr<IImage> source, IImage& target, const UInt32& sourceSubresource, const UInt32& targetSubresource, const UInt32& subresources) const = 0;
-        virtual void cmdTransfer(SharedPtr<IImage> source, IBuffer& target, const UInt32& firstSubresource, const UInt32& targetElement, const UInt32& subresources) const = 0;
+        virtual void cmdTransfer(IBuffer& source, IBuffer& target, UInt32 sourceElement, UInt32 targetElement, UInt32 elements) const = 0;
+        virtual void cmdTransfer(IBuffer& source, IImage& target, UInt32 sourceElement, UInt32 firstSubresource, UInt32 elements) const = 0;
+        virtual void cmdTransfer(IImage& source, IImage& target, UInt32 sourceSubresource, UInt32 targetSubresource, UInt32 subresources) const = 0;
+        virtual void cmdTransfer(IImage& source, IBuffer& target, UInt32 firstSubresource, UInt32 targetElement, UInt32 subresources) const = 0;
+        virtual void cmdTransfer(SharedPtr<IBuffer> source, IBuffer& target, UInt32 sourceElement, UInt32 targetElement, UInt32 elements) const = 0;
+        virtual void cmdTransfer(SharedPtr<IBuffer> source, IImage& target, UInt32 sourceElement, UInt32 firstSubresource, UInt32 elements) const = 0;
+        virtual void cmdTransfer(SharedPtr<IImage> source, IImage& target, UInt32 sourceSubresource, UInt32 targetSubresource, UInt32 subresources) const = 0;
+        virtual void cmdTransfer(SharedPtr<IImage> source, IBuffer& target, UInt32 firstSubresource, UInt32 targetElement, UInt32 subresources) const = 0;
         virtual void cmdUse(const IPipeline& pipeline) const noexcept = 0;
         virtual void cmdBind(const IDescriptorSet& descriptorSet, const IPipeline& pipeline) const noexcept = 0;
         virtual void cmdBind(const IVertexBuffer& buffer) const noexcept = 0;
         virtual void cmdBind(const IIndexBuffer& buffer) const noexcept = 0;
         virtual void cmdPushConstants(const IPushConstantsLayout& layout, const void* const memory) const noexcept = 0;
-        virtual void cmdDraw(const IVertexBuffer& vertexBuffer, const UInt32& instances, const UInt32& firstVertex, const UInt32& firstInstance) const = 0;
-        virtual void cmdDrawIndexed(const IIndexBuffer& indexBuffer, const UInt32& instances, const UInt32& firstIndex, const Int32& vertexOffset, const UInt32& firstInstance) const = 0;
-        virtual void cmdDrawIndexed(const IVertexBuffer& vertexBuffer, const IIndexBuffer& indexBuffer, const UInt32& instances, const UInt32& firstIndex, const Int32& vertexOffset, const UInt32& firstInstance) const = 0;
+        virtual void cmdDraw(const IVertexBuffer& vertexBuffer, UInt32 instances, UInt32 firstVertex, UInt32 firstInstance) const = 0;
+        virtual void cmdDrawIndexed(const IIndexBuffer& indexBuffer, UInt32 instances, UInt32 firstIndex, Int32 vertexOffset, UInt32 firstInstance) const = 0;
+        virtual void cmdDrawIndexed(const IVertexBuffer& vertexBuffer, const IIndexBuffer& indexBuffer, UInt32 instances, UInt32 firstIndex, Int32 vertexOffset, UInt32 firstInstance) const = 0;
         virtual void cmdExecute(SharedPtr<const ICommandBuffer> commandBuffer) const = 0;
         virtual void cmdExecute(Enumerable<SharedPtr<const ICommandBuffer>> commandBuffer) const = 0;
 
@@ -4406,7 +4406,7 @@ namespace LiteFX::Rendering {
         /// <seealso href="https://en.wikipedia.org/wiki/Alpha_to_coverage" />
         /// <seealso href="https://www.khronos.org/registry/vulkan/specs/1.2-extensions/html/vkspec.html#fragops-covg" />
         /// <seealso href="https://docs.microsoft.com/en-us/windows/win32/direct3d11/d3d10-graphics-programming-guide-blend-state#alpha-to-coverage" />
-        virtual const bool& alphaToCoverage() const noexcept = 0;
+        virtual bool alphaToCoverage() const noexcept = 0;
 
     private:
         virtual SharedPtr<IInputAssembler> getInputAssembler() const noexcept = 0;
@@ -4437,7 +4437,7 @@ namespace LiteFX::Rendering {
         /// pass returns the current frame buffer instance (i.e. the same instance, as the one, the index has been requested from).
         /// </remarks>
         /// <returns>the index of the buffer within the <see cref="RenderPass" />.</returns>
-        virtual const UInt32& bufferIndex() const noexcept = 0;
+        virtual UInt32 bufferIndex() const noexcept = 0;
 
         /// <summary>
         /// Returns the current size of the frame buffer.
@@ -4482,7 +4482,7 @@ namespace LiteFX::Rendering {
         /// <returns>A command buffer that records draw commands for the frame buffer</returns>
         /// <exception cref="ArgumentOutOfRangeException">Thrown, if the frame buffer does not store a command buffer at <paramref name="index" />.</exception>
         /// <seealso cref="commandBuffers" />
-        SharedPtr<const ICommandBuffer> commandBuffer(const UInt32& index) const {
+        SharedPtr<const ICommandBuffer> commandBuffer(UInt32 index) const {
             return this->getCommandBuffer(index);
         }
 
@@ -4498,7 +4498,7 @@ namespace LiteFX::Rendering {
         /// Returns the image that stores the output attachment for the render target mapped the location passed with <paramref name="location" />.
         /// </summary>
         /// <returns>The image that stores the output attachment for the render target mapped the location passed with <paramref name="location" />.</returns>
-        virtual const IImage& image(const UInt32& location) const = 0;
+        virtual const IImage& image(UInt32 location) const = 0;
 
     public:
         /// <summary>
@@ -4514,7 +4514,7 @@ namespace LiteFX::Rendering {
         virtual void resize(const Size2d& renderArea) = 0;
 
     private:
-        virtual SharedPtr<const ICommandBuffer> getCommandBuffer(const UInt32& index) const noexcept = 0;
+        virtual SharedPtr<const ICommandBuffer> getCommandBuffer(UInt32 index) const noexcept = 0;
         virtual Enumerable<SharedPtr<const ICommandBuffer>> getCommandBuffers() const noexcept = 0;
         virtual Enumerable<const IImage*> getImages() const noexcept = 0;
     };
@@ -4530,10 +4530,10 @@ namespace LiteFX::Rendering {
         /// <seealso cref="IRenderPass::beginning" />
         struct BeginRenderPassEventArgs : public EventArgs {
         private:
-            const UInt32& m_backBuffer;
+            UInt32 m_backBuffer;
 
         public:
-            BeginRenderPassEventArgs(const UInt32& backBuffer) : 
+            BeginRenderPassEventArgs(UInt32 backBuffer) : 
                 EventArgs(), m_backBuffer(backBuffer) { }
             BeginRenderPassEventArgs(const BeginRenderPassEventArgs&) = default;
             BeginRenderPassEventArgs(BeginRenderPassEventArgs&&) = default;
@@ -4548,7 +4548,7 @@ namespace LiteFX::Rendering {
             /// Gets the index of the next back-buffer used in the render pass.
             /// </summary>
             /// <returns>The index of the next back-buffer used in the render pass.</returns>
-            const UInt32& backBuffer() const noexcept {
+            UInt32 backBuffer() const noexcept {
                 return m_backBuffer;
             }
         };
@@ -4590,7 +4590,7 @@ namespace LiteFX::Rendering {
         /// </summary>
         /// <param name="location">The location to return the render target for.</param>
         /// <returns>The render target mapped to the location provided by <paramref name="location" />.</returns>
-        virtual const RenderTarget& renderTarget(const UInt32& location) const = 0;
+        virtual const RenderTarget& renderTarget(UInt32 location) const = 0;
 
         /// <summary>
         /// Returns the list of render targets, the render pass renders into.
@@ -4639,7 +4639,7 @@ namespace LiteFX::Rendering {
         /// Begins the render pass.
         /// </summary>
         /// <param name="buffer">The back buffer to use. Typically this is the same as the value returned from <see cref="ISwapChain::swapBackBuffer" />.</param>
-        virtual void begin(const UInt32& buffer) = 0;
+        virtual void begin(UInt32 buffer) = 0;
 
         /// <summary>
         /// Ends the render pass.
@@ -4694,10 +4694,10 @@ namespace LiteFX::Rendering {
         private:
             Format m_surfaceFormat;
             const Size2d& m_renderArea;
-            const UInt32& m_buffers;
+            UInt32 m_buffers;
 
         public:
-            SwapChainResetEventArgs(Format surfaceFormat, const Size2d& renderArea, const UInt32& buffers) :
+            SwapChainResetEventArgs(Format surfaceFormat, const Size2d& renderArea, UInt32 buffers) :
                 EventArgs(), m_surfaceFormat(surfaceFormat), m_renderArea(renderArea), m_buffers(buffers) { }
             SwapChainResetEventArgs(const SwapChainResetEventArgs&) = default;
             SwapChainResetEventArgs(SwapChainResetEventArgs&&) = default;
@@ -4728,7 +4728,7 @@ namespace LiteFX::Rendering {
             /// Gets the number of back-buffers in the swap chain.
             /// </summary>
             /// <returns>The number of back-buffers in the swap chain.</returns>
-            const UInt32& buffers() const noexcept {
+            UInt32 buffers() const noexcept {
                 return m_buffers;
             }
         };
@@ -4763,7 +4763,7 @@ namespace LiteFX::Rendering {
         /// </summary>
         /// <param name="queryId">The query ID of the timing event.</param>
         /// <returns>The timing event registered for <paramref name="queryId" />.</returns>
-        virtual SharedPtr<TimingEvent> timingEvent(const UInt32& queryId) const = 0;
+        virtual SharedPtr<TimingEvent> timingEvent(UInt32 queryId) const = 0;
 
         /// <summary>
         /// Reads the current time stamp value (in ticks) of a timing event.
@@ -4796,7 +4796,7 @@ namespace LiteFX::Rendering {
         /// Returns the number of images in the swap chain.
         /// </summary>
         /// <returns>The number of images in the swap chain.</returns>
-        virtual const UInt32& buffers() const noexcept = 0;
+        virtual UInt32 buffers() const noexcept = 0;
 
         /// <summary>
         /// Returns the size of the render area.
@@ -4809,7 +4809,7 @@ namespace LiteFX::Rendering {
         /// </summary>
         /// <param name="backBuffer">The index of the back buffer for which to return the swap chain present image.</param>
         /// <returns>A pointer to the back buffers swap chain present image.</returns>
-        virtual const IImage* image(const UInt32& backBuffer) const = 0;
+        virtual const IImage* image(UInt32 backBuffer) const = 0;
 
         /// <summary>
         /// Returns an array of the swap chain present images.
@@ -4860,7 +4860,7 @@ namespace LiteFX::Rendering {
         /// <param name="renderArea">The dimensions of the frame buffers.</param>
         /// <param name="buffers">The number of buffers in the swap chain.</param>
         /// <seealso cref="multiSamplingLevel" />
-        virtual void reset(Format surfaceFormat, const Size2d& renderArea, const UInt32& buffers) = 0;
+        virtual void reset(Format surfaceFormat, const Size2d& renderArea, UInt32 buffers) = 0;
 
         /// <summary>
         /// Swaps the front buffer with the next back buffer in order.
@@ -4911,10 +4911,10 @@ namespace LiteFX::Rendering {
         /// </summary>
         struct QueueSubmittedEventArgs : public EventArgs {
         private:
-            const UInt64& m_fence;
+            UInt64 m_fence;
 
         public:
-            QueueSubmittedEventArgs(const UInt64& fence) :
+            QueueSubmittedEventArgs(UInt64 fence) :
                 EventArgs(), m_fence(fence) { }
             QueueSubmittedEventArgs(const QueueSubmittedEventArgs&) = default;
             QueueSubmittedEventArgs(QueueSubmittedEventArgs&&) = default;
@@ -4929,7 +4929,7 @@ namespace LiteFX::Rendering {
             /// Gets the fence that is triggered, if the command buffers have been executed.
             /// </summary>
             /// <returns>The fence that is triggered, if the command buffers have been executed.</returns>
-            const UInt64& fence() const noexcept {
+            UInt64 fence() const noexcept {
                 return m_fence;
             }
         };
@@ -5036,7 +5036,7 @@ namespace LiteFX::Rendering {
         /// <param name="beginRecording">If set to <c>true</c>, the command buffer will be initialized in recording state and can receive commands straight away.</param>
         /// <param name="secondary">If set to `true`, the method will create a secondary command buffer/bundle.</param>
         /// <returns>The instance of the command buffer.</returns>
-        SharedPtr<ICommandBuffer> createCommandBuffer(const bool& beginRecording = false, const bool& secondary = false) const {
+        SharedPtr<ICommandBuffer> createCommandBuffer(bool beginRecording = false, bool secondary = false) const {
             return this->getCommandBuffer(beginRecording, secondary);
         }
 
@@ -5119,7 +5119,7 @@ namespace LiteFX::Rendering {
         /// </remarks>
         /// <param name="fence">The value of the fence to wait for.</param>
         /// <seealso cref="submit" />
-        virtual void waitFor(const UInt64& fence) const noexcept = 0;
+        virtual void waitFor(UInt64 fence) const noexcept = 0;
 
         /// <summary>
         /// Returns the value of the latest fence inserted into the queue.
@@ -5129,7 +5129,7 @@ namespace LiteFX::Rendering {
         virtual UInt64 currentFence() const noexcept = 0;
 
     private:
-        virtual SharedPtr<ICommandBuffer> getCommandBuffer(const bool& beginRecording, const bool& secondary) const = 0;
+        virtual SharedPtr<ICommandBuffer> getCommandBuffer(bool beginRecording, bool secondary) const = 0;
         virtual UInt64 submitCommandBuffer(SharedPtr<const ICommandBuffer> commandBuffer) const = 0;
         virtual UInt64 submitCommandBuffers(const Enumerable<SharedPtr<const ICommandBuffer>>& commandBuffers) const = 0;
         
@@ -5156,7 +5156,7 @@ namespace LiteFX::Rendering {
         /// <param name="elements">The number of elements in the buffer (in case the buffer is an array).</param>
         /// <param name="allowWrite">Allows the resource to be bound to a read/write descriptor.</param>
         /// <returns>The instance of the buffer.</returns>
-        UniquePtr<IBuffer> createBuffer(BufferType type, BufferUsage usage, const size_t& elementSize, const UInt32& elements = 1, const bool& allowWrite = false) const {
+        UniquePtr<IBuffer> createBuffer(BufferType type, BufferUsage usage, size_t elementSize, UInt32 elements = 1, bool allowWrite = false) const {
             return this->getBuffer(type, usage, elementSize, elements, allowWrite);
         };
 
@@ -5169,7 +5169,7 @@ namespace LiteFX::Rendering {
         /// <param name="elements">The number of elements in the buffer (in case the buffer is an array).</param>
         /// <param name="allowWrite">Allows the resource to be bound to a read/write descriptor.</param>
         /// <returns>The instance of the buffer.</returns>
-        UniquePtr<IBuffer> createBuffer(const IDescriptorSetLayout& descriptorSet, const UInt32& binding, BufferUsage usage, const UInt32& elements = 1, const bool& allowWrite = false) const {
+        UniquePtr<IBuffer> createBuffer(const IDescriptorSetLayout& descriptorSet, UInt32 binding, BufferUsage usage, UInt32 elements = 1, bool allowWrite = false) const {
             auto& descriptor = descriptorSet.descriptor(binding);
             return this->createBuffer(descriptor.type(), usage, descriptor.elementSize(), elements, allowWrite);
         };
@@ -5183,7 +5183,7 @@ namespace LiteFX::Rendering {
         /// <param name="elements">The number of elements in the buffer (in case the buffer is an array).</param>
         /// <param name="allowWrite">Allows the resource to be bound to a read/write descriptor.</param>
         /// <returns>The instance of the buffer.</returns>
-        UniquePtr<IBuffer> createBuffer(const IDescriptorSetLayout& descriptorSet, const UInt32& binding, BufferUsage usage, const UInt32& elementSize, const UInt32& elements, const bool& allowWrite = false) const {
+        UniquePtr<IBuffer> createBuffer(const IDescriptorSetLayout& descriptorSet, UInt32 binding, BufferUsage usage, UInt32 elementSize, UInt32 elements, bool allowWrite = false) const {
             auto& descriptor = descriptorSet.descriptor(binding);
             return this->createBuffer(descriptor.type(), usage, elementSize, elements, allowWrite);
         };
@@ -5198,7 +5198,7 @@ namespace LiteFX::Rendering {
         /// <param name="elements">The number of elements in the buffer (in case the buffer is an array).</param>
         /// <param name="allowWrite">Allows the resource to be bound to a read/write descriptor.</param>
         /// <returns>The instance of the buffer.</returns>
-        UniquePtr<IBuffer> createBuffer(const IPipeline& pipeline, const UInt32& space, const UInt32& binding, BufferUsage usage, const UInt32& elementSize, const UInt32& elements, const bool& allowWrite = false) const {
+        UniquePtr<IBuffer> createBuffer(const IPipeline& pipeline, UInt32 space, UInt32 binding, BufferUsage usage, UInt32 elementSize, UInt32 elements, bool allowWrite = false) const {
             return this->createBuffer(pipeline.layout()->descriptorSet(space), binding, usage, elementSize, elements, allowWrite);
         };
 
@@ -5212,7 +5212,7 @@ namespace LiteFX::Rendering {
         /// <param name="elements">The number of elements in the buffer (in case the buffer is an array).</param>
         /// <param name="allowWrite">Allows the resource to be bound to a read/write descriptor.</param>
         /// <returns>The instance of the buffer.</returns>
-        UniquePtr<IBuffer> createBuffer(const IPipeline& pipeline, const UInt32& space, const UInt32& binding, BufferUsage usage, const UInt32& elements = 1, const bool& allowWrite = false) const {
+        UniquePtr<IBuffer> createBuffer(const IPipeline& pipeline, UInt32 space, UInt32 binding, BufferUsage usage, UInt32 elements = 1, bool allowWrite = false) const {
             return this->createBuffer(pipeline.layout()->descriptorSet(space), binding, usage, elements, allowWrite);
         };
 
@@ -5226,7 +5226,7 @@ namespace LiteFX::Rendering {
         /// <param name="elements">The number of elements in the buffer (in case the buffer is an array).</param>
         /// <param name="allowWrite">Allows the resource to be bound to a read/write descriptor.</param>
         /// <returns>The instance of the buffer.</returns>
-        UniquePtr<IBuffer> createBuffer(const String& name, BufferType type, BufferUsage usage, const size_t& elementSize, const UInt32& elements, const bool& allowWrite = false) const {
+        UniquePtr<IBuffer> createBuffer(const String& name, BufferType type, BufferUsage usage, size_t elementSize, UInt32 elements, bool allowWrite = false) const {
             return this->getBuffer(name, type, usage, elementSize, elements, allowWrite);
         };
 
@@ -5240,7 +5240,7 @@ namespace LiteFX::Rendering {
         /// <param name="elements">The number of elements in the buffer (in case the buffer is an array).</param>
         /// <param name="allowWrite">Allows the resource to be bound to a read/write descriptor.</param>
         /// <returns>The instance of the buffer.</returns>
-        UniquePtr<IBuffer> createBuffer(const String& name, const IDescriptorSetLayout& descriptorSet, const UInt32& binding, BufferUsage usage, const UInt32& elements = 1, const bool& allowWrite = false) const {
+        UniquePtr<IBuffer> createBuffer(const String& name, const IDescriptorSetLayout& descriptorSet, UInt32 binding, BufferUsage usage, UInt32 elements = 1, bool allowWrite = false) const {
             auto& descriptor = descriptorSet.descriptor(binding);
             return this->createBuffer(name, descriptor.type(), usage, descriptor.elementSize(), elements, allowWrite);
         };
@@ -5256,7 +5256,7 @@ namespace LiteFX::Rendering {
         /// <param name="elements">The number of elements in the buffer (in case the buffer is an array).</param>
         /// <param name="allowWrite">Allows the resource to be bound to a read/write descriptor.</param>
         /// <returns>The instance of the buffer.</returns>
-        UniquePtr<IBuffer> createBuffer(const String& name, const IDescriptorSetLayout& descriptorSet, const UInt32& binding, BufferUsage usage, const size_t& elementSize, const UInt32& elements, const bool& allowWrite = false) const {
+        UniquePtr<IBuffer> createBuffer(const String& name, const IDescriptorSetLayout& descriptorSet, UInt32 binding, BufferUsage usage, size_t elementSize, UInt32 elements, bool allowWrite = false) const {
             auto& descriptor = descriptorSet.descriptor(binding);
             return this->createBuffer(name, descriptor.type(), usage, elementSize, elements, allowWrite);
         };
@@ -5272,7 +5272,7 @@ namespace LiteFX::Rendering {
         /// <param name="elements">The number of elements in the buffer (in case the buffer is an array).</param>
         /// <param name="allowWrite">Allows the resource to be bound to a read/write descriptor.</param>
         /// <returns>The instance of the buffer.</returns>
-        UniquePtr<IBuffer> createBuffer(const String& name, const IPipeline& pipeline, const UInt32& space, const UInt32& binding, BufferUsage usage, const UInt32& elements = 1, const bool& allowWrite = false) const {
+        UniquePtr<IBuffer> createBuffer(const String& name, const IPipeline& pipeline, UInt32 space, UInt32 binding, BufferUsage usage, UInt32 elements = 1, bool allowWrite = false) const {
             return this->createBuffer(name, pipeline.layout()->descriptorSet(space), binding, usage, elements, allowWrite);
         };
 
@@ -5288,7 +5288,7 @@ namespace LiteFX::Rendering {
         /// <param name="elements">The number of elements in the buffer (in case the buffer is an array).</param>
         /// <param name="allowWrite">Allows the resource to be bound to a read/write descriptor.</param>
         /// <returns>The instance of the buffer.</returns>
-        UniquePtr<IBuffer> createBuffer(const String& name, const IPipeline& pipeline, const UInt32& space, const UInt32& binding, BufferUsage usage, const size_t& elementSize, const UInt32& elements = 1, const bool& allowWrite = false) const {
+        UniquePtr<IBuffer> createBuffer(const String& name, const IPipeline& pipeline, UInt32 space, UInt32 binding, BufferUsage usage, size_t elementSize, UInt32 elements = 1, bool allowWrite = false) const {
             return this->createBuffer(name, pipeline.layout()->descriptorSet(space), binding, usage, elementSize, elements, allowWrite);
         };
 
@@ -5304,7 +5304,7 @@ namespace LiteFX::Rendering {
         /// <param name="usage">The buffer usage.</param>
         /// <param name="elements">The number of elements within the vertex buffer (i.e. the number of vertices).</param>
         /// <returns>The instance of the vertex buffer.</returns>
-        UniquePtr<IVertexBuffer> createVertexBuffer(const IVertexBufferLayout& layout, BufferUsage usage, const UInt32& elements = 1) const {
+        UniquePtr<IVertexBuffer> createVertexBuffer(const IVertexBufferLayout& layout, BufferUsage usage, UInt32 elements = 1) const {
             return this->getVertexBuffer(layout, usage, elements);
         }
 
@@ -5321,7 +5321,7 @@ namespace LiteFX::Rendering {
         /// <param name="usage">The buffer usage.</param>
         /// <param name="elements">The number of elements within the vertex buffer (i.e. the number of vertices).</param>
         /// <returns>The instance of the vertex buffer.</returns>
-        UniquePtr<IVertexBuffer> createVertexBuffer(const String& name, const IVertexBufferLayout& layout, BufferUsage usage, const UInt32& elements = 1) const {
+        UniquePtr<IVertexBuffer> createVertexBuffer(const String& name, const IVertexBufferLayout& layout, BufferUsage usage, UInt32 elements = 1) const {
             return this->getVertexBuffer(name, layout, usage, elements);
         }
 
@@ -5337,7 +5337,7 @@ namespace LiteFX::Rendering {
         /// <param name="usage">The buffer usage.</param>
         /// <param name="elements">The number of elements within the vertex buffer (i.e. the number of indices).</param>
         /// <returns>The instance of the index buffer.</returns>
-        UniquePtr<IIndexBuffer> createIndexBuffer(const IIndexBufferLayout& layout, BufferUsage usage, const UInt32& elements) const {
+        UniquePtr<IIndexBuffer> createIndexBuffer(const IIndexBufferLayout& layout, BufferUsage usage, UInt32 elements) const {
             return this->getIndexBuffer(layout, usage, elements);
         }
 
@@ -5354,7 +5354,7 @@ namespace LiteFX::Rendering {
         /// <param name="usage">The buffer usage.</param>
         /// <param name="elements">The number of elements within the vertex buffer (i.e. the number of indices).</param>
         /// <returns>The instance of the index buffer.</returns>
-        UniquePtr<IIndexBuffer> createIndexBuffer(const String& name, const IIndexBufferLayout& layout, BufferUsage usage, const UInt32& elements) const {
+        UniquePtr<IIndexBuffer> createIndexBuffer(const String& name, const IIndexBufferLayout& layout, BufferUsage usage, UInt32 elements) const {
             return this->getIndexBuffer(name, layout, usage, elements);
         }
 
@@ -5397,7 +5397,7 @@ namespace LiteFX::Rendering {
         /// <param name="allowWrite">Allows the resource to be bound to a read/write descriptor.</param>
         /// <returns>The instance of the texture.</returns>
         /// <seealso cref="createTextures" />
-        UniquePtr<IImage> createTexture(Format format, const Size3d& size, ImageDimensions dimension = ImageDimensions::DIM_2, const UInt32& levels = 1, const UInt32& layers = 1, MultiSamplingLevel samples = MultiSamplingLevel::x1, const bool& allowWrite = false) const {
+        UniquePtr<IImage> createTexture(Format format, const Size3d& size, ImageDimensions dimension = ImageDimensions::DIM_2, UInt32 levels = 1, UInt32 layers = 1, MultiSamplingLevel samples = MultiSamplingLevel::x1, bool allowWrite = false) const {
             return this->getTexture(format, size, dimension, levels, layers, samples, allowWrite);
         }
 
@@ -5418,7 +5418,7 @@ namespace LiteFX::Rendering {
         /// <param name="allowWrite">Allows the resource to be bound to a read/write descriptor.</param>
         /// <returns>The instance of the texture.</returns>
         /// <seealso cref="createTextures" />
-        UniquePtr<IImage> createTexture(const String& name, Format format, const Size3d& size, ImageDimensions dimension = ImageDimensions::DIM_2, const UInt32& levels = 1, const UInt32& layers = 1, MultiSamplingLevel samples = MultiSamplingLevel::x1, const bool& allowWrite = false) const {
+        UniquePtr<IImage> createTexture(const String& name, Format format, const Size3d& size, ImageDimensions dimension = ImageDimensions::DIM_2, UInt32 levels = 1, UInt32 layers = 1, MultiSamplingLevel samples = MultiSamplingLevel::x1, bool allowWrite = false) const {
             return this->getTexture(name, format, size, dimension, levels, layers, samples, allowWrite);
         }
 
@@ -5435,7 +5435,7 @@ namespace LiteFX::Rendering {
         /// <param name="allowWrite">Allows the resource to be bound to a read/write descriptor.</param>
         /// <returns>An array of texture instances.</returns>
         /// <seealso cref="createTexture" />
-        Enumerable<UniquePtr<IImage>> createTextures(const UInt32& elements, Format format, const Size3d& size, ImageDimensions dimension = ImageDimensions::DIM_2, const UInt32& layers = 1, const UInt32& levels = 1, MultiSamplingLevel samples = MultiSamplingLevel::x1, const bool& allowWrite = false) const {
+        Enumerable<UniquePtr<IImage>> createTextures(UInt32 elements, Format format, const Size3d& size, ImageDimensions dimension = ImageDimensions::DIM_2, UInt32 layers = 1, UInt32 levels = 1, MultiSamplingLevel samples = MultiSamplingLevel::x1, bool allowWrite = false) const {
             return this->getTextures(elements, format, size, dimension, layers, levels, samples, allowWrite);
         }
 
@@ -5454,7 +5454,7 @@ namespace LiteFX::Rendering {
         /// <param name="anisotropy">The level of anisotropic filtering.</param>
         /// <returns>The instance of the sampler.</returns>
         /// <seealso cref="createSamplers" />
-        UniquePtr<ISampler> createSampler(FilterMode magFilter = FilterMode::Nearest, FilterMode minFilter = FilterMode::Nearest, BorderMode borderU = BorderMode::Repeat, BorderMode borderV = BorderMode::Repeat, BorderMode borderW = BorderMode::Repeat, MipMapMode mipMapMode = MipMapMode::Nearest, const Float& mipMapBias = 0.f, const Float& maxLod = std::numeric_limits<Float>::max(), const Float& minLod = 0.f, const Float& anisotropy = 0.f) const {
+        UniquePtr<ISampler> createSampler(FilterMode magFilter = FilterMode::Nearest, FilterMode minFilter = FilterMode::Nearest, BorderMode borderU = BorderMode::Repeat, BorderMode borderV = BorderMode::Repeat, BorderMode borderW = BorderMode::Repeat, MipMapMode mipMapMode = MipMapMode::Nearest, Float mipMapBias = 0.f, Float maxLod = std::numeric_limits<Float>::max(), Float minLod = 0.f, Float anisotropy = 0.f) const {
             return this->getSampler(magFilter, minFilter, borderU, borderV, borderW, mipMapMode, mipMapBias, maxLod, minLod, anisotropy);
         }
 
@@ -5474,7 +5474,7 @@ namespace LiteFX::Rendering {
         /// <param name="anisotropy">The level of anisotropic filtering.</param>
         /// <returns>The instance of the sampler.</returns>
         /// <seealso cref="createSamplers" />
-        UniquePtr<ISampler> createSampler(const String& name, FilterMode magFilter = FilterMode::Nearest, FilterMode minFilter = FilterMode::Nearest, BorderMode borderU = BorderMode::Repeat, BorderMode borderV = BorderMode::Repeat, BorderMode borderW = BorderMode::Repeat, MipMapMode mipMapMode = MipMapMode::Nearest, const Float& mipMapBias = 0.f, const Float& maxLod = std::numeric_limits<Float>::max(), const Float& minLod = 0.f, const Float& anisotropy = 0.f) const {
+        UniquePtr<ISampler> createSampler(const String& name, FilterMode magFilter = FilterMode::Nearest, FilterMode minFilter = FilterMode::Nearest, BorderMode borderU = BorderMode::Repeat, BorderMode borderV = BorderMode::Repeat, BorderMode borderW = BorderMode::Repeat, MipMapMode mipMapMode = MipMapMode::Nearest, Float mipMapBias = 0.f, Float maxLod = std::numeric_limits<Float>::max(), Float minLod = 0.f, Float anisotropy = 0.f) const {
             return this->getSampler(name, magFilter, minFilter, borderU, borderV, borderW, mipMapMode, mipMapBias, maxLod, minLod, anisotropy);
         }
 
@@ -5494,25 +5494,25 @@ namespace LiteFX::Rendering {
         /// <param name="anisotropy">The level of anisotropic filtering.</param>
         /// <returns>An array of sampler instances.</returns>
         /// <seealso cref="createSampler" />
-        Enumerable<UniquePtr<ISampler>> createSamplers(const UInt32& elements, FilterMode magFilter = FilterMode::Nearest, FilterMode minFilter = FilterMode::Nearest, BorderMode borderU = BorderMode::Repeat, BorderMode borderV = BorderMode::Repeat, BorderMode borderW = BorderMode::Repeat, MipMapMode mipMapMode = MipMapMode::Nearest, const Float& mipMapBias = 0.f, const Float& maxLod = std::numeric_limits<Float>::max(), const Float& minLod = 0.f, const Float& anisotropy = 0.f) const {
+        Enumerable<UniquePtr<ISampler>> createSamplers(UInt32 elements, FilterMode magFilter = FilterMode::Nearest, FilterMode minFilter = FilterMode::Nearest, BorderMode borderU = BorderMode::Repeat, BorderMode borderV = BorderMode::Repeat, BorderMode borderW = BorderMode::Repeat, MipMapMode mipMapMode = MipMapMode::Nearest, Float mipMapBias = 0.f, Float maxLod = std::numeric_limits<Float>::max(), Float minLod = 0.f, Float anisotropy = 0.f) const {
             return this->getSamplers(elements, magFilter, minFilter, borderU, borderV, borderW, mipMapMode, mipMapBias, maxLod, minLod, anisotropy);
         }
 
     private:
-        virtual UniquePtr<IBuffer> getBuffer(BufferType type, BufferUsage usage, const size_t& elementSize, const UInt32& elements, const bool& allowWrite) const = 0;
-        virtual UniquePtr<IBuffer> getBuffer(const String& name, BufferType type, BufferUsage usage, const size_t& elementSize, const UInt32& elements, const bool& allowWrite) const = 0;
-        virtual UniquePtr<IVertexBuffer> getVertexBuffer(const IVertexBufferLayout& layout, BufferUsage usage, const UInt32& elements) const = 0;
-        virtual UniquePtr<IVertexBuffer> getVertexBuffer(const String& name, const IVertexBufferLayout& layout, BufferUsage usage, const UInt32& elements) const = 0;
-        virtual UniquePtr<IIndexBuffer> getIndexBuffer(const IIndexBufferLayout& layout, BufferUsage usage, const UInt32& elements) const = 0;
-        virtual UniquePtr<IIndexBuffer> getIndexBuffer(const String& name, const IIndexBufferLayout& layout, BufferUsage usage, const UInt32& elements) const = 0;
+        virtual UniquePtr<IBuffer> getBuffer(BufferType type, BufferUsage usage, size_t elementSize, UInt32 elements, bool allowWrite) const = 0;
+        virtual UniquePtr<IBuffer> getBuffer(const String& name, BufferType type, BufferUsage usage, size_t elementSize, UInt32 elements, bool allowWrite) const = 0;
+        virtual UniquePtr<IVertexBuffer> getVertexBuffer(const IVertexBufferLayout& layout, BufferUsage usage, UInt32 elements) const = 0;
+        virtual UniquePtr<IVertexBuffer> getVertexBuffer(const String& name, const IVertexBufferLayout& layout, BufferUsage usage, UInt32 elements) const = 0;
+        virtual UniquePtr<IIndexBuffer> getIndexBuffer(const IIndexBufferLayout& layout, BufferUsage usage, UInt32 elements) const = 0;
+        virtual UniquePtr<IIndexBuffer> getIndexBuffer(const String& name, const IIndexBufferLayout& layout, BufferUsage usage, UInt32 elements) const = 0;
         virtual UniquePtr<IImage> getAttachment(Format format, const Size2d& size, MultiSamplingLevel samples) const = 0;
         virtual UniquePtr<IImage> getAttachment(const String& name, Format format, const Size2d& size, MultiSamplingLevel samples) const = 0;
-        virtual UniquePtr<IImage> getTexture(Format format, const Size3d& size, ImageDimensions dimension, const UInt32& levels, const UInt32& layers, MultiSamplingLevel samples, const bool& allowWrite) const = 0;
-        virtual UniquePtr<IImage> getTexture(const String& name, Format format, const Size3d& size, ImageDimensions dimension, const UInt32& levels, const UInt32& layers, MultiSamplingLevel samples, const bool& allowWrite) const = 0;
-        virtual Enumerable<UniquePtr<IImage>> getTextures(const UInt32& elements, Format format, const Size3d& size, ImageDimensions dimension, const UInt32& layers, const UInt32& levels, MultiSamplingLevel samples, const bool& allowWrite) const = 0;
-        virtual UniquePtr<ISampler> getSampler(FilterMode magFilter, FilterMode minFilter, BorderMode borderU, BorderMode borderV, BorderMode borderW, MipMapMode mipMapMode, const Float& mipMapBias, const Float& maxLod, const Float& minLod, const Float& anisotropy) const = 0;
-        virtual UniquePtr<ISampler> getSampler(const String& name, FilterMode magFilter, FilterMode minFilter, BorderMode borderU, BorderMode borderV, BorderMode borderW, MipMapMode mipMapMode, const Float& mipMapBias, const Float& maxLod, const Float& minLod, const Float& anisotropy) const = 0;
-        virtual Enumerable<UniquePtr<ISampler>> getSamplers(const UInt32& elements, FilterMode magFilter, FilterMode minFilter, BorderMode borderU, BorderMode borderV, BorderMode borderW, MipMapMode mipMapMode, const Float& mipMapBias, const Float& maxLod, const Float& minLod, const Float& anisotropy) const = 0;
+        virtual UniquePtr<IImage> getTexture(Format format, const Size3d& size, ImageDimensions dimension, UInt32 levels, UInt32 layers, MultiSamplingLevel samples, bool allowWrite) const = 0;
+        virtual UniquePtr<IImage> getTexture(const String& name, Format format, const Size3d& size, ImageDimensions dimension, UInt32 levels, UInt32 layers, MultiSamplingLevel samples, bool allowWrite) const = 0;
+        virtual Enumerable<UniquePtr<IImage>> getTextures(UInt32 elements, Format format, const Size3d& size, ImageDimensions dimension, UInt32 layers, UInt32 levels, MultiSamplingLevel samples, bool allowWrite) const = 0;
+        virtual UniquePtr<ISampler> getSampler(FilterMode magFilter, FilterMode minFilter, BorderMode borderU, BorderMode borderV, BorderMode borderW, MipMapMode mipMapMode, Float mipMapBias, Float maxLod, Float minLod, Float anisotropy) const = 0;
+        virtual UniquePtr<ISampler> getSampler(const String& name, FilterMode magFilter, FilterMode minFilter, BorderMode borderU, BorderMode borderV, BorderMode borderW, MipMapMode mipMapMode, Float mipMapBias, Float maxLod, Float minLod, Float anisotropy) const = 0;
+        virtual Enumerable<UniquePtr<ISampler>> getSamplers(UInt32 elements, FilterMode magFilter, FilterMode minFilter, BorderMode borderU, BorderMode borderV, BorderMode borderW, MipMapMode mipMapMode, Float mipMapBias, Float maxLod, Float minLod, Float anisotropy) const = 0;
     };
 
     /// <summary>

--- a/src/Rendering/include/litefx/rendering_api.hpp
+++ b/src/Rendering/include/litefx/rendering_api.hpp
@@ -1438,7 +1438,7 @@ namespace LiteFX::Rendering {
     /// Returns the number of channels for a buffer format.
     /// </summary>
     /// <seealso cref="BufferFormat" />
-    inline UInt32 getBufferFormatChannels(const BufferFormat& format) {
+    constexpr inline UInt32 getBufferFormatChannels(BufferFormat format) {
         return static_cast<UInt32>(format) & 0x000000FF;
     }
 
@@ -1446,7 +1446,7 @@ namespace LiteFX::Rendering {
     /// Returns the number of bytes used by a channel of a buffer format.
     /// </summary>
     /// <seealso cref="BufferFormat" />
-    inline UInt32 getBufferFormatChannelSize(const BufferFormat& format) {
+    constexpr inline UInt32 getBufferFormatChannelSize(BufferFormat format) {
         return (static_cast<UInt32>(format) & 0xFF000000) >> 24;
     }
 
@@ -1454,26 +1454,26 @@ namespace LiteFX::Rendering {
     /// Returns the underlying data type of a buffer format.
     /// </summary>
     /// <seealso cref="BufferFormat" />
-    inline UInt32 getBufferFormatType(const BufferFormat& format) {
+    constexpr inline UInt32 getBufferFormatType(BufferFormat format) {
         return (static_cast<UInt32>(format) & 0x0000FF00) >> 8;
     }
 
     /// <summary>
     /// Returns the size of an element of a specified format.
     /// </summary>
-    size_t LITEFX_RENDERING_API getSize(const Format& format);
+    constexpr inline size_t LITEFX_RENDERING_API getSize(Format format);
 
     /// <summary>
     /// Returns <c>true</c>, if the format contains a depth channel.
     /// </summary>
     /// <seealso cref="DepthStencilState" />
-    bool LITEFX_RENDERING_API hasDepth(const Format& format);
+    constexpr inline bool LITEFX_RENDERING_API hasDepth(Format format);
 
     /// <summary>
     /// Returns <c>true</c>, if the format contains a stencil channel.
     /// </summary>
     /// <seealso cref="DepthStencilState" />
-    bool LITEFX_RENDERING_API hasStencil(const Format& format);
+    constexpr inline bool LITEFX_RENDERING_API hasStencil(Format format);
 
 #pragma endregion
 
@@ -1878,7 +1878,7 @@ namespace LiteFX::Rendering {
         /// Returns the type of the shader module.
         /// </summary>
         /// <returns>The type of the shader module.</returns>
-        virtual const ShaderStage& type() const noexcept = 0;
+        virtual ShaderStage type() const noexcept = 0;
 
         /// <summary>
         /// Returns the file name of the shader module.
@@ -1976,13 +1976,13 @@ namespace LiteFX::Rendering {
         /// Returns the type of the render target.
         /// </summary>
         /// <returns>The type of the render target.</returns>
-        virtual const RenderTargetType& type() const noexcept = 0;
+        virtual RenderTargetType type() const noexcept = 0;
 
         /// <summary>
         /// Returns the internal format of the render target.
         /// </summary>
         /// <returns>The internal format of the render target.</returns>
-        virtual const Format& format() const noexcept = 0;
+        virtual Format format() const noexcept = 0;
 
         /// <summary>
         /// Returns <c>true</c>, if the render target should be cleared, when the render pass is started. If the <see cref="format" /> is set to a depth format, this clears the
@@ -2053,7 +2053,7 @@ namespace LiteFX::Rendering {
         /// <param name="clearStencil"><c>true</c>, if the render target stencil should be cleared, when a render pass is started.</param>
         /// <param name="isVolatile"><c>true</c>, if the target should not be made persistent for access after the render pass has finished.</param>
         /// <param name="blendState">The render target blend state.</param>
-        explicit RenderTarget(const UInt32& location, const RenderTargetType& type, const Format& format, const bool& clearBuffer, const Vector4f& clearValues = { 0.f , 0.f, 0.f, 0.f }, const bool& clearStencil = true, const bool& isVolatile = false, const BlendState& blendState = {});
+        explicit RenderTarget(const UInt32& location, RenderTargetType type, Format format, const bool& clearBuffer, const Vector4f& clearValues = { 0.f , 0.f, 0.f, 0.f }, const bool& clearStencil = true, const bool& isVolatile = false, const BlendState& blendState = {});
 
         /// <summary>
         /// Initializes the render target.
@@ -2067,7 +2067,7 @@ namespace LiteFX::Rendering {
         /// <param name="clearStencil"><c>true</c>, if the render target stencil should be cleared, when a render pass is started.</param>
         /// <param name="isVolatile"><c>true</c>, if the target should not be made persistent for access after the render pass has finished.</param>
         /// <param name="blendState">The render target blend state.</param>
-        explicit RenderTarget(const String& name, const UInt32& location, const RenderTargetType& type, const Format& format, const bool& clearBuffer, const Vector4f& clearValues = { 0.f , 0.f, 0.f, 0.f }, const bool& clearStencil = true, const bool& isVolatile = false, const BlendState& blendState = {});
+        explicit RenderTarget(const String& name, const UInt32& location, RenderTargetType type, Format format, const bool& clearBuffer, const Vector4f& clearValues = { 0.f , 0.f, 0.f, 0.f }, const bool& clearStencil = true, const bool& isVolatile = false, const BlendState& blendState = {});
         RenderTarget(const RenderTarget&) noexcept;
         RenderTarget(RenderTarget&&) noexcept;
         virtual ~RenderTarget() noexcept;
@@ -2084,10 +2084,10 @@ namespace LiteFX::Rendering {
         virtual const UInt32& location() const noexcept override;
 
         /// <inheritdoc />
-        virtual const RenderTargetType& type() const noexcept override;
+        virtual RenderTargetType type() const noexcept override;
 
         /// <inheritdoc />
-        virtual const Format& format() const noexcept override;
+        virtual Format format() const noexcept override;
 
         /// <inheritdoc />
         virtual const bool& clearBuffer() const noexcept override;
@@ -2295,19 +2295,19 @@ namespace LiteFX::Rendering {
         /// Returns the polygon mode of the rasterizer state.
         /// </summary>
         /// <returns>The polygon mode of the rasterizer state.</returns>
-        virtual const PolygonMode& polygonMode() const noexcept = 0;
+        virtual PolygonMode polygonMode() const noexcept = 0;
 
         /// <summary>
         /// Returns the cull mode of the rasterizer state.
         /// </summary>
         /// <returns>The cull mode of the rasterizer state.</returns>
-        virtual const CullMode& cullMode() const noexcept = 0;
+        virtual CullMode cullMode() const noexcept = 0;
 
         /// <summary>
         /// Returns the cull mode of the rasterizer state.
         /// </summary>
         /// <returns>The cull mode of the rasterizer state.</returns>
-        virtual const CullOrder& cullOrder() const noexcept = 0;
+        virtual CullOrder cullOrder() const noexcept = 0;
 
         /// <summary>
         /// Returns the line width of the rasterizer state.
@@ -2341,20 +2341,20 @@ namespace LiteFX::Rendering {
         /// <param name="cullOrder">The cull order of the rasterizer state.</param>
         /// <param name="lineWidth">The line width of the rasterizer state.</param>
         /// <param name="depthStencilState">The rasterizer depth/stencil state.</param>
-        explicit Rasterizer(const PolygonMode& polygonMode, const CullMode& cullMode, const CullOrder& cullOrder, const Float& lineWidth = 1.f, const DepthStencilState& depthStencilState = {}) noexcept;
+        explicit Rasterizer(PolygonMode polygonMode, CullMode cullMode, CullOrder cullOrder, const Float& lineWidth = 1.f, const DepthStencilState& depthStencilState = {}) noexcept;
         Rasterizer(Rasterizer&&) noexcept;
         Rasterizer(const Rasterizer&) noexcept;
         virtual ~Rasterizer() noexcept;
 
     public:
         /// <inheritdoc />
-        virtual const PolygonMode& polygonMode() const noexcept override;
+        virtual PolygonMode polygonMode() const noexcept override;
 
         /// <inheritdoc />
-        virtual const CullMode& cullMode() const noexcept override;
+        virtual CullMode cullMode() const noexcept override;
 
         /// <inheritdoc />
-        virtual const CullOrder& cullOrder() const noexcept override;
+        virtual CullOrder cullOrder() const noexcept override;
 
         /// <inheritdoc />
         virtual const Float& lineWidth() const noexcept override;
@@ -2585,7 +2585,7 @@ namespace LiteFX::Rendering {
         /// <param name="format">The format of the buffer attribute.</param>
         /// <param name="semantic">The semantic of the buffer attribute.</param>
         /// <param name="semanticIndex">The semantic index of the buffer attribute.</param>
-        BufferAttribute(const UInt32& location, const UInt32& offset, const BufferFormat& format, const AttributeSemantic& semantic, const UInt32& semanticIndex = 0);
+        BufferAttribute(const UInt32& location, const UInt32& offset, BufferFormat format, AttributeSemantic semantic, const UInt32& semanticIndex = 0);
         BufferAttribute(BufferAttribute&&) noexcept;
         BufferAttribute(const BufferAttribute&);
         virtual ~BufferAttribute() noexcept;
@@ -2604,7 +2604,7 @@ namespace LiteFX::Rendering {
         /// Returns the format of the buffer attribute.
         /// </summary>
         /// <returns>The format of the buffer attribute.</returns>
-        virtual const BufferFormat& format() const noexcept;
+        virtual BufferFormat format() const noexcept;
 
         /// <summary>
         /// Returns the offset of the buffer attribute.
@@ -2620,7 +2620,7 @@ namespace LiteFX::Rendering {
         /// </remarks>
         /// <returns>The semantic of the buffer attribute.</returns>
         /// <seealso cref="semanticIndex" />
-        virtual const AttributeSemantic& semantic() const noexcept;
+        virtual AttributeSemantic semantic() const noexcept;
 
         /// <summary>
         /// Returns the semantic index of the buffer attribute.
@@ -2663,7 +2663,7 @@ namespace LiteFX::Rendering {
         /// Returns the buffer type of the buffer.
         /// </summary>
         /// <returns>The buffer type of the buffer.</returns>
-        virtual const BufferType& type() const noexcept = 0;
+        virtual BufferType type() const noexcept = 0;
     };
 
     /// <summary>
@@ -2695,7 +2695,7 @@ namespace LiteFX::Rendering {
         /// Returns the index type of the index buffer.
         /// </summary>
         /// <returns>The index type of the index buffer.</returns>
-        virtual const IndexType& indexType() const noexcept = 0;
+        virtual IndexType indexType() const noexcept = 0;
     };
 
     /// <summary>
@@ -2729,7 +2729,7 @@ namespace LiteFX::Rendering {
         /// Returns the type of the descriptor.
         /// </summary>
         /// <returns>The type of the descriptor.</returns>
-        virtual const DescriptorType& descriptorType() const noexcept = 0;
+        virtual DescriptorType descriptorType() const noexcept = 0;
 
         /// <summary>
         /// Returns the number of descriptors in the descriptor array, or `-1` if the array is unbounded.
@@ -2884,7 +2884,7 @@ namespace LiteFX::Rendering {
         /// Returns the type of the buffer.
         /// </summary>
         /// <returns>The type of the buffer.</returns>
-        virtual const BufferType& type() const noexcept = 0;
+        virtual BufferType type() const noexcept = 0;
     };
 
     /// <summary>
@@ -2921,7 +2921,7 @@ namespace LiteFX::Rendering {
         /// Gets the internal format of the image.
         /// </summary>
         /// <returns>The internal format of the image.</returns>
-        virtual const Format& format() const noexcept = 0;
+        virtual Format format() const noexcept = 0;
 
         /// <summary>
         /// Gets the images dimensionality.
@@ -2931,7 +2931,7 @@ namespace LiteFX::Rendering {
         /// extent is used.
         /// </remarks>
         /// <returns>The images dimensionality.</returns>
-        virtual const ImageDimensions& dimensions() const noexcept = 0;
+        virtual ImageDimensions dimensions() const noexcept = 0;
 
         /// <summary>
         /// Gets the number of mip-map levels of the image.
@@ -2959,7 +2959,7 @@ namespace LiteFX::Rendering {
         /// Gets the number of samples of the texture.
         /// </summary>
         /// <returns>The number of samples of the texture.</returns>
-        virtual const MultiSamplingLevel& samples() const noexcept = 0;
+        virtual MultiSamplingLevel samples() const noexcept = 0;
 
         /// <summary>
         /// Returns the current image layout.
@@ -2967,7 +2967,7 @@ namespace LiteFX::Rendering {
         /// <param name="subresource">The sub-resource ID for which to return the layout.</param>
         /// <returns>The current image layout.</returns>
         /// <seealso cref="subresourceId" />
-        virtual const ImageLayout& layout(const UInt32& subresource = 0) const = 0;
+        virtual ImageLayout layout(const UInt32& subresource = 0) const = 0;
 
         // TODO: getSampler() for combined samplers?
 
@@ -3013,31 +3013,31 @@ namespace LiteFX::Rendering {
         /// Gets the filtering mode that is used for minifying lookups.
         /// </summary>
         /// <returns>The filtering mode that is used for minifying lookups.</returns>
-        virtual const FilterMode& getMinifyingFilter() const noexcept = 0;
+        virtual FilterMode getMinifyingFilter() const noexcept = 0;
 
         /// <summary>
         /// Gets the filtering mode that is used for magnifying lookups.
         /// </summary>
         /// <returns>The filtering mode that is used for magnifying lookups.</returns>
-        virtual const FilterMode& getMagnifyingFilter() const noexcept = 0;
+        virtual FilterMode getMagnifyingFilter() const noexcept = 0;
 
         /// <summary>
         /// Gets the addressing mode at the horizontal border.
         /// </summary>
         /// <returns>The addressing mode at the horizontal border.</returns>
-        virtual const BorderMode& getBorderModeU() const noexcept = 0;
+        virtual BorderMode getBorderModeU() const noexcept = 0;
 
         /// <summary>
         /// Gets the addressing mode at the vertical border.
         /// </summary>
         /// <returns>The addressing mode at the vertical border.</returns>
-        virtual const BorderMode& getBorderModeV() const noexcept = 0;
+        virtual BorderMode getBorderModeV() const noexcept = 0;
 
         /// <summary>
         /// Gets the addressing mode at the depth border.
         /// </summary>
         /// <returns>The addressing mode at the depth border.</returns>
-        virtual const BorderMode& getBorderModeW() const noexcept = 0;
+        virtual BorderMode getBorderModeW() const noexcept = 0;
 
         /// <summary>
         /// Gets the anisotropy value used when sampling this texture.
@@ -3052,7 +3052,7 @@ namespace LiteFX::Rendering {
         /// Gets the mip-map selection mode.
         /// </summary>
         /// <returns>The mip-map selection mode.</returns>
-        virtual const MipMapMode& getMipMapMode() const noexcept = 0;
+        virtual MipMapMode getMipMapMode() const noexcept = 0;
 
         /// <summary>
         /// Gets the mip-map level of detail bias.
@@ -3125,13 +3125,13 @@ namespace LiteFX::Rendering {
         /// Returns the stage that all previous commands need to reach before continuing execution.
         /// </summary>
         /// <returns>The stage that all previous commands need to reach before continuing execution.</returns>
-        constexpr inline virtual const PipelineStage& syncBefore() const noexcept = 0;
+        constexpr inline virtual PipelineStage syncBefore() const noexcept = 0;
         
         /// <summary>
         /// Returns the stage all subsequent commands need to wait for before continuing execution.
         /// </summary>
         /// <returns>The stage all subsequent commands need to wait for before continuing execution.</returns>
-        constexpr inline virtual const PipelineStage& syncAfter() const noexcept = 0;
+        constexpr inline virtual PipelineStage syncAfter() const noexcept = 0;
 
         /// <summary>
         /// Inserts a global barrier that waits for previous commands to finish accesses described by <paramref name="accessBefore" /> before subsequent commands can continue
@@ -3139,7 +3139,7 @@ namespace LiteFX::Rendering {
         /// </summary>
         /// <param name="accessBefore">The access types previous commands have to finish.</param>
         /// <param name="accessAfter">The access types that subsequent commands continue with.</param>
-        constexpr inline virtual void wait(const ResourceAccess& accessBefore, const ResourceAccess& accessAfter) noexcept = 0;
+        constexpr inline virtual void wait(ResourceAccess accessBefore, ResourceAccess accessAfter) noexcept = 0;
 
         /// <summary>
         /// Inserts a buffer barrier that blocks access to <paramref name="buffer"/> of types contained in <paramref name="accessAfter" /> for subsequent commands until 
@@ -3148,7 +3148,7 @@ namespace LiteFX::Rendering {
         /// <param name="buffer">The buffer resource to transition.</param>
         /// <param name="accessBefore">The access types previous commands have to finish.</param>
         /// <param name="accessAfter">The access types that subsequent commands continue with.</param>
-        constexpr inline void transition(IBuffer& buffer, const ResourceAccess& accessBefore, const ResourceAccess& accessAfter) {
+        constexpr inline void transition(IBuffer& buffer, ResourceAccess accessBefore, ResourceAccess accessAfter) {
             this->doTransition(buffer, accessBefore, accessAfter);
         };
 
@@ -3164,7 +3164,7 @@ namespace LiteFX::Rendering {
         /// <param name="element">The element of the resource to transition.</param>
         /// <param name="accessBefore">The access types previous commands have to finish.</param>
         /// <param name="accessAfter">The access types that subsequent commands continue with.</param>
-        constexpr inline void transition(IBuffer& buffer, const UInt32& element, const ResourceAccess& accessBefore, const ResourceAccess& accessAfter) {
+        constexpr inline void transition(IBuffer& buffer, const UInt32& element, ResourceAccess accessBefore, ResourceAccess accessAfter) {
             this->doTransition(buffer, element, accessBefore, accessAfter);
         }
 
@@ -3177,7 +3177,7 @@ namespace LiteFX::Rendering {
         /// <param name="accessBefore">The access types previous commands have to finish.</param>
         /// <param name="accessAfter">The access types that subsequent commands continue with.</param>
         /// <param name="layout">The image layout to transition into.</param>
-        constexpr inline void transition(IImage& image, const ResourceAccess& accessBefore, const ResourceAccess& accessAfter, const ImageLayout& layout) {
+        constexpr inline void transition(IImage& image, ResourceAccess accessBefore, ResourceAccess accessAfter, ImageLayout layout) {
             this->doTransition(image, accessBefore, accessAfter, layout);
         }
 
@@ -3195,7 +3195,7 @@ namespace LiteFX::Rendering {
         /// <param name="accessBefore">The access types previous commands have to finish.</param>
         /// <param name="accessAfter">The access types that subsequent commands continue with.</param>
         /// <param name="layout">The image layout to transition into.</param>
-        constexpr inline void transition(IImage& image, const UInt32& level, const UInt32& levels, const UInt32& layer, const UInt32& layers, const UInt32& plane, const ResourceAccess& accessBefore, const ResourceAccess& accessAfter, const ImageLayout& layout) {
+        constexpr inline void transition(IImage& image, const UInt32& level, const UInt32& levels, const UInt32& layer, const UInt32& layers, const UInt32& plane, ResourceAccess accessBefore, ResourceAccess accessAfter, ImageLayout layout) {
             this->doTransition(image, level, levels, layer, layers, plane, accessBefore, accessAfter, layout);
         }
 
@@ -3213,7 +3213,7 @@ namespace LiteFX::Rendering {
         /// <param name="accessAfter">The access types that subsequent commands continue with.</param>
         /// <param name="fromLayout">The image layout to transition from.</param>
         /// <param name="toLayout">The image layout to transition into.</param>
-        constexpr inline void transition(IImage& image, const ResourceAccess& accessBefore, const ResourceAccess& accessAfter, const ImageLayout& fromLayout, const ImageLayout& toLayout) {
+        constexpr inline void transition(IImage& image, ResourceAccess accessBefore, ResourceAccess accessAfter, ImageLayout fromLayout, ImageLayout toLayout) {
             this->doTransition(image, accessBefore, accessAfter, fromLayout, toLayout);
         }
 
@@ -3236,17 +3236,17 @@ namespace LiteFX::Rendering {
         /// <param name="accessAfter">The access types that subsequent commands continue with.</param>
         /// <param name="fromLayout">The image layout to transition from.</param>
         /// <param name="toLayout">The image layout to transition into.</param>
-        constexpr inline void transition(IImage& image, const UInt32& level, const UInt32& levels, const UInt32& layer, const UInt32& layers, const UInt32& plane, const ResourceAccess& accessBefore, const ResourceAccess& accessAfter, const ImageLayout& fromLayout, const ImageLayout& toLayout) {
+        constexpr inline void transition(IImage& image, const UInt32& level, const UInt32& levels, const UInt32& layer, const UInt32& layers, const UInt32& plane, ResourceAccess accessBefore, ResourceAccess accessAfter, ImageLayout fromLayout, ImageLayout toLayout) {
             this->doTransition(image, level, levels, layer, layers, plane, accessBefore, accessAfter, fromLayout, toLayout);
         }
 
     private:
-        constexpr inline virtual void doTransition(IBuffer& buffer, const ResourceAccess& accessBefore, const ResourceAccess& accessAfter) = 0;
-        constexpr inline virtual void doTransition(IBuffer& buffer, const UInt32& element, const ResourceAccess& accessBefore, const ResourceAccess& accessAfter) = 0;
-        constexpr inline virtual void doTransition(IImage& image, const ResourceAccess& accessBefore, const ResourceAccess& accessAfter, const ImageLayout& layout) = 0;
-        constexpr inline virtual void doTransition(IImage& image, const ResourceAccess& accessBefore, const ResourceAccess& accessAfter, const ImageLayout& fromLayout, const ImageLayout& toLayout) = 0;
-        constexpr inline virtual void doTransition(IImage& image, const UInt32& level, const UInt32& levels, const UInt32& layer, const UInt32& layers, const UInt32& plane, const ResourceAccess& accessBefore, const ResourceAccess& accessAfter, const ImageLayout& layout) = 0;
-        constexpr inline virtual void doTransition(IImage& image, const UInt32& level, const UInt32& levels, const UInt32& layer, const UInt32& layers, const UInt32& plane, const ResourceAccess& accessBefore, const ResourceAccess& accessAfter, const ImageLayout& fromLayout, const ImageLayout& toLayout) = 0;
+        constexpr inline virtual void doTransition(IBuffer& buffer, ResourceAccess accessBefore, ResourceAccess accessAfter) = 0;
+        constexpr inline virtual void doTransition(IBuffer& buffer, const UInt32& element, ResourceAccess accessBefore, ResourceAccess accessAfter) = 0;
+        constexpr inline virtual void doTransition(IImage& image, ResourceAccess accessBefore, ResourceAccess accessAfter, ImageLayout layout) = 0;
+        constexpr inline virtual void doTransition(IImage& image, ResourceAccess accessBefore, ResourceAccess accessAfter, ImageLayout fromLayout, ImageLayout toLayout) = 0;
+        constexpr inline virtual void doTransition(IImage& image, const UInt32& level, const UInt32& levels, const UInt32& layer, const UInt32& layers, const UInt32& plane, ResourceAccess accessBefore, ResourceAccess accessAfter, ImageLayout layout) = 0;
+        constexpr inline virtual void doTransition(IImage& image, const UInt32& level, const UInt32& levels, const UInt32& layer, const UInt32& layers, const UInt32& plane, ResourceAccess accessBefore, ResourceAccess accessAfter, ImageLayout fromLayout, ImageLayout toLayout) = 0;
     };
 
     /// <summary>
@@ -3425,7 +3425,7 @@ namespace LiteFX::Rendering {
         /// Returns the shader stages, the descriptor set is used in.
         /// </summary>
         /// <returns>The shader stages, the descriptor set is used in.</returns>
-        virtual const ShaderStage& shaderStages() const noexcept = 0;
+        virtual ShaderStage shaderStages() const noexcept = 0;
 
         /// <summary>
         /// Returns the number of uniform/constant buffer descriptors within the descriptor set.
@@ -3613,7 +3613,7 @@ namespace LiteFX::Rendering {
         /// Returns the shader stage(s), the range is accessible from.
         /// </summary>
         /// <returns>The shader stage(s), the range is accessible from.</returns>
-        virtual const ShaderStage& stage() const noexcept = 0;
+        virtual ShaderStage stage() const noexcept = 0;
     };
 
     /// <summary>
@@ -3638,7 +3638,7 @@ namespace LiteFX::Rendering {
         /// <exception cref="ArgumentOutOfRangeException">Thrown, if no range is mapped to the provided shader stage.</exception>
         /// <exception cref="InvalidArgumentException">Thrown, if <paramref name="stage" /> contains multiple shader stages.</exception>
         /// <seealso cref="ranges" />
-        virtual const IPushConstantsRange& range(const ShaderStage& stage) const = 0;
+        virtual const IPushConstantsRange& range(ShaderStage stage) const = 0;
 
         /// <summary>
         /// Returns all push constant ranges.
@@ -4620,7 +4620,7 @@ namespace LiteFX::Rendering {
         /// Returns the number of samples, the render targets are sampled with.
         /// </summary>
         /// <returns>The number of samples, the render targets are sampled with.</returns>
-        virtual const MultiSamplingLevel& multiSamplingLevel() const noexcept = 0;
+        virtual MultiSamplingLevel multiSamplingLevel() const noexcept = 0;
 
     public:
         /// <summary>
@@ -4666,7 +4666,7 @@ namespace LiteFX::Rendering {
         /// </remarks>
         /// <param name="samples">The number of samples per edge pixel.</param>
         /// <exception cref="InvalidArgumentException">Thrown, if one or more of the render targets have a format, that does not support the provided multi-sampling level.</exception>
-        virtual void changeMultiSamplingLevel(const MultiSamplingLevel& samples) = 0;
+        virtual void changeMultiSamplingLevel(MultiSamplingLevel samples) = 0;
 
         /// <summary>
         /// Resolves the input attachments mapped to the render pass and updates them on the descriptor set provided with <see cref="descriptorSet" />.
@@ -4692,12 +4692,12 @@ namespace LiteFX::Rendering {
         /// </summary>
         struct SwapChainResetEventArgs : public EventArgs {
         private:
-            const Format& m_surfaceFormat;
+            Format m_surfaceFormat;
             const Size2d& m_renderArea;
             const UInt32& m_buffers;
 
         public:
-            SwapChainResetEventArgs(const Format& surfaceFormat, const Size2d& renderArea, const UInt32& buffers) :
+            SwapChainResetEventArgs(Format surfaceFormat, const Size2d& renderArea, const UInt32& buffers) :
                 EventArgs(), m_surfaceFormat(surfaceFormat), m_renderArea(renderArea), m_buffers(buffers) { }
             SwapChainResetEventArgs(const SwapChainResetEventArgs&) = default;
             SwapChainResetEventArgs(SwapChainResetEventArgs&&) = default;
@@ -4712,7 +4712,7 @@ namespace LiteFX::Rendering {
             /// Gets the new surface format of the swap chain back-buffers.
             /// </summary>
             /// <returns>The new surface format of the swap chain back-buffers.</returns>
-            const Format& surfaceFormat() const noexcept {
+            Format surfaceFormat() const noexcept {
                 return m_surfaceFormat;
             }
 
@@ -4790,7 +4790,7 @@ namespace LiteFX::Rendering {
         /// Returns the swap chain image format.
         /// </summary>
         /// <returns>The swap chain image format.</returns>
-        virtual const Format& surfaceFormat() const noexcept = 0;
+        virtual Format surfaceFormat() const noexcept = 0;
 
         /// <summary>
         /// Returns the number of images in the swap chain.
@@ -4860,7 +4860,7 @@ namespace LiteFX::Rendering {
         /// <param name="renderArea">The dimensions of the frame buffers.</param>
         /// <param name="buffers">The number of buffers in the swap chain.</param>
         /// <seealso cref="multiSamplingLevel" />
-        virtual void reset(const Format& surfaceFormat, const Size2d& renderArea, const UInt32& buffers) = 0;
+        virtual void reset(Format surfaceFormat, const Size2d& renderArea, const UInt32& buffers) = 0;
 
         /// <summary>
         /// Swaps the front buffer with the next back buffer in order.
@@ -4954,13 +4954,13 @@ namespace LiteFX::Rendering {
         /// Returns the priority of the queue.
         /// </summary>
         /// <returns>The priority of the queue.</returns>
-        virtual const QueuePriority& priority() const noexcept = 0;
+        virtual QueuePriority priority() const noexcept = 0;
 
         /// <summary>
         /// Returns the type of the queue.
         /// </summary>
         /// <returns>The type of the queue.</returns>
-        virtual const QueueType& type() const noexcept = 0;
+        virtual QueueType type() const noexcept = 0;
 
     public:
         /// <summary>
@@ -5156,7 +5156,7 @@ namespace LiteFX::Rendering {
         /// <param name="elements">The number of elements in the buffer (in case the buffer is an array).</param>
         /// <param name="allowWrite">Allows the resource to be bound to a read/write descriptor.</param>
         /// <returns>The instance of the buffer.</returns>
-        UniquePtr<IBuffer> createBuffer(const BufferType& type, const BufferUsage& usage, const size_t& elementSize, const UInt32& elements = 1, const bool& allowWrite = false) const {
+        UniquePtr<IBuffer> createBuffer(BufferType type, BufferUsage usage, const size_t& elementSize, const UInt32& elements = 1, const bool& allowWrite = false) const {
             return this->getBuffer(type, usage, elementSize, elements, allowWrite);
         };
 
@@ -5169,7 +5169,7 @@ namespace LiteFX::Rendering {
         /// <param name="elements">The number of elements in the buffer (in case the buffer is an array).</param>
         /// <param name="allowWrite">Allows the resource to be bound to a read/write descriptor.</param>
         /// <returns>The instance of the buffer.</returns>
-        UniquePtr<IBuffer> createBuffer(const IDescriptorSetLayout& descriptorSet, const UInt32& binding, const BufferUsage& usage, const UInt32& elements = 1, const bool& allowWrite = false) const {
+        UniquePtr<IBuffer> createBuffer(const IDescriptorSetLayout& descriptorSet, const UInt32& binding, BufferUsage usage, const UInt32& elements = 1, const bool& allowWrite = false) const {
             auto& descriptor = descriptorSet.descriptor(binding);
             return this->createBuffer(descriptor.type(), usage, descriptor.elementSize(), elements, allowWrite);
         };
@@ -5183,7 +5183,7 @@ namespace LiteFX::Rendering {
         /// <param name="elements">The number of elements in the buffer (in case the buffer is an array).</param>
         /// <param name="allowWrite">Allows the resource to be bound to a read/write descriptor.</param>
         /// <returns>The instance of the buffer.</returns>
-        UniquePtr<IBuffer> createBuffer(const IDescriptorSetLayout& descriptorSet, const UInt32& binding, const BufferUsage& usage, const UInt32& elementSize, const UInt32& elements, const bool& allowWrite = false) const {
+        UniquePtr<IBuffer> createBuffer(const IDescriptorSetLayout& descriptorSet, const UInt32& binding, BufferUsage usage, const UInt32& elementSize, const UInt32& elements, const bool& allowWrite = false) const {
             auto& descriptor = descriptorSet.descriptor(binding);
             return this->createBuffer(descriptor.type(), usage, elementSize, elements, allowWrite);
         };
@@ -5198,7 +5198,7 @@ namespace LiteFX::Rendering {
         /// <param name="elements">The number of elements in the buffer (in case the buffer is an array).</param>
         /// <param name="allowWrite">Allows the resource to be bound to a read/write descriptor.</param>
         /// <returns>The instance of the buffer.</returns>
-        UniquePtr<IBuffer> createBuffer(const IPipeline& pipeline, const UInt32& space, const UInt32& binding, const BufferUsage& usage, const UInt32& elementSize, const UInt32& elements, const bool& allowWrite = false) const {
+        UniquePtr<IBuffer> createBuffer(const IPipeline& pipeline, const UInt32& space, const UInt32& binding, BufferUsage usage, const UInt32& elementSize, const UInt32& elements, const bool& allowWrite = false) const {
             return this->createBuffer(pipeline.layout()->descriptorSet(space), binding, usage, elementSize, elements, allowWrite);
         };
 
@@ -5212,7 +5212,7 @@ namespace LiteFX::Rendering {
         /// <param name="elements">The number of elements in the buffer (in case the buffer is an array).</param>
         /// <param name="allowWrite">Allows the resource to be bound to a read/write descriptor.</param>
         /// <returns>The instance of the buffer.</returns>
-        UniquePtr<IBuffer> createBuffer(const IPipeline& pipeline, const UInt32& space, const UInt32& binding, const BufferUsage& usage, const UInt32& elements = 1, const bool& allowWrite = false) const {
+        UniquePtr<IBuffer> createBuffer(const IPipeline& pipeline, const UInt32& space, const UInt32& binding, BufferUsage usage, const UInt32& elements = 1, const bool& allowWrite = false) const {
             return this->createBuffer(pipeline.layout()->descriptorSet(space), binding, usage, elements, allowWrite);
         };
 
@@ -5226,7 +5226,7 @@ namespace LiteFX::Rendering {
         /// <param name="elements">The number of elements in the buffer (in case the buffer is an array).</param>
         /// <param name="allowWrite">Allows the resource to be bound to a read/write descriptor.</param>
         /// <returns>The instance of the buffer.</returns>
-        UniquePtr<IBuffer> createBuffer(const String& name, const BufferType& type, const BufferUsage& usage, const size_t& elementSize, const UInt32& elements, const bool& allowWrite = false) const {
+        UniquePtr<IBuffer> createBuffer(const String& name, BufferType type, BufferUsage usage, const size_t& elementSize, const UInt32& elements, const bool& allowWrite = false) const {
             return this->getBuffer(name, type, usage, elementSize, elements, allowWrite);
         };
 
@@ -5240,7 +5240,7 @@ namespace LiteFX::Rendering {
         /// <param name="elements">The number of elements in the buffer (in case the buffer is an array).</param>
         /// <param name="allowWrite">Allows the resource to be bound to a read/write descriptor.</param>
         /// <returns>The instance of the buffer.</returns>
-        UniquePtr<IBuffer> createBuffer(const String& name, const IDescriptorSetLayout& descriptorSet, const UInt32& binding, const BufferUsage& usage, const UInt32& elements = 1, const bool& allowWrite = false) const {
+        UniquePtr<IBuffer> createBuffer(const String& name, const IDescriptorSetLayout& descriptorSet, const UInt32& binding, BufferUsage usage, const UInt32& elements = 1, const bool& allowWrite = false) const {
             auto& descriptor = descriptorSet.descriptor(binding);
             return this->createBuffer(name, descriptor.type(), usage, descriptor.elementSize(), elements, allowWrite);
         };
@@ -5256,7 +5256,7 @@ namespace LiteFX::Rendering {
         /// <param name="elements">The number of elements in the buffer (in case the buffer is an array).</param>
         /// <param name="allowWrite">Allows the resource to be bound to a read/write descriptor.</param>
         /// <returns>The instance of the buffer.</returns>
-        UniquePtr<IBuffer> createBuffer(const String& name, const IDescriptorSetLayout& descriptorSet, const UInt32& binding, const BufferUsage& usage, const size_t& elementSize, const UInt32& elements, const bool& allowWrite = false) const {
+        UniquePtr<IBuffer> createBuffer(const String& name, const IDescriptorSetLayout& descriptorSet, const UInt32& binding, BufferUsage usage, const size_t& elementSize, const UInt32& elements, const bool& allowWrite = false) const {
             auto& descriptor = descriptorSet.descriptor(binding);
             return this->createBuffer(name, descriptor.type(), usage, elementSize, elements, allowWrite);
         };
@@ -5272,7 +5272,7 @@ namespace LiteFX::Rendering {
         /// <param name="elements">The number of elements in the buffer (in case the buffer is an array).</param>
         /// <param name="allowWrite">Allows the resource to be bound to a read/write descriptor.</param>
         /// <returns>The instance of the buffer.</returns>
-        UniquePtr<IBuffer> createBuffer(const String& name, const IPipeline& pipeline, const UInt32& space, const UInt32& binding, const BufferUsage& usage, const UInt32& elements = 1, const bool& allowWrite = false) const {
+        UniquePtr<IBuffer> createBuffer(const String& name, const IPipeline& pipeline, const UInt32& space, const UInt32& binding, BufferUsage usage, const UInt32& elements = 1, const bool& allowWrite = false) const {
             return this->createBuffer(name, pipeline.layout()->descriptorSet(space), binding, usage, elements, allowWrite);
         };
 
@@ -5288,7 +5288,7 @@ namespace LiteFX::Rendering {
         /// <param name="elements">The number of elements in the buffer (in case the buffer is an array).</param>
         /// <param name="allowWrite">Allows the resource to be bound to a read/write descriptor.</param>
         /// <returns>The instance of the buffer.</returns>
-        UniquePtr<IBuffer> createBuffer(const String& name, const IPipeline& pipeline, const UInt32& space, const UInt32& binding, const BufferUsage& usage, const size_t& elementSize, const UInt32& elements = 1, const bool& allowWrite = false) const {
+        UniquePtr<IBuffer> createBuffer(const String& name, const IPipeline& pipeline, const UInt32& space, const UInt32& binding, BufferUsage usage, const size_t& elementSize, const UInt32& elements = 1, const bool& allowWrite = false) const {
             return this->createBuffer(name, pipeline.layout()->descriptorSet(space), binding, usage, elementSize, elements, allowWrite);
         };
 
@@ -5304,7 +5304,7 @@ namespace LiteFX::Rendering {
         /// <param name="usage">The buffer usage.</param>
         /// <param name="elements">The number of elements within the vertex buffer (i.e. the number of vertices).</param>
         /// <returns>The instance of the vertex buffer.</returns>
-        UniquePtr<IVertexBuffer> createVertexBuffer(const IVertexBufferLayout& layout, const BufferUsage& usage, const UInt32& elements = 1) const {
+        UniquePtr<IVertexBuffer> createVertexBuffer(const IVertexBufferLayout& layout, BufferUsage usage, const UInt32& elements = 1) const {
             return this->getVertexBuffer(layout, usage, elements);
         }
 
@@ -5321,7 +5321,7 @@ namespace LiteFX::Rendering {
         /// <param name="usage">The buffer usage.</param>
         /// <param name="elements">The number of elements within the vertex buffer (i.e. the number of vertices).</param>
         /// <returns>The instance of the vertex buffer.</returns>
-        UniquePtr<IVertexBuffer> createVertexBuffer(const String& name, const IVertexBufferLayout& layout, const BufferUsage& usage, const UInt32& elements = 1) const {
+        UniquePtr<IVertexBuffer> createVertexBuffer(const String& name, const IVertexBufferLayout& layout, BufferUsage usage, const UInt32& elements = 1) const {
             return this->getVertexBuffer(name, layout, usage, elements);
         }
 
@@ -5337,7 +5337,7 @@ namespace LiteFX::Rendering {
         /// <param name="usage">The buffer usage.</param>
         /// <param name="elements">The number of elements within the vertex buffer (i.e. the number of indices).</param>
         /// <returns>The instance of the index buffer.</returns>
-        UniquePtr<IIndexBuffer> createIndexBuffer(const IIndexBufferLayout& layout, const BufferUsage& usage, const UInt32& elements) const {
+        UniquePtr<IIndexBuffer> createIndexBuffer(const IIndexBufferLayout& layout, BufferUsage usage, const UInt32& elements) const {
             return this->getIndexBuffer(layout, usage, elements);
         }
 
@@ -5354,7 +5354,7 @@ namespace LiteFX::Rendering {
         /// <param name="usage">The buffer usage.</param>
         /// <param name="elements">The number of elements within the vertex buffer (i.e. the number of indices).</param>
         /// <returns>The instance of the index buffer.</returns>
-        UniquePtr<IIndexBuffer> createIndexBuffer(const String& name, const IIndexBufferLayout& layout, const BufferUsage& usage, const UInt32& elements) const {
+        UniquePtr<IIndexBuffer> createIndexBuffer(const String& name, const IIndexBufferLayout& layout, BufferUsage usage, const UInt32& elements) const {
             return this->getIndexBuffer(name, layout, usage, elements);
         }
 
@@ -5365,7 +5365,7 @@ namespace LiteFX::Rendering {
         /// <param name="size">The extent of the image.</param>
         /// <param name="samples">The number of samples, the image should be sampled with.</param>
         /// <returns>The instance of the attachment image.</returns>
-        UniquePtr<IImage> createAttachment(const Format& format, const Size2d& size, const MultiSamplingLevel& samples = MultiSamplingLevel::x1) const {
+        UniquePtr<IImage> createAttachment(Format format, const Size2d& size, MultiSamplingLevel samples = MultiSamplingLevel::x1) const {
             return this->getAttachment(format, size, samples);
         }
 
@@ -5377,7 +5377,7 @@ namespace LiteFX::Rendering {
         /// <param name="size">The extent of the image.</param>
         /// <param name="samples">The number of samples, the image should be sampled with.</param>
         /// <returns>The instance of the attachment image.</returns>
-        UniquePtr<IImage> createAttachment(const String& name, const Format& format, const Size2d& size, const MultiSamplingLevel& samples = MultiSamplingLevel::x1) const {
+        UniquePtr<IImage> createAttachment(const String& name, Format format, const Size2d& size, MultiSamplingLevel samples = MultiSamplingLevel::x1) const {
             return this->getAttachment(name, format, size, samples);
         }
 
@@ -5397,7 +5397,7 @@ namespace LiteFX::Rendering {
         /// <param name="allowWrite">Allows the resource to be bound to a read/write descriptor.</param>
         /// <returns>The instance of the texture.</returns>
         /// <seealso cref="createTextures" />
-        UniquePtr<IImage> createTexture(const Format& format, const Size3d& size, const ImageDimensions& dimension = ImageDimensions::DIM_2, const UInt32& levels = 1, const UInt32& layers = 1, const MultiSamplingLevel& samples = MultiSamplingLevel::x1, const bool& allowWrite = false) const {
+        UniquePtr<IImage> createTexture(Format format, const Size3d& size, ImageDimensions dimension = ImageDimensions::DIM_2, const UInt32& levels = 1, const UInt32& layers = 1, MultiSamplingLevel samples = MultiSamplingLevel::x1, const bool& allowWrite = false) const {
             return this->getTexture(format, size, dimension, levels, layers, samples, allowWrite);
         }
 
@@ -5418,7 +5418,7 @@ namespace LiteFX::Rendering {
         /// <param name="allowWrite">Allows the resource to be bound to a read/write descriptor.</param>
         /// <returns>The instance of the texture.</returns>
         /// <seealso cref="createTextures" />
-        UniquePtr<IImage> createTexture(const String& name, const Format& format, const Size3d& size, const ImageDimensions& dimension = ImageDimensions::DIM_2, const UInt32& levels = 1, const UInt32& layers = 1, const MultiSamplingLevel& samples = MultiSamplingLevel::x1, const bool& allowWrite = false) const {
+        UniquePtr<IImage> createTexture(const String& name, Format format, const Size3d& size, ImageDimensions dimension = ImageDimensions::DIM_2, const UInt32& levels = 1, const UInt32& layers = 1, MultiSamplingLevel samples = MultiSamplingLevel::x1, const bool& allowWrite = false) const {
             return this->getTexture(name, format, size, dimension, levels, layers, samples, allowWrite);
         }
 
@@ -5435,7 +5435,7 @@ namespace LiteFX::Rendering {
         /// <param name="allowWrite">Allows the resource to be bound to a read/write descriptor.</param>
         /// <returns>An array of texture instances.</returns>
         /// <seealso cref="createTexture" />
-        Enumerable<UniquePtr<IImage>> createTextures(const UInt32& elements, const Format& format, const Size3d& size, const ImageDimensions& dimension = ImageDimensions::DIM_2, const UInt32& layers = 1, const UInt32& levels = 1, const MultiSamplingLevel& samples = MultiSamplingLevel::x1, const bool& allowWrite = false) const {
+        Enumerable<UniquePtr<IImage>> createTextures(const UInt32& elements, Format format, const Size3d& size, ImageDimensions dimension = ImageDimensions::DIM_2, const UInt32& layers = 1, const UInt32& levels = 1, MultiSamplingLevel samples = MultiSamplingLevel::x1, const bool& allowWrite = false) const {
             return this->getTextures(elements, format, size, dimension, layers, levels, samples, allowWrite);
         }
 
@@ -5454,7 +5454,7 @@ namespace LiteFX::Rendering {
         /// <param name="anisotropy">The level of anisotropic filtering.</param>
         /// <returns>The instance of the sampler.</returns>
         /// <seealso cref="createSamplers" />
-        UniquePtr<ISampler> createSampler(const FilterMode& magFilter = FilterMode::Nearest, const FilterMode& minFilter = FilterMode::Nearest, const BorderMode& borderU = BorderMode::Repeat, const BorderMode& borderV = BorderMode::Repeat, const BorderMode& borderW = BorderMode::Repeat, const MipMapMode& mipMapMode = MipMapMode::Nearest, const Float& mipMapBias = 0.f, const Float& maxLod = std::numeric_limits<Float>::max(), const Float& minLod = 0.f, const Float& anisotropy = 0.f) const {
+        UniquePtr<ISampler> createSampler(FilterMode magFilter = FilterMode::Nearest, FilterMode minFilter = FilterMode::Nearest, BorderMode borderU = BorderMode::Repeat, BorderMode borderV = BorderMode::Repeat, BorderMode borderW = BorderMode::Repeat, MipMapMode mipMapMode = MipMapMode::Nearest, const Float& mipMapBias = 0.f, const Float& maxLod = std::numeric_limits<Float>::max(), const Float& minLod = 0.f, const Float& anisotropy = 0.f) const {
             return this->getSampler(magFilter, minFilter, borderU, borderV, borderW, mipMapMode, mipMapBias, maxLod, minLod, anisotropy);
         }
 
@@ -5474,7 +5474,7 @@ namespace LiteFX::Rendering {
         /// <param name="anisotropy">The level of anisotropic filtering.</param>
         /// <returns>The instance of the sampler.</returns>
         /// <seealso cref="createSamplers" />
-        UniquePtr<ISampler> createSampler(const String& name, const FilterMode& magFilter = FilterMode::Nearest, const FilterMode& minFilter = FilterMode::Nearest, const BorderMode& borderU = BorderMode::Repeat, const BorderMode& borderV = BorderMode::Repeat, const BorderMode& borderW = BorderMode::Repeat, const MipMapMode& mipMapMode = MipMapMode::Nearest, const Float& mipMapBias = 0.f, const Float& maxLod = std::numeric_limits<Float>::max(), const Float& minLod = 0.f, const Float& anisotropy = 0.f) const {
+        UniquePtr<ISampler> createSampler(const String& name, FilterMode magFilter = FilterMode::Nearest, FilterMode minFilter = FilterMode::Nearest, BorderMode borderU = BorderMode::Repeat, BorderMode borderV = BorderMode::Repeat, BorderMode borderW = BorderMode::Repeat, MipMapMode mipMapMode = MipMapMode::Nearest, const Float& mipMapBias = 0.f, const Float& maxLod = std::numeric_limits<Float>::max(), const Float& minLod = 0.f, const Float& anisotropy = 0.f) const {
             return this->getSampler(name, magFilter, minFilter, borderU, borderV, borderW, mipMapMode, mipMapBias, maxLod, minLod, anisotropy);
         }
 
@@ -5494,25 +5494,25 @@ namespace LiteFX::Rendering {
         /// <param name="anisotropy">The level of anisotropic filtering.</param>
         /// <returns>An array of sampler instances.</returns>
         /// <seealso cref="createSampler" />
-        Enumerable<UniquePtr<ISampler>> createSamplers(const UInt32& elements, const FilterMode& magFilter = FilterMode::Nearest, const FilterMode& minFilter = FilterMode::Nearest, const BorderMode& borderU = BorderMode::Repeat, const BorderMode& borderV = BorderMode::Repeat, const BorderMode& borderW = BorderMode::Repeat, const MipMapMode& mipMapMode = MipMapMode::Nearest, const Float& mipMapBias = 0.f, const Float& maxLod = std::numeric_limits<Float>::max(), const Float& minLod = 0.f, const Float& anisotropy = 0.f) const {
+        Enumerable<UniquePtr<ISampler>> createSamplers(const UInt32& elements, FilterMode magFilter = FilterMode::Nearest, FilterMode minFilter = FilterMode::Nearest, BorderMode borderU = BorderMode::Repeat, BorderMode borderV = BorderMode::Repeat, BorderMode borderW = BorderMode::Repeat, MipMapMode mipMapMode = MipMapMode::Nearest, const Float& mipMapBias = 0.f, const Float& maxLod = std::numeric_limits<Float>::max(), const Float& minLod = 0.f, const Float& anisotropy = 0.f) const {
             return this->getSamplers(elements, magFilter, minFilter, borderU, borderV, borderW, mipMapMode, mipMapBias, maxLod, minLod, anisotropy);
         }
 
     private:
-        virtual UniquePtr<IBuffer> getBuffer(const BufferType& type, const BufferUsage& usage, const size_t& elementSize, const UInt32& elements, const bool& allowWrite) const = 0;
-        virtual UniquePtr<IBuffer> getBuffer(const String& name, const BufferType& type, const BufferUsage& usage, const size_t& elementSize, const UInt32& elements, const bool& allowWrite) const = 0;
-        virtual UniquePtr<IVertexBuffer> getVertexBuffer(const IVertexBufferLayout& layout, const BufferUsage& usage, const UInt32& elements) const = 0;
-        virtual UniquePtr<IVertexBuffer> getVertexBuffer(const String& name, const IVertexBufferLayout& layout, const BufferUsage& usage, const UInt32& elements) const = 0;
-        virtual UniquePtr<IIndexBuffer> getIndexBuffer(const IIndexBufferLayout& layout, const BufferUsage& usage, const UInt32& elements) const = 0;
-        virtual UniquePtr<IIndexBuffer> getIndexBuffer(const String& name, const IIndexBufferLayout& layout, const BufferUsage& usage, const UInt32& elements) const = 0;
-        virtual UniquePtr<IImage> getAttachment(const Format& format, const Size2d& size, const MultiSamplingLevel& samples) const = 0;
-        virtual UniquePtr<IImage> getAttachment(const String& name, const Format& format, const Size2d& size, const MultiSamplingLevel& samples) const = 0;
-        virtual UniquePtr<IImage> getTexture(const Format& format, const Size3d& size, const ImageDimensions& dimension, const UInt32& levels, const UInt32& layers, const MultiSamplingLevel& samples, const bool& allowWrite) const = 0;
-        virtual UniquePtr<IImage> getTexture(const String& name, const Format& format, const Size3d& size, const ImageDimensions& dimension, const UInt32& levels, const UInt32& layers, const MultiSamplingLevel& samples, const bool& allowWrite) const = 0;
-        virtual Enumerable<UniquePtr<IImage>> getTextures(const UInt32& elements, const Format& format, const Size3d& size, const ImageDimensions& dimension, const UInt32& layers, const UInt32& levels, const MultiSamplingLevel& samples, const bool& allowWrite) const = 0;
-        virtual UniquePtr<ISampler> getSampler(const FilterMode& magFilter, const FilterMode& minFilter, const BorderMode& borderU, const BorderMode& borderV, const BorderMode& borderW, const MipMapMode& mipMapMode, const Float& mipMapBias, const Float& maxLod, const Float& minLod, const Float& anisotropy) const = 0;
-        virtual UniquePtr<ISampler> getSampler(const String& name, const FilterMode& magFilter, const FilterMode& minFilter, const BorderMode& borderU, const BorderMode& borderV, const BorderMode& borderW, const MipMapMode& mipMapMode, const Float& mipMapBias, const Float& maxLod, const Float& minLod, const Float& anisotropy) const = 0;
-        virtual Enumerable<UniquePtr<ISampler>> getSamplers(const UInt32& elements, const FilterMode& magFilter, const FilterMode& minFilter, const BorderMode& borderU, const BorderMode& borderV, const BorderMode& borderW, const MipMapMode& mipMapMode, const Float& mipMapBias, const Float& maxLod, const Float& minLod, const Float& anisotropy) const = 0;
+        virtual UniquePtr<IBuffer> getBuffer(BufferType type, BufferUsage usage, const size_t& elementSize, const UInt32& elements, const bool& allowWrite) const = 0;
+        virtual UniquePtr<IBuffer> getBuffer(const String& name, BufferType type, BufferUsage usage, const size_t& elementSize, const UInt32& elements, const bool& allowWrite) const = 0;
+        virtual UniquePtr<IVertexBuffer> getVertexBuffer(const IVertexBufferLayout& layout, BufferUsage usage, const UInt32& elements) const = 0;
+        virtual UniquePtr<IVertexBuffer> getVertexBuffer(const String& name, const IVertexBufferLayout& layout, BufferUsage usage, const UInt32& elements) const = 0;
+        virtual UniquePtr<IIndexBuffer> getIndexBuffer(const IIndexBufferLayout& layout, BufferUsage usage, const UInt32& elements) const = 0;
+        virtual UniquePtr<IIndexBuffer> getIndexBuffer(const String& name, const IIndexBufferLayout& layout, BufferUsage usage, const UInt32& elements) const = 0;
+        virtual UniquePtr<IImage> getAttachment(Format format, const Size2d& size, MultiSamplingLevel samples) const = 0;
+        virtual UniquePtr<IImage> getAttachment(const String& name, Format format, const Size2d& size, MultiSamplingLevel samples) const = 0;
+        virtual UniquePtr<IImage> getTexture(Format format, const Size3d& size, ImageDimensions dimension, const UInt32& levels, const UInt32& layers, MultiSamplingLevel samples, const bool& allowWrite) const = 0;
+        virtual UniquePtr<IImage> getTexture(const String& name, Format format, const Size3d& size, ImageDimensions dimension, const UInt32& levels, const UInt32& layers, MultiSamplingLevel samples, const bool& allowWrite) const = 0;
+        virtual Enumerable<UniquePtr<IImage>> getTextures(const UInt32& elements, Format format, const Size3d& size, ImageDimensions dimension, const UInt32& layers, const UInt32& levels, MultiSamplingLevel samples, const bool& allowWrite) const = 0;
+        virtual UniquePtr<ISampler> getSampler(FilterMode magFilter, FilterMode minFilter, BorderMode borderU, BorderMode borderV, BorderMode borderW, MipMapMode mipMapMode, const Float& mipMapBias, const Float& maxLod, const Float& minLod, const Float& anisotropy) const = 0;
+        virtual UniquePtr<ISampler> getSampler(const String& name, FilterMode magFilter, FilterMode minFilter, BorderMode borderU, BorderMode borderV, BorderMode borderW, MipMapMode mipMapMode, const Float& mipMapBias, const Float& maxLod, const Float& minLod, const Float& anisotropy) const = 0;
+        virtual Enumerable<UniquePtr<ISampler>> getSamplers(const UInt32& elements, FilterMode magFilter, FilterMode minFilter, BorderMode borderU, BorderMode borderV, BorderMode borderW, MipMapMode mipMapMode, const Float& mipMapBias, const Float& maxLod, const Float& minLod, const Float& anisotropy) const = 0;
     };
 
     /// <summary>
@@ -5598,7 +5598,7 @@ namespace LiteFX::Rendering {
 		/// <param name="syncBefore">The pipeline stage(s) all previous commands have to finish before the barrier is executed.</param>
 		/// <param name="syncAfter">The pipeline stage(s) all subsequent commands are blocked at until the barrier is executed.</param>
         /// <returns>The instance of the memory barrier.</returns>
-        UniquePtr<IBarrier> makeBarrier(const PipelineStage& syncBefore, const PipelineStage& syncAfter) const noexcept {
+        UniquePtr<IBarrier> makeBarrier(PipelineStage syncBefore, PipelineStage syncAfter) const noexcept {
             return this->getNewBarrier(syncBefore, syncAfter);
         }
 
@@ -5611,7 +5611,7 @@ namespace LiteFX::Rendering {
         /// </remarks>
         /// <param name="format">The target (i.e. back-buffer) format.</param>
         /// <returns>The maximum multi-sampling level.</returns>
-        virtual MultiSamplingLevel maximumMultiSamplingLevel(const Format& format) const noexcept = 0;
+        virtual MultiSamplingLevel maximumMultiSamplingLevel(Format format) const noexcept = 0;
 
         /// <summary>
         /// Returns the number of GPU ticks per milliseconds.
@@ -5631,7 +5631,7 @@ namespace LiteFX::Rendering {
         virtual void wait() const = 0;
 
     private:
-        virtual UniquePtr<IBarrier> getNewBarrier(const PipelineStage& syncBefore, const PipelineStage& syncAfter) const noexcept = 0;
+        virtual UniquePtr<IBarrier> getNewBarrier(PipelineStage syncBefore, PipelineStage syncAfter) const noexcept = 0;
     };
 
     /// <summary>

--- a/src/Rendering/include/litefx/rendering_api.hpp
+++ b/src/Rendering/include/litefx/rendering_api.hpp
@@ -3799,7 +3799,7 @@ namespace LiteFX::Rendering {
         /// Returns the primitive topology.
         /// </summary>
         /// <returns>The primitive topology.</returns>
-        virtual const PrimitiveTopology& topology() const noexcept = 0;
+        virtual PrimitiveTopology topology() const noexcept = 0;
 
     private:
         virtual Enumerable<const IVertexBufferLayout*> getVertexBufferLayouts() const noexcept = 0;

--- a/src/Rendering/src/buffer_attribute.cpp
+++ b/src/Rendering/src/buffer_attribute.cpp
@@ -16,7 +16,7 @@ private:
     AttributeSemantic m_semantic;
 
 public:
-    BufferAttributeImpl(BufferAttribute* parent, const UInt32& location, const UInt32& offset, const BufferFormat& format, const AttributeSemantic& semantic, const UInt32& semanticIndex) :
+    BufferAttributeImpl(BufferAttribute* parent, const UInt32& location, const UInt32& offset, BufferFormat format, AttributeSemantic semantic, const UInt32& semanticIndex) :
         base(parent), m_location(location), m_offset(offset), m_format(format), m_semantic(semantic), m_semanticIndex(semanticIndex) 
     {
     }
@@ -31,7 +31,7 @@ BufferAttribute::BufferAttribute() :
 {
 }
 
-BufferAttribute::BufferAttribute(const UInt32& location, const UInt32& offset, const BufferFormat& format, const AttributeSemantic& semantic, const UInt32& semanticIndex) :
+BufferAttribute::BufferAttribute(const UInt32& location, const UInt32& offset, BufferFormat format, AttributeSemantic semantic, const UInt32& semanticIndex) :
     m_impl(makePimpl<BufferAttributeImpl>(this, location, offset, format, semantic, semanticIndex))
 {
 }
@@ -54,7 +54,7 @@ const UInt32& BufferAttribute::location() const noexcept
     return m_impl->m_location;
 }
 
-const BufferFormat& BufferAttribute::format() const noexcept
+BufferFormat BufferAttribute::format() const noexcept
 {
     return m_impl->m_format;
 }
@@ -64,7 +64,7 @@ const UInt32& BufferAttribute::offset() const noexcept
     return m_impl->m_offset;
 }
 
-const AttributeSemantic& BufferAttribute::semantic() const noexcept
+AttributeSemantic BufferAttribute::semantic() const noexcept
 {
     return m_impl->m_semantic;
 }

--- a/src/Rendering/src/buffer_attribute.cpp
+++ b/src/Rendering/src/buffer_attribute.cpp
@@ -16,7 +16,7 @@ private:
     AttributeSemantic m_semantic;
 
 public:
-    BufferAttributeImpl(BufferAttribute* parent, const UInt32& location, const UInt32& offset, BufferFormat format, AttributeSemantic semantic, const UInt32& semanticIndex) :
+    BufferAttributeImpl(BufferAttribute* parent, UInt32 location, UInt32 offset, BufferFormat format, AttributeSemantic semantic, UInt32 semanticIndex) :
         base(parent), m_location(location), m_offset(offset), m_format(format), m_semantic(semantic), m_semanticIndex(semanticIndex) 
     {
     }
@@ -31,7 +31,7 @@ BufferAttribute::BufferAttribute() :
 {
 }
 
-BufferAttribute::BufferAttribute(const UInt32& location, const UInt32& offset, BufferFormat format, AttributeSemantic semantic, const UInt32& semanticIndex) :
+BufferAttribute::BufferAttribute(UInt32 location, UInt32 offset, BufferFormat format, AttributeSemantic semantic, UInt32 semanticIndex) :
     m_impl(makePimpl<BufferAttributeImpl>(this, location, offset, format, semantic, semanticIndex))
 {
 }
@@ -49,7 +49,7 @@ BufferAttribute::BufferAttribute(BufferAttribute&& _other) noexcept :
 
 BufferAttribute::~BufferAttribute() noexcept = default;
 
-const UInt32& BufferAttribute::location() const noexcept
+UInt32 BufferAttribute::location() const noexcept
 {
     return m_impl->m_location;
 }
@@ -59,7 +59,7 @@ BufferFormat BufferAttribute::format() const noexcept
     return m_impl->m_format;
 }
 
-const UInt32& BufferAttribute::offset() const noexcept
+UInt32 BufferAttribute::offset() const noexcept
 {
     return m_impl->m_offset;
 }
@@ -69,7 +69,7 @@ AttributeSemantic BufferAttribute::semantic() const noexcept
     return m_impl->m_semantic;
 }
 
-const UInt32& BufferAttribute::semanticIndex() const noexcept
+UInt32 BufferAttribute::semanticIndex() const noexcept
 {
     return m_impl->m_semanticIndex;
 }

--- a/src/Rendering/src/convert.cpp
+++ b/src/Rendering/src/convert.cpp
@@ -3,7 +3,7 @@
 
 using namespace LiteFX::Rendering;
 
-size_t LiteFX::Rendering::getSize(const Format& format)
+constexpr size_t LiteFX::Rendering::getSize(Format format)
 {
 	switch (format) {
 	using enum Format;
@@ -170,7 +170,7 @@ size_t LiteFX::Rendering::getSize(const Format& format)
 	}
 }
 
-bool LiteFX::Rendering::hasDepth(const Format& format)
+constexpr bool LiteFX::Rendering::hasDepth(Format format)
 {
 	const Array<Format> depthFormats = {
 		Format::D16_UNORM,
@@ -181,10 +181,10 @@ bool LiteFX::Rendering::hasDepth(const Format& format)
 		Format::D32_SFLOAT_S8_UINT
 	};
 
-	return std::any_of(std::begin(depthFormats), std::end(depthFormats), [&](const Format& f) { return f == format; });
+	return std::any_of(std::begin(depthFormats), std::end(depthFormats), [&](Format f) { return f == format; });
 }
 
-bool LiteFX::Rendering::hasStencil(const Format& format)
+constexpr bool LiteFX::Rendering::hasStencil(Format format)
 {
 	const Array<Format> stencilFormats = {
 		Format::D16_UNORM_S8_UINT,
@@ -193,5 +193,5 @@ bool LiteFX::Rendering::hasStencil(const Format& format)
 		Format::S8_UINT
 	};
 
-	return std::any_of(std::begin(stencilFormats), std::end(stencilFormats), [&](const Format& f) { return f == format; });
+	return std::any_of(std::begin(stencilFormats), std::end(stencilFormats), [&](Format f) { return f == format; });
 }

--- a/src/Rendering/src/rasterizer.cpp
+++ b/src/Rendering/src/rasterizer.cpp
@@ -18,7 +18,7 @@ private:
     DepthStencilState m_depthStencilState;
 
 public:
-    RasterizerImpl(Rasterizer* parent, const PolygonMode& polygonMode, const CullMode& cullMode, const CullOrder& cullOrder, const Float& lineWidth, const DepthStencilState& depthStencilState) :
+    RasterizerImpl(Rasterizer* parent, PolygonMode polygonMode, CullMode cullMode, CullOrder cullOrder, const Float& lineWidth, const DepthStencilState& depthStencilState) :
         base(parent), m_polygonMode(polygonMode), m_cullMode(cullMode), m_cullOrder(cullOrder), m_lineWidth(lineWidth), m_depthStencilState(depthStencilState)
     {
     }
@@ -28,7 +28,7 @@ public:
 // Shared interface.
 // ------------------------------------------------------------------------------------------------
 
-Rasterizer::Rasterizer(const PolygonMode& polygonMode, const CullMode& cullMode, const CullOrder& cullOrder, const Float& lineWidth, const DepthStencilState& depthStencilState) noexcept :
+Rasterizer::Rasterizer(PolygonMode polygonMode, CullMode cullMode, CullOrder cullOrder, const Float& lineWidth, const DepthStencilState& depthStencilState) noexcept :
     m_impl(makePimpl<RasterizerImpl>(this, polygonMode, cullMode, cullOrder, lineWidth, depthStencilState))
 {
 }
@@ -47,17 +47,17 @@ Rasterizer::Rasterizer(Rasterizer&& _other) noexcept :
 
 Rasterizer::~Rasterizer() noexcept = default;
 
-const PolygonMode& Rasterizer::polygonMode() const noexcept
+PolygonMode Rasterizer::polygonMode() const noexcept
 {
     return m_impl->m_polygonMode;
 }
 
-const CullMode& Rasterizer::cullMode() const noexcept
+CullMode Rasterizer::cullMode() const noexcept
 {
     return m_impl->m_cullMode;
 }
 
-const CullOrder& Rasterizer::cullOrder() const noexcept
+CullOrder Rasterizer::cullOrder() const noexcept
 {
     return m_impl->m_cullOrder;
 }

--- a/src/Rendering/src/rasterizer.cpp
+++ b/src/Rendering/src/rasterizer.cpp
@@ -18,7 +18,7 @@ private:
     DepthStencilState m_depthStencilState;
 
 public:
-    RasterizerImpl(Rasterizer* parent, PolygonMode polygonMode, CullMode cullMode, CullOrder cullOrder, const Float& lineWidth, const DepthStencilState& depthStencilState) :
+    RasterizerImpl(Rasterizer* parent, PolygonMode polygonMode, CullMode cullMode, CullOrder cullOrder, Float lineWidth, const DepthStencilState& depthStencilState) :
         base(parent), m_polygonMode(polygonMode), m_cullMode(cullMode), m_cullOrder(cullOrder), m_lineWidth(lineWidth), m_depthStencilState(depthStencilState)
     {
     }
@@ -28,7 +28,7 @@ public:
 // Shared interface.
 // ------------------------------------------------------------------------------------------------
 
-Rasterizer::Rasterizer(PolygonMode polygonMode, CullMode cullMode, CullOrder cullOrder, const Float& lineWidth, const DepthStencilState& depthStencilState) noexcept :
+Rasterizer::Rasterizer(PolygonMode polygonMode, CullMode cullMode, CullOrder cullOrder, Float lineWidth, const DepthStencilState& depthStencilState) noexcept :
     m_impl(makePimpl<RasterizerImpl>(this, polygonMode, cullMode, cullOrder, lineWidth, depthStencilState))
 {
 }
@@ -62,7 +62,7 @@ CullOrder Rasterizer::cullOrder() const noexcept
     return m_impl->m_cullOrder;
 }
 
-const Float& Rasterizer::lineWidth() const noexcept
+Float Rasterizer::lineWidth() const noexcept
 {
     return m_impl->m_lineWidth;
 }

--- a/src/Rendering/src/render_target.cpp
+++ b/src/Rendering/src/render_target.cpp
@@ -20,7 +20,7 @@ private:
     String m_name;
 
 public:
-    RenderTargetImpl(RenderTarget* parent, const String& name, const UInt32& location, const RenderTargetType& type, const Format& format, const bool& clearBuffer, const Vector4f& clearValues, const bool& clearStencil, const bool& isVolatile, const BlendState& blendState) :
+    RenderTargetImpl(RenderTarget* parent, const String& name, const UInt32& location, RenderTargetType type, Format format, const bool& clearBuffer, const Vector4f& clearValues, const bool& clearStencil, const bool& isVolatile, const BlendState& blendState) :
         base(parent), m_name(name), m_location(location), m_type(type), m_format(format), m_clearBuffer(clearBuffer), m_clearValues(clearValues), m_clearStencil(clearStencil), m_volatile(isVolatile), m_blendState(blendState)
     {
     }
@@ -35,12 +35,12 @@ RenderTarget::RenderTarget() noexcept :
 {
 }
 
-RenderTarget::RenderTarget(const UInt32& location, const RenderTargetType& type, const Format& format, const bool& clearBuffer, const Vector4f& clearValues, const bool& clearStencil, const bool& isVolatile, const BlendState& blendState) :
+RenderTarget::RenderTarget(const UInt32& location, RenderTargetType type, Format format, const bool& clearBuffer, const Vector4f& clearValues, const bool& clearStencil, const bool& isVolatile, const BlendState& blendState) :
     RenderTarget("", location, type, format, clearBuffer, clearValues, clearStencil, isVolatile, blendState)
 {
 }
 
-RenderTarget::RenderTarget(const String& name, const UInt32& location, const RenderTargetType& type, const Format& format, const bool& clearBuffer, const Vector4f& clearValues, const bool& clearStencil, const bool& isVolatile, const BlendState& blendState) :
+RenderTarget::RenderTarget(const String& name, const UInt32& location, RenderTargetType type, Format format, const bool& clearBuffer, const Vector4f& clearValues, const bool& clearStencil, const bool& isVolatile, const BlendState& blendState) :
     m_impl(makePimpl<RenderTargetImpl>(this, name, location, type, format, clearBuffer, clearValues, clearStencil, isVolatile, blendState))
 {
 }
@@ -97,12 +97,12 @@ const UInt32& RenderTarget::location() const noexcept
     return m_impl->m_location;
 }
 
-const RenderTargetType& RenderTarget::type() const noexcept
+RenderTargetType RenderTarget::type() const noexcept
 {
     return m_impl->m_type;
 }
 
-const Format& RenderTarget::format() const noexcept
+Format RenderTarget::format() const noexcept
 {
     return m_impl->m_format;
 }

--- a/src/Rendering/src/render_target.cpp
+++ b/src/Rendering/src/render_target.cpp
@@ -20,7 +20,7 @@ private:
     String m_name;
 
 public:
-    RenderTargetImpl(RenderTarget* parent, const String& name, const UInt32& location, RenderTargetType type, Format format, const bool& clearBuffer, const Vector4f& clearValues, const bool& clearStencil, const bool& isVolatile, const BlendState& blendState) :
+    RenderTargetImpl(RenderTarget* parent, const String& name, UInt32 location, RenderTargetType type, Format format, bool clearBuffer, const Vector4f& clearValues, bool clearStencil, bool isVolatile, const BlendState& blendState) :
         base(parent), m_name(name), m_location(location), m_type(type), m_format(format), m_clearBuffer(clearBuffer), m_clearValues(clearValues), m_clearStencil(clearStencil), m_volatile(isVolatile), m_blendState(blendState)
     {
     }
@@ -35,12 +35,12 @@ RenderTarget::RenderTarget() noexcept :
 {
 }
 
-RenderTarget::RenderTarget(const UInt32& location, RenderTargetType type, Format format, const bool& clearBuffer, const Vector4f& clearValues, const bool& clearStencil, const bool& isVolatile, const BlendState& blendState) :
+RenderTarget::RenderTarget(UInt32 location, RenderTargetType type, Format format, bool clearBuffer, const Vector4f& clearValues, bool clearStencil, bool isVolatile, const BlendState& blendState) :
     RenderTarget("", location, type, format, clearBuffer, clearValues, clearStencil, isVolatile, blendState)
 {
 }
 
-RenderTarget::RenderTarget(const String& name, const UInt32& location, RenderTargetType type, Format format, const bool& clearBuffer, const Vector4f& clearValues, const bool& clearStencil, const bool& isVolatile, const BlendState& blendState) :
+RenderTarget::RenderTarget(const String& name, UInt32 location, RenderTargetType type, Format format, bool clearBuffer, const Vector4f& clearValues, bool clearStencil, bool isVolatile, const BlendState& blendState) :
     m_impl(makePimpl<RenderTargetImpl>(this, name, location, type, format, clearBuffer, clearValues, clearStencil, isVolatile, blendState))
 {
 }
@@ -92,7 +92,7 @@ const String& RenderTarget::name() const noexcept
     return m_impl->m_name;
 }
 
-const UInt32& RenderTarget::location() const noexcept
+UInt32 RenderTarget::location() const noexcept
 {
     return m_impl->m_location;
 }
@@ -107,12 +107,12 @@ Format RenderTarget::format() const noexcept
     return m_impl->m_format;
 }
 
-const bool& RenderTarget::clearBuffer() const noexcept
+bool RenderTarget::clearBuffer() const noexcept
 {
     return m_impl->m_clearBuffer;
 }
 
-const bool& RenderTarget::clearStencil() const noexcept
+bool RenderTarget::clearStencil() const noexcept
 {
     return m_impl->m_clearStencil;
 }
@@ -122,7 +122,7 @@ const Vector4f& RenderTarget::clearValues() const noexcept
     return m_impl->m_clearValues;
 }
 
-const bool& RenderTarget::isVolatile() const noexcept
+bool RenderTarget::isVolatile() const noexcept
 {
     return m_impl->m_volatile;
 }

--- a/src/Rendering/src/viewport.cpp
+++ b/src/Rendering/src/viewport.cpp
@@ -15,7 +15,7 @@ private:
     Float m_minDepth{ 0.f }, m_maxDepth{ 1.f };
 
 public:
-    ViewportImpl(Viewport* parent, const RectF& clientRect, const Float& minDepth, const Float& maxDepth) :
+    ViewportImpl(Viewport* parent, const RectF& clientRect, Float minDepth, Float maxDepth) :
         base(parent), m_clientRect(clientRect), m_minDepth(minDepth), m_maxDepth(maxDepth)
     {
     }
@@ -25,7 +25,7 @@ public:
 // Shared interface.
 // ------------------------------------------------------------------------------------------------
 
-Viewport::Viewport(const RectF& rect, const Float& minDepth, const Float& maxDepth) :
+Viewport::Viewport(const RectF& rect, Float minDepth, Float maxDepth) :
     m_impl(makePimpl<ViewportImpl>(this, rect, minDepth, maxDepth))
 {
 }
@@ -47,7 +47,7 @@ Float Viewport::getMinDepth() const noexcept
     return m_impl->m_minDepth;
 }
 
-void Viewport::setMinDepth(const Float& depth) const noexcept
+void Viewport::setMinDepth(Float depth) const noexcept
 {
     m_impl->m_minDepth = depth;
 }
@@ -57,7 +57,7 @@ Float Viewport::getMaxDepth() const noexcept
     return m_impl->m_maxDepth;
 }
 
-void Viewport::setMaxDepth(const Float& depth) const noexcept
+void Viewport::setMaxDepth(Float depth) const noexcept
 {
     m_impl->m_maxDepth = depth;
 }

--- a/src/Samples/Multithreading/src/sample.cpp
+++ b/src/Samples/Multithreading/src/sample.cpp
@@ -143,7 +143,7 @@ void SampleApp::initBuffers(IRenderBackend* backend)
     // Create a transform buffer array for each worker and bind it to one of the descriptor sets.
     Array<UniquePtr<IBuffer>> transformBuffers(NUM_WORKERS);
     std::ranges::generate(transformBuffers, [&, i = 0]() mutable { return m_device->factory().createBuffer(fmt::format("Transform {0}", i++), transformBindingLayout, 0, BufferUsage::Dynamic, 3); });
-    auto transformBindings = transformBindingLayout.allocateMultiple(3 * NUM_WORKERS, [&transformBuffers](const UInt32& set) -> Enumerable<DescriptorBinding> { 
+    auto transformBindings = transformBindingLayout.allocateMultiple(3 * NUM_WORKERS, [&transformBuffers](UInt32 set) -> Enumerable<DescriptorBinding> { 
         return { { .binding = 0, .resource = *transformBuffers[set % NUM_WORKERS], .firstElement = set / NUM_WORKERS, .elements = 1 } }; 
     });
     

--- a/src/Tests/Core.Enumerable/common.h
+++ b/src/Tests/Core.Enumerable/common.h
@@ -19,7 +19,7 @@ public:
     Foo(int i) : _i(i) { }
     virtual ~Foo() noexcept = default;
 
-    virtual int index() const noexcept override {
+    int index() const noexcept override {
         return _i;
     }
 };
@@ -32,7 +32,7 @@ public:
     Bar(int i) : _i(i) { }
     virtual ~Bar() noexcept = default;
 
-    virtual int index() const noexcept override {
+    int index() const noexcept override {
         return _i;
     }
 };


### PR DESCRIPTION
**Describe the pull request**

This PR improves conformance with the C++ core guidelines in two aspects:

1. It removes redundant combined occurrences of `virtual` and `override` ([C.128](https://isocpp.github.io/CppCoreGuidelines/CppCoreGuidelines#Rh-override)) and declares backend classes `final`.
2. Enumerations and integrated types that can be trivially passed on the stack are now no longer passed by-reference ([F.15](https://isocpp.github.io/CppCoreGuidelines/CppCoreGuidelines#Rf-conventional)).

