### PR TITLE
Improve descriptor set handling.

### DIFF
--- a/docs/release-logs/0.4.1.md
+++ b/docs/release-logs/0.4.1.md
@@ -10,9 +10,10 @@
 - Improvements to C++ core guideline conformance ([See PR #103](https://github.com/crud89/LiteFX/pull/103)).
 - New event infrastructure. ([See PR #81](https://github.com/crud89/LiteFX/pull/81))
 - Add support for user-defined debug markers. ([See PR #82](https://github.com/crud89/LiteFX/pull/82))
-- Improved resource allocation and binding: ([See PR #83](https://github.com/crud89/LiteFX/pull/83))
+- Improved resource allocation and binding: ([See PR #83](https://github.com/crud89/LiteFX/pull/83) and [PR #110](https://github.com/crud89/LiteFX/pull/110))
   - Resources can now be created without querying the descriptor set layout or descriptor layout in advance.
   - When allocating descriptor sets, default bindings can be provided to make bind-once scenarios more straightforward.
+  - Descriptor sets can also be allocated without providing any binding index (in which case continous counting is assumed) or resources (which enables late binding or resource updating).
 - Improved handling of temporary command buffers. ([See PR #89](https://github.com/crud89/LiteFX/pull/89))
   - Command buffers can now be submitted with shared ownership to a command queue, which then stores them and releases the references, if the submit fence is passed (during `waitFor`).
   - Command buffer transfers can now receive resources with shared ownership. Resource references are released in a similar fashion.
@@ -29,6 +30,7 @@
 - Raise minimum Vulkan SDK version to 1.3.204.1. ([See PR #86](https://github.com/crud89/LiteFX/pull/86) and [See PR #88](https://github.com/crud89/LiteFX/pull/88))
 - `VK_EXT_debug_utils` is now enabled by default for the Vulkan backend in debug builds. ([See PR #82](https://github.com/crud89/LiteFX/pull/82))
 - Images are now implicitly transitioned during transfer operations. ([See PR #93](https://github.com/crud89/LiteFX/pull/93))
+- Empty descriptor sets are now allowed and may be automatically created to fill gaps in descriptor set space indices. ([See PR#110](https://github.com/crud89/LiteFX/pull/110))
 
 **❎ DirectX 12:**
 

--- a/src/Backends/Vulkan/src/descriptor_set_layout.cpp
+++ b/src/Backends/Vulkan/src/descriptor_set_layout.cpp
@@ -336,12 +336,17 @@ UniquePtr<VulkanDescriptorSet> VulkanDescriptorSetLayout::allocate(UInt32 descri
     }
 
     // Apply the default bindings.
-    for (auto& binding : bindings)
+    for (UInt32 i{ 0 }; auto & binding : bindings)
+    {
         std::visit(type_switch{
-            [&descriptorSet, &binding](const ISampler& sampler) { descriptorSet->update(binding.binding, sampler, binding.firstDescriptor); },
-            [&descriptorSet, &binding](const IBuffer& buffer) { descriptorSet->update(binding.binding, buffer, binding.firstElement, binding.elements, binding.firstDescriptor); },
-            [&descriptorSet, &binding](const IImage& image) { descriptorSet->update(binding.binding, image, binding.firstDescriptor, binding.firstLevel, binding.levels, binding.firstElement, binding.elements); }
+            [](const std::monostate&) { }, // Default: don't bind anything.
+            [&descriptorSet, &binding, i](const ISampler& sampler) { descriptorSet->update(binding.binding.value_or(i), sampler, binding.firstDescriptor); },
+            [&descriptorSet, &binding, i](const IBuffer& buffer) { descriptorSet->update(binding.binding.value_or(i), buffer, binding.firstElement, binding.elements, binding.firstDescriptor); },
+            [&descriptorSet, &binding, i](const IImage& image) { descriptorSet->update(binding.binding.value_or(i), image, binding.firstDescriptor, binding.firstLevel, binding.levels, binding.firstElement, binding.elements); }
         }, binding.resource);
+
+        ++i;
+    }
 
     // Return the descriptor set.
     return descriptorSet;

--- a/src/Rendering/include/litefx/rendering_api.hpp
+++ b/src/Rendering/include/litefx/rendering_api.hpp
@@ -3327,21 +3327,26 @@ namespace LiteFX::Rendering {
     /// <seealso cref="IDescriptorSetLayout" />
     struct LITEFX_RENDERING_API DescriptorBinding {
     public:
-        using resource_container = Variant<Ref<IBuffer>, Ref<IImage>, Ref<ISampler>>;
+        using resource_container = Variant<std::monostate, Ref<IBuffer>, Ref<IImage>, Ref<ISampler>>;
         
     public:
         /// <summary>
-        /// The binding point to bind the resource at.
+        /// The binding point to bind the resource at. If not provided (i.e., `std::nullopt`), the index within the collection of `DescriptorBindings` is used.
         /// </summary>
-        UInt32 binding;
+        Optional<UInt32> binding = std::nullopt;
 
         /// <summary>
-        /// The resource to bind.
+        /// The resource to bind or `std::monostate` if no resource should be bound.
         /// </summary>
+        /// <remarks>
+        /// Note that not providing any resource does not perform any binding, in which case a resource needs to be manually bound to the descriptor set later 
+        /// (<see cref="IDescriptorSet::update" />). This is useful in situations where you frequently update the resource bound to a descriptor set or where you do no have
+        /// access to the resource at the time the descriptor set is allocated.
+        /// </remarks>
         /// <seealso cref="IBuffer" />
         /// <seealso cref="IImage" />
         /// <seealso cref="ISampler" />
-        resource_container resource;
+        resource_container resource = {};
 
         /// <summary>
         /// The index of the descriptor in a descriptor array at which binding the resource arrays starts.

--- a/src/Samples/BasicRendering/src/sample.cpp
+++ b/src/Samples/BasicRendering/src/sample.cpp
@@ -117,7 +117,7 @@ void SampleApp::initBuffers(IRenderBackend* backend)
     auto& geometryPipeline = m_device->state().pipeline("Geometry");
     auto& cameraBindingLayout = geometryPipeline.layout()->descriptorSet(DescriptorSets::Constant);
     auto cameraBuffer = m_device->factory().createBuffer("Camera", cameraBindingLayout, 0, BufferUsage::Resource);
-    auto cameraBindings = cameraBindingLayout.allocate({ { 0, *cameraBuffer } });
+    auto cameraBindings = cameraBindingLayout.allocate({ { .resource = *cameraBuffer } });
 
     // Update the camera. Since the descriptor set already points to the proper buffer, all changes are implicitly visible.
     this->updateCamera(*commandBuffer, *cameraBuffer);
@@ -127,9 +127,9 @@ void SampleApp::initBuffers(IRenderBackend* backend)
     auto& transformBindingLayout = geometryPipeline.layout()->descriptorSet(DescriptorSets::PerFrame);
     auto transformBuffer = m_device->factory().createBuffer("Transform", transformBindingLayout, 0, BufferUsage::Dynamic, 3);
     auto transformBindings = transformBindingLayout.allocateMultiple(3, {
-        { { .binding = 0, .resource = *transformBuffer, .firstElement = 0, .elements = 1 } },
-        { { .binding = 0, .resource = *transformBuffer, .firstElement = 1, .elements = 1 } },
-        { { .binding = 0, .resource = *transformBuffer, .firstElement = 2, .elements = 1 } }
+        { { .resource = *transformBuffer, .firstElement = 0, .elements = 1 } },
+        { { .resource = *transformBuffer, .firstElement = 1, .elements = 1 } },
+        { { .resource = *transformBuffer, .firstElement = 2, .elements = 1 } }
     });
     
     // End and submit the command buffer.


### PR DESCRIPTION
**Describe the pull request**

This PR slightly reworks descriptor set layouts and their allocation. First of all, it is now more easy to allocate descriptor sets without providing a resource to bind to it directly. The resource in this case needs to be bound before using the descriptor set later:

```cxx
auto& geometryPipeline = m_device->state().pipeline("Geometry");
auto& cameraBindingLayout = geometryPipeline.layout()->descriptorSet(DescriptorSets::Constant);
auto cameraBindings = cameraBindingLayout.allocate();
// ...
auto cameraBuffer = m_device->factory().createBuffer("Camera", cameraBindingLayout, 0, BufferUsage::Resource);
cameraBindings->update(*cameraBuffer);
```

This is enabled by a `std::monostate` overload for the descriptor binding resource container, which together with the binding now being optional allows for default-constructable `DescriptorBinding`s. This second change to the `binding` property allows to use pre-ordered indices for register bindings:

```cxx
auto transformBindings = transformBindingLayout.allocate({
    { .resource = *transformBuffer, .firstElement = 0, .elements = 0 }, // Binds to space 0, descriptor 0
    { .resource = *transformBuffer, .firstElement = 0, .elements = 1 }, // Binds to space 0, descriptor 1
    { .resource = *transformBuffer, .firstElement = 0, .elements = 1 }  // Binds to space 0, descriptor 2
});
```

Note that a single `DescriptorBinding` refers to one descriptor within a descriptor set. For `allocateMultiple` this means that counting descriptor indices is reset for each element of the outer collection.

Additionally, t is now valid for the Vulkan backend to define empty descriptor sets. Earlier this would have resulted in validation errors and failures when attempting to bind the descriptor set. When creating a pipeline layout, empty descriptor sets are created for spaces that have no layout associated with them (up until the layout with the highest space index). The following shader can now be used for both backends:

```hlsl
ConstantBuffer<Camera> camera : register(b1, s1);
ConstantBuffer<Transform> transform : register(b0, s2);
```

The space indices are now validate for both backends. Within one pipeline each descriptor set layout must use distinct spaces. If two layouts share the same space, an error will be raised when attempting to create the pipeline layout.

**Related issues**

- Closes #106. 
- Closes #107. 