### PR TITLE
Simplify binding descriptor sets.

### DIFF
--- a/docs/release-logs/0.4.1.md
+++ b/docs/release-logs/0.4.1.md
@@ -10,10 +10,11 @@
 - Improvements to C++ core guideline conformance ([See PR #103](https://github.com/crud89/LiteFX/pull/103)).
 - New event infrastructure. ([See PR #81](https://github.com/crud89/LiteFX/pull/81))
 - Add support for user-defined debug markers. ([See PR #82](https://github.com/crud89/LiteFX/pull/82))
-- Improved resource allocation and binding: ([See PR #83](https://github.com/crud89/LiteFX/pull/83) and [PR #110](https://github.com/crud89/LiteFX/pull/110))
+- Improved resource allocation and binding: ([See PR #83](https://github.com/crud89/LiteFX/pull/83), [PR #110](https://github.com/crud89/LiteFX/pull/110) and [PR #111](https://github.com/crud89/LiteFX/pull/111))
   - Resources can now be created without querying the descriptor set layout or descriptor layout in advance.
   - When allocating descriptor sets, default bindings can be provided to make bind-once scenarios more straightforward.
   - Descriptor sets can also be allocated without providing any binding index (in which case continous counting is assumed) or resources (which enables late binding or resource updating).
+  - Descriptor set binding has been simplified by caching last used pipeline on command buffers.
 - Improved handling of temporary command buffers. ([See PR #89](https://github.com/crud89/LiteFX/pull/89))
   - Command buffers can now be submitted with shared ownership to a command queue, which then stores them and releases the references, if the submit fence is passed (during `waitFor`).
   - Command buffer transfers can now receive resources with shared ownership. Resource references are released in a similar fashion.

--- a/src/Backends/DirectX12/include/litefx/backends/dx12.hpp
+++ b/src/Backends/DirectX12/include/litefx/backends/dx12.hpp
@@ -902,6 +902,9 @@ namespace LiteFX::Rendering::Backends {
 		void use(const DirectX12PipelineState& pipeline) const noexcept override;
 
 		/// <inheritdoc />
+		void bind(const DirectX12DescriptorSet& descriptorSet) const override;
+
+		/// <inheritdoc />
 		void bind(const DirectX12DescriptorSet& descriptorSet, const DirectX12PipelineState& pipeline) const noexcept override;
 
 		/// <inheritdoc />

--- a/src/Backends/DirectX12/src/command_buffer.cpp
+++ b/src/Backends/DirectX12/src/command_buffer.cpp
@@ -15,6 +15,7 @@ private:
 	bool m_recording{ false }, m_secondary{ false };
 	const DirectX12Queue& m_queue;
 	Array<SharedPtr<const IStateResource>> m_sharedResources;
+	const DirectX12PipelineState* m_lastPipeline = nullptr;
 
 public:
 	DirectX12CommandBufferImpl(DirectX12CommandBuffer* parent, const DirectX12Queue& queue) :
@@ -328,7 +329,16 @@ void DirectX12CommandBuffer::transfer(SharedPtr<IDirectX12Image> source, IDirect
 
 void DirectX12CommandBuffer::use(const DirectX12PipelineState& pipeline) const noexcept
 {
+	m_impl->m_lastPipeline = &pipeline;
 	pipeline.use(*this);
+}
+
+void DirectX12CommandBuffer::bind(const DirectX12DescriptorSet& descriptorSet) const
+{
+	if (m_impl->m_lastPipeline) [[likely]]
+		m_impl->m_queue.device().bindDescriptorSet(*this, descriptorSet, *m_impl->m_lastPipeline);
+	else
+		throw RuntimeException("No pipeline has been used on the command buffer before attempting to bind the descriptor set.");
 }
 
 void DirectX12CommandBuffer::bind(const DirectX12DescriptorSet& descriptorSet, const DirectX12PipelineState& pipeline) const noexcept

--- a/src/Backends/Vulkan/include/litefx/backends/vulkan.hpp
+++ b/src/Backends/Vulkan/include/litefx/backends/vulkan.hpp
@@ -915,6 +915,9 @@ namespace LiteFX::Rendering::Backends {
 		void use(const VulkanPipelineState& pipeline) const noexcept override;
 
 		/// <inheritdoc />
+		void bind(const VulkanDescriptorSet& descriptorSet) const override;
+
+		/// <inheritdoc />
 		void bind(const VulkanDescriptorSet& descriptorSet, const VulkanPipelineState& pipeline) const noexcept override;
 
 		/// <inheritdoc />

--- a/src/Rendering/include/litefx/rendering.hpp
+++ b/src/Rendering/include/litefx/rendering.hpp
@@ -534,6 +534,9 @@ namespace LiteFX::Rendering {
         virtual void use(const pipeline_type& pipeline) const noexcept = 0;
 
         /// <inheritdoc />
+        virtual void bind(const descriptor_set_type& descriptorSet) const = 0;
+
+        /// <inheritdoc />
         virtual void bind(const descriptor_set_type& descriptorSet, const pipeline_type& pipeline) const noexcept = 0;
 
         /// <inheritdoc />
@@ -613,6 +616,10 @@ namespace LiteFX::Rendering {
 
         void cmdUse(const IPipeline& pipeline) const noexcept override { 
             this->use(dynamic_cast<const pipeline_type&>(pipeline));
+        }
+
+        void cmdBind(const IDescriptorSet& descriptorSet) const override {
+            this->bind(dynamic_cast<const descriptor_set_type&>(descriptorSet));
         }
 
         void cmdBind(const IDescriptorSet& descriptorSet, const IPipeline& pipeline) const noexcept override { 

--- a/src/Rendering/include/litefx/rendering_api.hpp
+++ b/src/Rendering/include/litefx/rendering_api.hpp
@@ -4167,8 +4167,15 @@ namespace LiteFX::Rendering {
             this->cmdUse(pipeline);
         }
 
-        // TODO: Allow bind to last used pipeline (throw, if no pipeline is in use).
-        //void bind(const IDescriptorSet& descriptorSet) const;
+        /// <summary>
+        /// Binds the provided descriptor to the last pipeline that was used by the command buffer.
+        /// </summary>
+        /// <param name="descriptorSet">The descriptor set to bind.</param>
+        /// <exception cref="RuntimeException">Thrown, if no pipeline has been used before attempting to bind the descriptor set.</exception>
+        /// <seealso cref="use" />
+        void bind(const IDescriptorSet& descriptorSet) const {
+            this->cmdBind(descriptorSet);
+        }
 
         /// <summary>
         /// Binds the provided descriptor set to the provided pipeline.
@@ -4359,6 +4366,7 @@ namespace LiteFX::Rendering {
         virtual void cmdTransfer(SharedPtr<IImage> source, IImage& target, UInt32 sourceSubresource, UInt32 targetSubresource, UInt32 subresources) const = 0;
         virtual void cmdTransfer(SharedPtr<IImage> source, IBuffer& target, UInt32 firstSubresource, UInt32 targetElement, UInt32 subresources) const = 0;
         virtual void cmdUse(const IPipeline& pipeline) const noexcept = 0;
+        virtual void cmdBind(const IDescriptorSet& descriptorSet) const = 0;
         virtual void cmdBind(const IDescriptorSet& descriptorSet, const IPipeline& pipeline) const noexcept = 0;
         virtual void cmdBind(const IVertexBuffer& buffer) const noexcept = 0;
         virtual void cmdBind(const IIndexBuffer& buffer) const noexcept = 0;

--- a/src/Samples/BasicRendering/src/sample.cpp
+++ b/src/Samples/BasicRendering/src/sample.cpp
@@ -390,8 +390,8 @@ void SampleApp::drawFrame()
     transformBuffer.map(reinterpret_cast<const void*>(&transform), sizeof(transform), backBuffer);
 
     // Bind both descriptor sets to the pipeline.
-    commandBuffer->bind(cameraBindings, geometryPipeline);
-    commandBuffer->bind(transformBindings, geometryPipeline);
+    commandBuffer->bind(cameraBindings);
+    commandBuffer->bind(transformBindings);
 
     // Bind the vertex and index buffers.
     commandBuffer->bind(vertexBuffer);


### PR DESCRIPTION
**Describe the pull request**

This PR simplifies binding descriptor sets. Previously the pipeline that consumes the descriptor sets had to be explicitly provided every time a descriptor set was bound. With the new overload to `ICommandBuffer::bind`, the pipeline that has been passed to the last call to `ICommandBuffer::use` will be stored and used for binding. If no pipeline has been used before calling this overload, an error is raised. Those changes make it easier decouple resource binding from pipeline management and keeps the interface more in line with the other `bind` overloads that handle index and vertex buffers:

```cxx
commandBuffer->use(geometryPipeline);
commandBuffer->bind(cameraBindings); // Equivalent to calling commandBuffer->bind(cameraBindings, geometryPipeline) in this case.

// Binding index and vertex buffers for comparison:
commandBuffer->bind(vertexBuffer);
commandBuffer->bind(indexBuffer);
```