### PR TITLE
Bump vcpkg

### DIFF
--- a/docs/release-logs/0.4.1.md
+++ b/docs/release-logs/0.4.1.md
@@ -1,5 +1,6 @@
 # LiteFX 0.4.1 - Alpha 04
 
+- Updated vcpkg to version 2023.11.20. ([See PR #104](https://github.com/crud89/LiteFX/pull/104))
 - Adapt C++23 where applicable ([See PR #98](https://github.com/crud89/LiteFX/pull/98) and [PR #102](https://github.com/crud89/LiteFX/pull/102)). This includes:
   - Many of the range adaptors could be simplified.
   - The adaptor `ranges::to` has been replaced with the STL counterpart.
@@ -38,3 +39,4 @@
 **🐞 Bug Fixes:**
 
 - Image dimensions are always clamped to a minimum of 1, so that resources with zero-dimensions can no longer be created. ([See PR #90](https://github.com/crud89/LiteFX/pull/90))
+- Missing formatters for DXIL and SPIR-V reflection types have been added. ([See PR #104](https://github.com/crud89/LiteFX/pull/104))

--- a/src/Backends/DirectX12/include/litefx/backends/dx12_formatters.hpp
+++ b/src/Backends/DirectX12/include/litefx/backends/dx12_formatters.hpp
@@ -857,3 +857,52 @@ struct LITEFX_DIRECTX12_API fmt::formatter<D3D12_MESSAGE_ID> : formatter<string_
         return formatter<string_view>::format(name, ctx);
     }
 };
+
+template <>
+struct LITEFX_DIRECTX12_API fmt::formatter<D3D12_ROOT_PARAMETER_TYPE> : formatter<string_view> {
+    template <typename FormatContext>
+    auto format(D3D12_ROOT_PARAMETER_TYPE t, FormatContext& ctx) {
+        std::string_view name;
+
+        switch (t)
+        {
+        case D3D12_ROOT_PARAMETER_TYPE_DESCRIPTOR_TABLE: name = "D3D12_ROOT_PARAMETER_TYPE_DESCRIPTOR_TABLE"; break;
+        case D3D12_ROOT_PARAMETER_TYPE_32BIT_CONSTANTS: name = "D3D12_ROOT_PARAMETER_TYPE_32BIT_CONSTANTS"; break;
+        case D3D12_ROOT_PARAMETER_TYPE_CBV: name = "D3D12_ROOT_PARAMETER_TYPE_CBV"; break;
+        case D3D12_ROOT_PARAMETER_TYPE_SRV: name = "D3D12_ROOT_PARAMETER_TYPE_SRV"; break;
+        case D3D12_ROOT_PARAMETER_TYPE_UAV: name = "D3D12_ROOT_PARAMETER_TYPE_UAV"; break;
+        default: name = "Invalid"; break;
+        }
+
+        return formatter<string_view>::format(name, ctx);
+    }
+};
+
+template <>
+struct LITEFX_DIRECTX12_API fmt::formatter<D3D_SHADER_INPUT_TYPE> : formatter<string_view> {
+    template <typename FormatContext>
+    auto format(D3D_SHADER_INPUT_TYPE t, FormatContext& ctx) {
+        std::string_view name;
+
+        switch (t)
+        {
+        case D3D_SIT_CBUFFER: name = "D3D_SIT_CBUFFER"; break;
+        case D3D_SIT_TBUFFER: name = "D3D_SIT_TBUFFER"; break;
+        case D3D_SIT_TEXTURE: name = "D3D_SIT_TEXTURE"; break;
+        case D3D_SIT_SAMPLER: name = "D3D_SIT_SAMPLER"; break;
+        case D3D_SIT_UAV_RWTYPED: name = "D3D_SIT_UAV_RWTYPED"; break;
+        case D3D_SIT_STRUCTURED: name = "D3D_SIT_STRUCTURED"; break;
+        case D3D_SIT_UAV_RWSTRUCTURED: name = "D3D_SIT_UAV_RWSTRUCTURED"; break;
+        case D3D_SIT_BYTEADDRESS: name = "D3D_SIT_BYTEADDRESS"; break;
+        case D3D_SIT_UAV_RWBYTEADDRESS: name = "D3D_SIT_UAV_RWBYTEADDRESS"; break;
+        case D3D_SIT_UAV_APPEND_STRUCTURED: name = "D3D_SIT_UAV_APPEND_STRUCTURED"; break;
+        case D3D_SIT_UAV_CONSUME_STRUCTURED: name = "D3D_SIT_UAV_CONSUME_STRUCTURED"; break;
+        case D3D_SIT_UAV_RWSTRUCTURED_WITH_COUNTER: name = "D3D_SIT_UAV_RWSTRUCTURED_WITH_COUNTER"; break;
+        case D3D_SIT_RTACCELERATIONSTRUCTURE: name = "D3D_SIT_RTACCELERATIONSTRUCTURE"; break;
+        case D3D_SIT_UAV_FEEDBACKTEXTURE: name = "D3D_SIT_UAV_FEEDBACKTEXTURE"; break;
+        default: name = "Unknown"; break;
+        }
+
+        return formatter<string_view>::format(name, ctx);
+    }
+};

--- a/src/Backends/DirectX12/src/convert.cpp
+++ b/src/Backends/DirectX12/src/convert.cpp
@@ -620,7 +620,7 @@ constexpr D3D12_BARRIER_SYNC LITEFX_DIRECTX12_API LiteFX::Rendering::Backends::D
 	D3D12_BARRIER_SYNC sync { };
 
 	if (LITEFX_FLAG_IS_SET(pipelineStage, PipelineStage::InputAssembly))
-		sync |= D3D12_BARRIER_SYNC_INPUT_ASSEMBLER;
+		sync |= D3D12_BARRIER_SYNC_INDEX_INPUT;	// D3D12_BARRIER_SYNC_INPUT_ASSEMBLER appears to be deprecated but I could not find any info about the deprecation.
 
 	if (LITEFX_FLAG_IS_SET(pipelineStage, PipelineStage::Vertex) || 
 		LITEFX_FLAG_IS_SET(pipelineStage, PipelineStage::TessellationControl) ||

--- a/src/Backends/Vulkan/CMakeLists.txt
+++ b/src/Backends/Vulkan/CMakeLists.txt
@@ -9,7 +9,7 @@ MESSAGE(STATUS "Initializing: ${PROJECT_NAME}...")
 
 # Resolve package dependencies.
 FIND_PACKAGE(Vulkan REQUIRED)
-FIND_PACKAGE(unofficial-vulkan-memory-allocator CONFIG REQUIRED)
+FIND_PACKAGE(VulkanMemoryAllocator CONFIG REQUIRED)
 FIND_PACKAGE(unofficial-spirv-reflect CONFIG REQUIRED)
 
 # Collect header & source files.
@@ -84,8 +84,8 @@ TARGET_INCLUDE_DIRECTORIES(${PROJECT_NAME}
 
 # Link project dependencies.
 TARGET_LINK_LIBRARIES(${PROJECT_NAME}
-    PUBLIC LiteFX.Core LiteFX.Math LiteFX.Rendering LiteFX.AppModel Vulkan::Vulkan 
-    PRIVATE unofficial::vulkan-memory-allocator::vulkan-memory-allocator unofficial::spirv-reflect::spirv-reflect
+    PUBLIC LiteFX.Core LiteFX.Math LiteFX.Rendering LiteFX.AppModel Vulkan::Vulkan
+    PRIVATE GPUOpen::VulkanMemoryAllocator unofficial::spirv-reflect::spirv-reflect
 )
 
 # Link against D3D12 to enable flip-model swap chains.

--- a/src/Backends/Vulkan/include/litefx/backends/vulkan_formatters.hpp
+++ b/src/Backends/Vulkan/include/litefx/backends/vulkan_formatters.hpp
@@ -4,12 +4,12 @@
 
 template <>
 struct LITEFX_VULKAN_API fmt::formatter<VkResult> : formatter<string_view> {
-	template <typename FormatContext>
-	auto format(VkResult t, FormatContext& ctx) {
-		string_view name;
+    template <typename FormatContext>
+    auto format(VkResult t, FormatContext& ctx) {
+        string_view name;
 
-		switch (t)
-		{
+        switch (t)
+        {
         case VK_SUCCESS: name = "VK_SUCCESS"; break;
         case VK_NOT_READY: name = "VK_NOT_READY"; break;
         case VK_TIMEOUT: name = "VK_TIMEOUT"; break;
@@ -43,9 +43,9 @@ struct LITEFX_VULKAN_API fmt::formatter<VkResult> : formatter<string_view> {
         case VK_ERROR_INVALID_DRM_FORMAT_MODIFIER_PLANE_LAYOUT_EXT: name = "VK_ERROR_INVALID_DRM_FORMAT_MODIFIER_PLANE_LAYOUT_EXT"; break;
         case VK_ERROR_NOT_PERMITTED_EXT: name = "VK_ERROR_NOT_PERMITTED_EXT"; break;
         case VK_ERROR_FULL_SCREEN_EXCLUSIVE_MODE_LOST_EXT: name = "VK_ERROR_FULL_SCREEN_EXCLUSIVE_MODE_LOST_EXT"; break;
-		default: name = "Status: unknown"; break;
-		}
+        default: name = "Status: unknown"; break;
+        }
 
-		return formatter<string_view>::format(name, ctx);
-	}
+        return formatter<string_view>::format(name, ctx);
+    }
 };

--- a/src/Backends/Vulkan/src/shader_program.cpp
+++ b/src/Backends/Vulkan/src/shader_program.cpp
@@ -7,6 +7,46 @@
 using namespace LiteFX::Rendering::Backends;
 
 // ------------------------------------------------------------------------------------------------
+// Formatter for SpvReflectResult.
+// ------------------------------------------------------------------------------------------------
+
+template <>
+struct LITEFX_VULKAN_API fmt::formatter<SpvReflectResult> : formatter<string_view> {
+    template <typename FormatContext>
+    auto format(SpvReflectResult t, FormatContext& ctx) {
+        string_view name;
+
+        switch (t)
+        {
+        case SPV_REFLECT_RESULT_SUCCESS: name = "SPV_REFLECT_RESULT_SUCCESS"; break;
+        case SPV_REFLECT_RESULT_NOT_READY: name = "SPV_REFLECT_RESULT_NOT_READY"; break;
+        case SPV_REFLECT_RESULT_ERROR_PARSE_FAILED: name = "SPV_REFLECT_RESULT_ERROR_PARSE_FAILED"; break;
+        case SPV_REFLECT_RESULT_ERROR_ALLOC_FAILED: name = "SPV_REFLECT_RESULT_ERROR_ALLOC_FAILED"; break;
+        case SPV_REFLECT_RESULT_ERROR_RANGE_EXCEEDED: name = "SPV_REFLECT_RESULT_ERROR_RANGE_EXCEEDED"; break;
+        case SPV_REFLECT_RESULT_ERROR_NULL_POINTER: name = "SPV_REFLECT_RESULT_ERROR_NULL_POINTER"; break;
+        case SPV_REFLECT_RESULT_ERROR_INTERNAL_ERROR: name = "SPV_REFLECT_RESULT_ERROR_INTERNAL_ERROR"; break;
+        case SPV_REFLECT_RESULT_ERROR_COUNT_MISMATCH: name = "SPV_REFLECT_RESULT_ERROR_COUNT_MISMATCH"; break;
+        case SPV_REFLECT_RESULT_ERROR_ELEMENT_NOT_FOUND: name = "SPV_REFLECT_RESULT_ERROR_ELEMENT_NOT_FOUND"; break;
+        case SPV_REFLECT_RESULT_ERROR_SPIRV_INVALID_CODE_SIZE: name = "SPV_REFLECT_RESULT_ERROR_SPIRV_INVALID_CODE_SIZE"; break;
+        case SPV_REFLECT_RESULT_ERROR_SPIRV_INVALID_MAGIC_NUMBER: name = "SPV_REFLECT_RESULT_ERROR_SPIRV_INVALID_MAGIC_NUMBER"; break;
+        case SPV_REFLECT_RESULT_ERROR_SPIRV_UNEXPECTED_EOF: name = "SPV_REFLECT_RESULT_ERROR_SPIRV_UNEXPECTED_EOF"; break;
+        case SPV_REFLECT_RESULT_ERROR_SPIRV_INVALID_ID_REFERENCE: name = "SPV_REFLECT_RESULT_ERROR_SPIRV_INVALID_ID_REFERENCE"; break;
+        case SPV_REFLECT_RESULT_ERROR_SPIRV_SET_NUMBER_OVERFLOW: name = "SPV_REFLECT_RESULT_ERROR_SPIRV_SET_NUMBER_OVERFLOW"; break;
+        case SPV_REFLECT_RESULT_ERROR_SPIRV_INVALID_STORAGE_CLASS: name = "SPV_REFLECT_RESULT_ERROR_SPIRV_INVALID_STORAGE_CLASS"; break;
+        case SPV_REFLECT_RESULT_ERROR_SPIRV_RECURSION: name = "SPV_REFLECT_RESULT_ERROR_SPIRV_RECURSION"; break;
+        case SPV_REFLECT_RESULT_ERROR_SPIRV_INVALID_INSTRUCTION: name = "SPV_REFLECT_RESULT_ERROR_SPIRV_INVALID_INSTRUCTION"; break;
+        case SPV_REFLECT_RESULT_ERROR_SPIRV_UNEXPECTED_BLOCK_DATA: name = "SPV_REFLECT_RESULT_ERROR_SPIRV_UNEXPECTED_BLOCK_DATA"; break;
+        case SPV_REFLECT_RESULT_ERROR_SPIRV_INVALID_BLOCK_MEMBER_REFERENCE: name = "SPV_REFLECT_RESULT_ERROR_SPIRV_INVALID_BLOCK_MEMBER_REFERENCE"; break;
+        case SPV_REFLECT_RESULT_ERROR_SPIRV_INVALID_ENTRY_POINT: name = "SPV_REFLECT_RESULT_ERROR_SPIRV_INVALID_ENTRY_POINT"; break;
+        case SPV_REFLECT_RESULT_ERROR_SPIRV_INVALID_EXECUTION_MODE: name = "SPV_REFLECT_RESULT_ERROR_SPIRV_INVALID_EXECUTION_MODE"; break;
+        default: name = "Status: unknown"; break;
+        }
+
+        return formatter<string_view>::format(name, ctx);
+    }
+};
+
+// ------------------------------------------------------------------------------------------------
 // Implementation.
 // ------------------------------------------------------------------------------------------------
 


### PR DESCRIPTION
**Describe the pull request**

This PR updates vcpkg to the latest release in order to fix a CI build failure caused by a removed mingw version, which is a transient dependency of CLI11. This also updates some other dependencies, most importantly `fmt`, which now requires enum formatters to be explicitly defined (they no longer implicitly fall back to an integer representation). Missing formatters have now been added for D3D and Vulkan reflection types.