### PR TITLE
Dedicated command queues.

### DIFF
--- a/docs/release-logs/0.4.1.md
+++ b/docs/release-logs/0.4.1.md
@@ -1,12 +1,12 @@
 # LiteFX 0.4.1 - Alpha 04
 
-- Adapt C++23 where applicable ([See PR #98](https://github.com/crud89/LiteFX/pull/98) and [PR #102](https://github.com/crud89/LiteFX/pull/102)). This includes:
+- Adapt C++23 where applicable. ([See PR #98](https://github.com/crud89/LiteFX/pull/98) and [PR #102](https://github.com/crud89/LiteFX/pull/102)) This includes:
   - Many of the range adaptors could be simplified.
   - The adaptor `ranges::to` has been replaced with the STL counterpart.
   - A novel `Enumerable` container is introduced to pass around immutable collections.
   - Some places that previously used `std::ranges::generate` or `std::generate` now use `std::generator`.
   - Builders are now `constexpr` where possible and are implemented using `deducing this` in place of CRTP, which makes them more lightweight.
-- Improvements to C++ core guideline conformance ([See PR #103](https://github.com/crud89/LiteFX/pull/103)).
+- Improvements to C++ core guideline conformance. ([See PR #103](https://github.com/crud89/LiteFX/pull/103))
 - New event infrastructure. ([See PR #81](https://github.com/crud89/LiteFX/pull/81))
 - Add support for user-defined debug markers. ([See PR #82](https://github.com/crud89/LiteFX/pull/82))
 - Improved resource allocation and binding: ([See PR #83](https://github.com/crud89/LiteFX/pull/83))
@@ -16,6 +16,7 @@
   - Command buffers can now be submitted with shared ownership to a command queue, which then stores them and releases the references, if the submit fence is passed (during `waitFor`).
   - Command buffer transfers can now receive resources with shared ownership. Resource references are released in a similar fashion.
   - To share ownership, the `asShared` function can be used.
+- Allow manual command queue allocation for advanced parallel workloads. ([See PR #104](https://github.com/crud89/LiteFX/pull/104))
 - Make most of the render pipeline state dynamic (viewports, scissors, ...). ([See PR #86](https://github.com/crud89/LiteFX/pull/86))
 - Vector conversion to math types can now be done for constant vectors. ([See PR #87](https://github.com/crud89/LiteFX/pull/87))
 - Backend types now import contra-variant interface functions instead of hiding them. ([See PR #91](https://github.com/crud89/LiteFX/pull/91))
@@ -28,6 +29,8 @@
 - Raise minimum Vulkan SDK version to 1.3.204.1. ([See PR #86](https://github.com/crud89/LiteFX/pull/86) and [See PR #88](https://github.com/crud89/LiteFX/pull/88))
 - `VK_EXT_debug_utils` is now enabled by default for the Vulkan backend in debug builds. ([See PR #82](https://github.com/crud89/LiteFX/pull/82))
 - Images are now implicitly transitioned during transfer operations. ([See PR #93](https://github.com/crud89/LiteFX/pull/93))
+- Command buffers no longer share a command pool, improving multi-threading behavior. ([See PR #104](https://github.com/crud89/LiteFX/pull/104))
+  - Queue allocation has also been reworked so that a queue from the most specialized queue family for a provided `QueueType` is returned.
 
 **❎ DirectX 12:**
 

--- a/docs/release-logs/0.4.1.md
+++ b/docs/release-logs/0.4.1.md
@@ -6,6 +6,7 @@
   - A novel `Enumerable` container is introduced to pass around immutable collections.
   - Some places that previously used `std::ranges::generate` or `std::generate` now use `std::generator`.
   - Builders are now `constexpr` where possible and are implemented using `deducing this` in place of CRTP, which makes them more lightweight.
+- Improvements to C++ core guideline conformance ([See PR #103](https://github.com/crud89/LiteFX/pull/103)).
 - New event infrastructure. ([See PR #81](https://github.com/crud89/LiteFX/pull/81))
 - Add support for user-defined debug markers. ([See PR #82](https://github.com/crud89/LiteFX/pull/82))
 - Improved resource allocation and binding: ([See PR #83](https://github.com/crud89/LiteFX/pull/83))

--- a/docs/tutorials/quick-start.markdown
+++ b/docs/tutorials/quick-start.markdown
@@ -435,7 +435,7 @@ Next, let's transfer the buffers to the GPU. We start of by storing the input as
 
 ```cxx
 auto inputAssembler = m_pipeline->inputAssembler();
-auto commandBuffer = m_device->bufferQueue().createCommandBuffer(true);
+auto commandBuffer = m_device->defaultQueue(QueueType::Transfer).createCommandBuffer(true);
 ```
 
 We then create a CPU visible vertex buffer and copy the vertex data into it:
@@ -525,7 +525,7 @@ m_cameraBindings->update(cameraBufferLayout.binding(), *m_cameraBuffer, 0);
 Here we first allocate a descriptor set that holds our descriptor for the camera buffer. We then update the descriptor bound to register *0* to point to the GPU-visible camera buffer. Finally, with all the transfer commands being recorded to the command buffer, we can submit the buffer and wait for it to be executed:
 
 ```cxx
-auto fence = m_device->bufferQueue().submit(commandBuffer);
+auto fence = commandBuffer->submit();
 m_device->bufferQueue().waitFor(fence);
 commandBuffer = nullptr;
 stagedVertices = nullptr;
@@ -684,7 +684,7 @@ glm::mat4 projection = glm::perspective(glm::radians(60.0f), aspectRatio, 0.0001
 projection[1][1] *= -1.f;   // Fix GLM clip coordinate scaling.
 camera.ViewProjection = projection * view;
 
-auto commandBuffer = m_device->bufferQueue().createCommandBuffer(true);
+auto commandBuffer = m_device->defaultQueue(QueueType::Transfer).createCommandBuffer(true);
 m_cameraStagingBuffer->map(reinterpret_cast<const void*>(&camera), sizeof(camera));
 commandBuffer->transfer(*m_cameraStagingBuffer, *m_cameraBuffer);
 commandBuffer->end(true, true);

--- a/src/Backends/DirectX12/include/litefx/backends/dx12.hpp
+++ b/src/Backends/DirectX12/include/litefx/backends/dx12.hpp
@@ -1134,17 +1134,17 @@ namespace LiteFX::Rendering::Backends {
     /// Implements a DirectX 12 render pass.
     /// </summary>
     /// <seealso cref="DirectX12RenderPassBuilder" />
-    class LITEFX_DIRECTX12_API DirectX12RenderPass final : public RenderPass<DirectX12RenderPipeline, DirectX12FrameBuffer, DirectX12InputAttachmentMapping> {
+    class LITEFX_DIRECTX12_API DirectX12RenderPass final : public RenderPass<DirectX12RenderPipeline, DirectX12Queue, DirectX12FrameBuffer, DirectX12InputAttachmentMapping> {
         LITEFX_IMPLEMENTATION(DirectX12RenderPassImpl);
         LITEFX_BUILDER(DirectX12RenderPassBuilder);
 
     public:
-        using base_type = RenderPass<DirectX12RenderPipeline, DirectX12FrameBuffer, DirectX12InputAttachmentMapping>;
+        using base_type = RenderPass<DirectX12RenderPipeline, DirectX12Queue, DirectX12FrameBuffer, DirectX12InputAttachmentMapping>;
         using base_type::updateAttachments;
 
     public:
         /// <summary>
-        /// Creates and initializes a new DirectX 12 render pass instance.
+        /// Creates and initializes a new DirectX 12 render pass instance that executes on the default graphics queue.
         /// </summary>
         /// <param name="device">The parent device instance.</param>
         /// <param name="commandBuffers">The number of command buffers in each frame buffer.</param>
@@ -1154,7 +1154,7 @@ namespace LiteFX::Rendering::Backends {
         explicit DirectX12RenderPass(const DirectX12Device& device, Span<RenderTarget> renderTargets, UInt32 commandBuffers = 1, MultiSamplingLevel samples = MultiSamplingLevel::x1, Span<DirectX12InputAttachmentMapping> inputAttachments = { });
 
         /// <summary>
-        /// Creates and initializes a new DirectX 12 render pass instance.
+        /// Creates and initializes a new DirectX 12 render pass instance that executes on the default graphics queue.
         /// </summary>
         /// <param name="device">The parent device instance.</param>
         /// <param name="name">The name of the render pass state resource.</param>
@@ -1163,6 +1163,29 @@ namespace LiteFX::Rendering::Backends {
         /// <param name="samples">The number of samples for the render targets in this render pass.</param>
         /// <param name="inputAttachments">The input attachments that are read by the render pass.</param>
         explicit DirectX12RenderPass(const DirectX12Device& device, const String& name, Span<RenderTarget> renderTargets, UInt32 commandBuffers = 1, MultiSamplingLevel samples = MultiSamplingLevel::x1, Span<DirectX12InputAttachmentMapping> inputAttachments = { });
+        
+        /// <summary>
+        /// Creates and initializes a new DirectX 12 render pass instance.
+        /// </summary>
+        /// <param name="device">The parent device instance.</param>
+        /// <param name="queue">The command queue to execute the render pass on.</param>
+        /// <param name="commandBuffers">The number of command buffers in each frame buffer.</param>
+        /// <param name="renderTargets">The render targets that are output by the render pass.</param>
+        /// <param name="samples">The number of samples for the render targets in this render pass.</param>
+        /// <param name="inputAttachments">The input attachments that are read by the render pass.</param>
+        explicit DirectX12RenderPass(const DirectX12Device& device, const DirectX12Queue& queue, Span<RenderTarget> renderTargets, UInt32 commandBuffers = 1, MultiSamplingLevel samples = MultiSamplingLevel::x1, Span<DirectX12InputAttachmentMapping> inputAttachments = { });
+
+        /// <summary>
+        /// Creates and initializes a new DirectX 12 render pass instance.
+        /// </summary>
+        /// <param name="device">The parent device instance.</param>
+        /// <param name="name">The name of the render pass state resource.</param>
+        /// <param name="queue">The command queue to execute the render pass on.</param>
+        /// <param name="commandBuffers">The number of command buffers in each frame buffer.</param>
+        /// <param name="renderTargets">The render targets that are output by the render pass.</param>
+        /// <param name="samples">The number of samples for the render targets in this render pass.</param>
+        /// <param name="inputAttachments">The input attachments that are read by the render pass.</param>
+        explicit DirectX12RenderPass(const DirectX12Device& device, const String& name, const DirectX12Queue& queue, Span<RenderTarget> renderTargets, UInt32 commandBuffers = 1, MultiSamplingLevel samples = MultiSamplingLevel::x1, Span<DirectX12InputAttachmentMapping> inputAttachments = { });
 
         DirectX12RenderPass(const DirectX12RenderPass&) = delete;
         DirectX12RenderPass(DirectX12RenderPass&&) = delete;
@@ -1195,6 +1218,9 @@ namespace LiteFX::Rendering::Backends {
 
         /// <inheritdoc />
         const DirectX12FrameBuffer& activeFrameBuffer() const override;
+
+        /// <inheritdoc />
+        const DirectX12Queue& commandQueue() const noexcept override;
 
         /// <inheritdoc />
         Enumerable<const DirectX12FrameBuffer*> frameBuffers() const noexcept override;
@@ -1411,9 +1437,6 @@ namespace LiteFX::Rendering::Backends {
         // CommandQueue interface.
     public:
         /// <inheritdoc />
-        bool isBound() const noexcept override;
-
-        /// <inheritdoc />
         QueuePriority priority() const noexcept override;
 
         /// <inheritdoc />
@@ -1432,12 +1455,6 @@ namespace LiteFX::Rendering::Backends {
 #endif // !defined(NDEBUG) && defined(_WIN64)
 
     public:
-        /// <inheritdoc />
-        void bind() override;
-
-        /// <inheritdoc />
-        void release() override;
-
         /// <inheritdoc />
         SharedPtr<DirectX12CommandBuffer> createCommandBuffer(bool beginRecording = false, bool secondary = false) const override;
 
@@ -1681,16 +1698,10 @@ namespace LiteFX::Rendering::Backends {
         const DirectX12GraphicsFactory& factory() const noexcept override;
 
         /// <inheritdoc />
-        const DirectX12Queue& graphicsQueue() const noexcept override;
+        const DirectX12Queue& defaultQueue(QueueType type) const override;
 
         /// <inheritdoc />
-        const DirectX12Queue& transferQueue() const noexcept override;
-
-        /// <inheritdoc />
-        const DirectX12Queue& bufferQueue() const noexcept override;
-
-        /// <inheritdoc />
-        const DirectX12Queue& computeQueue() const noexcept override;
+        const DirectX12Queue* createQueue(QueueType type, QueuePriority priority) noexcept override;
 
         /// <inheritdoc />
         [[nodiscard]] UniquePtr<DirectX12Barrier> makeBarrier(PipelineStage syncBefore, PipelineStage syncAfter) const noexcept override;

--- a/src/Backends/DirectX12/include/litefx/backends/dx12.hpp
+++ b/src/Backends/DirectX12/include/litefx/backends/dx12.hpp
@@ -6,1791 +6,1804 @@
 #include "dx12_formatters.hpp"
 
 namespace LiteFX::Rendering::Backends {
-	using namespace LiteFX::Math;
-	using namespace LiteFX::Rendering;
-
-	/// <summary>
-	/// Implements a DirectX 12 vertex buffer layout.
-	/// </summary>
-	/// <seealso cref="DirectX12VertexBuffer" />
-	/// <seealso cref="DirectX12IndexBuffer" />
-	/// <seealso cref="DirectX12VertexBufferLayoutBuilder" />
-	class LITEFX_DIRECTX12_API DirectX12VertexBufferLayout final : public IVertexBufferLayout {
-		LITEFX_IMPLEMENTATION(DirectX12VertexBufferLayoutImpl);
-		LITEFX_BUILDER(DirectX12VertexBufferLayoutBuilder);
-
-	public:
-		/// <summary>
-		/// Initializes a new vertex buffer layout.
-		/// </summary>
-		/// <param name="vertexSize">The size of a single vertex.</param>
-		/// <param name="binding">The binding point of the vertex buffers using this layout.</param>
-		explicit DirectX12VertexBufferLayout(size_t vertexSize, UInt32 binding = 0);
-		DirectX12VertexBufferLayout(DirectX12VertexBufferLayout&&) = delete;
-		DirectX12VertexBufferLayout(const DirectX12VertexBufferLayout&) = delete;
-		virtual ~DirectX12VertexBufferLayout() noexcept;
-
-		// IVertexBufferLayout interface.
-	public:
-		/// <inheritdoc />
-		Enumerable<const BufferAttribute*> attributes() const noexcept override;
-
-		// IBufferLayout interface.
-	public:
-		/// <inheritdoc />
-		size_t elementSize() const noexcept override;
-
-		/// <inheritdoc />
-		UInt32 binding() const noexcept override;
-
-		/// <inheritdoc />
-		BufferType type() const noexcept override;
-	};
-
-	/// <summary>
-	/// Implements a DirectX 12 index buffer layout.
-	/// </summary>
-	/// <seealso cref="DirectX12IndexBuffer" />
-	/// <seealso cref="DirectX12VertexBufferLayout" />
-	class LITEFX_DIRECTX12_API DirectX12IndexBufferLayout final : public IIndexBufferLayout {
-		LITEFX_IMPLEMENTATION(DirectX12IndexBufferLayoutImpl);
-
-	public:
-		/// <summary>
-		/// Initializes a new index buffer layout
-		/// </summary>
-		/// <param name="type">The type of the indices within the index buffer.</param>
-		explicit DirectX12IndexBufferLayout(IndexType type);
-		DirectX12IndexBufferLayout(DirectX12IndexBufferLayout&&) = delete;
-		DirectX12IndexBufferLayout(const DirectX12IndexBufferLayout&) = delete;
-		virtual ~DirectX12IndexBufferLayout() noexcept;
-
-		// IIndexBufferLayout interface.
-	public:
-		/// <inheritdoc />
-		IndexType indexType() const noexcept override;
-
-		// IBufferLayout interface.
-	public:
-		/// <inheritdoc />
-		size_t elementSize() const noexcept override;
-
-		/// <inheritdoc />
-		UInt32 binding() const noexcept override;
-
-		/// <inheritdoc />
-		BufferType type() const noexcept override;
-	};
-
-	/// <summary>
-	/// Represents the base interface for a DirectX 12 buffer implementation.
-	/// </summary>
-	/// <seealso cref="DirectX12DescriptorSet" />
-	/// <seealso cref="IDirectX12Image" />
-	/// <seealso cref="IDirectX12VertexBuffer" />
-	/// <seealso cref="IDirectX12IndexBuffer" />
-	class LITEFX_DIRECTX12_API IDirectX12Buffer : public virtual IBuffer, public virtual IResource<ComPtr<ID3D12Resource>> {
-	public:
-		virtual ~IDirectX12Buffer() noexcept = default;
-	};
-
-	/// <summary>
-	/// Represents a DirectX 12 vertex buffer.
-	/// </summary>
-	/// <seealso cref="DirectX12VertexBufferLayout" />
-	/// <seealso cref="IDirectX12Buffer" />
-	class LITEFX_DIRECTX12_API IDirectX12VertexBuffer : public virtual VertexBuffer<DirectX12VertexBufferLayout>, public virtual IDirectX12Buffer {
-	public:
-		virtual ~IDirectX12VertexBuffer() noexcept = default;
-
-	public:
-		virtual const D3D12_VERTEX_BUFFER_VIEW& view() const noexcept = 0;
-	};
-
-	/// <summary>
-	/// Represents a DirectX 12 index buffer.
-	/// </summary>
-	/// <seealso cref="DirectX12IndexBufferLayout" />
-	/// <seealso cref="IDirectX12Buffer" />
-	class LITEFX_DIRECTX12_API IDirectX12IndexBuffer : public virtual IndexBuffer<DirectX12IndexBufferLayout>, public virtual IDirectX12Buffer {
-	public:
-		virtual ~IDirectX12IndexBuffer() noexcept = default;
-
-	public:
-		virtual const D3D12_INDEX_BUFFER_VIEW& view() const noexcept = 0;
-	};
-
-	/// <summary>
-	/// Represents a DirectX 12 sampled image or the base interface for a texture.
-	/// </summary>
-	/// <seealso cref="DirectX12DescriptorLayout" />
-	/// <seealso cref="DirectX12DescriptorSet" />
-	/// <seealso cref="DirectX12DescriptorSetLayout" />
-	/// <seealso cref="IDirectX12Sampler" />
-	class LITEFX_DIRECTX12_API IDirectX12Image : public virtual IImage, public virtual IResource<ComPtr<ID3D12Resource>> {
-	public:
-		friend class DirectX12Barrier;
-
-	public:
-		virtual ~IDirectX12Image() noexcept = default;
-
-	private:
-		virtual ImageLayout& layout(UInt32 subresource) = 0;
-	};
-
-	/// <summary>
-	/// Represents a DirectX 12 sampler.
-	/// </summary>
-	/// <seealso cref="DirectX12DescriptorLayout" />
-	/// <seealso cref="DirectX12DescriptorSet" />
-	/// <seealso cref="DirectX12DescriptorSetLayout" />
-	/// <seealso cref="IDirectX12Image" />
-	class LITEFX_DIRECTX12_API IDirectX12Sampler : public virtual ISampler {
-	public:
-		virtual ~IDirectX12Sampler() noexcept = default;
-	};
-
-	/// <summary>
-	/// Implements a DirectX 12 resource barrier.
-	/// </summary>
-	/// <seealso cref="DirectX12CommandBuffer" />
-	/// <seealso cref="IDirectX12Buffer" />
-	/// <seealso cref="IDirectX12Image" />
-	/// <seealso cref="Barrier" />
-	class LITEFX_DIRECTX12_API DirectX12Barrier final : public Barrier<IDirectX12Buffer, IDirectX12Image> {
-		LITEFX_IMPLEMENTATION(DirectX12BarrierImpl);
-		LITEFX_BUILDER(DirectX12BarrierBuilder);
-
-	public:
-		using base_type = Barrier<IDirectX12Buffer, IDirectX12Image>;
-		using base_type::transition;
-
-	public:
-		/// <summary>
-		/// Initializes a new DirectX 12 barrier.
-		/// </summary>
-		/// <param name="syncBefore">The pipeline stage(s) all previous commands have to finish before the barrier is executed.</param>
-		/// <param name="syncAfter">The pipeline stage(s) all subsequent commands are blocked at until the barrier is executed.</param>
-		constexpr inline explicit DirectX12Barrier(PipelineStage syncBefore, PipelineStage syncAfter) noexcept;
-		DirectX12Barrier(const DirectX12Barrier&) = delete;
-		DirectX12Barrier(DirectX12Barrier&&) = delete;
-		constexpr inline virtual ~DirectX12Barrier() noexcept;
-
-	private:
-		constexpr inline explicit DirectX12Barrier() noexcept;
-		constexpr inline PipelineStage& syncBefore() noexcept;
-		constexpr inline PipelineStage& syncAfter() noexcept;
-
-		// Barrier interface.
-	public:
-		/// <inheritdoc />
-		constexpr inline PipelineStage syncBefore() const noexcept override;
-
-		/// <inheritdoc />
-		constexpr inline PipelineStage syncAfter() const noexcept override;
-
-		/// <inheritdoc />
-		constexpr inline void wait(ResourceAccess accessBefore, ResourceAccess accessAfter) noexcept override;
-
-		/// <inheritdoc />
-		constexpr inline void transition(IDirectX12Buffer& buffer, ResourceAccess accessBefore, ResourceAccess accessAfter) override;
-
-		/// <inheritdoc />
-		constexpr inline void transition(IDirectX12Buffer& buffer, UInt32 element, ResourceAccess accessBefore, ResourceAccess accessAfter) override;
-
-		/// <inheritdoc />
-		constexpr inline void transition(IDirectX12Image& image, ResourceAccess accessBefore, ResourceAccess accessAfter, ImageLayout layout) override;
-
-		/// <inheritdoc />
-		constexpr inline void transition(IDirectX12Image& image, ResourceAccess accessBefore, ResourceAccess accessAfter, ImageLayout fromLayout, ImageLayout toLayout) override;
-
-		/// <inheritdoc />
-		constexpr inline void transition(IDirectX12Image& image, UInt32 level, UInt32 levels, UInt32 layer, UInt32 layers, UInt32 plane, ResourceAccess accessBefore, ResourceAccess accessAfter, ImageLayout layout) override;
-
-		/// <inheritdoc />
-		constexpr inline void transition(IDirectX12Image& image, UInt32 level, UInt32 levels, UInt32 layer, UInt32 layers, UInt32 plane, ResourceAccess accessBefore, ResourceAccess accessAfter, ImageLayout fromLayout, ImageLayout toLayout) override;
-
-	public:
-		/// <summary>
-		/// Adds the barrier to a command buffer and updates the resource target states.
-		/// </summary>
-		/// <param name="commandBuffer">The command buffer to add the barriers to.</param>
-		/// <exception cref="RuntimeException">Thrown, if any of the contained barriers is a image barrier that targets a sub-resource range that does not share the same <see cref="ImageLayout" /> in all sub-resources.</exception>
-		inline void execute(const DirectX12CommandBuffer& commandBuffer) const noexcept;
-	};
-
-	/// <summary>
-	/// Implements a DirectX 12 <see cref="IShaderModule" />.
-	/// </summary>
-	/// <seealso cref="DirectX12ShaderProgram" />
-	/// <seealso href="https://github.com/crud89/LiteFX/wiki/Shader-Development" />
-	class LITEFX_DIRECTX12_API DirectX12ShaderModule final : public IShaderModule, public ComResource<IDxcBlob> {
-		LITEFX_IMPLEMENTATION(DirectX12ShaderModuleImpl);
-
-	public:
-		/// <summary>
-		/// Initializes a new DirectX 12 shader module.
-		/// </summary>
-		/// <param name="device">The parent device, this shader module has been created from.</param>
-		/// <param name="type">The shader stage, this module is used in.</param>
-		/// <param name="fileName">The file name of the module source.</param>
-		/// <param name="entryPoint">The name of the module entry point.</param>
-		explicit DirectX12ShaderModule(const DirectX12Device& device, ShaderStage type, const String& fileName, const String& entryPoint = "main");
-
-		/// <summary>
-		/// Initializes a new DirectX 12 shader module.
-		/// </summary>
-		/// <param name="device">The parent device, this shader module has been created from.</param>
-		/// <param name="type">The shader stage, this module is used in.</param>
-		/// <param name="stream">The file stream to read the shader module from.</param>
-		/// <param name="name">The file name of the module source.</param>
-		/// <param name="entryPoint">The name of the module entry point.</param>
-		explicit DirectX12ShaderModule(const DirectX12Device& device, ShaderStage type, std::istream& stream, const String& name, const String& entryPoint = "main");
-		DirectX12ShaderModule(const DirectX12ShaderModule&) noexcept = delete;
-		DirectX12ShaderModule(DirectX12ShaderModule&&) noexcept = delete;
-		virtual ~DirectX12ShaderModule() noexcept;
-
-		// IShaderModule interface.
-	public:
-		/// <inheritdoc />
-		const String& fileName() const noexcept override;
-
-		/// <inheritdoc />
-		const String& entryPoint() const noexcept override;
-
-		/// <inheritdoc />
-		ShaderStage type() const noexcept override;
-	};
-
-	/// <summary>
-	/// Implements a DirectX 12 <see cref="ShaderProgram" />.
-	/// </summary>
-	/// <seealso cref="DirectX12ShaderProgramBuilder" />
-	/// <seealso href="https://github.com/crud89/LiteFX/wiki/Shader-Development" />
-	class LITEFX_DIRECTX12_API DirectX12ShaderProgram final : public ShaderProgram<DirectX12ShaderModule> {
-		LITEFX_IMPLEMENTATION(DirectX12ShaderProgramImpl);
-		LITEFX_BUILDER(DirectX12ShaderProgramBuilder);
-
-	public:
-		/// <summary>
-		/// Initializes a new DirectX 12 shader program.
-		/// </summary>
-		/// <param name="device">The parent device of the shader program.</param>
-		/// <param name="modules">The shader modules used by the shader program.</param>
-		explicit DirectX12ShaderProgram(const DirectX12Device& device, Enumerable<UniquePtr<DirectX12ShaderModule>>&& modules) noexcept;
-		DirectX12ShaderProgram(DirectX12ShaderProgram&&) noexcept = delete;
-		DirectX12ShaderProgram(const DirectX12ShaderProgram&) noexcept = delete;
-		virtual ~DirectX12ShaderProgram() noexcept;
-
-	private:
-		/// <summary>
-		/// Initializes a new DirectX 12 shader program.
-		/// </summary>
-		/// <param name="device">The parent device of the shader program.</param>
-		explicit DirectX12ShaderProgram(const DirectX12Device& device) noexcept;
-
-	public:
-		/// <inheritdoc />
-		Enumerable<const DirectX12ShaderModule*> modules() const noexcept override;
-
-		/// <inheritdoc />
-		virtual SharedPtr<DirectX12PipelineLayout> reflectPipelineLayout() const;
-
-	private:
-		SharedPtr<IPipelineLayout> parsePipelineLayout() const override {
-			return std::static_pointer_cast<IPipelineLayout>(this->reflectPipelineLayout());
-		}
-
-	public:
-		/// <summary>
-		/// Suppresses the warning that is issued, if no root signature is found on a shader module when calling <see cref="reflectPipelineLayout" />.
-		/// </summary>
-		/// <remarks>
-		/// When a shader program is asked to build a pipeline layout, it first checks if a root signature is provided within the shader bytecode. If no root signature could 
-		/// be found, it falls back to using plain reflection to extract the descriptor sets. This has the drawback, that some features are not or only partially supported.
-		/// Most notably, it is not possible to reflect a pipeline layout that uses push constants this way. To ensure that you are not missing the root signature by accident,
-		/// the engine warns you when it encounters this situation. However, if you are only using plain descriptor sets, this can result in noise warnings that clutter the 
-		/// log. You can call this function to disable the warnings explicitly.
-		/// </remarks>
-		/// <param name="disableWarning"><c>true</c> to stop issuing the warning or <c>false</c> to continue.</param>
-		/// <seealso cref="reflectPipelineLayout" />
-		static void suppressMissingRootSignatureWarning(bool disableWarning = true) noexcept;
-	};
-
-	/// <summary>
-	/// Implements a DirectX 12 <see cref="DescriptorSet" />.
-	/// </summary>
-	/// <seealso cref="DirectX12DescriptorSetLayout" />
-	class LITEFX_DIRECTX12_API DirectX12DescriptorSet final : public DescriptorSet<IDirectX12Buffer, IDirectX12Image, IDirectX12Sampler> {
-		LITEFX_IMPLEMENTATION(DirectX12DescriptorSetImpl);
-
-	public:
-		using base_type = DescriptorSet<IDirectX12Buffer, IDirectX12Image, IDirectX12Sampler>;
-		using base_type::update;
-		using base_type::attach;
-
-	public:
-		/// <summary>
-		/// Initializes a new descriptor set.
-		/// </summary>
-		/// <param name="layout">The parent descriptor set layout.</param>
-		/// <param name="bufferHeap">A CPU-visible descriptor heap that contains all buffer descriptors of the descriptor set.</param>
-		/// <param name="samplerHeap">A CPU-visible descriptor heap that contains all sampler descriptors of the descriptor set.</param>
-		explicit DirectX12DescriptorSet(const DirectX12DescriptorSetLayout& layout, ComPtr<ID3D12DescriptorHeap>&& bufferHeap, ComPtr<ID3D12DescriptorHeap>&& samplerHeap);
-		DirectX12DescriptorSet(DirectX12DescriptorSet&&) = delete;
-		DirectX12DescriptorSet(const DirectX12DescriptorSet&) = delete;
-		virtual ~DirectX12DescriptorSet() noexcept;
-
-	public:
-		/// <summary>
-		/// Returns the parent descriptor set layout.
-		/// </summary>
-		/// <returns>The parent descriptor set layout.</returns>
-		virtual const DirectX12DescriptorSetLayout& layout() const noexcept;
-
-	public:
-		/// <inheritdoc />
-		void update(UInt32 binding, const IDirectX12Buffer& buffer, UInt32 bufferElement = 0, UInt32 elements = 0, UInt32 firstDescriptor = 0) const override;
-
-		/// <inheritdoc />
-		void update(UInt32 binding, const IDirectX12Image& texture, UInt32 descriptor = 0, UInt32 firstLevel = 0, UInt32 levels = 0, UInt32 firstLayer = 0, UInt32 layers = 0) const override;
-
-		/// <inheritdoc />
-		void update(UInt32 binding, const IDirectX12Sampler& sampler, UInt32 descriptor = 0) const override;
-
-		/// <inheritdoc />
-		void attach(UInt32 binding, const IDirectX12Image& image) const override;
-
-	public:
-		/// <summary>
-		/// Returns the local (CPU-visible) heap that contains the buffer descriptors.
-		/// </summary>
-		/// <returns>The local (CPU-visible) heap that contains the buffer descriptors, or <c>nullptr</c>, if the descriptor set does not contain any buffers.</returns>
-		virtual const ComPtr<ID3D12DescriptorHeap>& bufferHeap() const noexcept;
-
-		/// <summary>
-		/// Returns the offset of the buffer descriptors in the global descriptor heap.
-		/// </summary>
-		/// <returns>The offset of the buffer descriptors in the global descriptor heap.</returns>
-		virtual UInt32 bufferOffset() const noexcept;
-
-		/// <summary>
-		/// Returns the local (CPU-visible) heap that contains the sampler descriptors.
-		/// </summary>
-		/// <returns>The local (CPU-visible) heap that contains the sampler descriptors, or <c>nullptr</c>, if the descriptor set does not contain any samplers.</returns>
-		virtual const ComPtr<ID3D12DescriptorHeap>& samplerHeap() const noexcept;
-
-		/// <summary>
-		/// Returns the offset of the sampler descriptors in the global descriptor heap.
-		/// </summary>
-		/// <returns>The offset of the sampler descriptors in the global descriptor heap.</returns>
-		virtual UInt32 samplerOffset() const noexcept;
-	};
-
-	/// <summary>
-	/// Implements a DirectX 12 <see cref="IDescriptorLayout" />
-	/// </summary>
-	/// <seealso cref="IDirectX12Buffer" />
-	/// <seealso cref="IDirectX12Image" />
-	/// <seealso cref="IDirectX12Sampler" />
-	/// <seealso cref="DirectX12DescriptorSet" />
-	/// <seealso cref="DirectX12DescriptorSetLayout" />
-	class LITEFX_DIRECTX12_API DirectX12DescriptorLayout final : public IDescriptorLayout {
-		LITEFX_IMPLEMENTATION(DirectX12DescriptorLayoutImpl);
-
-	public:
-		/// <summary>
-		/// Initializes a new DirectX 12 descriptor layout.
-		/// </summary>
-		/// <param name="type">The type of the descriptor.</param>
-		/// <param name="binding">The binding point for the descriptor.</param>
-		/// <param name="elementSize">The size of the descriptor.</param>
-		/// <param name="elementSize">The number of descriptors in the descriptor array.</param>
-		explicit DirectX12DescriptorLayout(DescriptorType type, UInt32 binding, size_t elementSize, UInt32 descriptors = 1);
-
-		/// <summary>
-		/// Initializes a new DirectX 12 descriptor layout for a static sampler.
-		/// </summary>
-		/// <param name="staticSampler">The static sampler to initialize the state with.</param>
-		/// <param name="binding">The binding point for the descriptor.</param>
-		explicit DirectX12DescriptorLayout(UniquePtr<IDirectX12Sampler>&& staticSampler, UInt32 binding);
-
-		DirectX12DescriptorLayout(DirectX12DescriptorLayout&&) = delete;
-		DirectX12DescriptorLayout(const DirectX12DescriptorLayout&) = delete;
-		virtual ~DirectX12DescriptorLayout() noexcept;
-
-		// IDescriptorLayout interface.
-	public:
-		/// <inheritdoc />
-		DescriptorType descriptorType() const noexcept override;
-
-		/// <inheritdoc />
-		UInt32 descriptors() const noexcept override;
-
-		/// <inheritdoc />
-		const IDirectX12Sampler* staticSampler() const noexcept override;
-
-		// IBufferLayout interface.
-	public:
-		/// <inheritdoc />
-		size_t elementSize() const noexcept override;
-
-		/// <inheritdoc />
-		UInt32 binding() const noexcept override;
-
-		/// <inheritdoc />
-		BufferType type() const noexcept override;
-	};
-
-	/// <summary>
-	/// Implements a DirectX 12 <see cref="DescriptorSetLayout" />.
-	/// </summary>
-	/// <seealso cref="DirectX12DescriptorSet" />
-	/// <seealso cref="DirectX12PipelineDescriptorSetLayoutBuilder" />
-	class LITEFX_DIRECTX12_API DirectX12DescriptorSetLayout final : public DescriptorSetLayout<DirectX12DescriptorLayout, DirectX12DescriptorSet> {
-		LITEFX_IMPLEMENTATION(DirectX12DescriptorSetLayoutImpl);
-		LITEFX_BUILDER(DirectX12DescriptorSetLayoutBuilder);
-		friend class DirectX12PipelineLayout;
-
-	public:
-		using base_type = DescriptorSetLayout<DirectX12DescriptorLayout, DirectX12DescriptorSet>;
-		using base_type::free;
-
-	public:
-		/// <summary>
-		/// Initializes a DirectX 12 descriptor set layout.
-		/// </summary>
-		/// <param name="device">The device, the descriptor set layout is created on.</param>
-		/// <param name="descriptorLayouts">The descriptor layouts of the descriptors within the descriptor set.</param>
-		/// <param name="space">The space or set id of the descriptor set.</param>
-		/// <param name="stages">The shader stages, the descriptor sets are bound to.</param>
-		explicit DirectX12DescriptorSetLayout(const DirectX12Device& device, Enumerable<UniquePtr<DirectX12DescriptorLayout>>&& descriptorLayouts, UInt32 space, ShaderStage stages);
-		DirectX12DescriptorSetLayout(DirectX12DescriptorSetLayout&&) = delete;
-		DirectX12DescriptorSetLayout(const DirectX12DescriptorSetLayout&) = delete;
-		virtual ~DirectX12DescriptorSetLayout() noexcept;
-
-	private:
-		/// <summary>
-		/// Initializes a DirectX 12 descriptor set layout.
-		/// </summary>
-		/// <param name="device">The device, the descriptor set layout is created on.</param>
-		explicit DirectX12DescriptorSetLayout(const DirectX12Device& device) noexcept;
-
-	public:
-		/// <summary>
-		/// Returns the index of the descriptor set root parameter.
-		/// </summary>
-		/// <returns>The index of the descriptor set root parameter.</returns>
-		virtual UInt32 rootParameterIndex() const noexcept;
-
-		/// <summary>
-		/// Returns the index of the first descriptor for a certain binding. The offset is relative to the heap for the descriptor (i.e. sampler for sampler descriptors and
-		/// CBV/SRV/UAV for other descriptors).
-		/// </summary>
-		/// <param name="binding">The binding of the descriptor.</param>
-		/// <returns>The index of the first descriptor for the binding.</returns>
-		/// <exception cref="ArgumentOutOfRangeException">Thrown, if the descriptor set does not contain a descriptor bound to the binding point specified by <paramref name="binding"/>.</exception>
-		virtual UInt32 descriptorOffsetForBinding(UInt32 binding) const;
-
-		/// <summary>
-		/// Returns the parent device.
-		/// </summary>
-		/// <returns>A reference of the parent device.</returns>
-		virtual const DirectX12Device& device() const noexcept;
-
-	protected:
-		/// <summary>
-		/// Returns a reference of the index of the descriptor set root parameter.
-		/// </summary>
-		/// <returns>A reference of the index of the descriptor set root parameter.</returns>
-		virtual UInt32& rootParameterIndex() noexcept;
-
-		/// <summary>
-		/// Returns <c>true</c>, if the descriptor set contains an (unbounded) runtime array.
-		/// </summary>
-		/// <remarks>
-		/// A descriptor set is a runtime array, if it contains exactly one descriptor, which is an unbounded array, i.e. which has a descriptor count of `-1` (or `0xFFFFFFFF`).
-		/// </remarks>
-		/// <returns><c>true</c>, if the descriptor set contains an (unbounded) runtime array and <c>false</c> otherwise.</returns>
-		virtual bool isRuntimeArray() const noexcept;
-
-	public:
-		/// <inheritdoc />
-		Enumerable<const DirectX12DescriptorLayout*> descriptors() const noexcept override;
-
-		/// <inheritdoc />
-		const DirectX12DescriptorLayout& descriptor(UInt32 binding) const override;
-
-		/// <inheritdoc />
-		UInt32 space() const noexcept override;
-
-		/// <inheritdoc />
-		ShaderStage shaderStages() const noexcept override;
-
-		/// <inheritdoc />
-		UInt32 uniforms() const noexcept override;
-
-		/// <inheritdoc />
-		UInt32 storages() const noexcept override;
-
-		/// <inheritdoc />
-		UInt32 images() const noexcept override;
-
-		/// <inheritdoc />
-		UInt32 buffers() const noexcept override;
-
-		/// <inheritdoc />
-		UInt32 samplers() const noexcept override;
-
-		/// <inheritdoc />
-		UInt32 staticSamplers() const noexcept override;
-
-		/// <inheritdoc />
-		UInt32 inputAttachments() const noexcept override;
-
-	public:
-		/// <inheritdoc />
-		UniquePtr<DirectX12DescriptorSet> allocate(const Enumerable<DescriptorBinding>& bindings = { }) const override;
-
-		/// <inheritdoc />
-		UniquePtr<DirectX12DescriptorSet> allocate(UInt32 descriptors, const Enumerable<DescriptorBinding>& bindings = { }) const override;
-
-		/// <inheritdoc />
-		Enumerable<UniquePtr<DirectX12DescriptorSet>> allocateMultiple(UInt32 descriptorSets, const Enumerable<Enumerable<DescriptorBinding>>& bindings = { }) const override;
-
-		/// <inheritdoc />
-		Enumerable<UniquePtr<DirectX12DescriptorSet>> allocateMultiple(UInt32 descriptorSets, std::function<Enumerable<DescriptorBinding>(UInt32)> bindingFactory) const override;
-
-		/// <inheritdoc />
-		Enumerable<UniquePtr<DirectX12DescriptorSet>> allocateMultiple(UInt32 descriptorSets, UInt32 descriptors, const Enumerable<Enumerable<DescriptorBinding>>& bindings = { }) const override;
-
-		/// <inheritdoc />
-		Enumerable<UniquePtr<DirectX12DescriptorSet>> allocateMultiple(UInt32 descriptorSets, UInt32 descriptors, std::function<Enumerable<DescriptorBinding>(UInt32)> bindingFactory) const override;
-
-		/// <inheritdoc />
-		void free(const DirectX12DescriptorSet& descriptorSet) const noexcept override;
-	};
-
-	/// <summary>
-	/// Implements the DirectX 12 <see cref="IPushConstantsRange" />.
-	/// </summary>
-	/// <seealso cref="DirectX12PushConstantsLayout" />
-	class LITEFX_DIRECTX12_API DirectX12PushConstantsRange final : public IPushConstantsRange {
-		LITEFX_IMPLEMENTATION(DirectX12PushConstantsRangeImpl);
-		friend class DirectX12PipelineLayout;
-
-	public:
-		/// <summary>
-		/// Initializes a new push constants range.
-		/// </summary>
-		/// <param name="shaderStages">The shader stages, that access the push constants from the range.</param>
-		/// <param name="offset">The offset relative to the parent push constants backing memory that marks the beginning of the range.</param>
-		/// <param name="size">The size of the push constants range.</param>
-		/// <param name="space">The space from which the push constants of the range will be accessible in the shader.</param>
-		/// <param name="binding">The register from which the push constants of the range will be accessible in the shader.</param>
-		explicit DirectX12PushConstantsRange(ShaderStage shaderStages, UInt32 offset, UInt32 size, UInt32 space, UInt32 binding);
-		DirectX12PushConstantsRange(const DirectX12PushConstantsRange&) = delete;
-		DirectX12PushConstantsRange(DirectX12PushConstantsRange&&) = delete;
-		virtual ~DirectX12PushConstantsRange() noexcept;
-
-	public:
-		/// <inheritdoc />
-		UInt32 space() const noexcept override;
-
-		/// <inheritdoc />
-		UInt32 binding() const noexcept override;
-
-		/// <inheritdoc />
-		UInt32 offset() const noexcept override;
-
-		/// <inheritdoc />
-		UInt32 size() const noexcept override;
-
-		/// <inheritdoc />
-		ShaderStage stage() const noexcept override;
-
-	public:
-		/// <summary>
-		/// Returns the index of the root parameter, the range is bound to.
-		/// </summary>
-		/// <returns>The index of the root parameter, the range is bound to.</returns>
-		virtual UInt32 rootParameterIndex() const noexcept;
-
-	protected:
-		/// <summary>
-		/// Returns a reference of the index of the root parameter, the range is bound to.
-		/// </summary>
-		/// <returns>A reference of the index of the root parameter, the range is bound to.</returns>
-		virtual UInt32& rootParameterIndex() noexcept;
-	};
-
-	/// <summary>
-	/// Implements the DirectX 12 <see cref="PushConstantsLayout" />.
-	/// </summary>
-	/// <remarks>
-	/// In DirectX 12, push constants map to root constants. Those are 32 bit values that are directly stored on the root signature. Thus, push constants can bloat your root 
-	/// signature, since all the required memory is directly reserved on it. The way they are implemented is, that each range gets directly written in 4 byte chunks into the
-	/// command buffer. Thus, overlapping is not directly supported (as opposed to Vulkan). If you have overlapping push constants ranges, the overlap will be duplicated in
-	/// the root signature.
-	/// </remarks>
-	/// <seealso cref="DirectX12PushConstantsRange" />
-	/// <seealso cref="DirectX12PipelinePushConstantsLayoutBuilder" />
-	class LITEFX_DIRECTX12_API DirectX12PushConstantsLayout final : public PushConstantsLayout<DirectX12PushConstantsRange> {
-		LITEFX_IMPLEMENTATION(DirectX12PushConstantsLayoutImpl);
-		LITEFX_BUILDER(DirectX12PushConstantsLayoutBuilder);
-		friend class DirectX12PipelineLayout;
-
-	public:
-		/// <summary>
-		/// Initializes a new push constants layout.
-		/// </summary>
-		/// <param name="ranges">The ranges contained by the layout.</param>
-		/// <param name="size">The overall size (in bytes) of the push constants backing memory.</param>
-		explicit DirectX12PushConstantsLayout(Enumerable<UniquePtr<DirectX12PushConstantsRange>>&& ranges, UInt32 size);
-		DirectX12PushConstantsLayout(const DirectX12PushConstantsLayout&) = delete;
-		DirectX12PushConstantsLayout(DirectX12PushConstantsLayout&&) = delete;
-		virtual ~DirectX12PushConstantsLayout() noexcept;
-
-	private:
-		/// <summary>
-		/// Initializes a new push constants layout.
-		/// </summary>
-		/// <param name="size">The overall size (in bytes) of the push constants backing memory.</param>
-		explicit DirectX12PushConstantsLayout(UInt32 size);
-
-	public:
-		/// <inheritdoc />
-		UInt32 size() const noexcept override;
-
-		/// <inheritdoc />
-		const DirectX12PushConstantsRange& range(ShaderStage stage) const override;
-
-		/// <inheritdoc />
-		Enumerable<const DirectX12PushConstantsRange*> ranges() const noexcept override;
-
-	protected:
-		/// <summary>
-		/// Returns an array of pointers to the push constant ranges of the layout.
-		/// </summary>
-		/// <returns>An array of pointers to the push constant ranges of the layout.</returns>
-		virtual Enumerable<DirectX12PushConstantsRange*> ranges() noexcept;
-	};
-
-	/// <summary>
-	/// Implements a DirectX 12 <see cref="PipelineLayout" />.
-	/// </summary>
-	/// <seealso cref="DirectX12PipelineLayoutBuilder" />
-	class LITEFX_DIRECTX12_API DirectX12PipelineLayout final : public PipelineLayout<DirectX12DescriptorSetLayout, DirectX12PushConstantsLayout>, public ComResource<ID3D12RootSignature> {
-		LITEFX_IMPLEMENTATION(DirectX12PipelineLayoutImpl);
-		LITEFX_BUILDER(DirectX12PipelineLayoutBuilder);
-
-	public:
-		/// <summary>
-		/// Initializes a new DirectX 12 render pipeline layout.
-		/// </summary>
-		/// <param name="device">The parent device, the layout is created from.</param>
-		/// <param name="descriptorSetLayouts">The descriptor set layouts used by the pipeline.</param>
-		/// <param name="pushConstantsLayout">The push constants layout used by the pipeline.</param>
-		explicit DirectX12PipelineLayout(const DirectX12Device& device, Enumerable<UniquePtr<DirectX12DescriptorSetLayout>>&& descriptorSetLayouts, UniquePtr<DirectX12PushConstantsLayout>&& pushConstantsLayout);
-		DirectX12PipelineLayout(DirectX12PipelineLayout&&) noexcept = delete;
-		DirectX12PipelineLayout(const DirectX12PipelineLayout&) noexcept = delete;
-		virtual ~DirectX12PipelineLayout() noexcept;
-
-	private:
-		/// <summary>
-		/// Initializes a new DirectX 12 render pipeline layout.
-		/// </summary>
-		/// <param name="device">The parent device, the layout is created from.</param>
-		explicit DirectX12PipelineLayout(const DirectX12Device& device) noexcept;
-
-	public:
-		/// <summary>
-		/// Returns a reference to the device that provides this layout.
-		/// </summary>
-		/// <returns>A reference to the layouts parent device.</returns>
-		virtual const DirectX12Device& device() const noexcept;
-
-		// PipelineLayout interface.
-	public:
-		/// <inheritdoc />
-		const DirectX12DescriptorSetLayout& descriptorSet(UInt32 space) const override;
-
-		/// <inheritdoc />
-		Enumerable<const DirectX12DescriptorSetLayout*> descriptorSets() const noexcept override;
-
-		/// <inheritdoc />
-		const DirectX12PushConstantsLayout* pushConstants() const noexcept override;
-	};
-
-	/// <summary>
-	/// Implements the DirectX 12 input assembler state.
-	/// </summary>
-	/// <seealso cref="DirectX12InputAssemblerBuilder" />
-	class LITEFX_DIRECTX12_API DirectX12InputAssembler final : public InputAssembler<DirectX12VertexBufferLayout, DirectX12IndexBufferLayout> {
-		LITEFX_IMPLEMENTATION(DirectX12InputAssemblerImpl);
-		LITEFX_BUILDER(DirectX12InputAssemblerBuilder);
-
-	public:
-		/// <summary>
-		/// Initializes a new DirectX 12 input assembler state.
-		/// </summary>
-		/// <param name="vertexBufferLayouts">The vertex buffer layouts supported by the input assembler state. Each layout must have a unique binding.</param>
-		/// <param name="indexBufferLayout">The index buffer layout.</param>
-		/// <param name="primitiveTopology">The primitive topology.</param>
-		explicit DirectX12InputAssembler(Enumerable<UniquePtr<DirectX12VertexBufferLayout>>&& vertexBufferLayouts, UniquePtr<DirectX12IndexBufferLayout>&& indexBufferLayout, PrimitiveTopology primitiveTopology = PrimitiveTopology::TriangleList);
-		DirectX12InputAssembler(DirectX12InputAssembler&&) noexcept = delete;
-		DirectX12InputAssembler(const DirectX12InputAssembler&) noexcept = delete;
-		virtual ~DirectX12InputAssembler() noexcept;
-
-	private:
-		/// <summary>
-		/// Initializes a new DirectX 12 input assembler state.
-		/// </summary>
-		explicit DirectX12InputAssembler() noexcept;
-
-	public:
-		/// <inheritdoc />
-		Enumerable<const DirectX12VertexBufferLayout*> vertexBufferLayouts() const noexcept override;
-
-		/// <inheritdoc />
-		const DirectX12VertexBufferLayout& vertexBufferLayout(UInt32 binding) const override;
-
-		/// <inheritdoc />
-		const DirectX12IndexBufferLayout& indexBufferLayout() const override;
-
-		/// <inheritdoc />
-		PrimitiveTopology topology() const noexcept override;
-	};
-
-	/// <summary>
-	/// Implements a DirectX 12 <see cref="IRasterizer" />.
-	/// </summary>
-	/// <seealso cref="DirectX12RasterizerBuilder" />
-	class LITEFX_DIRECTX12_API DirectX12Rasterizer final : public Rasterizer {
-		LITEFX_BUILDER(DirectX12RasterizerBuilder);
-
-	public:
-		/// <summary>
-		/// Initializes a new DirectX 12 rasterizer state.
-		/// </summary>
-		/// <param name="polygonMode">The polygon mode used by the pipeline.</param>
-		/// <param name="cullMode">The cull mode used by the pipeline.</param>
-		/// <param name="cullOrder">The cull order used by the pipeline.</param>
-		/// <param name="lineWidth">The line width used by the pipeline.</param>
-		/// <param name="depthStencilState">The rasterizer depth/stencil state.</param>
-		explicit DirectX12Rasterizer(PolygonMode polygonMode, CullMode cullMode, CullOrder cullOrder, Float lineWidth = 1.f, const DepthStencilState& depthStencilState = {}) noexcept;
-		DirectX12Rasterizer(DirectX12Rasterizer&&) noexcept = delete;
-		DirectX12Rasterizer(const DirectX12Rasterizer&) noexcept = delete;
-		virtual ~DirectX12Rasterizer() noexcept;
-
-	private:
-		/// <summary>
-		/// Initializes a new DirectX 12 rasterizer state.
-		/// </summary>
-		explicit DirectX12Rasterizer() noexcept;
-	};
-
-	/// <summary>
-	/// Defines the base class for DirectX 12 pipeline state objects.
-	/// </summary>
-	/// <seealso cref="DirectX12RenderPipeline" />
-	/// <seealso cref="DirectX12ComputePipeline" />
-	class LITEFX_DIRECTX12_API DirectX12PipelineState : public virtual Pipeline<DirectX12PipelineLayout, DirectX12ShaderProgram>, public ComResource<ID3D12PipelineState> {
-	public:
-		using ComResource<ID3D12PipelineState>::ComResource;
-		virtual ~DirectX12PipelineState() noexcept = default;
-
-	public:
-		/// <summary>
-		/// Sets the current pipeline state on the <paramref name="commandBuffer" />.
-		/// </summary>
-		/// <param name="commandBuffer">The command buffer to set the current pipeline state on.</param>
-		virtual void use(const DirectX12CommandBuffer& commandBuffer) const noexcept = 0;
-	};
-
-	/// <summary>
-	/// Records commands for a <see cref="DirectX12CommandQueue" />
-	/// </summary>
-	/// <seealso cref="DirectX12CommandQueue" />
-	class LITEFX_DIRECTX12_API DirectX12CommandBuffer final : public CommandBuffer<DirectX12CommandBuffer, IDirectX12Buffer, IDirectX12VertexBuffer, IDirectX12IndexBuffer, IDirectX12Image, DirectX12Barrier, DirectX12PipelineState>, public ComResource<ID3D12GraphicsCommandList7> {
-		LITEFX_IMPLEMENTATION(DirectX12CommandBufferImpl);
-
-	public:
-		using base_type = CommandBuffer<DirectX12CommandBuffer, IDirectX12Buffer, IDirectX12VertexBuffer, IDirectX12IndexBuffer, IDirectX12Image, DirectX12Barrier, DirectX12PipelineState>;
-		using base_type::dispatch;
-		using base_type::draw;
-		using base_type::drawIndexed;
-		using base_type::barrier;
-		using base_type::transfer;
-		using base_type::generateMipMaps;
-		using base_type::bind;
-		using base_type::use;
-		using base_type::pushConstants;
-
-	public:
-		/// <summary>
-		/// Initializes the command buffer from a command queue.
-		/// </summary>
-		/// <param name="queue">The parent command queue, the buffer gets submitted to.</param>
-		/// <param name="begin">If set to <c>true</c>, the command buffer automatically starts recording by calling <see cref="begin" />.</param>
-		/// <param name="primary"><c>true</c>, if the command buffer is a primary command buffer.</param>
-		explicit DirectX12CommandBuffer(const DirectX12Queue& queue, bool begin = false, bool primary = true);
-		DirectX12CommandBuffer(const DirectX12CommandBuffer&) = delete;
-		DirectX12CommandBuffer(DirectX12CommandBuffer&&) = delete;
-		virtual ~DirectX12CommandBuffer() noexcept;
-
-		// CommandBuffer interface.
-	public:
-		/// <inheritdoc />
-		void begin() const override;
-
-		/// <inheritdoc />
-		void end() const override;
-
-		/// <inheritdoc />
-		bool isSecondary() const noexcept override;
-
-		/// <inheritdoc />
-		void setViewports(Span<const IViewport*> viewports) const noexcept override;
-
-		/// <inheritdoc />
-		void setViewports(const IViewport* viewport) const noexcept override;
-
-		/// <inheritdoc />
-		void setScissors(Span<const IScissor*> scissors) const noexcept override;
-
-		/// <inheritdoc />
-		void setScissors(const IScissor* scissor) const noexcept override;
-
-		/// <inheritdoc />
-		void setBlendFactors(const Vector4f& blendFactors) const noexcept override;
-
-		/// <inheritdoc />
-		void setStencilRef(UInt32 stencilRef) const noexcept override;
-
-		/// <inheritdoc />
-		void generateMipMaps(IDirectX12Image& image) noexcept override;
-
-		/// <inheritdoc />
-		void barrier(const DirectX12Barrier& barrier) const noexcept override;
-
-		/// <inheritdoc />
-		void transfer(IDirectX12Buffer& source, IDirectX12Buffer& target, UInt32 sourceElement = 0, UInt32 targetElement = 0, UInt32 elements = 1) const override;
-
-		/// <inheritdoc />
-		void transfer(IDirectX12Buffer& source, IDirectX12Image& target, UInt32 sourceElement = 0, UInt32 firstSubresource = 0, UInt32 elements = 1) const override;
-
-		/// <inheritdoc />
-		void transfer(IDirectX12Image& source, IDirectX12Image& target, UInt32 sourceSubresource = 0, UInt32 targetSubresource = 0, UInt32 subresources = 1) const override;
-
-		/// <inheritdoc />
-		void transfer(IDirectX12Image& source, IDirectX12Buffer& target, UInt32 firstSubresource = 0, UInt32 targetElement = 0, UInt32 subresources = 1) const override;
-
-		/// <inheritdoc />
-		void transfer(SharedPtr<IDirectX12Buffer> source, IDirectX12Buffer& target, UInt32 sourceElement = 0, UInt32 targetElement = 0, UInt32 elements = 1) const override;
-
-		/// <inheritdoc />
-		void transfer(SharedPtr<IDirectX12Buffer> source, IDirectX12Image& target, UInt32 sourceElement = 0, UInt32 firstSubresource = 0, UInt32 elements = 1) const override;
-
-		/// <inheritdoc />
-		void transfer(SharedPtr<IDirectX12Image> source, IDirectX12Image& target, UInt32 sourceSubresource = 0, UInt32 targetSubresource = 0, UInt32 subresources = 1) const override;
-
-		/// <inheritdoc />
-		void transfer(SharedPtr<IDirectX12Image> source, IDirectX12Buffer& target, UInt32 firstSubresource = 0, UInt32 targetElement = 0, UInt32 subresources = 1) const override;
-
-		/// <inheritdoc />
-		void use(const DirectX12PipelineState& pipeline) const noexcept override;
-
-		/// <inheritdoc />
-		void bind(const DirectX12DescriptorSet& descriptorSet, const DirectX12PipelineState& pipeline) const noexcept override;
-
-		/// <inheritdoc />
-		void bind(const IDirectX12VertexBuffer& buffer) const noexcept override;
-
-		/// <inheritdoc />
-		void bind(const IDirectX12IndexBuffer& buffer) const noexcept override;
-
-		/// <inheritdoc />
-		void dispatch(const Vector3u& threadCount) const noexcept override;
-
-		/// <inheritdoc />
-		void draw(UInt32 vertices, UInt32 instances = 1, UInt32 firstVertex = 0, UInt32 firstInstance = 0) const noexcept override;
-
-		/// <inheritdoc />
-		void drawIndexed(UInt32 indices, UInt32 instances = 1, UInt32 firstIndex = 0, Int32 vertexOffset = 0, UInt32 firstInstance = 0) const noexcept override;
-		
-		/// <inheritdoc />
-		void pushConstants(const DirectX12PushConstantsLayout& layout, const void* const memory) const noexcept override;
-
-		/// <inheritdoc />
-		void writeTimingEvent(SharedPtr<const TimingEvent> timingEvent) const override;
-
-		/// <inheritdoc />
-		void execute(SharedPtr<const DirectX12CommandBuffer> commandBuffer) const override;
-
-		/// <inheritdoc />
-		void execute(Enumerable<SharedPtr<const DirectX12CommandBuffer>> commandBuffers) const override;
-
-	private:
-		void releaseSharedState() const override;
-	};
-
-	/// <summary>
-	/// Implements a DirectX 12 <see cref="RenderPipeline" />.
-	/// </summary>
-	/// <seealso cref="DirectX12ComputePipeline" />
-	/// <seealso cref="DirectX12RenderPipelineBuilder" />
-	class LITEFX_DIRECTX12_API DirectX12RenderPipeline final : public virtual DirectX12PipelineState, public RenderPipeline<DirectX12PipelineLayout, DirectX12ShaderProgram, DirectX12InputAssembler, DirectX12Rasterizer> {
-		LITEFX_IMPLEMENTATION(DirectX12RenderPipelineImpl);
-		LITEFX_BUILDER(DirectX12RenderPipelineBuilder);
-
-	public:
-		/// <summary>
-		/// Initializes a new DirectX 12 render pipeline.
-		/// </summary>
-		/// <param name="renderPass">The parent render pass.</param>
-		/// <param name="shaderProgram">The shader program used by the pipeline.</param>
-		/// <param name="layout">The layout of the pipeline.</param>
-		/// <param name="inputAssembler">The input assembler state of the pipeline.</param>
-		/// <param name="rasterizer">The rasterizer state of the pipeline.</param>
-		/// <param name="name">The optional name of the render pipeline.</param>
-		/// <param name="enableAlphaToCoverage">Whether or not to enable Alpha-to-Coverage multi-sampling.</param>
-		explicit DirectX12RenderPipeline(const DirectX12RenderPass& renderPass, SharedPtr<DirectX12PipelineLayout> layout, SharedPtr<DirectX12ShaderProgram> shaderProgram, SharedPtr<DirectX12InputAssembler> inputAssembler, SharedPtr<DirectX12Rasterizer> rasterizer, const bool enableAlphaToCoverage = false, const String& name = "");
-		DirectX12RenderPipeline(DirectX12RenderPipeline&&) noexcept = delete;
-		DirectX12RenderPipeline(const DirectX12RenderPipeline&) noexcept = delete;
-		virtual ~DirectX12RenderPipeline() noexcept;
-
-	private:
-		/// <summary>
-		/// Initializes a new DirectX 12 render pipeline.
-		/// </summary>
-		/// <param name="renderPass">The parent render pass.</param>
-		/// <param name="name">The optional name of the render pipeline.</param>
-		DirectX12RenderPipeline(const DirectX12RenderPass& renderPass, const String& name = "") noexcept;
-
-		// Pipeline interface.
-	public:
-		/// <inheritdoc />
-		SharedPtr<const DirectX12ShaderProgram> program() const noexcept override;
-
-		/// <inheritdoc />
-		SharedPtr<const DirectX12PipelineLayout> layout() const noexcept override;
-
-		// RenderPipeline interface.
-	public:
-		/// <inheritdoc />
-		SharedPtr<DirectX12InputAssembler> inputAssembler() const noexcept override;
-
-		/// <inheritdoc />
-		SharedPtr<DirectX12Rasterizer> rasterizer() const noexcept override;
-
-		/// <inheritdoc />
-		bool alphaToCoverage() const noexcept override;
-
-		// DirectX12PipelineState interface.
-	public:
-		/// <inheritdoc />
-		void use(const DirectX12CommandBuffer& commandBuffer) const noexcept override;
-	};
-
-	/// <summary>
-	/// Implements a DirectX 12 <see cref="ComputePipeline" />.
-	/// </summary>
-	/// <seealso cref="DirectX12RenderPipeline" />
-	/// <seealso cref="DirectX12ComputePipelineBuilder" />
-	class LITEFX_DIRECTX12_API DirectX12ComputePipeline final : public virtual DirectX12PipelineState, public ComputePipeline<DirectX12PipelineLayout, DirectX12ShaderProgram> {
-		LITEFX_IMPLEMENTATION(DirectX12ComputePipelineImpl);
-		LITEFX_BUILDER(DirectX12ComputePipelineBuilder);
-
-	public:
-		/// <summary>
-		/// Initializes a new DirectX 12 compute pipeline.
-		/// </summary>
-		/// <param name="device">The parent device.</param>
-		/// <param name="layout">The layout of the pipeline.</param>
-		/// <param name="shaderProgram">The shader program used by this pipeline.</param>
-		/// <param name="name">The optional debug name of the compute pipeline.</param>
-		explicit DirectX12ComputePipeline(const DirectX12Device& device, SharedPtr<DirectX12PipelineLayout> layout, SharedPtr<DirectX12ShaderProgram> shaderProgram, const String& name = "");
-		DirectX12ComputePipeline(DirectX12ComputePipeline&&) noexcept = delete;
-		DirectX12ComputePipeline(const DirectX12ComputePipeline&) noexcept = delete;
-		virtual ~DirectX12ComputePipeline() noexcept;
-
-	private:
-		/// <summary>
-		/// Initializes a new DirectX 12 compute pipeline.
-		/// </summary>
-		/// <param name="device">The parent device.</param>
-		DirectX12ComputePipeline(const DirectX12Device& device) noexcept;
-
-		// Pipeline interface.
-	public:
-		/// <inheritdoc />
-		SharedPtr<const DirectX12ShaderProgram> program() const noexcept override;
-
-		/// <inheritdoc />
-		SharedPtr<const DirectX12PipelineLayout> layout() const noexcept override;
-
-		// DirectX12PipelineState interface.
-	public:
-		void use(const DirectX12CommandBuffer& commandBuffer) const noexcept override;
-	};
-
-	/// <summary>
-	/// Implements a DirectX 12 frame buffer.
-	/// </summary>
-	/// <seealso cref="DirectX12RenderPass" />
-	class LITEFX_DIRECTX12_API DirectX12FrameBuffer final : public FrameBuffer<DirectX12CommandBuffer> {
-		LITEFX_IMPLEMENTATION(DirectX12FrameBufferImpl);
-
-	public:
-		/// <summary>
-		/// Initializes a DirectX 12 frame buffer.
-		/// </summary>
-		/// <param name="renderPass">The parent render pass of the frame buffer.</param>
-		/// <param name="bufferIndex">The index of the frame buffer within the parent render pass.</param>
-		/// <param name="renderArea">The initial size of the render area.</param>
-		/// <param name="commandBuffers">The number of command buffers, the frame buffer stores.</param>
-		DirectX12FrameBuffer(const DirectX12RenderPass& renderPass, UInt32 bufferIndex, const Size2d& renderArea, UInt32 commandBuffers = 1);
-		DirectX12FrameBuffer(const DirectX12FrameBuffer&) noexcept = delete;
-		DirectX12FrameBuffer(DirectX12FrameBuffer&&) noexcept = delete;
-		virtual ~DirectX12FrameBuffer() noexcept;
-
-		// DirectX 12 FrameBuffer
-	public:
-		/// <summary>
-		/// Returns a pointer to the descriptor heap that allocates the render targets for this frame buffer.
-		/// </summary>
-		/// <returns>A pointer to the descriptor heap that allocates the render targets for this frame buffer.</returns>
-		/// <seealso cref="depthStencilTargetHeap" />
-		/// <seealso cref="renderTargetDescriptorSize" />
-		virtual ID3D12DescriptorHeap* renderTargetHeap() const noexcept;
-
-		/// <summary>
-		/// Returns a pointer to the descriptor heap that allocates the depth/stencil views for this frame buffer.
-		/// </summary>
-		/// <remarks>
-		/// Note that it is typically not supported to have more than one depth/stencil output view bound to a <see cref="RenderPass" />.
-		/// </remarks>
-		/// <returns>A pointer to the descriptor heap that allocates the depth/stencil views for this frame buffer.</returns>
-		/// <seealso cref="renderTargetHeap" />
-		/// <seealso cref="depthStencilDescriptorSize" />
-		virtual ID3D12DescriptorHeap* depthStencilTargetHeap() const noexcept;
-
-		/// <summary>
-		/// Returns the size of a descriptor for a render target within the frame buffer.
-		/// </summary>
-		/// <returns>The size of a descriptor for a render target within the frame buffer.</returns>
-		/// <seealso cref="renderTargetHeap" />
-		virtual UInt32 renderTargetDescriptorSize() const noexcept;
-
-		/// <summary>
-		/// Returns the size of a descriptor for a depth/stencil view within the frame buffer.
-		/// </summary>
-		/// <returns>The size of a descriptor for a depth/stencil view within the frame buffer.</returns>
-		/// <seealso cref="depthStencilTargetHeap" />
-		virtual UInt32 depthStencilTargetDescriptorSize() const noexcept;
-
-		/// <summary>
-		/// Returns a reference of the last fence value for the frame buffer.
-		/// </summary>
-		/// <remarks>
-		/// The frame buffer must only be re-used, if this fence is reached in the graphics queue.
-		/// </remarks>
-		/// <returns>A reference of the last fence value for the frame buffer.</returns>
-		virtual UInt64& lastFence() const noexcept;
-
-		// FrameBuffer interface.
-	public:
-		/// <inheritdoc />
-		UInt32 bufferIndex() const noexcept override;
-
-		/// <inheritdoc />
-		const Size2d& size() const noexcept override;
-
-		/// <inheritdoc />
-		size_t getWidth() const noexcept override;
-
-		/// <inheritdoc />
-		size_t getHeight() const noexcept override;
-
-		/// <inheritdoc />
-		Enumerable<SharedPtr<const DirectX12CommandBuffer>> commandBuffers() const noexcept override;
-
-		/// <inheritdoc />
-		SharedPtr<const DirectX12CommandBuffer> commandBuffer(UInt32 index) const override;
-
-		/// <inheritdoc />
-		Enumerable<const IDirectX12Image*> images() const noexcept override;
-
-		/// <inheritdoc />
-		const IDirectX12Image& image(UInt32 location) const override;
-
-	public:
-		/// <inheritdoc />
-		void resize(const Size2d& renderArea) override;
-	};
-
-	/// <summary>
-	/// Implements a DirectX 12 render pass.
-	/// </summary>
-	/// <seealso cref="DirectX12RenderPassBuilder" />
-	class LITEFX_DIRECTX12_API DirectX12RenderPass final : public RenderPass<DirectX12RenderPipeline, DirectX12FrameBuffer, DirectX12InputAttachmentMapping> {
-		LITEFX_IMPLEMENTATION(DirectX12RenderPassImpl);
-		LITEFX_BUILDER(DirectX12RenderPassBuilder);
-
-	public:
-		using base_type = RenderPass<DirectX12RenderPipeline, DirectX12FrameBuffer, DirectX12InputAttachmentMapping>;
-		using base_type::updateAttachments;
-
-	public:
-		/// <summary>
-		/// Creates and initializes a new DirectX 12 render pass instance.
-		/// </summary>
-		/// <param name="device">The parent device instance.</param>
-		/// <param name="commandBuffers">The number of command buffers in each frame buffer.</param>
-		/// <param name="renderTargets">The render targets that are output by the render pass.</param>
-		/// <param name="samples">The number of samples for the render targets in this render pass.</param>
-		/// <param name="inputAttachments">The input attachments that are read by the render pass.</param>
-		explicit DirectX12RenderPass(const DirectX12Device& device, Span<RenderTarget> renderTargets, UInt32 commandBuffers = 1, MultiSamplingLevel samples = MultiSamplingLevel::x1, Span<DirectX12InputAttachmentMapping> inputAttachments = { });
-
-		/// <summary>
-		/// Creates and initializes a new DirectX 12 render pass instance.
-		/// </summary>
-		/// <param name="device">The parent device instance.</param>
-		/// <param name="name">The name of the render pass state resource.</param>
-		/// <param name="commandBuffers">The number of command buffers in each frame buffer.</param>
-		/// <param name="renderTargets">The render targets that are output by the render pass.</param>
-		/// <param name="samples">The number of samples for the render targets in this render pass.</param>
-		/// <param name="inputAttachments">The input attachments that are read by the render pass.</param>
-		explicit DirectX12RenderPass(const DirectX12Device& device, const String& name, Span<RenderTarget> renderTargets, UInt32 commandBuffers = 1, MultiSamplingLevel samples = MultiSamplingLevel::x1, Span<DirectX12InputAttachmentMapping> inputAttachments = { });
-
-		DirectX12RenderPass(const DirectX12RenderPass&) = delete;
-		DirectX12RenderPass(DirectX12RenderPass&&) = delete;
-		virtual ~DirectX12RenderPass() noexcept;
-
-	private:
-		/// <summary>
-		/// Creates an uninitialized DirectX 12 render pass instance.
-		/// </summary>
-		/// <remarks>
-		/// This constructor is called by the <see cref="DirectX12RenderPassBuilder" /> in order to create a render pass instance without initializing it. The instance 
-		/// is only initialized after calling <see cref="DirectX12RenderPassBuilder::go" />.
-		/// </remarks>
-		/// <param name="device">The parent device of the render pass.</param>
-		/// <param name="name">The name of the render pass state resource.</param>
-		explicit DirectX12RenderPass(const DirectX12Device& device, const String& name = "") noexcept;
-
-		// IInputAttachmentMappingSource interface.
-	public:
-		/// <inheritdoc />
-		const DirectX12FrameBuffer& frameBuffer(UInt32 buffer) const override;
-
-		// RenderPass interface.
-	public:
-		/// <summary>
-		/// Returns a reference to the device that provides this queue.
-		/// </summary>
-		/// <returns>A reference to the queue's parent device.</returns>
-		virtual const DirectX12Device& device() const noexcept;
-
-		/// <inheritdoc />
-		const DirectX12FrameBuffer& activeFrameBuffer() const override;
-
-		/// <inheritdoc />
-		Enumerable<const DirectX12FrameBuffer*> frameBuffers() const noexcept override;
-
-		/// <inheritdoc />
-		Enumerable<const DirectX12RenderPipeline*> pipelines() const noexcept override;
-
-		/// <inheritdoc />
-		const RenderTarget& renderTarget(UInt32 location) const override;
-
-		/// <inheritdoc />
-		Span<const RenderTarget> renderTargets() const noexcept override;
-
-		/// <inheritdoc />
-		bool hasPresentTarget() const noexcept override;
-
-		/// <inheritdoc />
-		Span<const DirectX12InputAttachmentMapping> inputAttachments() const noexcept override;
-
-		/// <inheritdoc />
-		MultiSamplingLevel multiSamplingLevel() const noexcept override;
-
-	public:
-		/// <inheritdoc />
-		void begin(UInt32 buffer) override;
-
-		/// <inheritdoc />
-		void end() const override;
-
-		/// <inheritdoc />
-		void resizeFrameBuffers(const Size2d& renderArea) override;
-
-		/// <inheritdoc />
-		void changeMultiSamplingLevel(MultiSamplingLevel samples) override;
-
-		/// <inheritdoc />
-		void updateAttachments(const DirectX12DescriptorSet& descriptorSet) const override;
-	};
-
-	/// <summary>
-	/// Implements a <see cref="IInputAttachmentMapping" />.
-	/// </summary>
-	/// <seealso cref="DirectX12RenderPass" />
-	/// <seealso cref="DirectX12RenderPassBuilder" />
-	class LITEFX_DIRECTX12_API DirectX12InputAttachmentMapping final : public IInputAttachmentMapping<DirectX12RenderPass> {
-		LITEFX_IMPLEMENTATION(DirectX12InputAttachmentMappingImpl);
-
-	public:
-		/// <summary>
-		/// Creates a new DirectX 12 input attachment mapping.
-		/// </summary>
-		DirectX12InputAttachmentMapping() noexcept;
-
-		/// <summary>
-		/// Creates a new DirectX 12 input attachment mapping.
-		/// </summary>
-		/// <param name="renderPass">The render pass to fetch the input attachment from.</param>
-		/// <param name="renderTarget">The render target of the <paramref name="renderPass"/> that is used for the input attachment.</param>
-		/// <param name="location">The location to bind the input attachment to.</param>
-		DirectX12InputAttachmentMapping(const DirectX12RenderPass& renderPass, const RenderTarget& renderTarget, UInt32 location);
-
-		/// <summary>
-		/// Copies another input attachment mapping.
-		/// </summary>
-		DirectX12InputAttachmentMapping(const DirectX12InputAttachmentMapping&) noexcept;
-
-		/// <summary>
-		/// Takes over another input attachment mapping.
-		/// </summary>
-		DirectX12InputAttachmentMapping(DirectX12InputAttachmentMapping&&) noexcept;
-
-		virtual ~DirectX12InputAttachmentMapping() noexcept;
-
-	public:
-		/// <summary>
-		/// Copies another input attachment mapping.
-		/// </summary>
-		inline DirectX12InputAttachmentMapping& operator=(const DirectX12InputAttachmentMapping&) noexcept;
-
-		/// <summary>
-		/// Takes over another input attachment mapping.
-		/// </summary>
-		inline DirectX12InputAttachmentMapping& operator=(DirectX12InputAttachmentMapping&&) noexcept;
-
-	public:
-		/// <inheritdoc />
-		const DirectX12RenderPass* inputAttachmentSource() const noexcept override;
-
-		/// <inheritdoc />
-		const RenderTarget& renderTarget() const noexcept override;
-
-		/// <inheritdoc />
-		UInt32 location() const noexcept override;
-	};
-
-	/// <summary>
-	/// Implements a DirectX 12 swap chain.
-	/// </summary>
-	class LITEFX_DIRECTX12_API DirectX12SwapChain final : public SwapChain<IDirectX12Image, DirectX12FrameBuffer>, public ComResource<IDXGISwapChain4> {
-		LITEFX_IMPLEMENTATION(DirectX12SwapChainImpl);
-		friend class DirectX12RenderPass;
-
-	public:
-		using base_type = SwapChain<IDirectX12Image, DirectX12FrameBuffer>;
-		using base_type::present;
-
-	public:
-		/// <summary>
-		/// Initializes a DirectX 12 swap chain.
-		/// </summary>
-		/// <param name="device">The device that owns the swap chain.</param>
-		/// <param name="format">The initial surface format.</param>
-		/// <param name="renderArea">The initial size of the render area.</param>
-		/// <param name="buffers">The initial number of buffers.</param>
-		explicit DirectX12SwapChain(const DirectX12Device& device, Format surfaceFormat = Format::B8G8R8A8_SRGB, const Size2d& renderArea = { 800, 600 }, UInt32 buffers = 3);
-		DirectX12SwapChain(const DirectX12SwapChain&) = delete;
-		DirectX12SwapChain(DirectX12SwapChain&&) = delete;
-		virtual ~DirectX12SwapChain() noexcept;
-
-		// DirectX 12 swap chain.
-	public:
-		/// <summary>
-		/// Returns <c>true</c>, if the adapter supports variable refresh rates (i.e. tearing is allowed).
-		/// </summary>
-		/// <returns><c>true</c>, if the adapter supports variable refresh rates (i.e. tearing is allowed).</returns>
-		virtual bool supportsVariableRefreshRate() const noexcept;
-
-		/// <summary>
-		/// Returns the query heap for the current frame.
-		/// </summary>
-		/// <returns>A pointer to the query heap for the current frame.</returns>
-		virtual ID3D12QueryHeap* timestampQueryHeap() const noexcept;
-
-		// SwapChain interface.
-	public:
-		/// <inheritdoc />
-		Enumerable<SharedPtr<TimingEvent>> timingEvents() const noexcept override;
-
-		/// <inheritdoc />
-		SharedPtr<TimingEvent> timingEvent(UInt32 queryId) const override;
-
-		/// <inheritdoc />
-		UInt64 readTimingEvent(SharedPtr<const TimingEvent> timingEvent) const override;
-
-		/// <inheritdoc />
-		UInt32 resolveQueryId(SharedPtr<const TimingEvent> timingEvent) const override;
-
-		/// <inheritdoc />
-		Format surfaceFormat() const noexcept override;
-
-		/// <inheritdoc />
-		UInt32 buffers() const noexcept override;
-
-		/// <inheritdoc />
-		const Size2d& renderArea() const noexcept override;
-
-		/// <inheritdoc />
-		const IDirectX12Image* image(UInt32 backBuffer) const override;
-
-		/// <inheritdoc />
-		Enumerable<const IDirectX12Image*> images() const noexcept override;
-
-		/// <inheritdoc />
-		void present(const DirectX12FrameBuffer& frameBuffer) const override;
-
-	public:
-		/// <inheritdoc />
-		Enumerable<Format> getSurfaceFormats() const noexcept override;
-
-		/// <inheritdoc />
-		void addTimingEvent(SharedPtr<TimingEvent> timingEvent) override;
-
-		/// <inheritdoc />
-		void reset(Format surfaceFormat, const Size2d& renderArea, UInt32 buffers) override;
-
-		/// <inheritdoc />
-		[[nodiscard]] UInt32 swapBackBuffer() const override;
-
-	private:
-		void resolveQueryHeaps(const DirectX12CommandBuffer& commandBuffer) const noexcept;
-	};
-
-	/// <summary>
-	/// Implements a DirectX 12 command queue.
-	/// </summary>
-	/// <seealso cref="DirectX12CommandBuffer" />
-	class LITEFX_DIRECTX12_API DirectX12Queue final : public CommandQueue<DirectX12CommandBuffer>, public ComResource<ID3D12CommandQueue> {
-		LITEFX_IMPLEMENTATION(DirectX12QueueImpl);
-
-	public:
-		using base_type = CommandQueue<DirectX12CommandBuffer>;
-		using base_type::submit;
-
-	public:
-		/// <summary>
-		/// Initializes the DirectX 12 command queue.
-		/// </summary>
-		/// <param name="device">The device, commands get send to.</param>
-		/// <param name="type">The type of the command queue.</param>
-		/// <param name="priority">The priority, of which commands are issued on the device.</param>
-		explicit DirectX12Queue(const DirectX12Device& device, QueueType type, QueuePriority priority);
-		DirectX12Queue(const DirectX12Queue&) = delete;
-		DirectX12Queue(DirectX12Queue&&) = delete;
-		virtual ~DirectX12Queue() noexcept;
-
-		// DirectX12CommandQueue interface.
-	public:
-		/// <summary>
-		/// Returns a reference to the device that provides this queue.
-		/// </summary>
-		/// <returns>A reference to the queue's parent device.</returns>
-		virtual const DirectX12Device& device() const noexcept;
-
-		// CommandQueue interface.
-	public:
-		/// <inheritdoc />
-		bool isBound() const noexcept override;
-
-		/// <inheritdoc />
-		QueuePriority priority() const noexcept override;
-
-		/// <inheritdoc />
-		QueueType type() const noexcept override;
+    using namespace LiteFX::Math;
+    using namespace LiteFX::Rendering;
+
+    /// <summary>
+    /// Implements a DirectX 12 vertex buffer layout.
+    /// </summary>
+    /// <seealso cref="DirectX12VertexBuffer" />
+    /// <seealso cref="DirectX12IndexBuffer" />
+    /// <seealso cref="DirectX12VertexBufferLayoutBuilder" />
+    class LITEFX_DIRECTX12_API DirectX12VertexBufferLayout final : public IVertexBufferLayout {
+        LITEFX_IMPLEMENTATION(DirectX12VertexBufferLayoutImpl);
+        LITEFX_BUILDER(DirectX12VertexBufferLayoutBuilder);
+
+    public:
+        /// <summary>
+        /// Initializes a new vertex buffer layout.
+        /// </summary>
+        /// <param name="vertexSize">The size of a single vertex.</param>
+        /// <param name="binding">The binding point of the vertex buffers using this layout.</param>
+        explicit DirectX12VertexBufferLayout(size_t vertexSize, UInt32 binding = 0);
+        DirectX12VertexBufferLayout(DirectX12VertexBufferLayout&&) = delete;
+        DirectX12VertexBufferLayout(const DirectX12VertexBufferLayout&) = delete;
+        virtual ~DirectX12VertexBufferLayout() noexcept;
+
+        // IVertexBufferLayout interface.
+    public:
+        /// <inheritdoc />
+        Enumerable<const BufferAttribute*> attributes() const noexcept override;
+
+        // IBufferLayout interface.
+    public:
+        /// <inheritdoc />
+        size_t elementSize() const noexcept override;
+
+        /// <inheritdoc />
+        UInt32 binding() const noexcept override;
+
+        /// <inheritdoc />
+        BufferType type() const noexcept override;
+    };
+
+    /// <summary>
+    /// Implements a DirectX 12 index buffer layout.
+    /// </summary>
+    /// <seealso cref="DirectX12IndexBuffer" />
+    /// <seealso cref="DirectX12VertexBufferLayout" />
+    class LITEFX_DIRECTX12_API DirectX12IndexBufferLayout final : public IIndexBufferLayout {
+        LITEFX_IMPLEMENTATION(DirectX12IndexBufferLayoutImpl);
+
+    public:
+        /// <summary>
+        /// Initializes a new index buffer layout
+        /// </summary>
+        /// <param name="type">The type of the indices within the index buffer.</param>
+        explicit DirectX12IndexBufferLayout(IndexType type);
+        DirectX12IndexBufferLayout(DirectX12IndexBufferLayout&&) = delete;
+        DirectX12IndexBufferLayout(const DirectX12IndexBufferLayout&) = delete;
+        virtual ~DirectX12IndexBufferLayout() noexcept;
+
+        // IIndexBufferLayout interface.
+    public:
+        /// <inheritdoc />
+        IndexType indexType() const noexcept override;
+
+        // IBufferLayout interface.
+    public:
+        /// <inheritdoc />
+        size_t elementSize() const noexcept override;
+
+        /// <inheritdoc />
+        UInt32 binding() const noexcept override;
+
+        /// <inheritdoc />
+        BufferType type() const noexcept override;
+    };
+
+    /// <summary>
+    /// Represents the base interface for a DirectX 12 buffer implementation.
+    /// </summary>
+    /// <seealso cref="DirectX12DescriptorSet" />
+    /// <seealso cref="IDirectX12Image" />
+    /// <seealso cref="IDirectX12VertexBuffer" />
+    /// <seealso cref="IDirectX12IndexBuffer" />
+    class LITEFX_DIRECTX12_API IDirectX12Buffer : public virtual IBuffer, public virtual IResource<ComPtr<ID3D12Resource>> {
+    public:
+        virtual ~IDirectX12Buffer() noexcept = default;
+    };
+
+    /// <summary>
+    /// Represents a DirectX 12 vertex buffer.
+    /// </summary>
+    /// <seealso cref="DirectX12VertexBufferLayout" />
+    /// <seealso cref="IDirectX12Buffer" />
+    class LITEFX_DIRECTX12_API IDirectX12VertexBuffer : public virtual VertexBuffer<DirectX12VertexBufferLayout>, public virtual IDirectX12Buffer {
+    public:
+        virtual ~IDirectX12VertexBuffer() noexcept = default;
+
+    public:
+        virtual const D3D12_VERTEX_BUFFER_VIEW& view() const noexcept = 0;
+    };
+
+    /// <summary>
+    /// Represents a DirectX 12 index buffer.
+    /// </summary>
+    /// <seealso cref="DirectX12IndexBufferLayout" />
+    /// <seealso cref="IDirectX12Buffer" />
+    class LITEFX_DIRECTX12_API IDirectX12IndexBuffer : public virtual IndexBuffer<DirectX12IndexBufferLayout>, public virtual IDirectX12Buffer {
+    public:
+        virtual ~IDirectX12IndexBuffer() noexcept = default;
+
+    public:
+        virtual const D3D12_INDEX_BUFFER_VIEW& view() const noexcept = 0;
+    };
+
+    /// <summary>
+    /// Represents a DirectX 12 sampled image or the base interface for a texture.
+    /// </summary>
+    /// <seealso cref="DirectX12DescriptorLayout" />
+    /// <seealso cref="DirectX12DescriptorSet" />
+    /// <seealso cref="DirectX12DescriptorSetLayout" />
+    /// <seealso cref="IDirectX12Sampler" />
+    class LITEFX_DIRECTX12_API IDirectX12Image : public virtual IImage, public virtual IResource<ComPtr<ID3D12Resource>> {
+    public:
+        friend class DirectX12Barrier;
+
+    public:
+        virtual ~IDirectX12Image() noexcept = default;
+
+    private:
+        virtual ImageLayout& layout(UInt32 subresource) = 0;
+    };
+
+    /// <summary>
+    /// Represents a DirectX 12 sampler.
+    /// </summary>
+    /// <seealso cref="DirectX12DescriptorLayout" />
+    /// <seealso cref="DirectX12DescriptorSet" />
+    /// <seealso cref="DirectX12DescriptorSetLayout" />
+    /// <seealso cref="IDirectX12Image" />
+    class LITEFX_DIRECTX12_API IDirectX12Sampler : public virtual ISampler {
+    public:
+        virtual ~IDirectX12Sampler() noexcept = default;
+    };
+
+    /// <summary>
+    /// Implements a DirectX 12 resource barrier.
+    /// </summary>
+    /// <seealso cref="DirectX12CommandBuffer" />
+    /// <seealso cref="IDirectX12Buffer" />
+    /// <seealso cref="IDirectX12Image" />
+    /// <seealso cref="Barrier" />
+    class LITEFX_DIRECTX12_API DirectX12Barrier final : public Barrier<IDirectX12Buffer, IDirectX12Image> {
+        LITEFX_IMPLEMENTATION(DirectX12BarrierImpl);
+        LITEFX_BUILDER(DirectX12BarrierBuilder);
+
+    public:
+        using base_type = Barrier<IDirectX12Buffer, IDirectX12Image>;
+        using base_type::transition;
+
+    public:
+        /// <summary>
+        /// Initializes a new DirectX 12 barrier.
+        /// </summary>
+        /// <param name="syncBefore">The pipeline stage(s) all previous commands have to finish before the barrier is executed.</param>
+        /// <param name="syncAfter">The pipeline stage(s) all subsequent commands are blocked at until the barrier is executed.</param>
+        constexpr inline explicit DirectX12Barrier(PipelineStage syncBefore, PipelineStage syncAfter) noexcept;
+        DirectX12Barrier(const DirectX12Barrier&) = delete;
+        DirectX12Barrier(DirectX12Barrier&&) = delete;
+        constexpr inline virtual ~DirectX12Barrier() noexcept;
+
+    private:
+        constexpr inline explicit DirectX12Barrier() noexcept;
+        constexpr inline PipelineStage& syncBefore() noexcept;
+        constexpr inline PipelineStage& syncAfter() noexcept;
+
+        // Barrier interface.
+    public:
+        /// <inheritdoc />
+        constexpr inline PipelineStage syncBefore() const noexcept override;
+
+        /// <inheritdoc />
+        constexpr inline PipelineStage syncAfter() const noexcept override;
+
+        /// <inheritdoc />
+        constexpr inline void wait(ResourceAccess accessBefore, ResourceAccess accessAfter) noexcept override;
+
+        /// <inheritdoc />
+        constexpr inline void transition(IDirectX12Buffer& buffer, ResourceAccess accessBefore, ResourceAccess accessAfter) override;
+
+        /// <inheritdoc />
+        constexpr inline void transition(IDirectX12Buffer& buffer, UInt32 element, ResourceAccess accessBefore, ResourceAccess accessAfter) override;
+
+        /// <inheritdoc />
+        constexpr inline void transition(IDirectX12Image& image, ResourceAccess accessBefore, ResourceAccess accessAfter, ImageLayout layout) override;
+
+        /// <inheritdoc />
+        constexpr inline void transition(IDirectX12Image& image, ResourceAccess accessBefore, ResourceAccess accessAfter, ImageLayout fromLayout, ImageLayout toLayout) override;
+
+        /// <inheritdoc />
+        constexpr inline void transition(IDirectX12Image& image, UInt32 level, UInt32 levels, UInt32 layer, UInt32 layers, UInt32 plane, ResourceAccess accessBefore, ResourceAccess accessAfter, ImageLayout layout) override;
+
+        /// <inheritdoc />
+        constexpr inline void transition(IDirectX12Image& image, UInt32 level, UInt32 levels, UInt32 layer, UInt32 layers, UInt32 plane, ResourceAccess accessBefore, ResourceAccess accessAfter, ImageLayout fromLayout, ImageLayout toLayout) override;
+
+    public:
+        /// <summary>
+        /// Adds the barrier to a command buffer and updates the resource target states.
+        /// </summary>
+        /// <param name="commandBuffer">The command buffer to add the barriers to.</param>
+        /// <exception cref="RuntimeException">Thrown, if any of the contained barriers is a image barrier that targets a sub-resource range that does not share the same <see cref="ImageLayout" /> in all sub-resources.</exception>
+        inline void execute(const DirectX12CommandBuffer& commandBuffer) const noexcept;
+    };
+
+    /// <summary>
+    /// Implements a DirectX 12 <see cref="IShaderModule" />.
+    /// </summary>
+    /// <seealso cref="DirectX12ShaderProgram" />
+    /// <seealso href="https://github.com/crud89/LiteFX/wiki/Shader-Development" />
+    class LITEFX_DIRECTX12_API DirectX12ShaderModule final : public IShaderModule, public ComResource<IDxcBlob> {
+        LITEFX_IMPLEMENTATION(DirectX12ShaderModuleImpl);
+
+    public:
+        /// <summary>
+        /// Initializes a new DirectX 12 shader module.
+        /// </summary>
+        /// <param name="device">The parent device, this shader module has been created from.</param>
+        /// <param name="type">The shader stage, this module is used in.</param>
+        /// <param name="fileName">The file name of the module source.</param>
+        /// <param name="entryPoint">The name of the module entry point.</param>
+        explicit DirectX12ShaderModule(const DirectX12Device& device, ShaderStage type, const String& fileName, const String& entryPoint = "main");
+
+        /// <summary>
+        /// Initializes a new DirectX 12 shader module.
+        /// </summary>
+        /// <param name="device">The parent device, this shader module has been created from.</param>
+        /// <param name="type">The shader stage, this module is used in.</param>
+        /// <param name="stream">The file stream to read the shader module from.</param>
+        /// <param name="name">The file name of the module source.</param>
+        /// <param name="entryPoint">The name of the module entry point.</param>
+        explicit DirectX12ShaderModule(const DirectX12Device& device, ShaderStage type, std::istream& stream, const String& name, const String& entryPoint = "main");
+        DirectX12ShaderModule(const DirectX12ShaderModule&) noexcept = delete;
+        DirectX12ShaderModule(DirectX12ShaderModule&&) noexcept = delete;
+        virtual ~DirectX12ShaderModule() noexcept;
+
+        // IShaderModule interface.
+    public:
+        /// <inheritdoc />
+        const String& fileName() const noexcept override;
+
+        /// <inheritdoc />
+        const String& entryPoint() const noexcept override;
+
+        /// <inheritdoc />
+        ShaderStage type() const noexcept override;
+    };
+
+    /// <summary>
+    /// Implements a DirectX 12 <see cref="ShaderProgram" />.
+    /// </summary>
+    /// <seealso cref="DirectX12ShaderProgramBuilder" />
+    /// <seealso href="https://github.com/crud89/LiteFX/wiki/Shader-Development" />
+    class LITEFX_DIRECTX12_API DirectX12ShaderProgram final : public ShaderProgram<DirectX12ShaderModule> {
+        LITEFX_IMPLEMENTATION(DirectX12ShaderProgramImpl);
+        LITEFX_BUILDER(DirectX12ShaderProgramBuilder);
+
+    public:
+        /// <summary>
+        /// Initializes a new DirectX 12 shader program.
+        /// </summary>
+        /// <param name="device">The parent device of the shader program.</param>
+        /// <param name="modules">The shader modules used by the shader program.</param>
+        explicit DirectX12ShaderProgram(const DirectX12Device& device, Enumerable<UniquePtr<DirectX12ShaderModule>>&& modules) noexcept;
+        DirectX12ShaderProgram(DirectX12ShaderProgram&&) noexcept = delete;
+        DirectX12ShaderProgram(const DirectX12ShaderProgram&) noexcept = delete;
+        virtual ~DirectX12ShaderProgram() noexcept;
+
+    private:
+        /// <summary>
+        /// Initializes a new DirectX 12 shader program.
+        /// </summary>
+        /// <param name="device">The parent device of the shader program.</param>
+        explicit DirectX12ShaderProgram(const DirectX12Device& device) noexcept;
+
+    public:
+        /// <inheritdoc />
+        Enumerable<const DirectX12ShaderModule*> modules() const noexcept override;
+
+        /// <inheritdoc />
+        virtual SharedPtr<DirectX12PipelineLayout> reflectPipelineLayout() const;
+
+    private:
+        SharedPtr<IPipelineLayout> parsePipelineLayout() const override {
+            return std::static_pointer_cast<IPipelineLayout>(this->reflectPipelineLayout());
+        }
+
+    public:
+        /// <summary>
+        /// Suppresses the warning that is issued, if no root signature is found on a shader module when calling <see cref="reflectPipelineLayout" />.
+        /// </summary>
+        /// <remarks>
+        /// When a shader program is asked to build a pipeline layout, it first checks if a root signature is provided within the shader bytecode. If no root signature could 
+        /// be found, it falls back to using plain reflection to extract the descriptor sets. This has the drawback, that some features are not or only partially supported.
+        /// Most notably, it is not possible to reflect a pipeline layout that uses push constants this way. To ensure that you are not missing the root signature by accident,
+        /// the engine warns you when it encounters this situation. However, if you are only using plain descriptor sets, this can result in noise warnings that clutter the 
+        /// log. You can call this function to disable the warnings explicitly.
+        /// </remarks>
+        /// <param name="disableWarning"><c>true</c> to stop issuing the warning or <c>false</c> to continue.</param>
+        /// <seealso cref="reflectPipelineLayout" />
+        static void suppressMissingRootSignatureWarning(bool disableWarning = true) noexcept;
+    };
+
+    /// <summary>
+    /// Implements a DirectX 12 <see cref="DescriptorSet" />.
+    /// </summary>
+    /// <seealso cref="DirectX12DescriptorSetLayout" />
+    class LITEFX_DIRECTX12_API DirectX12DescriptorSet final : public DescriptorSet<IDirectX12Buffer, IDirectX12Image, IDirectX12Sampler> {
+        LITEFX_IMPLEMENTATION(DirectX12DescriptorSetImpl);
+
+    public:
+        using base_type = DescriptorSet<IDirectX12Buffer, IDirectX12Image, IDirectX12Sampler>;
+        using base_type::update;
+        using base_type::attach;
+
+    public:
+        /// <summary>
+        /// Initializes a new descriptor set.
+        /// </summary>
+        /// <param name="layout">The parent descriptor set layout.</param>
+        /// <param name="bufferHeap">A CPU-visible descriptor heap that contains all buffer descriptors of the descriptor set.</param>
+        /// <param name="samplerHeap">A CPU-visible descriptor heap that contains all sampler descriptors of the descriptor set.</param>
+        explicit DirectX12DescriptorSet(const DirectX12DescriptorSetLayout& layout, ComPtr<ID3D12DescriptorHeap>&& bufferHeap, ComPtr<ID3D12DescriptorHeap>&& samplerHeap);
+        DirectX12DescriptorSet(DirectX12DescriptorSet&&) = delete;
+        DirectX12DescriptorSet(const DirectX12DescriptorSet&) = delete;
+        virtual ~DirectX12DescriptorSet() noexcept;
+
+    public:
+        /// <summary>
+        /// Returns the parent descriptor set layout.
+        /// </summary>
+        /// <returns>The parent descriptor set layout.</returns>
+        virtual const DirectX12DescriptorSetLayout& layout() const noexcept;
+
+    public:
+        /// <inheritdoc />
+        void update(UInt32 binding, const IDirectX12Buffer& buffer, UInt32 bufferElement = 0, UInt32 elements = 0, UInt32 firstDescriptor = 0) const override;
+
+        /// <inheritdoc />
+        void update(UInt32 binding, const IDirectX12Image& texture, UInt32 descriptor = 0, UInt32 firstLevel = 0, UInt32 levels = 0, UInt32 firstLayer = 0, UInt32 layers = 0) const override;
+
+        /// <inheritdoc />
+        void update(UInt32 binding, const IDirectX12Sampler& sampler, UInt32 descriptor = 0) const override;
+
+        /// <inheritdoc />
+        void attach(UInt32 binding, const IDirectX12Image& image) const override;
+
+    public:
+        /// <summary>
+        /// Returns the local (CPU-visible) heap that contains the buffer descriptors.
+        /// </summary>
+        /// <returns>The local (CPU-visible) heap that contains the buffer descriptors, or <c>nullptr</c>, if the descriptor set does not contain any buffers.</returns>
+        virtual const ComPtr<ID3D12DescriptorHeap>& bufferHeap() const noexcept;
+
+        /// <summary>
+        /// Returns the offset of the buffer descriptors in the global descriptor heap.
+        /// </summary>
+        /// <returns>The offset of the buffer descriptors in the global descriptor heap.</returns>
+        virtual UInt32 bufferOffset() const noexcept;
+
+        /// <summary>
+        /// Returns the local (CPU-visible) heap that contains the sampler descriptors.
+        /// </summary>
+        /// <returns>The local (CPU-visible) heap that contains the sampler descriptors, or <c>nullptr</c>, if the descriptor set does not contain any samplers.</returns>
+        virtual const ComPtr<ID3D12DescriptorHeap>& samplerHeap() const noexcept;
+
+        /// <summary>
+        /// Returns the offset of the sampler descriptors in the global descriptor heap.
+        /// </summary>
+        /// <returns>The offset of the sampler descriptors in the global descriptor heap.</returns>
+        virtual UInt32 samplerOffset() const noexcept;
+    };
+
+    /// <summary>
+    /// Implements a DirectX 12 <see cref="IDescriptorLayout" />
+    /// </summary>
+    /// <seealso cref="IDirectX12Buffer" />
+    /// <seealso cref="IDirectX12Image" />
+    /// <seealso cref="IDirectX12Sampler" />
+    /// <seealso cref="DirectX12DescriptorSet" />
+    /// <seealso cref="DirectX12DescriptorSetLayout" />
+    class LITEFX_DIRECTX12_API DirectX12DescriptorLayout final : public IDescriptorLayout {
+        LITEFX_IMPLEMENTATION(DirectX12DescriptorLayoutImpl);
+
+    public:
+        /// <summary>
+        /// Initializes a new DirectX 12 descriptor layout.
+        /// </summary>
+        /// <param name="type">The type of the descriptor.</param>
+        /// <param name="binding">The binding point for the descriptor.</param>
+        /// <param name="elementSize">The size of the descriptor.</param>
+        /// <param name="elementSize">The number of descriptors in the descriptor array.</param>
+        explicit DirectX12DescriptorLayout(DescriptorType type, UInt32 binding, size_t elementSize, UInt32 descriptors = 1);
+
+        /// <summary>
+        /// Initializes a new DirectX 12 descriptor layout for a static sampler.
+        /// </summary>
+        /// <param name="staticSampler">The static sampler to initialize the state with.</param>
+        /// <param name="binding">The binding point for the descriptor.</param>
+        explicit DirectX12DescriptorLayout(UniquePtr<IDirectX12Sampler>&& staticSampler, UInt32 binding);
+
+        DirectX12DescriptorLayout(DirectX12DescriptorLayout&&) = delete;
+        DirectX12DescriptorLayout(const DirectX12DescriptorLayout&) = delete;
+        virtual ~DirectX12DescriptorLayout() noexcept;
+
+        // IDescriptorLayout interface.
+    public:
+        /// <inheritdoc />
+        DescriptorType descriptorType() const noexcept override;
+
+        /// <inheritdoc />
+        UInt32 descriptors() const noexcept override;
+
+        /// <inheritdoc />
+        const IDirectX12Sampler* staticSampler() const noexcept override;
+
+        // IBufferLayout interface.
+    public:
+        /// <inheritdoc />
+        size_t elementSize() const noexcept override;
+
+        /// <inheritdoc />
+        UInt32 binding() const noexcept override;
+
+        /// <inheritdoc />
+        BufferType type() const noexcept override;
+    };
+
+    /// <summary>
+    /// Implements a DirectX 12 <see cref="DescriptorSetLayout" />.
+    /// </summary>
+    /// <seealso cref="DirectX12DescriptorSet" />
+    /// <seealso cref="DirectX12PipelineDescriptorSetLayoutBuilder" />
+    class LITEFX_DIRECTX12_API DirectX12DescriptorSetLayout final : public DescriptorSetLayout<DirectX12DescriptorLayout, DirectX12DescriptorSet> {
+        LITEFX_IMPLEMENTATION(DirectX12DescriptorSetLayoutImpl);
+        LITEFX_BUILDER(DirectX12DescriptorSetLayoutBuilder);
+        friend class DirectX12PipelineLayout;
+
+    public:
+        using base_type = DescriptorSetLayout<DirectX12DescriptorLayout, DirectX12DescriptorSet>;
+        using base_type::free;
+
+    public:
+        /// <summary>
+        /// Initializes a DirectX 12 descriptor set layout.
+        /// </summary>
+        /// <param name="device">The device, the descriptor set layout is created on.</param>
+        /// <param name="descriptorLayouts">The descriptor layouts of the descriptors within the descriptor set.</param>
+        /// <param name="space">The space or set id of the descriptor set.</param>
+        /// <param name="stages">The shader stages, the descriptor sets are bound to.</param>
+        explicit DirectX12DescriptorSetLayout(const DirectX12Device& device, Enumerable<UniquePtr<DirectX12DescriptorLayout>>&& descriptorLayouts, UInt32 space, ShaderStage stages);
+        DirectX12DescriptorSetLayout(DirectX12DescriptorSetLayout&&) = delete;
+        DirectX12DescriptorSetLayout(const DirectX12DescriptorSetLayout&) = delete;
+        virtual ~DirectX12DescriptorSetLayout() noexcept;
+
+    private:
+        /// <summary>
+        /// Initializes a DirectX 12 descriptor set layout.
+        /// </summary>
+        /// <param name="device">The device, the descriptor set layout is created on.</param>
+        explicit DirectX12DescriptorSetLayout(const DirectX12Device& device) noexcept;
+
+    public:
+        /// <summary>
+        /// Returns the index of the descriptor set root parameter.
+        /// </summary>
+        /// <returns>The index of the descriptor set root parameter.</returns>
+        virtual UInt32 rootParameterIndex() const noexcept;
+
+        /// <summary>
+        /// Returns the index of the first descriptor for a certain binding. The offset is relative to the heap for the descriptor (i.e. sampler for sampler descriptors and
+        /// CBV/SRV/UAV for other descriptors).
+        /// </summary>
+        /// <param name="binding">The binding of the descriptor.</param>
+        /// <returns>The index of the first descriptor for the binding.</returns>
+        /// <exception cref="ArgumentOutOfRangeException">Thrown, if the descriptor set does not contain a descriptor bound to the binding point specified by <paramref name="binding"/>.</exception>
+        virtual UInt32 descriptorOffsetForBinding(UInt32 binding) const;
+
+        /// <summary>
+        /// Returns the parent device.
+        /// </summary>
+        /// <returns>A reference of the parent device.</returns>
+        virtual const DirectX12Device& device() const noexcept;
+
+    protected:
+        /// <summary>
+        /// Returns a reference of the index of the descriptor set root parameter.
+        /// </summary>
+        /// <returns>A reference of the index of the descriptor set root parameter.</returns>
+        virtual UInt32& rootParameterIndex() noexcept;
+
+        /// <summary>
+        /// Returns <c>true</c>, if the descriptor set contains an (unbounded) runtime array.
+        /// </summary>
+        /// <remarks>
+        /// A descriptor set is a runtime array, if it contains exactly one descriptor, which is an unbounded array, i.e. which has a descriptor count of `-1` (or `0xFFFFFFFF`).
+        /// </remarks>
+        /// <returns><c>true</c>, if the descriptor set contains an (unbounded) runtime array and <c>false</c> otherwise.</returns>
+        virtual bool isRuntimeArray() const noexcept;
+
+    public:
+        /// <inheritdoc />
+        Enumerable<const DirectX12DescriptorLayout*> descriptors() const noexcept override;
+
+        /// <inheritdoc />
+        const DirectX12DescriptorLayout& descriptor(UInt32 binding) const override;
+
+        /// <inheritdoc />
+        UInt32 space() const noexcept override;
+
+        /// <inheritdoc />
+        ShaderStage shaderStages() const noexcept override;
+
+        /// <inheritdoc />
+        UInt32 uniforms() const noexcept override;
+
+        /// <inheritdoc />
+        UInt32 storages() const noexcept override;
+
+        /// <inheritdoc />
+        UInt32 images() const noexcept override;
+
+        /// <inheritdoc />
+        UInt32 buffers() const noexcept override;
+
+        /// <inheritdoc />
+        UInt32 samplers() const noexcept override;
+
+        /// <inheritdoc />
+        UInt32 staticSamplers() const noexcept override;
+
+        /// <inheritdoc />
+        UInt32 inputAttachments() const noexcept override;
+
+    public:
+        /// <inheritdoc />
+        UniquePtr<DirectX12DescriptorSet> allocate(const Enumerable<DescriptorBinding>& bindings = { }) const override;
+
+        /// <inheritdoc />
+        UniquePtr<DirectX12DescriptorSet> allocate(UInt32 descriptors, const Enumerable<DescriptorBinding>& bindings = { }) const override;
+
+        /// <inheritdoc />
+        Enumerable<UniquePtr<DirectX12DescriptorSet>> allocateMultiple(UInt32 descriptorSets, const Enumerable<Enumerable<DescriptorBinding>>& bindings = { }) const override;
+
+        /// <inheritdoc />
+        Enumerable<UniquePtr<DirectX12DescriptorSet>> allocateMultiple(UInt32 descriptorSets, std::function<Enumerable<DescriptorBinding>(UInt32)> bindingFactory) const override;
+
+        /// <inheritdoc />
+        Enumerable<UniquePtr<DirectX12DescriptorSet>> allocateMultiple(UInt32 descriptorSets, UInt32 descriptors, const Enumerable<Enumerable<DescriptorBinding>>& bindings = { }) const override;
+
+        /// <inheritdoc />
+        Enumerable<UniquePtr<DirectX12DescriptorSet>> allocateMultiple(UInt32 descriptorSets, UInt32 descriptors, std::function<Enumerable<DescriptorBinding>(UInt32)> bindingFactory) const override;
+
+        /// <inheritdoc />
+        void free(const DirectX12DescriptorSet& descriptorSet) const noexcept override;
+    };
+
+    /// <summary>
+    /// Implements the DirectX 12 <see cref="IPushConstantsRange" />.
+    /// </summary>
+    /// <seealso cref="DirectX12PushConstantsLayout" />
+    class LITEFX_DIRECTX12_API DirectX12PushConstantsRange final : public IPushConstantsRange {
+        LITEFX_IMPLEMENTATION(DirectX12PushConstantsRangeImpl);
+        friend class DirectX12PipelineLayout;
+
+    public:
+        /// <summary>
+        /// Initializes a new push constants range.
+        /// </summary>
+        /// <param name="shaderStages">The shader stages, that access the push constants from the range.</param>
+        /// <param name="offset">The offset relative to the parent push constants backing memory that marks the beginning of the range.</param>
+        /// <param name="size">The size of the push constants range.</param>
+        /// <param name="space">The space from which the push constants of the range will be accessible in the shader.</param>
+        /// <param name="binding">The register from which the push constants of the range will be accessible in the shader.</param>
+        explicit DirectX12PushConstantsRange(ShaderStage shaderStages, UInt32 offset, UInt32 size, UInt32 space, UInt32 binding);
+        DirectX12PushConstantsRange(const DirectX12PushConstantsRange&) = delete;
+        DirectX12PushConstantsRange(DirectX12PushConstantsRange&&) = delete;
+        virtual ~DirectX12PushConstantsRange() noexcept;
+
+    public:
+        /// <inheritdoc />
+        UInt32 space() const noexcept override;
+
+        /// <inheritdoc />
+        UInt32 binding() const noexcept override;
+
+        /// <inheritdoc />
+        UInt32 offset() const noexcept override;
+
+        /// <inheritdoc />
+        UInt32 size() const noexcept override;
+
+        /// <inheritdoc />
+        ShaderStage stage() const noexcept override;
+
+    public:
+        /// <summary>
+        /// Returns the index of the root parameter, the range is bound to.
+        /// </summary>
+        /// <returns>The index of the root parameter, the range is bound to.</returns>
+        virtual UInt32 rootParameterIndex() const noexcept;
+
+    protected:
+        /// <summary>
+        /// Returns a reference of the index of the root parameter, the range is bound to.
+        /// </summary>
+        /// <returns>A reference of the index of the root parameter, the range is bound to.</returns>
+        virtual UInt32& rootParameterIndex() noexcept;
+    };
+
+    /// <summary>
+    /// Implements the DirectX 12 <see cref="PushConstantsLayout" />.
+    /// </summary>
+    /// <remarks>
+    /// In DirectX 12, push constants map to root constants. Those are 32 bit values that are directly stored on the root signature. Thus, push constants can bloat your root 
+    /// signature, since all the required memory is directly reserved on it. The way they are implemented is, that each range gets directly written in 4 byte chunks into the
+    /// command buffer. Thus, overlapping is not directly supported (as opposed to Vulkan). If you have overlapping push constants ranges, the overlap will be duplicated in
+    /// the root signature.
+    /// </remarks>
+    /// <seealso cref="DirectX12PushConstantsRange" />
+    /// <seealso cref="DirectX12PipelinePushConstantsLayoutBuilder" />
+    class LITEFX_DIRECTX12_API DirectX12PushConstantsLayout final : public PushConstantsLayout<DirectX12PushConstantsRange> {
+        LITEFX_IMPLEMENTATION(DirectX12PushConstantsLayoutImpl);
+        LITEFX_BUILDER(DirectX12PushConstantsLayoutBuilder);
+        friend class DirectX12PipelineLayout;
+
+    public:
+        /// <summary>
+        /// Initializes a new push constants layout.
+        /// </summary>
+        /// <param name="ranges">The ranges contained by the layout.</param>
+        /// <param name="size">The overall size (in bytes) of the push constants backing memory.</param>
+        explicit DirectX12PushConstantsLayout(Enumerable<UniquePtr<DirectX12PushConstantsRange>>&& ranges, UInt32 size);
+        DirectX12PushConstantsLayout(const DirectX12PushConstantsLayout&) = delete;
+        DirectX12PushConstantsLayout(DirectX12PushConstantsLayout&&) = delete;
+        virtual ~DirectX12PushConstantsLayout() noexcept;
+
+    private:
+        /// <summary>
+        /// Initializes a new push constants layout.
+        /// </summary>
+        /// <param name="size">The overall size (in bytes) of the push constants backing memory.</param>
+        explicit DirectX12PushConstantsLayout(UInt32 size);
+
+    public:
+        /// <inheritdoc />
+        UInt32 size() const noexcept override;
+
+        /// <inheritdoc />
+        const DirectX12PushConstantsRange& range(ShaderStage stage) const override;
+
+        /// <inheritdoc />
+        Enumerable<const DirectX12PushConstantsRange*> ranges() const noexcept override;
+
+    protected:
+        /// <summary>
+        /// Returns an array of pointers to the push constant ranges of the layout.
+        /// </summary>
+        /// <returns>An array of pointers to the push constant ranges of the layout.</returns>
+        virtual Enumerable<DirectX12PushConstantsRange*> ranges() noexcept;
+    };
+
+    /// <summary>
+    /// Implements a DirectX 12 <see cref="PipelineLayout" />.
+    /// </summary>
+    /// <seealso cref="DirectX12PipelineLayoutBuilder" />
+    class LITEFX_DIRECTX12_API DirectX12PipelineLayout final : public PipelineLayout<DirectX12DescriptorSetLayout, DirectX12PushConstantsLayout>, public ComResource<ID3D12RootSignature> {
+        LITEFX_IMPLEMENTATION(DirectX12PipelineLayoutImpl);
+        LITEFX_BUILDER(DirectX12PipelineLayoutBuilder);
+
+    public:
+        /// <summary>
+        /// Initializes a new DirectX 12 render pipeline layout.
+        /// </summary>
+        /// <param name="device">The parent device, the layout is created from.</param>
+        /// <param name="descriptorSetLayouts">The descriptor set layouts used by the pipeline.</param>
+        /// <param name="pushConstantsLayout">The push constants layout used by the pipeline.</param>
+        explicit DirectX12PipelineLayout(const DirectX12Device& device, Enumerable<UniquePtr<DirectX12DescriptorSetLayout>>&& descriptorSetLayouts, UniquePtr<DirectX12PushConstantsLayout>&& pushConstantsLayout);
+        DirectX12PipelineLayout(DirectX12PipelineLayout&&) noexcept = delete;
+        DirectX12PipelineLayout(const DirectX12PipelineLayout&) noexcept = delete;
+        virtual ~DirectX12PipelineLayout() noexcept;
+
+    private:
+        /// <summary>
+        /// Initializes a new DirectX 12 render pipeline layout.
+        /// </summary>
+        /// <param name="device">The parent device, the layout is created from.</param>
+        explicit DirectX12PipelineLayout(const DirectX12Device& device) noexcept;
+
+    public:
+        /// <summary>
+        /// Returns a reference to the device that provides this layout.
+        /// </summary>
+        /// <returns>A reference to the layouts parent device.</returns>
+        virtual const DirectX12Device& device() const noexcept;
+
+        // PipelineLayout interface.
+    public:
+        /// <inheritdoc />
+        const DirectX12DescriptorSetLayout& descriptorSet(UInt32 space) const override;
+
+        /// <inheritdoc />
+        Enumerable<const DirectX12DescriptorSetLayout*> descriptorSets() const noexcept override;
+
+        /// <inheritdoc />
+        const DirectX12PushConstantsLayout* pushConstants() const noexcept override;
+    };
+
+    /// <summary>
+    /// Implements the DirectX 12 input assembler state.
+    /// </summary>
+    /// <seealso cref="DirectX12InputAssemblerBuilder" />
+    class LITEFX_DIRECTX12_API DirectX12InputAssembler final : public InputAssembler<DirectX12VertexBufferLayout, DirectX12IndexBufferLayout> {
+        LITEFX_IMPLEMENTATION(DirectX12InputAssemblerImpl);
+        LITEFX_BUILDER(DirectX12InputAssemblerBuilder);
+
+    public:
+        /// <summary>
+        /// Initializes a new DirectX 12 input assembler state.
+        /// </summary>
+        /// <param name="vertexBufferLayouts">The vertex buffer layouts supported by the input assembler state. Each layout must have a unique binding.</param>
+        /// <param name="indexBufferLayout">The index buffer layout.</param>
+        /// <param name="primitiveTopology">The primitive topology.</param>
+        explicit DirectX12InputAssembler(Enumerable<UniquePtr<DirectX12VertexBufferLayout>>&& vertexBufferLayouts, UniquePtr<DirectX12IndexBufferLayout>&& indexBufferLayout, PrimitiveTopology primitiveTopology = PrimitiveTopology::TriangleList);
+        DirectX12InputAssembler(DirectX12InputAssembler&&) noexcept = delete;
+        DirectX12InputAssembler(const DirectX12InputAssembler&) noexcept = delete;
+        virtual ~DirectX12InputAssembler() noexcept;
+
+    private:
+        /// <summary>
+        /// Initializes a new DirectX 12 input assembler state.
+        /// </summary>
+        explicit DirectX12InputAssembler() noexcept;
+
+    public:
+        /// <inheritdoc />
+        Enumerable<const DirectX12VertexBufferLayout*> vertexBufferLayouts() const noexcept override;
+
+        /// <inheritdoc />
+        const DirectX12VertexBufferLayout& vertexBufferLayout(UInt32 binding) const override;
+
+        /// <inheritdoc />
+        const DirectX12IndexBufferLayout& indexBufferLayout() const override;
+
+        /// <inheritdoc />
+        PrimitiveTopology topology() const noexcept override;
+    };
+
+    /// <summary>
+    /// Implements a DirectX 12 <see cref="IRasterizer" />.
+    /// </summary>
+    /// <seealso cref="DirectX12RasterizerBuilder" />
+    class LITEFX_DIRECTX12_API DirectX12Rasterizer final : public Rasterizer {
+        LITEFX_BUILDER(DirectX12RasterizerBuilder);
+
+    public:
+        /// <summary>
+        /// Initializes a new DirectX 12 rasterizer state.
+        /// </summary>
+        /// <param name="polygonMode">The polygon mode used by the pipeline.</param>
+        /// <param name="cullMode">The cull mode used by the pipeline.</param>
+        /// <param name="cullOrder">The cull order used by the pipeline.</param>
+        /// <param name="lineWidth">The line width used by the pipeline.</param>
+        /// <param name="depthStencilState">The rasterizer depth/stencil state.</param>
+        explicit DirectX12Rasterizer(PolygonMode polygonMode, CullMode cullMode, CullOrder cullOrder, Float lineWidth = 1.f, const DepthStencilState& depthStencilState = {}) noexcept;
+        DirectX12Rasterizer(DirectX12Rasterizer&&) noexcept = delete;
+        DirectX12Rasterizer(const DirectX12Rasterizer&) noexcept = delete;
+        virtual ~DirectX12Rasterizer() noexcept;
+
+    private:
+        /// <summary>
+        /// Initializes a new DirectX 12 rasterizer state.
+        /// </summary>
+        explicit DirectX12Rasterizer() noexcept;
+    };
+
+    /// <summary>
+    /// Defines the base class for DirectX 12 pipeline state objects.
+    /// </summary>
+    /// <seealso cref="DirectX12RenderPipeline" />
+    /// <seealso cref="DirectX12ComputePipeline" />
+    class LITEFX_DIRECTX12_API DirectX12PipelineState : public virtual Pipeline<DirectX12PipelineLayout, DirectX12ShaderProgram>, public ComResource<ID3D12PipelineState> {
+    public:
+        using ComResource<ID3D12PipelineState>::ComResource;
+        virtual ~DirectX12PipelineState() noexcept = default;
+
+    public:
+        /// <summary>
+        /// Sets the current pipeline state on the <paramref name="commandBuffer" />.
+        /// </summary>
+        /// <param name="commandBuffer">The command buffer to set the current pipeline state on.</param>
+        virtual void use(const DirectX12CommandBuffer& commandBuffer) const noexcept = 0;
+    };
+
+    /// <summary>
+    /// Records commands for a <see cref="DirectX12CommandQueue" />
+    /// </summary>
+    /// <seealso cref="DirectX12CommandQueue" />
+    class LITEFX_DIRECTX12_API DirectX12CommandBuffer final : public CommandBuffer<DirectX12CommandBuffer, IDirectX12Buffer, IDirectX12VertexBuffer, IDirectX12IndexBuffer, IDirectX12Image, DirectX12Barrier, DirectX12PipelineState>, public ComResource<ID3D12GraphicsCommandList7> {
+        LITEFX_IMPLEMENTATION(DirectX12CommandBufferImpl);
+
+    public:
+        using base_type = CommandBuffer<DirectX12CommandBuffer, IDirectX12Buffer, IDirectX12VertexBuffer, IDirectX12IndexBuffer, IDirectX12Image, DirectX12Barrier, DirectX12PipelineState>;
+        using base_type::dispatch;
+        using base_type::draw;
+        using base_type::drawIndexed;
+        using base_type::barrier;
+        using base_type::transfer;
+        using base_type::generateMipMaps;
+        using base_type::bind;
+        using base_type::use;
+        using base_type::pushConstants;
+
+    public:
+        /// <summary>
+        /// Initializes the command buffer from a command queue.
+        /// </summary>
+        /// <param name="queue">The parent command queue, the buffer gets submitted to.</param>
+        /// <param name="begin">If set to <c>true</c>, the command buffer automatically starts recording by calling <see cref="begin" />.</param>
+        /// <param name="primary"><c>true</c>, if the command buffer is a primary command buffer.</param>
+        explicit DirectX12CommandBuffer(const DirectX12Queue& queue, bool begin = false, bool primary = true);
+        DirectX12CommandBuffer(const DirectX12CommandBuffer&) = delete;
+        DirectX12CommandBuffer(DirectX12CommandBuffer&&) = delete;
+        virtual ~DirectX12CommandBuffer() noexcept;
+
+        // CommandBuffer interface.
+    public:
+        /// <inheritdoc />
+        void begin() const override;
+
+        /// <inheritdoc />
+        void end() const override;
+
+        /// <inheritdoc />
+        bool isSecondary() const noexcept override;
+
+        /// <inheritdoc />
+        void setViewports(Span<const IViewport*> viewports) const noexcept override;
+
+        /// <inheritdoc />
+        void setViewports(const IViewport* viewport) const noexcept override;
+
+        /// <inheritdoc />
+        void setScissors(Span<const IScissor*> scissors) const noexcept override;
+
+        /// <inheritdoc />
+        void setScissors(const IScissor* scissor) const noexcept override;
+
+        /// <inheritdoc />
+        void setBlendFactors(const Vector4f& blendFactors) const noexcept override;
+
+        /// <inheritdoc />
+        void setStencilRef(UInt32 stencilRef) const noexcept override;
+
+        /// <inheritdoc />
+        void generateMipMaps(IDirectX12Image& image) noexcept override;
+
+        /// <inheritdoc />
+        void barrier(const DirectX12Barrier& barrier) const noexcept override;
+
+        /// <inheritdoc />
+        void transfer(IDirectX12Buffer& source, IDirectX12Buffer& target, UInt32 sourceElement = 0, UInt32 targetElement = 0, UInt32 elements = 1) const override;
+
+        /// <inheritdoc />
+        void transfer(IDirectX12Buffer& source, IDirectX12Image& target, UInt32 sourceElement = 0, UInt32 firstSubresource = 0, UInt32 elements = 1) const override;
+
+        /// <inheritdoc />
+        void transfer(IDirectX12Image& source, IDirectX12Image& target, UInt32 sourceSubresource = 0, UInt32 targetSubresource = 0, UInt32 subresources = 1) const override;
+
+        /// <inheritdoc />
+        void transfer(IDirectX12Image& source, IDirectX12Buffer& target, UInt32 firstSubresource = 0, UInt32 targetElement = 0, UInt32 subresources = 1) const override;
+
+        /// <inheritdoc />
+        void transfer(SharedPtr<IDirectX12Buffer> source, IDirectX12Buffer& target, UInt32 sourceElement = 0, UInt32 targetElement = 0, UInt32 elements = 1) const override;
+
+        /// <inheritdoc />
+        void transfer(SharedPtr<IDirectX12Buffer> source, IDirectX12Image& target, UInt32 sourceElement = 0, UInt32 firstSubresource = 0, UInt32 elements = 1) const override;
+
+        /// <inheritdoc />
+        void transfer(SharedPtr<IDirectX12Image> source, IDirectX12Image& target, UInt32 sourceSubresource = 0, UInt32 targetSubresource = 0, UInt32 subresources = 1) const override;
+
+        /// <inheritdoc />
+        void transfer(SharedPtr<IDirectX12Image> source, IDirectX12Buffer& target, UInt32 firstSubresource = 0, UInt32 targetElement = 0, UInt32 subresources = 1) const override;
+
+        /// <inheritdoc />
+        void use(const DirectX12PipelineState& pipeline) const noexcept override;
+
+        /// <inheritdoc />
+        void bind(const DirectX12DescriptorSet& descriptorSet, const DirectX12PipelineState& pipeline) const noexcept override;
+
+        /// <inheritdoc />
+        void bind(const IDirectX12VertexBuffer& buffer) const noexcept override;
+
+        /// <inheritdoc />
+        void bind(const IDirectX12IndexBuffer& buffer) const noexcept override;
+
+        /// <inheritdoc />
+        void dispatch(const Vector3u& threadCount) const noexcept override;
+
+        /// <inheritdoc />
+        void draw(UInt32 vertices, UInt32 instances = 1, UInt32 firstVertex = 0, UInt32 firstInstance = 0) const noexcept override;
+
+        /// <inheritdoc />
+        void drawIndexed(UInt32 indices, UInt32 instances = 1, UInt32 firstIndex = 0, Int32 vertexOffset = 0, UInt32 firstInstance = 0) const noexcept override;
+        
+        /// <inheritdoc />
+        void pushConstants(const DirectX12PushConstantsLayout& layout, const void* const memory) const noexcept override;
+
+        /// <inheritdoc />
+        void writeTimingEvent(SharedPtr<const TimingEvent> timingEvent) const override;
+
+        /// <inheritdoc />
+        void execute(SharedPtr<const DirectX12CommandBuffer> commandBuffer) const override;
+
+        /// <inheritdoc />
+        void execute(Enumerable<SharedPtr<const DirectX12CommandBuffer>> commandBuffers) const override;
+
+    private:
+        void releaseSharedState() const override;
+    };
+
+    /// <summary>
+    /// Implements a DirectX 12 <see cref="RenderPipeline" />.
+    /// </summary>
+    /// <seealso cref="DirectX12ComputePipeline" />
+    /// <seealso cref="DirectX12RenderPipelineBuilder" />
+    class LITEFX_DIRECTX12_API DirectX12RenderPipeline final : public virtual DirectX12PipelineState, public RenderPipeline<DirectX12PipelineLayout, DirectX12ShaderProgram, DirectX12InputAssembler, DirectX12Rasterizer> {
+        LITEFX_IMPLEMENTATION(DirectX12RenderPipelineImpl);
+        LITEFX_BUILDER(DirectX12RenderPipelineBuilder);
+
+    public:
+        /// <summary>
+        /// Initializes a new DirectX 12 render pipeline.
+        /// </summary>
+        /// <param name="renderPass">The parent render pass.</param>
+        /// <param name="shaderProgram">The shader program used by the pipeline.</param>
+        /// <param name="layout">The layout of the pipeline.</param>
+        /// <param name="inputAssembler">The input assembler state of the pipeline.</param>
+        /// <param name="rasterizer">The rasterizer state of the pipeline.</param>
+        /// <param name="name">The optional name of the render pipeline.</param>
+        /// <param name="enableAlphaToCoverage">Whether or not to enable Alpha-to-Coverage multi-sampling.</param>
+        explicit DirectX12RenderPipeline(const DirectX12RenderPass& renderPass, SharedPtr<DirectX12PipelineLayout> layout, SharedPtr<DirectX12ShaderProgram> shaderProgram, SharedPtr<DirectX12InputAssembler> inputAssembler, SharedPtr<DirectX12Rasterizer> rasterizer, const bool enableAlphaToCoverage = false, const String& name = "");
+        DirectX12RenderPipeline(DirectX12RenderPipeline&&) noexcept = delete;
+        DirectX12RenderPipeline(const DirectX12RenderPipeline&) noexcept = delete;
+        virtual ~DirectX12RenderPipeline() noexcept;
+
+    private:
+        /// <summary>
+        /// Initializes a new DirectX 12 render pipeline.
+        /// </summary>
+        /// <param name="renderPass">The parent render pass.</param>
+        /// <param name="name">The optional name of the render pipeline.</param>
+        DirectX12RenderPipeline(const DirectX12RenderPass& renderPass, const String& name = "") noexcept;
+
+        // Pipeline interface.
+    public:
+        /// <inheritdoc />
+        SharedPtr<const DirectX12ShaderProgram> program() const noexcept override;
+
+        /// <inheritdoc />
+        SharedPtr<const DirectX12PipelineLayout> layout() const noexcept override;
+
+        // RenderPipeline interface.
+    public:
+        /// <inheritdoc />
+        SharedPtr<DirectX12InputAssembler> inputAssembler() const noexcept override;
+
+        /// <inheritdoc />
+        SharedPtr<DirectX12Rasterizer> rasterizer() const noexcept override;
+
+        /// <inheritdoc />
+        bool alphaToCoverage() const noexcept override;
+
+        // DirectX12PipelineState interface.
+    public:
+        /// <inheritdoc />
+        void use(const DirectX12CommandBuffer& commandBuffer) const noexcept override;
+    };
+
+    /// <summary>
+    /// Implements a DirectX 12 <see cref="ComputePipeline" />.
+    /// </summary>
+    /// <seealso cref="DirectX12RenderPipeline" />
+    /// <seealso cref="DirectX12ComputePipelineBuilder" />
+    class LITEFX_DIRECTX12_API DirectX12ComputePipeline final : public virtual DirectX12PipelineState, public ComputePipeline<DirectX12PipelineLayout, DirectX12ShaderProgram> {
+        LITEFX_IMPLEMENTATION(DirectX12ComputePipelineImpl);
+        LITEFX_BUILDER(DirectX12ComputePipelineBuilder);
+
+    public:
+        /// <summary>
+        /// Initializes a new DirectX 12 compute pipeline.
+        /// </summary>
+        /// <param name="device">The parent device.</param>
+        /// <param name="layout">The layout of the pipeline.</param>
+        /// <param name="shaderProgram">The shader program used by this pipeline.</param>
+        /// <param name="name">The optional debug name of the compute pipeline.</param>
+        explicit DirectX12ComputePipeline(const DirectX12Device& device, SharedPtr<DirectX12PipelineLayout> layout, SharedPtr<DirectX12ShaderProgram> shaderProgram, const String& name = "");
+        DirectX12ComputePipeline(DirectX12ComputePipeline&&) noexcept = delete;
+        DirectX12ComputePipeline(const DirectX12ComputePipeline&) noexcept = delete;
+        virtual ~DirectX12ComputePipeline() noexcept;
+
+    private:
+        /// <summary>
+        /// Initializes a new DirectX 12 compute pipeline.
+        /// </summary>
+        /// <param name="device">The parent device.</param>
+        DirectX12ComputePipeline(const DirectX12Device& device) noexcept;
+
+        // Pipeline interface.
+    public:
+        /// <inheritdoc />
+        SharedPtr<const DirectX12ShaderProgram> program() const noexcept override;
+
+        /// <inheritdoc />
+        SharedPtr<const DirectX12PipelineLayout> layout() const noexcept override;
+
+        // DirectX12PipelineState interface.
+    public:
+        void use(const DirectX12CommandBuffer& commandBuffer) const noexcept override;
+    };
+
+    /// <summary>
+    /// Implements a DirectX 12 frame buffer.
+    /// </summary>
+    /// <seealso cref="DirectX12RenderPass" />
+    class LITEFX_DIRECTX12_API DirectX12FrameBuffer final : public FrameBuffer<DirectX12CommandBuffer> {
+        LITEFX_IMPLEMENTATION(DirectX12FrameBufferImpl);
+
+    public:
+        /// <summary>
+        /// Initializes a DirectX 12 frame buffer.
+        /// </summary>
+        /// <param name="renderPass">The parent render pass of the frame buffer.</param>
+        /// <param name="bufferIndex">The index of the frame buffer within the parent render pass.</param>
+        /// <param name="renderArea">The initial size of the render area.</param>
+        /// <param name="commandBuffers">The number of command buffers, the frame buffer stores.</param>
+        DirectX12FrameBuffer(const DirectX12RenderPass& renderPass, UInt32 bufferIndex, const Size2d& renderArea, UInt32 commandBuffers = 1);
+        DirectX12FrameBuffer(const DirectX12FrameBuffer&) noexcept = delete;
+        DirectX12FrameBuffer(DirectX12FrameBuffer&&) noexcept = delete;
+        virtual ~DirectX12FrameBuffer() noexcept;
+
+        // DirectX 12 FrameBuffer
+    public:
+        /// <summary>
+        /// Returns a pointer to the descriptor heap that allocates the render targets for this frame buffer.
+        /// </summary>
+        /// <returns>A pointer to the descriptor heap that allocates the render targets for this frame buffer.</returns>
+        /// <seealso cref="depthStencilTargetHeap" />
+        /// <seealso cref="renderTargetDescriptorSize" />
+        virtual ID3D12DescriptorHeap* renderTargetHeap() const noexcept;
+
+        /// <summary>
+        /// Returns a pointer to the descriptor heap that allocates the depth/stencil views for this frame buffer.
+        /// </summary>
+        /// <remarks>
+        /// Note that it is typically not supported to have more than one depth/stencil output view bound to a <see cref="RenderPass" />.
+        /// </remarks>
+        /// <returns>A pointer to the descriptor heap that allocates the depth/stencil views for this frame buffer.</returns>
+        /// <seealso cref="renderTargetHeap" />
+        /// <seealso cref="depthStencilDescriptorSize" />
+        virtual ID3D12DescriptorHeap* depthStencilTargetHeap() const noexcept;
+
+        /// <summary>
+        /// Returns the size of a descriptor for a render target within the frame buffer.
+        /// </summary>
+        /// <returns>The size of a descriptor for a render target within the frame buffer.</returns>
+        /// <seealso cref="renderTargetHeap" />
+        virtual UInt32 renderTargetDescriptorSize() const noexcept;
+
+        /// <summary>
+        /// Returns the size of a descriptor for a depth/stencil view within the frame buffer.
+        /// </summary>
+        /// <returns>The size of a descriptor for a depth/stencil view within the frame buffer.</returns>
+        /// <seealso cref="depthStencilTargetHeap" />
+        virtual UInt32 depthStencilTargetDescriptorSize() const noexcept;
+
+        /// <summary>
+        /// Returns a reference of the last fence value for the frame buffer.
+        /// </summary>
+        /// <remarks>
+        /// The frame buffer must only be re-used, if this fence is reached in the graphics queue.
+        /// </remarks>
+        /// <returns>A reference of the last fence value for the frame buffer.</returns>
+        virtual UInt64& lastFence() const noexcept;
+
+        // FrameBuffer interface.
+    public:
+        /// <inheritdoc />
+        UInt32 bufferIndex() const noexcept override;
+
+        /// <inheritdoc />
+        const Size2d& size() const noexcept override;
+
+        /// <inheritdoc />
+        size_t getWidth() const noexcept override;
+
+        /// <inheritdoc />
+        size_t getHeight() const noexcept override;
+
+        /// <inheritdoc />
+        Enumerable<SharedPtr<const DirectX12CommandBuffer>> commandBuffers() const noexcept override;
+
+        /// <inheritdoc />
+        SharedPtr<const DirectX12CommandBuffer> commandBuffer(UInt32 index) const override;
+
+        /// <inheritdoc />
+        Enumerable<const IDirectX12Image*> images() const noexcept override;
+
+        /// <inheritdoc />
+        const IDirectX12Image& image(UInt32 location) const override;
+
+    public:
+        /// <inheritdoc />
+        void resize(const Size2d& renderArea) override;
+    };
+
+    /// <summary>
+    /// Implements a DirectX 12 render pass.
+    /// </summary>
+    /// <seealso cref="DirectX12RenderPassBuilder" />
+    class LITEFX_DIRECTX12_API DirectX12RenderPass final : public RenderPass<DirectX12RenderPipeline, DirectX12FrameBuffer, DirectX12InputAttachmentMapping> {
+        LITEFX_IMPLEMENTATION(DirectX12RenderPassImpl);
+        LITEFX_BUILDER(DirectX12RenderPassBuilder);
+
+    public:
+        using base_type = RenderPass<DirectX12RenderPipeline, DirectX12FrameBuffer, DirectX12InputAttachmentMapping>;
+        using base_type::updateAttachments;
+
+    public:
+        /// <summary>
+        /// Creates and initializes a new DirectX 12 render pass instance.
+        /// </summary>
+        /// <param name="device">The parent device instance.</param>
+        /// <param name="commandBuffers">The number of command buffers in each frame buffer.</param>
+        /// <param name="renderTargets">The render targets that are output by the render pass.</param>
+        /// <param name="samples">The number of samples for the render targets in this render pass.</param>
+        /// <param name="inputAttachments">The input attachments that are read by the render pass.</param>
+        explicit DirectX12RenderPass(const DirectX12Device& device, Span<RenderTarget> renderTargets, UInt32 commandBuffers = 1, MultiSamplingLevel samples = MultiSamplingLevel::x1, Span<DirectX12InputAttachmentMapping> inputAttachments = { });
+
+        /// <summary>
+        /// Creates and initializes a new DirectX 12 render pass instance.
+        /// </summary>
+        /// <param name="device">The parent device instance.</param>
+        /// <param name="name">The name of the render pass state resource.</param>
+        /// <param name="commandBuffers">The number of command buffers in each frame buffer.</param>
+        /// <param name="renderTargets">The render targets that are output by the render pass.</param>
+        /// <param name="samples">The number of samples for the render targets in this render pass.</param>
+        /// <param name="inputAttachments">The input attachments that are read by the render pass.</param>
+        explicit DirectX12RenderPass(const DirectX12Device& device, const String& name, Span<RenderTarget> renderTargets, UInt32 commandBuffers = 1, MultiSamplingLevel samples = MultiSamplingLevel::x1, Span<DirectX12InputAttachmentMapping> inputAttachments = { });
+
+        DirectX12RenderPass(const DirectX12RenderPass&) = delete;
+        DirectX12RenderPass(DirectX12RenderPass&&) = delete;
+        virtual ~DirectX12RenderPass() noexcept;
+
+    private:
+        /// <summary>
+        /// Creates an uninitialized DirectX 12 render pass instance.
+        /// </summary>
+        /// <remarks>
+        /// This constructor is called by the <see cref="DirectX12RenderPassBuilder" /> in order to create a render pass instance without initializing it. The instance 
+        /// is only initialized after calling <see cref="DirectX12RenderPassBuilder::go" />.
+        /// </remarks>
+        /// <param name="device">The parent device of the render pass.</param>
+        /// <param name="name">The name of the render pass state resource.</param>
+        explicit DirectX12RenderPass(const DirectX12Device& device, const String& name = "") noexcept;
+
+        // IInputAttachmentMappingSource interface.
+    public:
+        /// <inheritdoc />
+        const DirectX12FrameBuffer& frameBuffer(UInt32 buffer) const override;
+
+        // RenderPass interface.
+    public:
+        /// <summary>
+        /// Returns a reference to the device that provides this queue.
+        /// </summary>
+        /// <returns>A reference to the queue's parent device.</returns>
+        virtual const DirectX12Device& device() const noexcept;
+
+        /// <inheritdoc />
+        const DirectX12FrameBuffer& activeFrameBuffer() const override;
+
+        /// <inheritdoc />
+        Enumerable<const DirectX12FrameBuffer*> frameBuffers() const noexcept override;
+
+        /// <inheritdoc />
+        Enumerable<const DirectX12RenderPipeline*> pipelines() const noexcept override;
+
+        /// <inheritdoc />
+        const RenderTarget& renderTarget(UInt32 location) const override;
+
+        /// <inheritdoc />
+        Span<const RenderTarget> renderTargets() const noexcept override;
+
+        /// <inheritdoc />
+        bool hasPresentTarget() const noexcept override;
+
+        /// <inheritdoc />
+        Span<const DirectX12InputAttachmentMapping> inputAttachments() const noexcept override;
+
+        /// <inheritdoc />
+        MultiSamplingLevel multiSamplingLevel() const noexcept override;
+
+    public:
+        /// <inheritdoc />
+        void begin(UInt32 buffer) override;
+
+        /// <inheritdoc />
+        void end() const override;
+
+        /// <inheritdoc />
+        void resizeFrameBuffers(const Size2d& renderArea) override;
+
+        /// <inheritdoc />
+        void changeMultiSamplingLevel(MultiSamplingLevel samples) override;
+
+        /// <inheritdoc />
+        void updateAttachments(const DirectX12DescriptorSet& descriptorSet) const override;
+    };
+
+    /// <summary>
+    /// Implements a <see cref="IInputAttachmentMapping" />.
+    /// </summary>
+    /// <seealso cref="DirectX12RenderPass" />
+    /// <seealso cref="DirectX12RenderPassBuilder" />
+    class LITEFX_DIRECTX12_API DirectX12InputAttachmentMapping final : public IInputAttachmentMapping<DirectX12RenderPass> {
+        LITEFX_IMPLEMENTATION(DirectX12InputAttachmentMappingImpl);
+
+    public:
+        /// <summary>
+        /// Creates a new DirectX 12 input attachment mapping.
+        /// </summary>
+        DirectX12InputAttachmentMapping() noexcept;
+
+        /// <summary>
+        /// Creates a new DirectX 12 input attachment mapping.
+        /// </summary>
+        /// <param name="renderPass">The render pass to fetch the input attachment from.</param>
+        /// <param name="renderTarget">The render target of the <paramref name="renderPass"/> that is used for the input attachment.</param>
+        /// <param name="location">The location to bind the input attachment to.</param>
+        DirectX12InputAttachmentMapping(const DirectX12RenderPass& renderPass, const RenderTarget& renderTarget, UInt32 location);
+
+        /// <summary>
+        /// Copies another input attachment mapping.
+        /// </summary>
+        DirectX12InputAttachmentMapping(const DirectX12InputAttachmentMapping&) noexcept;
+
+        /// <summary>
+        /// Takes over another input attachment mapping.
+        /// </summary>
+        DirectX12InputAttachmentMapping(DirectX12InputAttachmentMapping&&) noexcept;
+
+        virtual ~DirectX12InputAttachmentMapping() noexcept;
+
+    public:
+        /// <summary>
+        /// Copies another input attachment mapping.
+        /// </summary>
+        inline DirectX12InputAttachmentMapping& operator=(const DirectX12InputAttachmentMapping&) noexcept;
+
+        /// <summary>
+        /// Takes over another input attachment mapping.
+        /// </summary>
+        inline DirectX12InputAttachmentMapping& operator=(DirectX12InputAttachmentMapping&&) noexcept;
+
+    public:
+        /// <inheritdoc />
+        const DirectX12RenderPass* inputAttachmentSource() const noexcept override;
+
+        /// <inheritdoc />
+        const RenderTarget& renderTarget() const noexcept override;
+
+        /// <inheritdoc />
+        UInt32 location() const noexcept override;
+    };
+
+    /// <summary>
+    /// Implements a DirectX 12 swap chain.
+    /// </summary>
+    class LITEFX_DIRECTX12_API DirectX12SwapChain final : public SwapChain<IDirectX12Image, DirectX12FrameBuffer>, public ComResource<IDXGISwapChain4> {
+        LITEFX_IMPLEMENTATION(DirectX12SwapChainImpl);
+        friend class DirectX12RenderPass;
+
+    public:
+        using base_type = SwapChain<IDirectX12Image, DirectX12FrameBuffer>;
+        using base_type::present;
+
+    public:
+        /// <summary>
+        /// Initializes a DirectX 12 swap chain.
+        /// </summary>
+        /// <param name="device">The device that owns the swap chain.</param>
+        /// <param name="format">The initial surface format.</param>
+        /// <param name="renderArea">The initial size of the render area.</param>
+        /// <param name="buffers">The initial number of buffers.</param>
+        explicit DirectX12SwapChain(const DirectX12Device& device, Format surfaceFormat = Format::B8G8R8A8_SRGB, const Size2d& renderArea = { 800, 600 }, UInt32 buffers = 3);
+        DirectX12SwapChain(const DirectX12SwapChain&) = delete;
+        DirectX12SwapChain(DirectX12SwapChain&&) = delete;
+        virtual ~DirectX12SwapChain() noexcept;
+
+        // DirectX 12 swap chain.
+    public:
+        /// <summary>
+        /// Returns <c>true</c>, if the adapter supports variable refresh rates (i.e. tearing is allowed).
+        /// </summary>
+        /// <returns><c>true</c>, if the adapter supports variable refresh rates (i.e. tearing is allowed).</returns>
+        virtual bool supportsVariableRefreshRate() const noexcept;
+
+        /// <summary>
+        /// Returns the query heap for the current frame.
+        /// </summary>
+        /// <returns>A pointer to the query heap for the current frame.</returns>
+        virtual ID3D12QueryHeap* timestampQueryHeap() const noexcept;
+
+        // SwapChain interface.
+    public:
+        /// <inheritdoc />
+        Enumerable<SharedPtr<TimingEvent>> timingEvents() const noexcept override;
+
+        /// <inheritdoc />
+        SharedPtr<TimingEvent> timingEvent(UInt32 queryId) const override;
+
+        /// <inheritdoc />
+        UInt64 readTimingEvent(SharedPtr<const TimingEvent> timingEvent) const override;
+
+        /// <inheritdoc />
+        UInt32 resolveQueryId(SharedPtr<const TimingEvent> timingEvent) const override;
+
+        /// <inheritdoc />
+        Format surfaceFormat() const noexcept override;
+
+        /// <inheritdoc />
+        UInt32 buffers() const noexcept override;
+
+        /// <inheritdoc />
+        const Size2d& renderArea() const noexcept override;
+
+        /// <inheritdoc />
+        const IDirectX12Image* image(UInt32 backBuffer) const override;
+
+        /// <inheritdoc />
+        Enumerable<const IDirectX12Image*> images() const noexcept override;
+
+        /// <inheritdoc />
+        void present(const DirectX12FrameBuffer& frameBuffer) const override;
+
+    public:
+        /// <inheritdoc />
+        Enumerable<Format> getSurfaceFormats() const noexcept override;
+
+        /// <inheritdoc />
+        void addTimingEvent(SharedPtr<TimingEvent> timingEvent) override;
+
+        /// <inheritdoc />
+        void reset(Format surfaceFormat, const Size2d& renderArea, UInt32 buffers) override;
+
+        /// <inheritdoc />
+        [[nodiscard]] UInt32 swapBackBuffer() const override;
+
+    private:
+        void resolveQueryHeaps(const DirectX12CommandBuffer& commandBuffer) const noexcept;
+    };
+
+    /// <summary>
+    /// Implements a DirectX 12 command queue.
+    /// </summary>
+    /// <seealso cref="DirectX12CommandBuffer" />
+    class LITEFX_DIRECTX12_API DirectX12Queue final : public CommandQueue<DirectX12CommandBuffer>, public ComResource<ID3D12CommandQueue> {
+        LITEFX_IMPLEMENTATION(DirectX12QueueImpl);
+
+    public:
+        using base_type = CommandQueue<DirectX12CommandBuffer>;
+        using base_type::submit;
+
+    public:
+        /// <summary>
+        /// Initializes the DirectX 12 command queue.
+        /// </summary>
+        /// <param name="device">The device, commands get send to.</param>
+        /// <param name="type">The type of the command queue.</param>
+        /// <param name="priority">The priority, of which commands are issued on the device.</param>
+        explicit DirectX12Queue(const DirectX12Device& device, QueueType type, QueuePriority priority);
+        DirectX12Queue(const DirectX12Queue&) = delete;
+        DirectX12Queue(DirectX12Queue&&) = delete;
+        virtual ~DirectX12Queue() noexcept;
+
+        // DirectX12CommandQueue interface.
+    public:
+        /// <summary>
+        /// Returns a reference to the device that provides this queue.
+        /// </summary>
+        /// <returns>A reference to the queue's parent device.</returns>
+        virtual const DirectX12Device& device() const noexcept;
+
+        // CommandQueue interface.
+    public:
+        /// <inheritdoc />
+        bool isBound() const noexcept override;
+
+        /// <inheritdoc />
+        QueuePriority priority() const noexcept override;
+
+        /// <inheritdoc />
+        QueueType type() const noexcept override;
 
 #if !defined(NDEBUG) && defined(_WIN64)
-	public:
-		/// <inheritdoc />
-		void BeginDebugRegion(const String& label, const Vectors::ByteVector3& color = { 128_b, 128_b, 128_b }) const noexcept override;
+    public:
+        /// <inheritdoc />
+        void BeginDebugRegion(const String& label, const Vectors::ByteVector3& color = { 128_b, 128_b, 128_b }) const noexcept override;
 
-		/// <inheritdoc />
-		void EndDebugRegion() const noexcept override;
+        /// <inheritdoc />
+        void EndDebugRegion() const noexcept override;
 
-		/// <inheritdoc />
-		void SetDebugMarker(const String& label, const Vectors::ByteVector3& color = { 128_b, 128_b, 128_b }) const noexcept override;
+        /// <inheritdoc />
+        void SetDebugMarker(const String& label, const Vectors::ByteVector3& color = { 128_b, 128_b, 128_b }) const noexcept override;
 #endif // !defined(NDEBUG) && defined(_WIN64)
 
-	public:
-		/// <inheritdoc />
-		void bind() override;
+    public:
+        /// <inheritdoc />
+        void bind() override;
 
-		/// <inheritdoc />
-		void release() override;
+        /// <inheritdoc />
+        void release() override;
 
-		/// <inheritdoc />
-		SharedPtr<DirectX12CommandBuffer> createCommandBuffer(bool beginRecording = false, bool secondary = false) const override;
+        /// <inheritdoc />
+        SharedPtr<DirectX12CommandBuffer> createCommandBuffer(bool beginRecording = false, bool secondary = false) const override;
 
-		/// <inheritdoc />
-		UInt64 submit(SharedPtr<const DirectX12CommandBuffer> commandBuffer) const override;
+        /// <inheritdoc />
+        UInt64 submit(SharedPtr<const DirectX12CommandBuffer> commandBuffer) const override;
 
-		/// <inheritdoc />
-		UInt64 submit(const Enumerable<SharedPtr<const DirectX12CommandBuffer>>& commandBuffers) const override;
+        /// <inheritdoc />
+        UInt64 submit(const Enumerable<SharedPtr<const DirectX12CommandBuffer>>& commandBuffers) const override;
 
-		/// <inheritdoc />
-		void waitFor(UInt64 fence) const noexcept override;
+        /// <inheritdoc />
+        void waitFor(UInt64 fence) const noexcept override;
 
-		/// <inheritdoc />
-		UInt64 currentFence() const noexcept override;
-	};
+        /// <inheritdoc />
+        void waitFor(const DirectX12Queue& queue, UInt64 fence) const noexcept;
 
-	/// <summary>
-	/// A graphics factory that produces objects for a <see cref="DirectX12Device" />.
-	/// </summary>
-	/// <remarks>
-	/// The DX12 graphics factory is implemented using <a href="https://gpuopen.com/d3d12-memory-allocator/" target="_blank">D3D12 Memory Allocator</a>.
-	/// </remarks>
-	class LITEFX_DIRECTX12_API DirectX12GraphicsFactory final : public GraphicsFactory<DirectX12DescriptorLayout, IDirectX12Buffer, IDirectX12VertexBuffer, IDirectX12IndexBuffer, IDirectX12Image, IDirectX12Sampler> {
-		LITEFX_IMPLEMENTATION(DirectX12GraphicsFactoryImpl);
+        /// <inheritdoc />
+        UInt64 currentFence() const noexcept override;
 
-	public:
-		using base_type = GraphicsFactory<DirectX12DescriptorLayout, IDirectX12Buffer, IDirectX12VertexBuffer, IDirectX12IndexBuffer, IDirectX12Image, IDirectX12Sampler>;
-		using base_type::createBuffer;
-		using base_type::createVertexBuffer;
-		using base_type::createIndexBuffer;
-		using base_type::createAttachment;
-		using base_type::createTexture;
-		using base_type::createTextures;
-		using base_type::createSampler;
-		using base_type::createSamplers;
+    private:
+        inline void waitForQueue(const ICommandQueue& queue, UInt64 fence) const override {
+            auto d3dQueue = dynamic_cast<const DirectX12Queue*>(&queue);
 
-	public:
-		/// <summary>
-		/// Creates a new graphics factory.
-		/// </summary>
-		/// <param name="device">The device the factory should produce objects for.</param>
-		explicit DirectX12GraphicsFactory(const DirectX12Device& device);
-		DirectX12GraphicsFactory(const DirectX12GraphicsFactory&) = delete;
-		DirectX12GraphicsFactory(DirectX12GraphicsFactory&&) = delete;
-		virtual ~DirectX12GraphicsFactory() noexcept;
+            if (d3dQueue == nullptr) [[unlikely]]
+                throw InvalidArgumentException("Cannot wait for queues from other backends.");
 
-	public:
-		/// <inheritdoc />
-		UniquePtr<IDirectX12Buffer> createBuffer(BufferType type, BufferUsage usage, size_t elementSize, UInt32 elements = 1, bool allowWrite = false) const override;
+            this->waitFor(*d3dQueue, fence);
+        }
+    };
 
-		/// <inheritdoc />
-		UniquePtr<IDirectX12Buffer> createBuffer(const String& name, BufferType type, BufferUsage usage, size_t elementSize, UInt32 elements = 1, bool allowWrite = false) const override;
+    /// <summary>
+    /// A graphics factory that produces objects for a <see cref="DirectX12Device" />.
+    /// </summary>
+    /// <remarks>
+    /// The DX12 graphics factory is implemented using <a href="https://gpuopen.com/d3d12-memory-allocator/" target="_blank">D3D12 Memory Allocator</a>.
+    /// </remarks>
+    class LITEFX_DIRECTX12_API DirectX12GraphicsFactory final : public GraphicsFactory<DirectX12DescriptorLayout, IDirectX12Buffer, IDirectX12VertexBuffer, IDirectX12IndexBuffer, IDirectX12Image, IDirectX12Sampler> {
+        LITEFX_IMPLEMENTATION(DirectX12GraphicsFactoryImpl);
 
-		/// <inheritdoc />
-		UniquePtr<IDirectX12VertexBuffer> createVertexBuffer(const DirectX12VertexBufferLayout& layout, BufferUsage usage, UInt32 elements = 1) const override;
+    public:
+        using base_type = GraphicsFactory<DirectX12DescriptorLayout, IDirectX12Buffer, IDirectX12VertexBuffer, IDirectX12IndexBuffer, IDirectX12Image, IDirectX12Sampler>;
+        using base_type::createBuffer;
+        using base_type::createVertexBuffer;
+        using base_type::createIndexBuffer;
+        using base_type::createAttachment;
+        using base_type::createTexture;
+        using base_type::createTextures;
+        using base_type::createSampler;
+        using base_type::createSamplers;
 
-		/// <inheritdoc />
-		UniquePtr<IDirectX12VertexBuffer> createVertexBuffer(const String& name, const DirectX12VertexBufferLayout& layout, BufferUsage usage, UInt32 elements = 1) const override;
+    public:
+        /// <summary>
+        /// Creates a new graphics factory.
+        /// </summary>
+        /// <param name="device">The device the factory should produce objects for.</param>
+        explicit DirectX12GraphicsFactory(const DirectX12Device& device);
+        DirectX12GraphicsFactory(const DirectX12GraphicsFactory&) = delete;
+        DirectX12GraphicsFactory(DirectX12GraphicsFactory&&) = delete;
+        virtual ~DirectX12GraphicsFactory() noexcept;
 
-		/// <inheritdoc />
-		UniquePtr<IDirectX12IndexBuffer> createIndexBuffer(const DirectX12IndexBufferLayout& layout, BufferUsage usage, UInt32 elements) const override;
+    public:
+        /// <inheritdoc />
+        UniquePtr<IDirectX12Buffer> createBuffer(BufferType type, BufferUsage usage, size_t elementSize, UInt32 elements = 1, bool allowWrite = false) const override;
 
-		/// <inheritdoc />
-		UniquePtr<IDirectX12IndexBuffer> createIndexBuffer(const String& name, const DirectX12IndexBufferLayout& layout, BufferUsage usage, UInt32 elements) const override;
+        /// <inheritdoc />
+        UniquePtr<IDirectX12Buffer> createBuffer(const String& name, BufferType type, BufferUsage usage, size_t elementSize, UInt32 elements = 1, bool allowWrite = false) const override;
 
-		/// <inheritdoc />
-		UniquePtr<IDirectX12Image> createAttachment(Format format, const Size2d& size, MultiSamplingLevel samples = MultiSamplingLevel::x1) const override;
+        /// <inheritdoc />
+        UniquePtr<IDirectX12VertexBuffer> createVertexBuffer(const DirectX12VertexBufferLayout& layout, BufferUsage usage, UInt32 elements = 1) const override;
 
-		/// <inheritdoc />
-		UniquePtr<IDirectX12Image> createAttachment(const String& name, Format format, const Size2d& size, MultiSamplingLevel samples = MultiSamplingLevel::x1) const override;
+        /// <inheritdoc />
+        UniquePtr<IDirectX12VertexBuffer> createVertexBuffer(const String& name, const DirectX12VertexBufferLayout& layout, BufferUsage usage, UInt32 elements = 1) const override;
 
-		/// <inheritdoc />
-		UniquePtr<IDirectX12Image> createTexture(Format format, const Size3d& size, ImageDimensions dimension = ImageDimensions::DIM_2, UInt32 levels = 1, UInt32 layers = 1, MultiSamplingLevel samples = MultiSamplingLevel::x1, bool allowWrite = false) const override;
+        /// <inheritdoc />
+        UniquePtr<IDirectX12IndexBuffer> createIndexBuffer(const DirectX12IndexBufferLayout& layout, BufferUsage usage, UInt32 elements) const override;
 
-		/// <inheritdoc />
-		UniquePtr<IDirectX12Image> createTexture(const String& name, Format format, const Size3d& size, ImageDimensions dimension = ImageDimensions::DIM_2, UInt32 levels = 1, UInt32 layers = 1, MultiSamplingLevel samples = MultiSamplingLevel::x1, bool allowWrite = false) const override;
+        /// <inheritdoc />
+        UniquePtr<IDirectX12IndexBuffer> createIndexBuffer(const String& name, const DirectX12IndexBufferLayout& layout, BufferUsage usage, UInt32 elements) const override;
 
-		/// <inheritdoc />
-		Enumerable<UniquePtr<IDirectX12Image>> createTextures(UInt32 elements, Format format, const Size3d& size, ImageDimensions dimension = ImageDimensions::DIM_2, UInt32 levels = 1, UInt32 layers = 1, MultiSamplingLevel samples = MultiSamplingLevel::x1, bool allowWrite = false) const override;
+        /// <inheritdoc />
+        UniquePtr<IDirectX12Image> createAttachment(Format format, const Size2d& size, MultiSamplingLevel samples = MultiSamplingLevel::x1) const override;
 
-		/// <inheritdoc />
-		UniquePtr<IDirectX12Sampler> createSampler(FilterMode magFilter = FilterMode::Nearest, FilterMode minFilter = FilterMode::Nearest, BorderMode borderU = BorderMode::Repeat, BorderMode borderV = BorderMode::Repeat, BorderMode borderW = BorderMode::Repeat, MipMapMode mipMapMode = MipMapMode::Nearest, Float mipMapBias = 0.f, Float maxLod = std::numeric_limits<Float>::max(), Float minLod = 0.f, Float anisotropy = 0.f) const override;
+        /// <inheritdoc />
+        UniquePtr<IDirectX12Image> createAttachment(const String& name, Format format, const Size2d& size, MultiSamplingLevel samples = MultiSamplingLevel::x1) const override;
 
-		/// <inheritdoc />
-		UniquePtr<IDirectX12Sampler> createSampler(const String& name, FilterMode magFilter = FilterMode::Nearest, FilterMode minFilter = FilterMode::Nearest, BorderMode borderU = BorderMode::Repeat, BorderMode borderV = BorderMode::Repeat, BorderMode borderW = BorderMode::Repeat, MipMapMode mipMapMode = MipMapMode::Nearest, Float mipMapBias = 0.f, Float maxLod = std::numeric_limits<Float>::max(), Float minLod = 0.f, Float anisotropy = 0.f) const override;
+        /// <inheritdoc />
+        UniquePtr<IDirectX12Image> createTexture(Format format, const Size3d& size, ImageDimensions dimension = ImageDimensions::DIM_2, UInt32 levels = 1, UInt32 layers = 1, MultiSamplingLevel samples = MultiSamplingLevel::x1, bool allowWrite = false) const override;
 
-		/// <inheritdoc />
-		Enumerable<UniquePtr<IDirectX12Sampler>> createSamplers(UInt32 elements, FilterMode magFilter = FilterMode::Nearest, FilterMode minFilter = FilterMode::Nearest, BorderMode borderU = BorderMode::Repeat, BorderMode borderV = BorderMode::Repeat, BorderMode borderW = BorderMode::Repeat, MipMapMode mipMapMode = MipMapMode::Nearest, Float mipMapBias = 0.f, Float maxLod = std::numeric_limits<Float>::max(), Float minLod = 0.f, Float anisotropy = 0.f) const override;
-	};
+        /// <inheritdoc />
+        UniquePtr<IDirectX12Image> createTexture(const String& name, Format format, const Size3d& size, ImageDimensions dimension = ImageDimensions::DIM_2, UInt32 levels = 1, UInt32 layers = 1, MultiSamplingLevel samples = MultiSamplingLevel::x1, bool allowWrite = false) const override;
 
-	/// <summary>
-	/// Implements a DirectX 12 graphics device.
-	/// </summary>
-	class LITEFX_DIRECTX12_API DirectX12Device final : public GraphicsDevice<DirectX12GraphicsFactory, DirectX12Surface, DirectX12GraphicsAdapter, DirectX12SwapChain, DirectX12Queue, DirectX12RenderPass, DirectX12ComputePipeline, DirectX12Barrier>, public ComResource<ID3D12Device10> {
-		LITEFX_IMPLEMENTATION(DirectX12DeviceImpl);
+        /// <inheritdoc />
+        Enumerable<UniquePtr<IDirectX12Image>> createTextures(UInt32 elements, Format format, const Size3d& size, ImageDimensions dimension = ImageDimensions::DIM_2, UInt32 levels = 1, UInt32 layers = 1, MultiSamplingLevel samples = MultiSamplingLevel::x1, bool allowWrite = false) const override;
 
-	public:
-		/// <summary>
-		/// Creates a new device instance.
-		/// </summary>
-		/// <param name="backend">The backend from which the device got created.</param>
-		/// <param name="adapter">The adapter the device uses for drawing.</param>
-		/// <param name="surface">The surface, the device should draw to.</param>
-		explicit DirectX12Device(const DirectX12Backend& backend, const DirectX12GraphicsAdapter& adapter, UniquePtr<DirectX12Surface>&& surface);
+        /// <inheritdoc />
+        UniquePtr<IDirectX12Sampler> createSampler(FilterMode magFilter = FilterMode::Nearest, FilterMode minFilter = FilterMode::Nearest, BorderMode borderU = BorderMode::Repeat, BorderMode borderV = BorderMode::Repeat, BorderMode borderW = BorderMode::Repeat, MipMapMode mipMapMode = MipMapMode::Nearest, Float mipMapBias = 0.f, Float maxLod = std::numeric_limits<Float>::max(), Float minLod = 0.f, Float anisotropy = 0.f) const override;
 
-		/// <summary>
-		/// Creates a new device instance.
-		/// </summary>
-		/// <param name="backend">The backend from which the device got created.</param>
-		/// <param name="adapter">The adapter the device uses for drawing.</param>
-		/// <param name="surface">The surface, the device should draw to.</param>
-		/// <param name="format">The initial surface format, device uses for drawing.</param>
-		/// <param name="frameBufferSize">The initial size of the frame buffers.</param>
-		/// <param name="frameBuffers">The initial number of frame buffers.</param>
-		/// <param name="globalBufferHeapSize">The size of the global heap for constant buffers, shader resources and images.</param>
-		/// <param name="globalSamplerHeapSize">The size of the global heap for samplers.</param>
-		explicit DirectX12Device(const DirectX12Backend& backend, const DirectX12GraphicsAdapter& adapter, UniquePtr<DirectX12Surface>&& surface, Format format, const Size2d& frameBufferSize, UInt32 frameBuffers, UInt32 globalBufferHeapSize = 524287, UInt32 globalSamplerHeapSize = 2048);
+        /// <inheritdoc />
+        UniquePtr<IDirectX12Sampler> createSampler(const String& name, FilterMode magFilter = FilterMode::Nearest, FilterMode minFilter = FilterMode::Nearest, BorderMode borderU = BorderMode::Repeat, BorderMode borderV = BorderMode::Repeat, BorderMode borderW = BorderMode::Repeat, MipMapMode mipMapMode = MipMapMode::Nearest, Float mipMapBias = 0.f, Float maxLod = std::numeric_limits<Float>::max(), Float minLod = 0.f, Float anisotropy = 0.f) const override;
 
-		DirectX12Device(const DirectX12Device&) = delete;
-		DirectX12Device(DirectX12Device&&) = delete;
-		virtual ~DirectX12Device() noexcept;
+        /// <inheritdoc />
+        Enumerable<UniquePtr<IDirectX12Sampler>> createSamplers(UInt32 elements, FilterMode magFilter = FilterMode::Nearest, FilterMode minFilter = FilterMode::Nearest, BorderMode borderU = BorderMode::Repeat, BorderMode borderV = BorderMode::Repeat, BorderMode borderW = BorderMode::Repeat, MipMapMode mipMapMode = MipMapMode::Nearest, Float mipMapBias = 0.f, Float maxLod = std::numeric_limits<Float>::max(), Float minLod = 0.f, Float anisotropy = 0.f) const override;
+    };
 
-		// DirectX 12 Device interface.
-	public:
-		/// <summary>
-		/// Returns the backend from which the device got created.
-		/// </summary>
-		/// <returns>The backend from which the device got created.</returns>
-		virtual const DirectX12Backend& backend() const noexcept;
+    /// <summary>
+    /// Implements a DirectX 12 graphics device.
+    /// </summary>
+    class LITEFX_DIRECTX12_API DirectX12Device final : public GraphicsDevice<DirectX12GraphicsFactory, DirectX12Surface, DirectX12GraphicsAdapter, DirectX12SwapChain, DirectX12Queue, DirectX12RenderPass, DirectX12ComputePipeline, DirectX12Barrier>, public ComResource<ID3D12Device10> {
+        LITEFX_IMPLEMENTATION(DirectX12DeviceImpl);
 
-		/// <summary>
-		/// Returns the global descriptor heap.
-		/// </summary>
-		/// <remarks>
-		/// The DirectX 12 device uses a global heap of descriptors and samplers in a ring-buffer fashion. The heap itself is managed by the device.
-		/// </remarks>
-		/// <returns>A pointer to the global descriptor heap.</returns>
-		virtual const ID3D12DescriptorHeap* globalBufferHeap() const noexcept;
+    public:
+        /// <summary>
+        /// Creates a new device instance.
+        /// </summary>
+        /// <param name="backend">The backend from which the device got created.</param>
+        /// <param name="adapter">The adapter the device uses for drawing.</param>
+        /// <param name="surface">The surface, the device should draw to.</param>
+        explicit DirectX12Device(const DirectX12Backend& backend, const DirectX12GraphicsAdapter& adapter, UniquePtr<DirectX12Surface>&& surface);
 
-		/// <summary>
-		/// Returns the global sampler heap.
-		/// </summary>
-		/// <returns>A pointer to the global sampler heap.</returns>
-		/// <seealso cref="globalBufferHeap" />
-		virtual const ID3D12DescriptorHeap* globalSamplerHeap() const noexcept;
+        /// <summary>
+        /// Creates a new device instance.
+        /// </summary>
+        /// <param name="backend">The backend from which the device got created.</param>
+        /// <param name="adapter">The adapter the device uses for drawing.</param>
+        /// <param name="surface">The surface, the device should draw to.</param>
+        /// <param name="format">The initial surface format, device uses for drawing.</param>
+        /// <param name="frameBufferSize">The initial size of the frame buffers.</param>
+        /// <param name="frameBuffers">The initial number of frame buffers.</param>
+        /// <param name="globalBufferHeapSize">The size of the global heap for constant buffers, shader resources and images.</param>
+        /// <param name="globalSamplerHeapSize">The size of the global heap for samplers.</param>
+        explicit DirectX12Device(const DirectX12Backend& backend, const DirectX12GraphicsAdapter& adapter, UniquePtr<DirectX12Surface>&& surface, Format format, const Size2d& frameBufferSize, UInt32 frameBuffers, UInt32 globalBufferHeapSize = 524287, UInt32 globalSamplerHeapSize = 2048);
 
-		/// <summary>
-		/// Allocates a range of descriptors in the global descriptor heaps for the provided <paramref name="descriptorSet" />.
-		/// </summary>
-		/// <param name="descriptorSet">The descriptor set containing the descriptors to update.</param>
-		/// <param name="bufferOffset">The offset of the descriptor range in the buffer heap.</param>
-		/// <param name="samplerOffset">The offset of the descriptor range in the sampler heap.</param>
-		virtual void allocateGlobalDescriptors(const DirectX12DescriptorSet& descriptorSet, UInt32& bufferOffset, UInt32& samplerOffset) const;
+        DirectX12Device(const DirectX12Device&) = delete;
+        DirectX12Device(DirectX12Device&&) = delete;
+        virtual ~DirectX12Device() noexcept;
 
-		/// <summary>
-		/// Releases a range of descriptors from the global descriptor heaps.
-		/// </summary>
-		/// <remarks>
-		/// This is done, if a descriptor set layout is destroyed, of a descriptor set, which contains an unbounded array is freed. It will cause the global 
-		/// descriptor heaps to fragment, which may result in inefficient future descriptor allocations and should be avoided. Consider caching descriptor
-		/// sets with unbounded arrays instead. Also avoid relying on creating and releasing pipeline layouts during runtime. Instead, it may be more efficient
-		/// to write shaders that support multiple pipeline variations, that can be kept alive for the lifetime of the whole application.
-		/// </remarks>
-		virtual void releaseGlobalDescriptors(const DirectX12DescriptorSet& descriptorSet) const noexcept;
+        // DirectX 12 Device interface.
+    public:
+        /// <summary>
+        /// Returns the backend from which the device got created.
+        /// </summary>
+        /// <returns>The backend from which the device got created.</returns>
+        virtual const DirectX12Backend& backend() const noexcept;
 
-		/// <summary>
-		/// Updates a range of descriptors in the global buffer descriptor heap with the descriptors from <paramref name="descriptorSet" />.
-		/// </summary>
-		/// <param name="descriptorSet">The descriptor set to copy the descriptors from.</param>
-		/// <param name="firstDescriptor">The index of the first descriptor to copy.</param>
-		/// <param name="descriptors">The number of descriptors to copy.</param>
-		virtual void updateBufferDescriptors(const DirectX12DescriptorSet& descriptorSet, UInt32 firstDescriptor, UInt32 descriptors) const noexcept;
+        /// <summary>
+        /// Returns the global descriptor heap.
+        /// </summary>
+        /// <remarks>
+        /// The DirectX 12 device uses a global heap of descriptors and samplers in a ring-buffer fashion. The heap itself is managed by the device.
+        /// </remarks>
+        /// <returns>A pointer to the global descriptor heap.</returns>
+        virtual const ID3D12DescriptorHeap* globalBufferHeap() const noexcept;
 
-		/// <summary>
-		/// Updates a sampler descriptors in the global buffer descriptor heap with a descriptor from <paramref name="descriptorSet" />.
-		/// </summary>
-		/// <param name="descriptorSet">The descriptor set to copy the descriptors from.</param>
-		/// <param name="firstDescriptor">The index of the first descriptor to copy.</param>
-		/// <param name="descriptors">The number of descriptors to copy.</param>
-		virtual void updateSamplerDescriptors(const DirectX12DescriptorSet& descriptorSet, UInt32 firstDescriptor, UInt32 descriptors) const noexcept;
+        /// <summary>
+        /// Returns the global sampler heap.
+        /// </summary>
+        /// <returns>A pointer to the global sampler heap.</returns>
+        /// <seealso cref="globalBufferHeap" />
+        virtual const ID3D12DescriptorHeap* globalSamplerHeap() const noexcept;
 
-		/// <summary>
-		/// Binds the descriptors of the descriptor set to the global descriptor heaps.
-		/// </summary>
-		/// <remarks>
-		/// Note that after binding the descriptor set, the descriptors must not be updated anymore, unless they are elements on unbounded descriptor arrays, 
-		/// in which case you have to ensure manually to not update them, as long as they may still be in use!
-		/// </remarks>
-		/// <param name="commandBuffer">The command buffer to bind the descriptor set on.</param>
-		/// <param name="descriptorSet">The descriptor set to bind.</param>
-		/// <param name="pipeline">The pipeline to bind the descriptor set to.</param>
-		virtual void bindDescriptorSet(const DirectX12CommandBuffer& commandBuffer, const DirectX12DescriptorSet& descriptorSet, const DirectX12PipelineState& pipeline) const noexcept;
+        /// <summary>
+        /// Allocates a range of descriptors in the global descriptor heaps for the provided <paramref name="descriptorSet" />.
+        /// </summary>
+        /// <param name="descriptorSet">The descriptor set containing the descriptors to update.</param>
+        /// <param name="bufferOffset">The offset of the descriptor range in the buffer heap.</param>
+        /// <param name="samplerOffset">The offset of the descriptor range in the sampler heap.</param>
+        virtual void allocateGlobalDescriptors(const DirectX12DescriptorSet& descriptorSet, UInt32& bufferOffset, UInt32& samplerOffset) const;
 
-		/// <summary>
-		/// Binds the global descriptor heap.
-		/// </summary>
-		/// <param name="commandBuffer">The command buffer to issue the bind command on.</param>
-		virtual void bindGlobalDescriptorHeaps(const DirectX12CommandBuffer& commandBuffer) const noexcept;
+        /// <summary>
+        /// Releases a range of descriptors from the global descriptor heaps.
+        /// </summary>
+        /// <remarks>
+        /// This is done, if a descriptor set layout is destroyed, of a descriptor set, which contains an unbounded array is freed. It will cause the global 
+        /// descriptor heaps to fragment, which may result in inefficient future descriptor allocations and should be avoided. Consider caching descriptor
+        /// sets with unbounded arrays instead. Also avoid relying on creating and releasing pipeline layouts during runtime. Instead, it may be more efficient
+        /// to write shaders that support multiple pipeline variations, that can be kept alive for the lifetime of the whole application.
+        /// </remarks>
+        virtual void releaseGlobalDescriptors(const DirectX12DescriptorSet& descriptorSet) const noexcept;
 
-		/// <summary>
-		/// Returns the compute pipeline that can be invoked to blit an image resource.
-		/// </summary>
-		/// <remarks>
-		/// Blitting is used by <see cref="DirectX12Texture" /> to generate mip maps.
-		/// </remarks>
-		/// <returns>The compute pipeline that can be invoked to blit an image resource.</returns>
-		/// <seealso cref="DirectX12Texture::generateMipMaps" />
-		virtual DirectX12ComputePipeline& blitPipeline() const noexcept;
+        /// <summary>
+        /// Updates a range of descriptors in the global buffer descriptor heap with the descriptors from <paramref name="descriptorSet" />.
+        /// </summary>
+        /// <param name="descriptorSet">The descriptor set to copy the descriptors from.</param>
+        /// <param name="firstDescriptor">The index of the first descriptor to copy.</param>
+        /// <param name="descriptors">The number of descriptors to copy.</param>
+        virtual void updateBufferDescriptors(const DirectX12DescriptorSet& descriptorSet, UInt32 firstDescriptor, UInt32 descriptors) const noexcept;
 
-		// GraphicsDevice interface.
-	public:
-		/// <inheritdoc />
-		DeviceState& state() const noexcept override;
+        /// <summary>
+        /// Updates a sampler descriptors in the global buffer descriptor heap with a descriptor from <paramref name="descriptorSet" />.
+        /// </summary>
+        /// <param name="descriptorSet">The descriptor set to copy the descriptors from.</param>
+        /// <param name="firstDescriptor">The index of the first descriptor to copy.</param>
+        /// <param name="descriptors">The number of descriptors to copy.</param>
+        virtual void updateSamplerDescriptors(const DirectX12DescriptorSet& descriptorSet, UInt32 firstDescriptor, UInt32 descriptors) const noexcept;
 
-		/// <inheritdoc />
-		const DirectX12SwapChain& swapChain() const noexcept override;
+        /// <summary>
+        /// Binds the descriptors of the descriptor set to the global descriptor heaps.
+        /// </summary>
+        /// <remarks>
+        /// Note that after binding the descriptor set, the descriptors must not be updated anymore, unless they are elements on unbounded descriptor arrays, 
+        /// in which case you have to ensure manually to not update them, as long as they may still be in use!
+        /// </remarks>
+        /// <param name="commandBuffer">The command buffer to bind the descriptor set on.</param>
+        /// <param name="descriptorSet">The descriptor set to bind.</param>
+        /// <param name="pipeline">The pipeline to bind the descriptor set to.</param>
+        virtual void bindDescriptorSet(const DirectX12CommandBuffer& commandBuffer, const DirectX12DescriptorSet& descriptorSet, const DirectX12PipelineState& pipeline) const noexcept;
 
-		/// <inheritdoc />
-		DirectX12SwapChain& swapChain() noexcept override;
+        /// <summary>
+        /// Binds the global descriptor heap.
+        /// </summary>
+        /// <param name="commandBuffer">The command buffer to issue the bind command on.</param>
+        virtual void bindGlobalDescriptorHeaps(const DirectX12CommandBuffer& commandBuffer) const noexcept;
 
-		/// <inheritdoc />
-		const DirectX12Surface& surface() const noexcept override;
+        /// <summary>
+        /// Returns the compute pipeline that can be invoked to blit an image resource.
+        /// </summary>
+        /// <remarks>
+        /// Blitting is used by <see cref="DirectX12Texture" /> to generate mip maps.
+        /// </remarks>
+        /// <returns>The compute pipeline that can be invoked to blit an image resource.</returns>
+        /// <seealso cref="DirectX12Texture::generateMipMaps" />
+        virtual DirectX12ComputePipeline& blitPipeline() const noexcept;
 
-		/// <inheritdoc />
-		const DirectX12GraphicsAdapter& adapter() const noexcept override;
+        // GraphicsDevice interface.
+    public:
+        /// <inheritdoc />
+        DeviceState& state() const noexcept override;
 
-		/// <inheritdoc />
-		const DirectX12GraphicsFactory& factory() const noexcept override;
+        /// <inheritdoc />
+        const DirectX12SwapChain& swapChain() const noexcept override;
 
-		/// <inheritdoc />
-		const DirectX12Queue& graphicsQueue() const noexcept override;
+        /// <inheritdoc />
+        DirectX12SwapChain& swapChain() noexcept override;
 
-		/// <inheritdoc />
-		const DirectX12Queue& transferQueue() const noexcept override;
+        /// <inheritdoc />
+        const DirectX12Surface& surface() const noexcept override;
 
-		/// <inheritdoc />
-		const DirectX12Queue& bufferQueue() const noexcept override;
+        /// <inheritdoc />
+        const DirectX12GraphicsAdapter& adapter() const noexcept override;
 
-		/// <inheritdoc />
-		const DirectX12Queue& computeQueue() const noexcept override;
+        /// <inheritdoc />
+        const DirectX12GraphicsFactory& factory() const noexcept override;
 
-		/// <inheritdoc />
-		[[nodiscard]] UniquePtr<DirectX12Barrier> makeBarrier(PipelineStage syncBefore, PipelineStage syncAfter) const noexcept override;
+        /// <inheritdoc />
+        const DirectX12Queue& graphicsQueue() const noexcept override;
 
-		/// <inheritdoc />
-		/// <seealso href="https://docs.microsoft.com/en-us/windows/win32/api/d3d11/ne-d3d11-d3d11_standard_multisample_quality_levels" />
-		MultiSamplingLevel maximumMultiSamplingLevel(Format format) const noexcept override;
+        /// <inheritdoc />
+        const DirectX12Queue& transferQueue() const noexcept override;
 
-		/// <inheritdoc />
-		double ticksPerMillisecond() const noexcept override;
+        /// <inheritdoc />
+        const DirectX12Queue& bufferQueue() const noexcept override;
 
-	public:
-		/// <inheritdoc />
-		void wait() const override;
+        /// <inheritdoc />
+        const DirectX12Queue& computeQueue() const noexcept override;
+
+        /// <inheritdoc />
+        [[nodiscard]] UniquePtr<DirectX12Barrier> makeBarrier(PipelineStage syncBefore, PipelineStage syncAfter) const noexcept override;
+
+        /// <inheritdoc />
+        /// <seealso href="https://docs.microsoft.com/en-us/windows/win32/api/d3d11/ne-d3d11-d3d11_standard_multisample_quality_levels" />
+        MultiSamplingLevel maximumMultiSamplingLevel(Format format) const noexcept override;
+
+        /// <inheritdoc />
+        double ticksPerMillisecond() const noexcept override;
+
+    public:
+        /// <inheritdoc />
+        void wait() const override;
 
 #if defined(BUILD_DEFINE_BUILDERS)
-	public:
-		/// <inheritdoc />
-		[[nodiscard]] DirectX12RenderPassBuilder buildRenderPass(MultiSamplingLevel samples = MultiSamplingLevel::x1, UInt32 commandBuffers = 1) const override;
+    public:
+        /// <inheritdoc />
+        [[nodiscard]] DirectX12RenderPassBuilder buildRenderPass(MultiSamplingLevel samples = MultiSamplingLevel::x1, UInt32 commandBuffers = 1) const override;
 
-		/// <inheritdoc />
-		[[nodiscard]] DirectX12RenderPassBuilder buildRenderPass(const String& name, MultiSamplingLevel samples = MultiSamplingLevel::x1, UInt32 commandBuffers = 1) const override;
+        /// <inheritdoc />
+        [[nodiscard]] DirectX12RenderPassBuilder buildRenderPass(const String& name, MultiSamplingLevel samples = MultiSamplingLevel::x1, UInt32 commandBuffers = 1) const override;
 
-		/// <inheritdoc />
-		//[[nodiscard]] DirectX12RenderPipelineBuilder buildRenderPipeline(const String& name) const override;
+        /// <inheritdoc />
+        //[[nodiscard]] DirectX12RenderPipelineBuilder buildRenderPipeline(const String& name) const override;
 
-		/// <inheritdoc />
-		[[nodiscard]] DirectX12RenderPipelineBuilder buildRenderPipeline(const DirectX12RenderPass& renderPass, const String& name) const override;
+        /// <inheritdoc />
+        [[nodiscard]] DirectX12RenderPipelineBuilder buildRenderPipeline(const DirectX12RenderPass& renderPass, const String& name) const override;
 
-		/// <inheritdoc />
-		[[nodiscard]] DirectX12ComputePipelineBuilder buildComputePipeline(const String& name) const override;
-		
-		/// <inheritdoc />
-		[[nodiscard]] DirectX12PipelineLayoutBuilder buildPipelineLayout() const override;
+        /// <inheritdoc />
+        [[nodiscard]] DirectX12ComputePipelineBuilder buildComputePipeline(const String& name) const override;
+        
+        /// <inheritdoc />
+        [[nodiscard]] DirectX12PipelineLayoutBuilder buildPipelineLayout() const override;
 
-		/// <inheritdoc />
-		[[nodiscard]] DirectX12InputAssemblerBuilder buildInputAssembler() const override;
+        /// <inheritdoc />
+        [[nodiscard]] DirectX12InputAssemblerBuilder buildInputAssembler() const override;
 
-		/// <inheritdoc />
-		[[nodiscard]] DirectX12RasterizerBuilder buildRasterizer() const override;
+        /// <inheritdoc />
+        [[nodiscard]] DirectX12RasterizerBuilder buildRasterizer() const override;
 
-		/// <inheritdoc />
-		[[nodiscard]] DirectX12ShaderProgramBuilder buildShaderProgram() const override;
+        /// <inheritdoc />
+        [[nodiscard]] DirectX12ShaderProgramBuilder buildShaderProgram() const override;
 
-		/// <inheritdoc />
-		[[nodiscard]] DirectX12BarrierBuilder buildBarrier() const override;
+        /// <inheritdoc />
+        [[nodiscard]] DirectX12BarrierBuilder buildBarrier() const override;
 #endif // defined(BUILD_DEFINE_BUILDERS)
-	};
-	
-	/// <summary>
-	/// Implements the DirectX 12 <see cref="RenderBackend" />.
-	/// </summary>
-	class LITEFX_DIRECTX12_API DirectX12Backend final : public RenderBackend<DirectX12Device>, public ComResource<IDXGIFactory7> {
-		LITEFX_IMPLEMENTATION(DirectX12BackendImpl);
+    };
+    
+    /// <summary>
+    /// Implements the DirectX 12 <see cref="RenderBackend" />.
+    /// </summary>
+    class LITEFX_DIRECTX12_API DirectX12Backend final : public RenderBackend<DirectX12Device>, public ComResource<IDXGIFactory7> {
+        LITEFX_IMPLEMENTATION(DirectX12BackendImpl);
 
-	public:
-		explicit DirectX12Backend(const App& app, bool advancedSoftwareRasterizer = false);
-		DirectX12Backend(const DirectX12Backend&) noexcept = delete;
-		DirectX12Backend(DirectX12Backend&&) noexcept = delete;
-		virtual ~DirectX12Backend();
+    public:
+        explicit DirectX12Backend(const App& app, bool advancedSoftwareRasterizer = false);
+        DirectX12Backend(const DirectX12Backend&) noexcept = delete;
+        DirectX12Backend(DirectX12Backend&&) noexcept = delete;
+        virtual ~DirectX12Backend();
 
-		// IBackend interface.
-	public:
-		/// <inheritdoc />
-		BackendType type() const noexcept override;
+        // IBackend interface.
+    public:
+        /// <inheritdoc />
+        BackendType type() const noexcept override;
 
-		/// <inheritdoc />
-		String name() const noexcept override;
+        /// <inheritdoc />
+        String name() const noexcept override;
 
-	protected:
-		/// <inheritdoc />
-		void activate() override;
+    protected:
+        /// <inheritdoc />
+        void activate() override;
 
-		/// <inheritdoc />
-		void deactivate() override;
+        /// <inheritdoc />
+        void deactivate() override;
 
-		// RenderBackend interface.
-	public:
-		/// <inheritdoc />
-		Enumerable<const DirectX12GraphicsAdapter*> listAdapters() const override;
+        // RenderBackend interface.
+    public:
+        /// <inheritdoc />
+        Enumerable<const DirectX12GraphicsAdapter*> listAdapters() const override;
 
-		/// <inheritdoc />
-		const DirectX12GraphicsAdapter* findAdapter(const Optional<UInt64>& adapterId = std::nullopt) const override;
+        /// <inheritdoc />
+        const DirectX12GraphicsAdapter* findAdapter(const Optional<UInt64>& adapterId = std::nullopt) const override;
 
-		/// <inheritdoc />
-		void registerDevice(String name, UniquePtr<DirectX12Device>&& device) override;
+        /// <inheritdoc />
+        void registerDevice(String name, UniquePtr<DirectX12Device>&& device) override;
 
-		/// <inheritdoc />
-		void releaseDevice(const String& name) override;
+        /// <inheritdoc />
+        void releaseDevice(const String& name) override;
 
-		/// <inheritdoc />
-		DirectX12Device* device(const String& name) noexcept override;
+        /// <inheritdoc />
+        DirectX12Device* device(const String& name) noexcept override;
 
-		/// <inheritdoc />
-		const DirectX12Device* device(const String& name) const noexcept override;
+        /// <inheritdoc />
+        const DirectX12Device* device(const String& name) const noexcept override;
 
-	public:
-		/// <summary>
-		/// Creates a surface on a window handle.
-		/// </summary>
-		/// <param name="hwnd">The window handle on which the surface should be created.</param>
-		/// <returns>The instance of the created surface.</returns>
-		UniquePtr<DirectX12Surface> createSurface(const HWND& hwnd) const;
+    public:
+        /// <summary>
+        /// Creates a surface on a window handle.
+        /// </summary>
+        /// <param name="hwnd">The window handle on which the surface should be created.</param>
+        /// <returns>The instance of the created surface.</returns>
+        UniquePtr<DirectX12Surface> createSurface(const HWND& hwnd) const;
 
-		/// <summary>
-		/// Enables <a href="https://docs.microsoft.com/en-us/windows/win32/direct3darticles/directx-warp" target="_blank">Windows Advanced Software Rasterization (WARP)</a>.
-		/// </summary>
-		/// <remarks>
-		/// Enabling software rasterization disables hardware rasterization. Requesting adapters using <see cref="findAdapter" /> or <see cref="listAdapters" />
-		/// will only return WARP-compatible adapters.
-		/// </remarks>
-		/// <param name="enable"><c>true</c>, if advanced software rasterization should be used.</param>
-		virtual void enableAdvancedSoftwareRasterizer(bool enable = false);
-	};
+        /// <summary>
+        /// Enables <a href="https://docs.microsoft.com/en-us/windows/win32/direct3darticles/directx-warp" target="_blank">Windows Advanced Software Rasterization (WARP)</a>.
+        /// </summary>
+        /// <remarks>
+        /// Enabling software rasterization disables hardware rasterization. Requesting adapters using <see cref="findAdapter" /> or <see cref="listAdapters" />
+        /// will only return WARP-compatible adapters.
+        /// </remarks>
+        /// <param name="enable"><c>true</c>, if advanced software rasterization should be used.</param>
+        virtual void enableAdvancedSoftwareRasterizer(bool enable = false);
+    };
 
 }

--- a/src/Backends/DirectX12/include/litefx/backends/dx12.hpp
+++ b/src/Backends/DirectX12/include/litefx/backends/dx12.hpp
@@ -812,7 +812,7 @@ namespace LiteFX::Rendering::Backends {
     /// Records commands for a <see cref="DirectX12CommandQueue" />
     /// </summary>
     /// <seealso cref="DirectX12CommandQueue" />
-    class LITEFX_DIRECTX12_API DirectX12CommandBuffer final : public CommandBuffer<DirectX12CommandBuffer, IDirectX12Buffer, IDirectX12VertexBuffer, IDirectX12IndexBuffer, IDirectX12Image, DirectX12Barrier, DirectX12PipelineState>, public ComResource<ID3D12GraphicsCommandList7>, std::enable_shared_from_this<DirectX12CommandBuffer> {
+    class LITEFX_DIRECTX12_API DirectX12CommandBuffer final : public CommandBuffer<DirectX12CommandBuffer, IDirectX12Buffer, IDirectX12VertexBuffer, IDirectX12IndexBuffer, IDirectX12Image, DirectX12Barrier, DirectX12PipelineState>, public ComResource<ID3D12GraphicsCommandList7>, public std::enable_shared_from_this<DirectX12CommandBuffer> {
         LITEFX_IMPLEMENTATION(DirectX12CommandBufferImpl);
 
     public:

--- a/src/Backends/DirectX12/include/litefx/backends/dx12.hpp
+++ b/src/Backends/DirectX12/include/litefx/backends/dx12.hpp
@@ -812,7 +812,7 @@ namespace LiteFX::Rendering::Backends {
     /// Records commands for a <see cref="DirectX12CommandQueue" />
     /// </summary>
     /// <seealso cref="DirectX12CommandQueue" />
-    class LITEFX_DIRECTX12_API DirectX12CommandBuffer final : public CommandBuffer<DirectX12CommandBuffer, IDirectX12Buffer, IDirectX12VertexBuffer, IDirectX12IndexBuffer, IDirectX12Image, DirectX12Barrier, DirectX12PipelineState>, public ComResource<ID3D12GraphicsCommandList7> {
+    class LITEFX_DIRECTX12_API DirectX12CommandBuffer final : public CommandBuffer<DirectX12CommandBuffer, IDirectX12Buffer, IDirectX12VertexBuffer, IDirectX12IndexBuffer, IDirectX12Image, DirectX12Barrier, DirectX12PipelineState>, public ComResource<ID3D12GraphicsCommandList7>, std::enable_shared_from_this<DirectX12CommandBuffer> {
         LITEFX_IMPLEMENTATION(DirectX12CommandBufferImpl);
 
     public:
@@ -827,7 +827,7 @@ namespace LiteFX::Rendering::Backends {
         using base_type::use;
         using base_type::pushConstants;
 
-    public:
+    private:
         /// <summary>
         /// Initializes the command buffer from a command queue.
         /// </summary>
@@ -835,9 +835,22 @@ namespace LiteFX::Rendering::Backends {
         /// <param name="begin">If set to <c>true</c>, the command buffer automatically starts recording by calling <see cref="begin" />.</param>
         /// <param name="primary"><c>true</c>, if the command buffer is a primary command buffer.</param>
         explicit DirectX12CommandBuffer(const DirectX12Queue& queue, bool begin = false, bool primary = true);
+
+    public:
         DirectX12CommandBuffer(const DirectX12CommandBuffer&) = delete;
         DirectX12CommandBuffer(DirectX12CommandBuffer&&) = delete;
         virtual ~DirectX12CommandBuffer() noexcept;
+
+    public:
+        /// <summary>
+        /// Initializes the command buffer from a command queue.
+        /// </summary>
+        /// <param name="queue">The parent command queue, the buffer gets submitted to.</param>
+        /// <param name="begin">If set to <c>true</c>, the command buffer automatically starts recording by calling <see cref="begin" />.</param>
+        /// <param name="primary"><c>true</c>, if the command buffer is a primary command buffer.</param>
+        static inline SharedPtr<DirectX12CommandBuffer> create(const DirectX12Queue& queue, bool begin = false, bool primary = true) {
+            return SharedPtr<DirectX12CommandBuffer>(new DirectX12CommandBuffer(queue, begin, primary));
+        }
 
         // CommandBuffer interface.
     public:
@@ -867,6 +880,9 @@ namespace LiteFX::Rendering::Backends {
 
         /// <inheritdoc />
         void setStencilRef(UInt32 stencilRef) const noexcept override;
+
+        /// <inheritdoc />
+        UInt64 submit() const override;
 
         /// <inheritdoc />
         void generateMipMaps(IDirectX12Image& image) noexcept override;

--- a/src/Backends/DirectX12/include/litefx/backends/dx12.hpp
+++ b/src/Backends/DirectX12/include/litefx/backends/dx12.hpp
@@ -1422,13 +1422,13 @@ namespace LiteFX::Rendering::Backends {
 #if !defined(NDEBUG) && defined(_WIN64)
     public:
         /// <inheritdoc />
-        void BeginDebugRegion(const String& label, const Vectors::ByteVector3& color = { 128_b, 128_b, 128_b }) const noexcept override;
+        void beginDebugRegion(const String& label, const Vectors::ByteVector3& color = { 128_b, 128_b, 128_b }) const noexcept override;
 
         /// <inheritdoc />
-        void EndDebugRegion() const noexcept override;
+        void endDebugRegion() const noexcept override;
 
         /// <inheritdoc />
-        void SetDebugMarker(const String& label, const Vectors::ByteVector3& color = { 128_b, 128_b, 128_b }) const noexcept override;
+        void setDebugMarker(const String& label, const Vectors::ByteVector3& color = { 128_b, 128_b, 128_b }) const noexcept override;
 #endif // !defined(NDEBUG) && defined(_WIN64)
 
     public:

--- a/src/Backends/DirectX12/src/command_buffer.cpp
+++ b/src/Backends/DirectX12/src/command_buffer.cpp
@@ -146,6 +146,14 @@ void DirectX12CommandBuffer::setStencilRef(UInt32 stencilRef) const noexcept
 	this->handle()->OMSetStencilRef(stencilRef);
 }
 
+UInt64 DirectX12CommandBuffer::submit() const
+{
+	if (this->isSecondary())
+		throw RuntimeException("A secondary command buffer cannot be directly submitted to a command queue and must be executed on a primary command buffer instead.");
+
+	return m_impl->m_queue.submit(this->shared_from_this());
+}
+
 void DirectX12CommandBuffer::generateMipMaps(IDirectX12Image& image) noexcept
 {
 	struct Parameters {

--- a/src/Backends/DirectX12/src/device.cpp
+++ b/src/Backends/DirectX12/src/device.cpp
@@ -184,8 +184,8 @@ public:
 	{
 		//m_graphicsQueue = makeUnique<DirectX12Queue>(*m_parent, QueueType::Graphics, QueuePriority::Realtime);
 		m_graphicsQueue = this->createQueue(QueueType::Graphics, QueuePriority::High);
-		m_transferQueue = this->createQueue(QueueType::Transfer, QueuePriority::Normal);
-		m_computeQueue = this->createQueue(QueueType::Compute, QueuePriority::High);
+		m_transferQueue = this->createQueue(QueueType::Transfer, QueuePriority::High);
+		m_computeQueue  = this->createQueue(QueueType::Compute,  QueuePriority::High);
 	}
 
 	DirectX12Queue* createQueue(QueueType type, QueuePriority priority)

--- a/src/Backends/DirectX12/src/frame_buffer.cpp
+++ b/src/Backends/DirectX12/src/frame_buffer.cpp
@@ -27,7 +27,7 @@ public:
     {
         // Initialize the command buffers from the graphics queue.
         m_commandBuffers.resize(commandBuffers);
-        std::ranges::generate(m_commandBuffers, [this]() { return m_renderPass.device().graphicsQueue().createCommandBuffer(false); });
+        std::ranges::generate(m_commandBuffers, [this]() { return m_renderPass.commandQueue().createCommandBuffer(false); });
     }
 
 public:

--- a/src/Backends/DirectX12/src/queue.cpp
+++ b/src/Backends/DirectX12/src/queue.cpp
@@ -251,6 +251,11 @@ void DirectX12Queue::waitFor(UInt64 fence) const noexcept
 	m_impl->m_submittedCommandBuffers.erase(from, to);
 }
 
+void DirectX12Queue::waitFor(const DirectX12Queue& queue, UInt64 fence) const noexcept
+{
+	this->handle()->Wait(queue.m_impl->m_fence.Get(), fence);
+}
+
 UInt64 DirectX12Queue::currentFence() const noexcept
 {
 	return m_impl->m_fenceValue;

--- a/src/Backends/DirectX12/src/queue.cpp
+++ b/src/Backends/DirectX12/src/queue.cpp
@@ -41,12 +41,18 @@ public:
 		desc.Flags = D3D12_COMMAND_QUEUE_FLAG_NONE;
 		desc.NodeMask = 0;
 
-		if (LITEFX_FLAG_IS_SET(m_type, QueueType::Graphics))
+		if (m_type == QueueType::Graphics)
 			desc.Type = D3D12_COMMAND_LIST_TYPE_DIRECT;
-		else if (LITEFX_FLAG_IS_SET(m_type, QueueType::Compute))
+		else if (m_type == QueueType::Compute)
 			desc.Type = D3D12_COMMAND_LIST_TYPE_COMPUTE;
-		else if (LITEFX_FLAG_IS_SET(m_type, QueueType::Transfer))
+		else if (m_type == QueueType::VideoDecode)
+			desc.Type = D3D12_COMMAND_LIST_TYPE_VIDEO_DECODE;
+		else if (m_type == QueueType::VideoEncode)
+			desc.Type = D3D12_COMMAND_LIST_TYPE_VIDEO_ENCODE;
+		else if (m_type == QueueType::Transfer)
 			desc.Type = D3D12_COMMAND_LIST_TYPE_COPY;
+		else // Combinations are not supported here. All queues implicitly support transfer operations, but it is not valid to provide combinations like `QueueType::Graphics | QueueType::VideoEncode`.
+			throw InvalidArgumentException("Unsupported combination of queue types. Only specify one queue type, even if the queue needs to support other tasks).");
 
 		switch (m_priority)
 		{

--- a/src/Backends/DirectX12/src/queue.cpp
+++ b/src/Backends/DirectX12/src/queue.cpp
@@ -116,17 +116,17 @@ QueueType DirectX12Queue::type() const noexcept
 }
 
 #if !defined(NDEBUG) && defined(_WIN64)
-void DirectX12Queue::BeginDebugRegion(const String& label, const Vectors::ByteVector3& color) const noexcept
+void DirectX12Queue::beginDebugRegion(const String& label, const Vectors::ByteVector3& color) const noexcept
 {
 	::PIXBeginEvent(this->handle().Get(), PIX_COLOR(color.x(), color.y(), color.z()), label.c_str());
 }
 
-void DirectX12Queue::EndDebugRegion() const noexcept
+void DirectX12Queue::endDebugRegion() const noexcept
 {
 	::PIXEndEvent(this->handle().Get());
 }
 
-void DirectX12Queue::SetDebugMarker(const String& label, const Vectors::ByteVector3& color) const noexcept
+void DirectX12Queue::setDebugMarker(const String& label, const Vectors::ByteVector3& color) const noexcept
 {
 	::PIXSetMarker(this->handle().Get(), PIX_COLOR(color.x(), color.y(), color.z()), label.c_str());
 }

--- a/src/Backends/DirectX12/src/queue.cpp
+++ b/src/Backends/DirectX12/src/queue.cpp
@@ -121,7 +121,7 @@ QueuePriority DirectX12Queue::priority() const noexcept
 
 SharedPtr<DirectX12CommandBuffer> DirectX12Queue::createCommandBuffer(bool beginRecording, bool secondary) const
 {
-	return makeShared<DirectX12CommandBuffer>(*this, beginRecording, !secondary);
+	return DirectX12CommandBuffer::create(*this, beginRecording, !secondary);
 }
 
 UInt64 DirectX12Queue::submit(SharedPtr<const DirectX12CommandBuffer> commandBuffer) const

--- a/src/Backends/DirectX12/src/render_pass.cpp
+++ b/src/Backends/DirectX12/src/render_pass.cpp
@@ -500,7 +500,10 @@ constexpr DirectX12RenderPassBuilder::~DirectX12RenderPassBuilder() noexcept = d
 void DirectX12RenderPassBuilder::build()
 {
     auto instance = this->instance();
-    instance->m_impl->m_queue = m_state.commandQueue;
+
+    if (m_state.commandQueue != nullptr)
+        instance->m_impl->m_queue = m_state.commandQueue;
+
     instance->m_impl->mapRenderTargets(m_state.renderTargets);
     instance->m_impl->mapInputAttachments(m_state.inputAttachments);
     instance->m_impl->m_multiSamplingLevel = m_state.multiSamplingLevel;

--- a/src/Backends/DirectX12/src/render_pass.cpp
+++ b/src/Backends/DirectX12/src/render_pass.cpp
@@ -27,19 +27,19 @@ private:
     MultiSamplingLevel m_multiSamplingLevel{ MultiSamplingLevel::x1 };
     Array<RenderPassContext> m_contexts;
     const DirectX12Device& m_device;
-    const DirectX12Queue& m_queue;
+    const DirectX12Queue* m_queue;
     String m_name;
 
 public:
     DirectX12RenderPassImpl(DirectX12RenderPass* parent, const DirectX12Device& device, const DirectX12Queue& queue, Span<RenderTarget> renderTargets, MultiSamplingLevel samples, Span<DirectX12InputAttachmentMapping> inputAttachments) :
-        base(parent), m_device(device), m_multiSamplingLevel(samples), m_queue(queue)
+        base(parent), m_device(device), m_multiSamplingLevel(samples), m_queue(&queue)
     {
         this->mapRenderTargets(renderTargets);
         this->mapInputAttachments(inputAttachments);
     }
 
     DirectX12RenderPassImpl(DirectX12RenderPass* parent, const DirectX12Device& device) :
-        base(parent), m_device(device), m_queue(device.defaultQueue(QueueType::Graphics))
+        base(parent), m_device(device), m_queue(&device.defaultQueue(QueueType::Graphics))
     {
     }
 
@@ -62,7 +62,7 @@ public:
 
         // TODO: If there is a present target, we need to check if the provided queue can actually present on the surface. Currently, 
         //       we simply check if the queue is the same as the swap chain queue (which is the default graphics queue).
-        if (m_presentTarget != nullptr && &m_queue != &m_device.defaultQueue(QueueType::Graphics)) [[unlikely]]
+        if (m_presentTarget != nullptr && m_queue != std::addressof(m_device.defaultQueue(QueueType::Graphics))) [[unlikely]]
             throw InvalidArgumentException("A render pass with a present target must be executed on the default graphics queue.");
     }
 
@@ -160,7 +160,7 @@ public:
         // Initialize the primary command buffers used to begin and end the render pass.
         this->m_beginCommandBuffers.resize(m_device.swapChain().buffers());
         std::ranges::generate(this->m_beginCommandBuffers, [&, i = 0]() mutable {
-            auto commandBuffer = m_queue.createCommandBuffer(false);
+            auto commandBuffer = m_queue->createCommandBuffer(false);
 
 #ifndef NDEBUG
             std::as_const(*commandBuffer).handle()->SetName(Widen(fmt::format("{0} Begin Commands {1}", m_parent->name(), i++)).c_str());
@@ -171,7 +171,7 @@ public:
 
         this->m_endCommandBuffers.resize(m_device.swapChain().buffers());
         std::ranges::generate(this->m_endCommandBuffers, [&, i = 0]() mutable {
-            auto commandBuffer = m_queue.createCommandBuffer(false);
+            auto commandBuffer = m_queue->createCommandBuffer(false);
 
 #ifndef NDEBUG
             std::as_const(*commandBuffer).handle()->SetName(Widen(fmt::format("{0} End Commands {1}", m_parent->name(), i++)).c_str());
@@ -247,7 +247,7 @@ const DirectX12FrameBuffer& DirectX12RenderPass::activeFrameBuffer() const
 
 const DirectX12Queue& DirectX12RenderPass::commandQueue() const noexcept 
 {
-    return m_impl->m_queue;
+    return *m_impl->m_queue;
 }
 
 Enumerable<const DirectX12FrameBuffer*> DirectX12RenderPass::frameBuffers() const noexcept
@@ -326,7 +326,7 @@ void DirectX12RenderPass::begin(UInt32 buffer)
     beginCommandBuffer->barrier(depthStencilBarrier);
 
     if (!m_impl->m_name.empty())
-        m_impl->m_queue.beginDebugRegion(fmt::format("{0} Render Pass", m_impl->m_name));
+        m_impl->m_queue->beginDebugRegion(fmt::format("{0} Render Pass", m_impl->m_name));
 
     // Begin a suspending render pass for the transition and a suspend-the-resume render pass on each command buffer of the frame buffer.
     std::as_const(*beginCommandBuffer).handle()->BeginRenderPass(std::get<0>(context).size(), std::get<0>(context).data(), std::get<1>(context).has_value() ? &std::get<1>(context).value() : nullptr, D3D12_RENDER_PASS_FLAG_SUSPENDING_PASS);
@@ -420,10 +420,10 @@ void DirectX12RenderPass::end() const
     commandBuffers.push_back(endCommandBuffer);
 
     // Submit and store the fence.
-    m_impl->m_activeFrameBuffer->lastFence() = m_impl->m_queue.submit(commandBuffers | std::ranges::to<Enumerable<SharedPtr<const DirectX12CommandBuffer>>>());
+    m_impl->m_activeFrameBuffer->lastFence() = m_impl->m_queue->submit(commandBuffers | std::ranges::to<Enumerable<SharedPtr<const DirectX12CommandBuffer>>>());
 
     if (!m_impl->m_name.empty())
-        m_impl->m_queue.endDebugRegion();
+        m_impl->m_queue->endDebugRegion();
 
     // NOTE: No need to wait for the fence here, since `Present` will wait for the back buffer to be ready. If we have multiple frames in flight, this will block until the first
     //       frame in the queue has been drawn and the back buffer can be written again.
@@ -500,6 +500,7 @@ constexpr DirectX12RenderPassBuilder::~DirectX12RenderPassBuilder() noexcept = d
 void DirectX12RenderPassBuilder::build()
 {
     auto instance = this->instance();
+    instance->m_impl->m_queue = m_state.commandQueue;
     instance->m_impl->mapRenderTargets(m_state.renderTargets);
     instance->m_impl->mapInputAttachments(m_state.inputAttachments);
     instance->m_impl->m_multiSamplingLevel = m_state.multiSamplingLevel;

--- a/src/Backends/DirectX12/src/render_pass.cpp
+++ b/src/Backends/DirectX12/src/render_pass.cpp
@@ -27,18 +27,19 @@ private:
     MultiSamplingLevel m_multiSamplingLevel{ MultiSamplingLevel::x1 };
     Array<RenderPassContext> m_contexts;
     const DirectX12Device& m_device;
+    const DirectX12Queue& m_queue;
     String m_name;
 
 public:
-    DirectX12RenderPassImpl(DirectX12RenderPass* parent, const DirectX12Device& device, Span<RenderTarget> renderTargets, MultiSamplingLevel samples, Span<DirectX12InputAttachmentMapping> inputAttachments) :
-        base(parent), m_device(device), m_multiSamplingLevel(samples)
+    DirectX12RenderPassImpl(DirectX12RenderPass* parent, const DirectX12Device& device, const DirectX12Queue& queue, Span<RenderTarget> renderTargets, MultiSamplingLevel samples, Span<DirectX12InputAttachmentMapping> inputAttachments) :
+        base(parent), m_device(device), m_multiSamplingLevel(samples), m_queue(queue)
     {
         this->mapRenderTargets(renderTargets);
         this->mapInputAttachments(inputAttachments);
     }
 
     DirectX12RenderPassImpl(DirectX12RenderPass* parent, const DirectX12Device& device) :
-        base(parent), m_device(device)
+        base(parent), m_device(device), m_queue(device.defaultQueue(QueueType::Graphics))
     {
     }
 
@@ -58,6 +59,11 @@ public:
             m_depthStencilTarget = match._Ptr;
         else
             m_depthStencilTarget = nullptr;
+
+        // TODO: If there is a present target, we need to check if the provided queue can actually present on the surface. Currently, 
+        //       we simply check if the queue is the same as the swap chain queue (which is the default graphics queue).
+        if (m_presentTarget != nullptr && &m_queue != &m_device.defaultQueue(QueueType::Graphics)) [[unlikely]]
+            throw InvalidArgumentException("A render pass with a present target must be executed on the default graphics queue.");
     }
 
     void mapInputAttachments(Span<DirectX12InputAttachmentMapping> inputAttachments)
@@ -154,7 +160,7 @@ public:
         // Initialize the primary command buffers used to begin and end the render pass.
         this->m_beginCommandBuffers.resize(m_device.swapChain().buffers());
         std::ranges::generate(this->m_beginCommandBuffers, [&, i = 0]() mutable {
-            auto commandBuffer = m_device.graphicsQueue().createCommandBuffer(false);
+            auto commandBuffer = m_queue.createCommandBuffer(false);
 
 #ifndef NDEBUG
             std::as_const(*commandBuffer).handle()->SetName(Widen(fmt::format("{0} Begin Commands {1}", m_parent->name(), i++)).c_str());
@@ -165,7 +171,7 @@ public:
 
         this->m_endCommandBuffers.resize(m_device.swapChain().buffers());
         std::ranges::generate(this->m_endCommandBuffers, [&, i = 0]() mutable {
-            auto commandBuffer = m_device.graphicsQueue().createCommandBuffer(false);
+            auto commandBuffer = m_queue.createCommandBuffer(false);
 
 #ifndef NDEBUG
             std::as_const(*commandBuffer).handle()->SetName(Widen(fmt::format("{0} End Commands {1}", m_parent->name(), i++)).c_str());
@@ -181,13 +187,23 @@ public:
 // ------------------------------------------------------------------------------------------------
 
 DirectX12RenderPass::DirectX12RenderPass(const DirectX12Device& device, Span<RenderTarget> renderTargets, UInt32 commandBuffers, MultiSamplingLevel samples, Span<DirectX12InputAttachmentMapping> inputAttachments) :
-    m_impl(makePimpl<DirectX12RenderPassImpl>(this, device, renderTargets, samples, inputAttachments))
+    DirectX12RenderPass(device, device.defaultQueue(QueueType::Graphics), renderTargets, commandBuffers, samples, inputAttachments)
+{
+}
+
+DirectX12RenderPass::DirectX12RenderPass(const DirectX12Device& device, const String& name, Span<RenderTarget> renderTargets, UInt32 commandBuffers, MultiSamplingLevel samples, Span<DirectX12InputAttachmentMapping> inputAttachments) :
+    DirectX12RenderPass(device, name, device.defaultQueue(QueueType::Graphics), renderTargets, commandBuffers, samples, inputAttachments)
+{
+}
+
+DirectX12RenderPass::DirectX12RenderPass(const DirectX12Device& device, const DirectX12Queue& queue, Span<RenderTarget> renderTargets, UInt32 commandBuffers, MultiSamplingLevel samples, Span<DirectX12InputAttachmentMapping> inputAttachments) :
+    m_impl(makePimpl<DirectX12RenderPassImpl>(this, device, queue, renderTargets, samples, inputAttachments))
 {
     m_impl->initializeFrameBuffers(commandBuffers);
 }
 
-DirectX12RenderPass::DirectX12RenderPass(const DirectX12Device& device, const String& name, Span<RenderTarget> renderTargets, UInt32 commandBuffers, MultiSamplingLevel samples, Span<DirectX12InputAttachmentMapping> inputAttachments) :
-    DirectX12RenderPass(device, renderTargets, commandBuffers, samples, inputAttachments)
+DirectX12RenderPass::DirectX12RenderPass(const DirectX12Device& device, const String& name, const DirectX12Queue& queue, Span<RenderTarget> renderTargets, UInt32 commandBuffers, MultiSamplingLevel samples, Span<DirectX12InputAttachmentMapping> inputAttachments) :
+    DirectX12RenderPass(device, queue, renderTargets, commandBuffers, samples, inputAttachments)
 {
     if (!name.empty())
     {
@@ -227,6 +243,11 @@ const DirectX12FrameBuffer& DirectX12RenderPass::activeFrameBuffer() const
         throw RuntimeException("No frame buffer is active, since the render pass has not begun.");
 
     return *m_impl->m_activeFrameBuffer;
+}
+
+const DirectX12Queue& DirectX12RenderPass::commandQueue() const noexcept 
+{
+    return m_impl->m_queue;
 }
 
 Enumerable<const DirectX12FrameBuffer*> DirectX12RenderPass::frameBuffers() const noexcept
@@ -285,7 +306,7 @@ void DirectX12RenderPass::begin(UInt32 buffer)
     const auto& context = m_impl->m_contexts[buffer];
 
     // Begin the command recording on the frame buffers command buffer. Before we can do that, we need to make sure it has not being executed anymore.
-    //m_impl->m_device.graphicsQueue().waitFor(frameBuffer->lastFence());   // Done by swapping back buffers.
+    //m_impl->m_queue.waitFor(frameBuffer->lastFence());   // Done by swapping back buffers.
     auto& beginCommandBuffer = m_impl->m_beginCommandBuffers[buffer];
     beginCommandBuffer->begin();
 
@@ -305,7 +326,7 @@ void DirectX12RenderPass::begin(UInt32 buffer)
     beginCommandBuffer->barrier(depthStencilBarrier);
 
     if (!m_impl->m_name.empty())
-        m_impl->m_device.graphicsQueue().BeginDebugRegion(fmt::format("{0} Render Pass", m_impl->m_name));
+        m_impl->m_queue.beginDebugRegion(fmt::format("{0} Render Pass", m_impl->m_name));
 
     // Begin a suspending render pass for the transition and a suspend-the-resume render pass on each command buffer of the frame buffer.
     std::as_const(*beginCommandBuffer).handle()->BeginRenderPass(std::get<0>(context).size(), std::get<0>(context).data(), std::get<1>(context).has_value() ? &std::get<1>(context).value() : nullptr, D3D12_RENDER_PASS_FLAG_SUSPENDING_PASS);
@@ -399,10 +420,10 @@ void DirectX12RenderPass::end() const
     commandBuffers.push_back(endCommandBuffer);
 
     // Submit and store the fence.
-    m_impl->m_activeFrameBuffer->lastFence() = m_impl->m_device.graphicsQueue().submit(commandBuffers | std::ranges::to<Enumerable<SharedPtr<const DirectX12CommandBuffer>>>());
+    m_impl->m_activeFrameBuffer->lastFence() = m_impl->m_queue.submit(commandBuffers | std::ranges::to<Enumerable<SharedPtr<const DirectX12CommandBuffer>>>());
 
     if (!m_impl->m_name.empty())
-        m_impl->m_device.graphicsQueue().EndDebugRegion();
+        m_impl->m_queue.endDebugRegion();
 
     // NOTE: No need to wait for the fence here, since `Present` will wait for the back buffer to be ready. If we have multiple frames in flight, this will block until the first
     //       frame in the queue has been drawn and the back buffer can be written again.

--- a/src/Backends/DirectX12/src/swapchain.cpp
+++ b/src/Backends/DirectX12/src/swapchain.cpp
@@ -53,7 +53,7 @@ public:
 
 		auto adapter = m_device.adapter().handle();
 		auto surface = m_device.surface().handle();
-		auto graphicsQueue = m_device.graphicsQueue().handle();
+		auto graphicsQueue = m_device.defaultQueue(QueueType::Graphics).handle();
 		const auto& backend = m_device.backend();
 
 		// Create the swap chain.
@@ -169,7 +169,7 @@ public:
 	UInt32 swapBackBuffer()
 	{
 		m_currentImage = m_parent->handle()->GetCurrentBackBufferIndex();
-		m_device.graphicsQueue().waitFor(m_presentFences[m_currentImage]);
+		m_device.defaultQueue(QueueType::Graphics).waitFor(m_presentFences[m_currentImage]);
 
 		// Read back the timestamps.
 		if (!m_timestamps.empty())

--- a/src/Backends/Vulkan/include/litefx/backends/vulkan.hpp
+++ b/src/Backends/Vulkan/include/litefx/backends/vulkan.hpp
@@ -1127,17 +1127,17 @@ namespace LiteFX::Rendering::Backends {
     /// Implements a Vulkan render pass.
     /// </summary>
     /// <seealso cref="VulkanRenderPassBuilder" />
-    class LITEFX_VULKAN_API VulkanRenderPass final : public RenderPass<VulkanRenderPipeline, VulkanFrameBuffer, VulkanInputAttachmentMapping>, public Resource<VkRenderPass> {
+    class LITEFX_VULKAN_API VulkanRenderPass final : public RenderPass<VulkanRenderPipeline, VulkanQueue, VulkanFrameBuffer, VulkanInputAttachmentMapping>, public Resource<VkRenderPass> {
         LITEFX_IMPLEMENTATION(VulkanRenderPassImpl);
         LITEFX_BUILDER(VulkanRenderPassBuilder);
 
     public:
-        using base_type = RenderPass<VulkanRenderPipeline, VulkanFrameBuffer, VulkanInputAttachmentMapping>;
+        using base_type = RenderPass<VulkanRenderPipeline, VulkanQueue, VulkanFrameBuffer, VulkanInputAttachmentMapping>;
         using base_type::updateAttachments;
 
     public:
         /// <summary>
-        /// Creates and initializes a new Vulkan render pass instance.
+        /// Creates and initializes a new Vulkan render pass instance that executes on the default graphics queue.
         /// </summary>
         /// <param name="device">The parent device instance.</param>
         /// <param name="commandBuffers">The number of command buffers in each frame buffer.</param>
@@ -1147,7 +1147,7 @@ namespace LiteFX::Rendering::Backends {
         explicit VulkanRenderPass(const VulkanDevice& device, Span<RenderTarget> renderTargets, UInt32 commandBuffers = 1, MultiSamplingLevel samples = MultiSamplingLevel::x1, Span<VulkanInputAttachmentMapping> inputAttachments = { });
 
         /// <summary>
-        /// Creates and initializes a new Vulkan render pass instance.
+        /// Creates and initializes a new Vulkan render pass instance that executes on the default graphics queue.
         /// </summary>
         /// <param name="device">The parent device instance.</param>
         /// <param name="name">The name of the render pass state resource.</param>
@@ -1157,6 +1157,29 @@ namespace LiteFX::Rendering::Backends {
         /// <param name="inputAttachments">The input attachments that are read by the render pass.</param>
         explicit VulkanRenderPass(const VulkanDevice& device, const String& name, Span<RenderTarget> renderTargets, UInt32 commandBuffers = 1, MultiSamplingLevel samples = MultiSamplingLevel::x1, Span<VulkanInputAttachmentMapping> inputAttachments = { });
         
+        /// <summary>
+        /// Creates and initializes a new Vulkan render pass instance.
+        /// </summary>
+        /// <param name="device">The parent device instance.</param>
+        /// <param name="queue">The command queue to execute the render pass on.</param>
+        /// <param name="commandBuffers">The number of command buffers in each frame buffer.</param>
+        /// <param name="renderTargets">The render targets that are output by the render pass.</param>
+        /// <param name="samples">The number of samples for the render targets in this render pass.</param>
+        /// <param name="inputAttachments">The input attachments that are read by the render pass.</param>
+        explicit VulkanRenderPass(const VulkanDevice& device, const VulkanQueue& queue, Span<RenderTarget> renderTargets, UInt32 commandBuffers = 1, MultiSamplingLevel samples = MultiSamplingLevel::x1, Span<VulkanInputAttachmentMapping> inputAttachments = { });
+
+        /// <summary>
+        /// Creates and initializes a new Vulkan render pass instance.
+        /// </summary>
+        /// <param name="device">The parent device instance.</param>
+        /// <param name="name">The name of the render pass state resource.</param>
+        /// <param name="queue">The command queue to execute the render pass on.</param>
+        /// <param name="commandBuffers">The number of command buffers in each frame buffer.</param>
+        /// <param name="renderTargets">The render targets that are output by the render pass.</param>
+        /// <param name="samples">The number of samples for the render targets in this render pass.</param>
+        /// <param name="inputAttachments">The input attachments that are read by the render pass.</param>
+        explicit VulkanRenderPass(const VulkanDevice& device, const String& name, const VulkanQueue& queue, Span<RenderTarget> renderTargets, UInt32 commandBuffers = 1, MultiSamplingLevel samples = MultiSamplingLevel::x1, Span<VulkanInputAttachmentMapping> inputAttachments = { });
+
         VulkanRenderPass(const VulkanRenderPass&) = delete;
         VulkanRenderPass(VulkanRenderPass&&) = delete;
         virtual ~VulkanRenderPass() noexcept;
@@ -1188,6 +1211,9 @@ namespace LiteFX::Rendering::Backends {
 
         /// <inheritdoc />
         const VulkanFrameBuffer& activeFrameBuffer() const override;
+
+        /// <inheritdoc />
+        const VulkanQueue& commandQueue() const noexcept override;
 
         /// <inheritdoc />
         Enumerable<const VulkanFrameBuffer*> frameBuffers() const noexcept override;

--- a/src/Backends/Vulkan/include/litefx/backends/vulkan.hpp
+++ b/src/Backends/Vulkan/include/litefx/backends/vulkan.hpp
@@ -1462,13 +1462,13 @@ namespace LiteFX::Rendering::Backends {
 #ifndef NDEBUG
     public:
         /// <inheritdoc />
-        void BeginDebugRegion(const String& label, const Vectors::ByteVector3& color = { 128_b, 128_b, 128_b }) const noexcept override;
+        void beginDebugRegion(const String& label, const Vectors::ByteVector3& color = { 128_b, 128_b, 128_b }) const noexcept override;
 
         /// <inheritdoc />
-        void EndDebugRegion() const noexcept override;
+        void endDebugRegion() const noexcept override;
 
         /// <inheritdoc />
-        void SetDebugMarker(const String& label, const Vectors::ByteVector3& color = { 128_b, 128_b, 128_b }) const noexcept override;
+        void setDebugMarker(const String& label, const Vectors::ByteVector3& color = { 128_b, 128_b, 128_b }) const noexcept override;
 #endif
 
     public:

--- a/src/Backends/Vulkan/include/litefx/backends/vulkan.hpp
+++ b/src/Backends/Vulkan/include/litefx/backends/vulkan.hpp
@@ -817,7 +817,7 @@ namespace LiteFX::Rendering::Backends {
     /// Records commands for a <see cref="VulkanCommandQueue" />
     /// </summary>
     /// <seealso cref="VulkanQueue" />
-    class LITEFX_VULKAN_API VulkanCommandBuffer final : public CommandBuffer<VulkanCommandBuffer, IVulkanBuffer, IVulkanVertexBuffer, IVulkanIndexBuffer, IVulkanImage, VulkanBarrier, VulkanPipelineState>, public Resource<VkCommandBuffer> {
+    class LITEFX_VULKAN_API VulkanCommandBuffer final : public CommandBuffer<VulkanCommandBuffer, IVulkanBuffer, IVulkanVertexBuffer, IVulkanIndexBuffer, IVulkanImage, VulkanBarrier, VulkanPipelineState>, public Resource<VkCommandBuffer>, public std::enable_shared_from_this<VulkanCommandBuffer> {
         LITEFX_IMPLEMENTATION(VulkanCommandBufferImpl);
 
     public:
@@ -832,7 +832,7 @@ namespace LiteFX::Rendering::Backends {
         using base_type::use;
         using base_type::pushConstants;
 
-    public:
+    private:
         /// <summary>
         /// Initializes a command buffer from a command queue.
         /// </summary>
@@ -840,9 +840,23 @@ namespace LiteFX::Rendering::Backends {
         /// <param name="begin">If set to <c>true</c>, the command buffer automatically starts recording by calling <see cref="begin" />.</param>
         /// <param name="primary"><c>true</c>, if the command buffer is a primary command buffer.</param>
         explicit VulkanCommandBuffer(const VulkanQueue& queue, bool begin = false, bool primary = true);
+
+    public:
         VulkanCommandBuffer(const VulkanCommandBuffer&) = delete;
         VulkanCommandBuffer(VulkanCommandBuffer&&) = delete;
         virtual ~VulkanCommandBuffer() noexcept;
+
+        // Factory method.
+    public:
+        /// <summary>
+        /// Initializes a command buffer from a command queue.
+        /// </summary>
+        /// <param name="queue">The parent command queue, the buffer gets submitted to.</param>
+        /// <param name="begin">If set to <c>true</c>, the command buffer automatically starts recording by calling <see cref="begin" />.</param>
+        /// <param name="primary"><c>true</c>, if the command buffer is a primary command buffer.</param>
+        static inline SharedPtr<VulkanCommandBuffer> create(const VulkanQueue& queue, bool begin = false, bool primary = true) {
+            return SharedPtr<VulkanCommandBuffer>(new VulkanCommandBuffer(queue, begin, primary));
+        }
 
         // Vulkan Command Buffer interface.
     public:
@@ -880,6 +894,9 @@ namespace LiteFX::Rendering::Backends {
 
         /// <inheritdoc />
         void setStencilRef(UInt32 stencilRef) const noexcept override;
+
+        /// <inheritdoc />
+        UInt64 submit() const override;
 
         /// <inheritdoc />
         void generateMipMaps(IVulkanImage& image) noexcept override;

--- a/src/Backends/Vulkan/include/litefx/backends/vulkan.hpp
+++ b/src/Backends/Vulkan/include/litefx/backends/vulkan.hpp
@@ -6,1831 +6,1804 @@
 #include "vulkan_formatters.hpp"
 
 namespace LiteFX::Rendering::Backends {
-	using namespace LiteFX::Math;
-	using namespace LiteFX::Rendering;
-
-	/// <summary>
-	/// Implements a Vulkan vertex buffer layout.
-	/// </summary>
-	/// <seealso cref="VulkanVertexBuffer" />
-	/// <seealso cref="VulkanIndexBufferLayout" />
-	/// <seealso cref="VulkanVertexBufferLayoutBuilder" />
-	class LITEFX_VULKAN_API VulkanVertexBufferLayout final : public IVertexBufferLayout {
-		LITEFX_IMPLEMENTATION(VulkanVertexBufferLayoutImpl);
-		LITEFX_BUILDER(VulkanVertexBufferLayoutBuilder);
-
-	public:
-		/// <summary>
-		/// Initializes a new vertex buffer layout.
-		/// </summary>
-		/// <param name="vertexSize">The size of a single vertex.</param>
-		/// <param name="binding">The binding point of the vertex buffers using this layout.</param>
-		explicit VulkanVertexBufferLayout(size_t vertexSize, UInt32 binding = 0);
-		VulkanVertexBufferLayout(VulkanVertexBufferLayout&&) = delete;
-		VulkanVertexBufferLayout(const VulkanVertexBufferLayout&) = delete;
-		virtual ~VulkanVertexBufferLayout() noexcept;
-
-		// IVertexBufferLayout interface.
-	public:
-		/// <inheritdoc />
-		Enumerable<const BufferAttribute*> attributes() const noexcept override;
-
-		// IBufferLayout interface.
-	public:
-		/// <inheritdoc />
-		size_t elementSize() const noexcept override;
-
-		/// <inheritdoc />
-		UInt32 binding() const noexcept override;
-
-		/// <inheritdoc />
-		BufferType type() const noexcept override;
-	};
-
-	/// <summary>
-	/// Implements a Vulkan index buffer layout.
-	/// </summary>
-	/// <seealso cref="VulkanIndexBuffer" />
-	/// <seealso cref="VulkanVertexBufferLayout" />
-	class LITEFX_VULKAN_API VulkanIndexBufferLayout final : public IIndexBufferLayout {
-		LITEFX_IMPLEMENTATION(VulkanIndexBufferLayoutImpl);
-
-	public:
-		/// <summary>
-		/// Initializes a new index buffer layout
-		/// </summary>
-		/// <param name="type">The type of the indices within the index buffer.</param>
-		explicit VulkanIndexBufferLayout(IndexType type);
-		VulkanIndexBufferLayout(VulkanIndexBufferLayout&&) = delete;
-		VulkanIndexBufferLayout(const VulkanIndexBufferLayout&) = delete;
-		virtual ~VulkanIndexBufferLayout() noexcept;
-
-		// IIndexBufferLayout interface.
-	public:
-		/// <inheritdoc />
-		IndexType indexType() const noexcept override;
-
-		// IBufferLayout interface.
-	public:
-		/// <inheritdoc />
-		size_t elementSize() const noexcept override;
-
-		/// <inheritdoc />
-		UInt32 binding() const noexcept override;
-
-		/// <inheritdoc />
-		BufferType type() const noexcept override;
-	};
-
-	/// <summary>
-	/// Represents the base interface for a Vulkan buffer implementation.
-	/// </summary>
-	/// <seealso cref="VulkanDescriptorSet" />
-	/// <seealso cref="IVulkanImage" />
-	/// <seealso cref="IVulkanVertexBuffer" />
-	/// <seealso cref="IVulkanIndexBuffer" />
-	class LITEFX_VULKAN_API IVulkanBuffer : public virtual IBuffer, public virtual IResource<VkBuffer> {
-	public:
-		virtual ~IVulkanBuffer() noexcept = default;
-	};
-
-	/// <summary>
-	/// Represents a Vulkan vertex buffer.
-	/// </summary>
-	/// <seealso cref="VulkanVertexBufferLayout" />
-	/// <seealso cref="IVulkanBuffer" />
-	class LITEFX_VULKAN_API IVulkanVertexBuffer : public virtual VertexBuffer<VulkanVertexBufferLayout>, public virtual IVulkanBuffer {
-	public:
-		virtual ~IVulkanVertexBuffer() noexcept = default;
-	};
-
-	/// <summary>
-	/// Represents a Vulkan index buffer.
-	/// </summary>
-	/// <seealso cref="VulkanIndexBufferLayout" />
-	/// <seealso cref="IVulkanBuffer" />
-	class LITEFX_VULKAN_API IVulkanIndexBuffer : public virtual IndexBuffer<VulkanIndexBufferLayout>, public virtual IVulkanBuffer {
-	public:
-		virtual ~IVulkanIndexBuffer() noexcept = default;
-	};
-
-	/// <summary>
-	/// Represents a Vulkan sampled image or the base interface for a texture.
-	/// </summary>
-	/// <seealso cref="VulkanDescriptorLayout" />
-	/// <seealso cref="VulkanDescriptorSet" />
-	/// <seealso cref="VulkanDescriptorSetLayout" />
-	/// <seealso cref="IVulkanBuffer" />
-	/// <seealso cref="IVulkanSampler" />
-	class LITEFX_VULKAN_API IVulkanImage : public virtual IImage, public virtual IResource<VkImage> {
-	public:
-		friend class VulkanBarrier;
-
-	public:
-		virtual ~IVulkanImage() noexcept = default;
-
-	public:
-		/// <summary>
-		/// Returns the image resource aspect mask for all sub-resources.
-		/// </summary>
-		/// <returns>The image resource aspect mask.</returns>
-		virtual VkImageAspectFlags aspectMask() const noexcept = 0;
-
-		/// <summary>
-		/// Returns the image resource aspect mask for a single sub-resource.
-		/// </summary>
-		/// <param name="plane">The sub-resource identifier to query the aspect mask from.</param>
-		/// <returns>The image resource aspect mask.</returns>
-		virtual VkImageAspectFlags aspectMask(UInt32 plane) const = 0;
-
-		/// <summary>
-		/// Returns the image view for a sub-resource.
-		/// </summary>
-		/// <param name="plane">The sub-resource index to return the image view for.</param>
-		/// <returns>The image view for the sub-resource.</returns>
-		virtual const VkImageView& imageView(UInt32 plane = 0) const = 0;
-		
-	private:
-		virtual ImageLayout& layout(UInt32 subresource) = 0;
-	};
-
-	/// <summary>
-	/// Represents a Vulkan sampler.
-	/// </summary>
-	/// <seealso cref="VulkanDescriptorLayout" />
-	/// <seealso cref="VulkanDescriptorSet" />
-	/// <seealso cref="VulkanDescriptorSetLayout" />
-	/// <seealso cref="IVulkanImage" />
-	class LITEFX_VULKAN_API IVulkanSampler : public virtual ISampler, public virtual IResource<VkSampler> {
-	public:
-		virtual ~IVulkanSampler() noexcept = default;
-	};
-
-	/// <summary>
-	/// Implements a Vulkan resource barrier.
-	/// </summary>
-	/// <seealso cref="VulkanCommandBuffer" />
-	/// <seealso cref="IVulkanBuffer" />
-	/// <seealso cref="IVulkanImage" />
-	/// <seealso cref="Barrier" />
-	class LITEFX_VULKAN_API VulkanBarrier final : public Barrier<IVulkanBuffer, IVulkanImage> {
-		LITEFX_IMPLEMENTATION(VulkanBarrierImpl);
-		LITEFX_BUILDER(VulkanBarrierBuilder);
-
-	public:
-		using base_type = Barrier<IVulkanBuffer, IVulkanImage>;
-		using base_type::transition;
-
-	public:
-		/// <summary>
-		/// Initializes a new Vulkan barrier.
-		/// </summary>
-		/// <param name="syncBefore">The pipeline stage(s) all previous commands have to finish before the barrier is executed.</param>
-		/// <param name="syncAfter">The pipeline stage(s) all subsequent commands are blocked at until the barrier is executed.</param>
-		constexpr inline explicit VulkanBarrier(PipelineStage syncBefore, PipelineStage syncAfter) noexcept;
-		VulkanBarrier(const VulkanBarrier&) = delete;
-		VulkanBarrier(VulkanBarrier&&) = delete;
-		constexpr inline virtual ~VulkanBarrier() noexcept;
-
-	private:
-		constexpr inline explicit VulkanBarrier() noexcept;
-		constexpr inline PipelineStage& syncBefore() noexcept;
-		constexpr inline PipelineStage& syncAfter() noexcept;
-
-		// Barrier interface.
-	public:
-		/// <inheritdoc />
-		constexpr inline PipelineStage syncBefore() const noexcept override;
-
-		/// <inheritdoc />
-		constexpr inline PipelineStage syncAfter() const noexcept override;
-
-		/// <inheritdoc />
-		constexpr inline void wait(ResourceAccess accessBefore, ResourceAccess accessAfter) noexcept override;
-
-		/// <inheritdoc />
-		constexpr inline void transition(IVulkanBuffer& buffer, ResourceAccess accessBefore, ResourceAccess accessAfter) override;
-
-		/// <inheritdoc />
-		constexpr inline void transition(IVulkanBuffer& buffer, UInt32 element, ResourceAccess accessBefore, ResourceAccess accessAfter) override;
-
-		/// <inheritdoc />
-		constexpr inline void transition(IVulkanImage& image, ResourceAccess accessBefore, ResourceAccess accessAfter, ImageLayout layout) override;
-
-		/// <inheritdoc />
-		constexpr inline void transition(IVulkanImage& image, ResourceAccess accessBefore, ResourceAccess accessAfter, ImageLayout fromLayout, ImageLayout toLayout) override;
-
-		/// <inheritdoc />
-		constexpr inline void transition(IVulkanImage& image, UInt32 level, UInt32 levels, UInt32 layer, UInt32 layers, UInt32 plane, ResourceAccess accessBefore, ResourceAccess accessAfter, ImageLayout layout) override;
-
-		/// <inheritdoc />
-		constexpr inline void transition(IVulkanImage& image, UInt32 level, UInt32 levels, UInt32 layer, UInt32 layers, UInt32 plane, ResourceAccess accessBefore, ResourceAccess accessAfter, ImageLayout fromLayout, ImageLayout toLayout) override;
-
-	public:
-		/// <summary>
-		/// Adds the barrier to a command buffer and updates the resource target states.
-		/// </summary>
-		/// <param name="commandBuffer">The command buffer to add the barriers to.</param>
-		/// <exception cref="RuntimeException">Thrown, if any of the contained barriers is a image barrier that targets a sub-resource range that does not share the same <see cref="ImageLayout" /> in all sub-resources.</exception>
-		inline void execute(const VulkanCommandBuffer& commandBuffer) const noexcept;
-	};
-
-	/// <summary>
-	/// Implements a Vulkan <see cref="IShaderModule" />.
-	/// </summary>
-	/// <seealso cref="VulkanShaderProgram" />
-	/// <seealso cref="VulkanDevice" />
-	/// <seealso href="https://github.com/crud89/LiteFX/wiki/Shader-Development" />
-	class LITEFX_VULKAN_API VulkanShaderModule final : public IShaderModule, public Resource<VkShaderModule> {
-		LITEFX_IMPLEMENTATION(VulkanShaderModuleImpl);
-
-	public:
-		/// <summary>
-		/// Initializes a new Vulkan shader module.
-		/// </summary>
-		/// <param name="device">The parent device, this shader module has been created from.</param>
-		/// <param name="type">The shader stage, this module is used in.</param>
-		/// <param name="fileName">The file name of the module source.</param>
-		/// <param name="entryPoint">The name of the module entry point.</param>
-		explicit VulkanShaderModule(const VulkanDevice& device, ShaderStage type, const String& fileName, const String& entryPoint = "main");
-
-		/// <summary>
-		/// Initializes a new Vulkan shader module.
-		/// </summary>
-		/// <param name="device">The parent device, this shader module has been created from.</param>
-		/// <param name="type">The shader stage, this module is used in.</param>
-		/// <param name="stream">The file stream of the module source.</param>
-		/// <param name="name">The file name of the module source.</param>
-		/// <param name="entryPoint">The name of the module entry point.</param>
-		explicit VulkanShaderModule(const VulkanDevice& device, ShaderStage type, std::istream& stream, const String& name, const String& entryPoint = "main");
-		VulkanShaderModule(const VulkanShaderModule&) noexcept = delete;
-		VulkanShaderModule(VulkanShaderModule&&) noexcept = delete;
-		virtual ~VulkanShaderModule() noexcept;
-
-		// ShaderModule interface.
-	public:
-		/// <inheritdoc />
-		const String& fileName() const noexcept override;
-
-		/// <inheritdoc />
-		const String& entryPoint() const noexcept override;
-
-		/// <inheritdoc />
-		ShaderStage type() const noexcept override;
-
-	public:
-		/// <summary>
-		/// Returns the shader byte code.
-		/// </summary>
-		/// <returns>The shader byte code.</returns>
-		virtual const String& bytecode() const noexcept;
-
-		/// <summary>
-		/// Returns the shader stage creation info for convenience.
-		/// </summary>
-		/// <returns>The shader stage creation info for convenience.</returns>
-		virtual VkPipelineShaderStageCreateInfo shaderStageDefinition() const;
-	};
-
-	/// <summary>
-	/// Implements a Vulkan <see cref="ShaderProgram" />.
-	/// </summary>
-	/// <seealso cref="VulkanShaderProgramBuilder" />
-	/// <seealso cref="VulkanShaderModule" />
-	/// <seealso href="https://github.com/crud89/LiteFX/wiki/Shader-Development" />
-	class LITEFX_VULKAN_API VulkanShaderProgram final : public ShaderProgram<VulkanShaderModule> {
-		LITEFX_IMPLEMENTATION(VulkanShaderProgramImpl);
-		LITEFX_BUILDER(VulkanShaderProgramBuilder);
-
-	public:
-		/// <summary>
-		/// Initializes a new Vulkan shader program.
-		/// </summary>
-		/// <param name="device">The parent device of the shader program.</param>
-		/// <param name="modules">The shader modules used by the shader program.</param>
-		explicit VulkanShaderProgram(const VulkanDevice& device, Enumerable<UniquePtr<VulkanShaderModule>>&& modules);
-		VulkanShaderProgram(VulkanShaderProgram&&) noexcept = delete;
-		VulkanShaderProgram(const VulkanShaderProgram&) noexcept = delete;
-		virtual ~VulkanShaderProgram() noexcept;
-
-	private:
-		/// <summary>
-		/// Initializes a new Vulkan shader program.
-		/// </summary>
-		/// <param name="device">The parent device of the shader program.</param>
-		explicit VulkanShaderProgram(const VulkanDevice& device) noexcept;
-
-	public:
-		/// <inheritdoc />
-		Enumerable<const VulkanShaderModule*> modules() const noexcept override;
-
-		/// <inheritdoc />
-		virtual SharedPtr<VulkanPipelineLayout> reflectPipelineLayout() const;
-
-	private:
-		SharedPtr<IPipelineLayout> parsePipelineLayout() const override {
-			return std::static_pointer_cast<IPipelineLayout>(this->reflectPipelineLayout());
-		}
-	};
-
-	/// <summary>
-	/// Implements a Vulkan <see cref="DescriptorSet" />.
-	/// </summary>
-	/// <seealso cref="VulkanDescriptorSetLayout" />
-	class LITEFX_VULKAN_API VulkanDescriptorSet final : public DescriptorSet<IVulkanBuffer, IVulkanImage, IVulkanSampler>, public Resource<VkDescriptorSet> {
-		LITEFX_IMPLEMENTATION(VulkanDescriptorSetImpl);
-
-	public:
-		using base_type = DescriptorSet<IVulkanBuffer, IVulkanImage, IVulkanSampler>;
-		using base_type::update;
-		using base_type::attach;
-
-	public:
-		/// <summary>
-		/// Initializes a new descriptor set.
-		/// </summary>
-		/// <param name="layout">The parent descriptor set layout.</param>
-		/// <param name="descriptorSet">The descriptor set handle.</param>
-		explicit VulkanDescriptorSet(const VulkanDescriptorSetLayout& layout, VkDescriptorSet descriptorSet);
-		VulkanDescriptorSet(VulkanDescriptorSet&&) = delete;
-		VulkanDescriptorSet(const VulkanDescriptorSet&) = delete;
-		virtual ~VulkanDescriptorSet() noexcept;
-
-	public:
-		/// <summary>
-		/// Returns the parent descriptor set layout.
-		/// </summary>
-		/// <returns>The parent descriptor set layout.</returns>
-		virtual const VulkanDescriptorSetLayout& layout() const noexcept;
-
-	public:
-		/// <inheritdoc />
-		void update(UInt32 binding, const IVulkanBuffer& buffer, UInt32 bufferElement = 0, UInt32 elements = 0, UInt32 firstDescriptor = 0) const override;
-
-		/// <inheritdoc />
-		void update(UInt32 binding, const IVulkanImage& texture, UInt32 descriptor = 0, UInt32 firstLevel = 0, UInt32 levels = 0, UInt32 firstLayer = 0, UInt32 layers = 0) const override;
-
-		/// <inheritdoc />
-		void update(UInt32 binding, const IVulkanSampler& sampler, UInt32 descriptor = 0) const override;
-
-		/// <inheritdoc />
-		void attach(UInt32 binding, const IVulkanImage& image) const override;
-	};
-
-	/// <summary>
-	/// Implements a Vulkan <see cref="IDescriptorLayout" />
-	/// </summary>
-	/// <seealso cref="IVulkanBuffer" />
-	/// <seealso cref="IVulkanImage" />
-	/// <seealso cref="IVulkanSampler" />
-	/// <seealso cref="VulkanDescriptorSet" />
-	/// <seealso cref="VulkanDescriptorSetLayout" />
-	class LITEFX_VULKAN_API VulkanDescriptorLayout final : public IDescriptorLayout {
-		LITEFX_IMPLEMENTATION(VulkanDescriptorLayoutImpl);
-
-	public:
-		/// <summary>
-		/// Initializes a new Vulkan descriptor layout.
-		/// </summary>
-		/// <param name="type">The type of the descriptor.</param>
-		/// <param name="binding">The binding point for the descriptor.</param>
-		/// <param name="elementSize">The size of the descriptor.</param>
-		/// <param name="descriptors">The number of descriptors in the descriptor array. If set to `-1`, the descriptor will be unbounded.</param>
-		/// <seealso cref="descriptors" />
-		explicit VulkanDescriptorLayout(DescriptorType type, UInt32 binding, size_t elementSize, UInt32 descriptors = 1);
-
-		/// <summary>
-		/// Initializes a new Vulkan descriptor layout for a static sampler.
-		/// </summary>
-		/// <param name="staticSampler">The static sampler to initialize the state with.</param>
-		/// <param name="binding">The binding point for the descriptor.</param>
-		explicit VulkanDescriptorLayout(UniquePtr<IVulkanSampler>&& staticSampler, UInt32 binding);
-
-		VulkanDescriptorLayout(VulkanDescriptorLayout&&) = delete;
-		VulkanDescriptorLayout(const VulkanDescriptorLayout&) = delete;
-		virtual ~VulkanDescriptorLayout() noexcept;
-
-		// IDescriptorLayout interface.
-	public:
-		/// <inheritdoc />
-		DescriptorType descriptorType() const noexcept override;
-
-		/// <inheritdoc />
-		UInt32 descriptors() const noexcept override;
-
-		/// <inheritdoc />
-		const IVulkanSampler* staticSampler() const noexcept override;
-
-		// IBufferLayout interface.
-	public:
-		/// <inheritdoc />
-		size_t elementSize() const noexcept override;
-
-		/// <inheritdoc />
-		UInt32 binding() const noexcept override;
-
-		/// <inheritdoc />
-		BufferType type() const noexcept override;
-	};
-
-	/// <summary>
-	/// Implements a Vulkan <see cref="DescriptorSetLayout" />.
-	/// </summary>
-	/// <seealso cref="VulkanDescriptorSet" />
-	/// <seealso cref="VulkanDescriptorSetLayoutBuilder" />
-	class LITEFX_VULKAN_API VulkanDescriptorSetLayout final : public DescriptorSetLayout<VulkanDescriptorLayout, VulkanDescriptorSet>, public Resource<VkDescriptorSetLayout> {
-		LITEFX_IMPLEMENTATION(VulkanDescriptorSetLayoutImpl);
-		LITEFX_BUILDER(VulkanDescriptorSetLayoutBuilder);
-
-	public:
-		using base_type = DescriptorSetLayout<VulkanDescriptorLayout, VulkanDescriptorSet>;
-		using base_type::free;
-
-	public:
-		/// <summary>
-		/// Initializes a Vulkan descriptor set layout.
-		/// </summary>
-		/// <remarks>
-		/// If the descriptor set contains an unbounded array, it still is not truly unbounded. Instead, only maximum number of descriptors can be allocated from the descriptor set. This
-		/// number is defined by the device limits and depends on the descriptor type. If you need more descriptors in one array, increase the <paramref name="maxUnboundedArraySize" />
-		/// parameter. Keep in mind that you may be only able to use less or smaller unbounded descriptor arrays in other descriptor sets as a result.
-		/// </remarks>
-		/// <param name="device">The parent device, the pipeline layout has been created from.</param>
-		/// <param name="descriptorLayouts">The descriptor layouts of the descriptors within the descriptor set.</param>
-		/// <param name="space">The space or set id of the descriptor set.</param>
-		/// <param name="stages">The shader stages, the descriptor sets are bound to.</param>
-		/// <param name="poolSize">The size of a descriptor pool.</param>
-		/// <param name="maxUnboundedArraySize">The maximum number of descriptors in an unbounded array.</param>
-		explicit VulkanDescriptorSetLayout(const VulkanDevice& device, Enumerable<UniquePtr<VulkanDescriptorLayout>>&& descriptorLayouts, UInt32 space, ShaderStage stages, UInt32 poolSize = 1024, UInt32 maxUnboundedArraySize = 104857);
-		VulkanDescriptorSetLayout(VulkanDescriptorSetLayout&&) = delete;
-		VulkanDescriptorSetLayout(const VulkanDescriptorSetLayout&) = delete;
-		virtual ~VulkanDescriptorSetLayout() noexcept;
-
-	private:
-		/// <summary>
-		/// Initializes a Vulkan descriptor set layout.
-		/// </summary>
-		/// <param name="device">The parent device, the pipeline layout has been created from.</param>
-		explicit VulkanDescriptorSetLayout(const VulkanDevice& device) noexcept;
-
-	public:
-		/// <summary>
-		/// Returns the device, the pipeline layout has been created from.
-		/// </summary>
-		/// <returns>A reference of the device, the pipeline layout has been created from.</returns>
-		virtual const VulkanDevice& device() const noexcept;
-
-	public:
-		/// <inheritdoc />
-		Enumerable<const VulkanDescriptorLayout*> descriptors() const noexcept override;
-
-		/// <inheritdoc />
-		const VulkanDescriptorLayout& descriptor(UInt32 binding) const override;
-
-		/// <inheritdoc />
-		UInt32 space() const noexcept override;
-
-		/// <inheritdoc />
-		ShaderStage shaderStages() const noexcept override;
-
-		/// <inheritdoc />
-		UInt32 uniforms() const noexcept override;
-
-		/// <inheritdoc />
-		UInt32 storages() const noexcept override;
-
-		/// <inheritdoc />
-		UInt32 images() const noexcept override;
-
-		/// <inheritdoc />
-		UInt32 buffers() const noexcept override;
-
-		/// <inheritdoc />
-		UInt32 samplers() const noexcept override;
-
-		/// <inheritdoc />
-		UInt32 staticSamplers() const noexcept override;
-
-		/// <inheritdoc />
-		UInt32 inputAttachments() const noexcept override;
-
-	public:
-		/// <inheritdoc />
-		UniquePtr<VulkanDescriptorSet> allocate(const Enumerable<DescriptorBinding>& bindings = { }) const override;
-
-		/// <inheritdoc />
-		UniquePtr<VulkanDescriptorSet> allocate(UInt32 descriptors, const Enumerable<DescriptorBinding>& bindings = { }) const override;
-
-		/// <inheritdoc />
-		Enumerable<UniquePtr<VulkanDescriptorSet>> allocateMultiple(UInt32 descriptorSets, const Enumerable<Enumerable<DescriptorBinding>>& bindings = { }) const override;
-
-		/// <inheritdoc />
-		Enumerable<UniquePtr<VulkanDescriptorSet>> allocateMultiple(UInt32 descriptorSets, std::function<Enumerable<DescriptorBinding>(UInt32)> bindingFactory) const override;
-
-		/// <inheritdoc />
-		Enumerable<UniquePtr<VulkanDescriptorSet>> allocateMultiple(UInt32 descriptorSets, UInt32 descriptors, const Enumerable<Enumerable<DescriptorBinding>>& bindings = { }) const override;
-
-		/// <inheritdoc />
-		Enumerable<UniquePtr<VulkanDescriptorSet>> allocateMultiple(UInt32 descriptorSets, UInt32 descriptors, std::function<Enumerable<DescriptorBinding>(UInt32)> bindingFactory) const override;
-
-		/// <inheritdoc />
-		void free(const VulkanDescriptorSet& descriptorSet) const noexcept override;
-
-	public:
-		/// <summary>
-		/// The size of each descriptor pool.
-		/// </summary>
-		/// <remarks>
-		/// Descriptors are allocated from descriptor pools in Vulkan. Each descriptor pool has a number of descriptor sets it can hand out. Before allocating a new descriptor set
-		/// the layout tries to find an unused descriptor set, that it can hand out. If there are no free descriptor sets, the layout tries to allocate a new one. This is only possible
-		/// if the descriptor pool is not yet full, in which case a new pool needs to be created. All created pools are cached and destroyed, if the layout itself gets destroyed, 
-		/// causing all descriptor sets allocated from the layout to be invalidated. 
-		/// 
-		/// In general, if the number of required descriptor sets can be pre-calculated, it should be used as a pool size. Otherwise there is a trade-off to be made, based on the 
-		/// frequency of which new descriptor sets are required. A small pool size is more memory efficient, but can have a significant runtime cost, as long as new allocations happen
-		/// and no descriptor sets can be reused. A large pool size on the other hand is faster, whilst it may leave a large chunk of descriptor sets unallocated. Keep in mind, that the 
-		/// layout might not be the only active layout, hence a large portion of descriptor sets might end up not being used.
-		/// </remarks>
-		/// <returns>The size of one descriptor pool.</returns>
-		/// <seealso cref="allocate" />
-		/// <seealso cref="free" />
-		/// <seealso cref="pools" />
-		virtual UInt32 poolSize() const noexcept;
-
-		/// <summary>
-		/// Returns the number of active descriptor pools.
-		/// </summary>
-		/// <returns>The number of active descriptor pools.</returns>
-		/// <seealso cref="allocate" />
-		/// <seealso cref="free" />
-		/// <seealso cref="poolSize" />
-		virtual size_t pools() const noexcept;
-	};
-
-	/// <summary>
-	/// Implements the Vulkan <see cref="IPushConstantsRange" />.
-	/// </summary>
-	/// <seealso cref="VulkanPushConstantsLayout" />
-	class LITEFX_VULKAN_API VulkanPushConstantsRange final : public IPushConstantsRange {
-		LITEFX_IMPLEMENTATION(VulkanPushConstantsRangeImpl);
-
-	public:
-		/// <summary>
-		/// Initializes a new push constants range.
-		/// </summary>
-		/// <param name="shaderStage">The shader stage, that access the push constants from the range.</param>
-		/// <param name="offset">The offset relative to the parent push constants backing memory that marks the beginning of the range.</param>
-		/// <param name="size">The size of the push constants range.</param>
-		/// <param name="space">The space from which the push constants of the range will be accessible in the shader.</param>
-		/// <param name="binding">The register from which the push constants of the range will be accessible in the shader.</param>
-		explicit VulkanPushConstantsRange(ShaderStage shaderStage, UInt32 offset, UInt32 size, UInt32 space, UInt32 binding);
-		VulkanPushConstantsRange(const VulkanPushConstantsRange&) = delete;
-		VulkanPushConstantsRange(VulkanPushConstantsRange&&) = delete;
-		virtual ~VulkanPushConstantsRange() noexcept;
-
-	public:
-		/// <inheritdoc />
-		UInt32 space() const noexcept override;
-
-		/// <inheritdoc />
-		UInt32 binding() const noexcept override;
-
-		/// <inheritdoc />
-		UInt32 offset() const noexcept override;
-
-		/// <inheritdoc />
-		UInt32 size() const noexcept override;
-
-		/// <inheritdoc />
-		ShaderStage stage() const noexcept override;
-	};
-
-	/// <summary>
-	/// Implements the Vulkan <see cref="PushConstantsLayout" />.
-	/// </summary>
-	/// <seealso cref="VulkanPushConstantsRange" />
-	/// <seealso cref="VulkanPushConstantsLayoutBuilder" />
-	/// <seealso cref="VulkanPushConstantsLayoutBuilder" />
-	class LITEFX_VULKAN_API VulkanPushConstantsLayout final : public PushConstantsLayout<VulkanPushConstantsRange> {
-		LITEFX_IMPLEMENTATION(VulkanPushConstantsLayoutImpl);
-		LITEFX_BUILDER(VulkanPushConstantsLayoutBuilder);
-		friend class VulkanPipelineLayout;
-
-	public:
-		/// <summary>
-		/// Initializes a new push constants layout.
-		/// </summary>
-		/// <param name="ranges">The ranges contained by the layout.</param>
-		/// <param name="size">The overall size (in bytes) of the push constants backing memory.</param>
-		explicit VulkanPushConstantsLayout(Enumerable<UniquePtr<VulkanPushConstantsRange>>&& ranges, UInt32 size);
-		VulkanPushConstantsLayout(const VulkanPushConstantsLayout&) = delete;
-		VulkanPushConstantsLayout(VulkanPushConstantsLayout&&) = delete;
-		virtual ~VulkanPushConstantsLayout() noexcept;
-
-	private:
-		/// <summary>
-		/// Initializes a new push constants layout.
-		/// </summary>
-		/// <param name="size">The overall size (in bytes) of the push constants backing memory.</param>
-		explicit VulkanPushConstantsLayout(UInt32 size);
-
-	public:
-		/// <summary>
-		/// Returns the parent pipeline layout, the push constants are described for.
-		/// </summary>
-		/// <returns>A reference of the parent pipeline layout.</returns>
-		virtual const VulkanPipelineLayout& pipelineLayout() const;
-
-	private:
-		/// <summary>
-		/// Sets the parent pipeline layout, the push constants are described for.
-		/// </summary>
-		/// <param name="pipelineLayout">The parent pipeline layout.</param>
-		virtual void pipelineLayout(const VulkanPipelineLayout& pipelineLayout);
-	
-	public:
-		/// <inheritdoc />
-		UInt32 size() const noexcept override;
-
-		/// <inheritdoc />
-		const VulkanPushConstantsRange& range(ShaderStage stage) const override;
-
-		/// <inheritdoc />
-		Enumerable<const VulkanPushConstantsRange*> ranges() const noexcept override;
-	};
-
-	/// <summary>
-	/// Implements a Vulkan <see cref="PipelineLayout" />.
-	/// </summary>
-	/// <seealso cref="VulkanPipelineLayoutBuilder" />
-	class LITEFX_VULKAN_API VulkanPipelineLayout final : public PipelineLayout<VulkanDescriptorSetLayout, VulkanPushConstantsLayout>, public Resource<VkPipelineLayout> {
-		LITEFX_IMPLEMENTATION(VulkanPipelineLayoutImpl);
-		LITEFX_BUILDER(VulkanPipelineLayoutBuilder);
-
-	public:
-		/// <summary>
-		/// Initializes a new Vulkan render pipeline layout.
-		/// </summary>
-		/// <param name="device">The parent device, the layout is created from.</param>
-		/// <param name="descriptorSetLayouts">The descriptor set layouts used by the pipeline.</param>
-		/// <param name="pushConstantsLayout">The push constants layout used by the pipeline.</param>
-		explicit VulkanPipelineLayout(const VulkanDevice& device, Enumerable<UniquePtr<VulkanDescriptorSetLayout>>&& descriptorSetLayouts, UniquePtr<VulkanPushConstantsLayout>&& pushConstantsLayout);
-		VulkanPipelineLayout(VulkanPipelineLayout&&) noexcept = delete;
-		VulkanPipelineLayout(const VulkanPipelineLayout&) noexcept = delete;
-		virtual ~VulkanPipelineLayout() noexcept;
-
-	private:
-		/// <summary>
-		/// Initializes a new Vulkan render pipeline layout.
-		/// </summary>
-		/// <param name="device">The parent device, the layout is created from.</param>
-		explicit VulkanPipelineLayout(const VulkanDevice& device) noexcept;
-
-	public:
-		/// <summary>
-		/// Returns a reference to the device that provides this layout.
-		/// </summary>
-		/// <returns>A reference to the layouts parent device.</returns>
-		virtual const VulkanDevice& device() const noexcept;
-
-		// PipelineLayout interface.
-	public:
-		/// <inheritdoc />
-		const VulkanDescriptorSetLayout& descriptorSet(UInt32 space) const override;
-
-		/// <inheritdoc />
-		Enumerable<const VulkanDescriptorSetLayout*> descriptorSets() const noexcept override;
-
-		/// <inheritdoc />
-		const VulkanPushConstantsLayout* pushConstants() const noexcept override;
-	};
-
-	/// <summary>
-	/// Implements the Vulkan input assembler state.
-	/// </summary>
-	/// <seealso cref="VulkanInputAssemblerBuilder" />
-	class LITEFX_VULKAN_API VulkanInputAssembler final : public InputAssembler<VulkanVertexBufferLayout, VulkanIndexBufferLayout> {
-		LITEFX_IMPLEMENTATION(VulkanInputAssemblerImpl);
-		LITEFX_BUILDER(VulkanInputAssemblerBuilder);
-
-	public:
-		/// <summary>
-		/// Initializes a new Vulkan input assembler state.
-		/// </summary>
-		/// <param name="vertexBufferLayouts">The vertex buffer layouts supported by the input assembler state. Each layout must have a unique binding.</param>
-		/// <param name="indexBufferLayout">The index buffer layout.</param>
-		/// <param name="primitiveTopology">The primitive topology.</param>
-		explicit VulkanInputAssembler(Enumerable<UniquePtr<VulkanVertexBufferLayout>>&& vertexBufferLayouts, UniquePtr<VulkanIndexBufferLayout>&& indexBufferLayout, PrimitiveTopology primitiveTopology = PrimitiveTopology::TriangleList);
-		VulkanInputAssembler(VulkanInputAssembler&&) noexcept = delete;
-		VulkanInputAssembler(const VulkanInputAssembler&) noexcept = delete;
-		virtual ~VulkanInputAssembler() noexcept;
-
-	private:
-		/// <summary>
-		/// Initializes a new Vulkan input assembler state.
-		/// </summary>
-		explicit VulkanInputAssembler() noexcept;
-
-	public:
-		/// <inheritdoc />
-		Enumerable<const VulkanVertexBufferLayout*> vertexBufferLayouts() const noexcept override;
-
-		/// <inheritdoc />
-		const VulkanVertexBufferLayout& vertexBufferLayout(UInt32 binding) const override;
-
-		/// <inheritdoc />
-		const VulkanIndexBufferLayout& indexBufferLayout() const override;
-
-		/// <inheritdoc />
-		PrimitiveTopology topology() const noexcept override;
-	};
-
-	/// <summary>
-	/// Implements a Vulkan <see cref="IRasterizer" />.
-	/// </summary>
-	/// <seealso cref="VulkanRasterizerBuilder" />
-	class LITEFX_VULKAN_API VulkanRasterizer final : public Rasterizer {
-		LITEFX_BUILDER(VulkanRasterizerBuilder);
-
-	public:
-		/// <summary>
-		/// Initializes a new Vulkan rasterizer state.
-		/// </summary>
-		/// <param name="polygonMode">The polygon mode used by the pipeline.</param>
-		/// <param name="cullMode">The cull mode used by the pipeline.</param>
-		/// <param name="cullOrder">The cull order used by the pipeline.</param>
-		/// <param name="lineWidth">The line width used by the pipeline.</param>
-		/// <param name="depthStencilState">The rasterizer depth/stencil state.</param>
-		explicit VulkanRasterizer(PolygonMode polygonMode, CullMode cullMode, CullOrder cullOrder, Float lineWidth = 1.f, const DepthStencilState& depthStencilState = {}) noexcept;
-		VulkanRasterizer(VulkanRasterizer&&) noexcept = delete;
-		VulkanRasterizer(const VulkanRasterizer&) noexcept = delete;
-		virtual ~VulkanRasterizer() noexcept;
-
-	private:
-		/// <summary>
-		/// Initializes a new Vulkan rasterizer state.
-		/// </summary>
-		explicit VulkanRasterizer() noexcept;
-
-	public:
-		/// <summary>
-		/// Sets the line width on the rasterizer.
-		/// </summary>
-		/// <remarks>
-		/// Note that updating the line width requires the "wide lines" feature to be available. If it is not, the line width **must** be `1.0`. This
-		/// constraint is not enforced by the engine and you are responsible of making sure that it is fulfilled.
-		/// 
-		/// Furthermore, note that the DirectX 12 back-end does have any representation for the line width concept. Thus you should only use the line 
-		/// width, if you plan to only support Vulkan.
-		/// </remarks>
-		/// <returns>A reference to the line width.</returns>
-		/// <seealso href="https://www.khronos.org/registry/vulkan/specs/1.2-extensions/html/vkspec.html#features-wideLines" />
-		virtual void updateLineWidth(Float lineWidth) noexcept;
-	};
-
-	/// <summary>
-	/// Defines the base class for Vulkan pipeline state objects.
-	/// </summary>
-	/// <seealso cref="VulkanRenderPipeline" />
-	/// <seealso cref="VulkanComputePipeline" />
-	class LITEFX_VULKAN_API VulkanPipelineState : public virtual Pipeline<VulkanPipelineLayout, VulkanShaderProgram>, public Resource<VkPipeline> {
-	public:
-		using Resource<VkPipeline>::Resource;
-		virtual ~VulkanPipelineState() noexcept = default;
-
-	public:
-		/// <summary>
-		/// Sets the current pipeline state on the <paramref name="commandBuffer" />.
-		/// </summary>
-		/// <param name="commandBuffer">The command buffer to set the current pipeline state on.</param>
-		virtual void use(const VulkanCommandBuffer& commandBuffer) const noexcept = 0;
-
-		/// <summary>
-		/// Binds a descriptor set on a command buffer.
-		/// </summary>
-		/// <param name="commandBuffer">The command buffer to issue the bind command on.</param>
-		/// <param name="descriptorSet">The descriptor set to bind.</param>
-		virtual void bind(const VulkanCommandBuffer& commandBuffer, const VulkanDescriptorSet& descriptorSet) const noexcept = 0;
-	};
-
-	/// <summary>
-	/// Records commands for a <see cref="VulkanCommandQueue" />
-	/// </summary>
-	/// <seealso cref="VulkanQueue" />
-	class LITEFX_VULKAN_API VulkanCommandBuffer final : public CommandBuffer<VulkanCommandBuffer, IVulkanBuffer, IVulkanVertexBuffer, IVulkanIndexBuffer, IVulkanImage, VulkanBarrier, VulkanPipelineState>, public Resource<VkCommandBuffer> {
-		LITEFX_IMPLEMENTATION(VulkanCommandBufferImpl);
-
-	public:
-		using base_type = CommandBuffer<VulkanCommandBuffer, IVulkanBuffer, IVulkanVertexBuffer, IVulkanIndexBuffer, IVulkanImage, VulkanBarrier, VulkanPipelineState>;
-		using base_type::dispatch;
-		using base_type::draw;
-		using base_type::drawIndexed;
-		using base_type::barrier;
-		using base_type::transfer;
-		using base_type::generateMipMaps;
-		using base_type::bind;
-		using base_type::use;
-		using base_type::pushConstants;
-
-	public:
-		/// <summary>
-		/// Initializes a command buffer from a command queue.
-		/// </summary>
-		/// <param name="queue">The parent command queue, the buffer gets submitted to.</param>
-		/// <param name="begin">If set to <c>true</c>, the command buffer automatically starts recording by calling <see cref="begin" />.</param>
-		/// <param name="primary"><c>true</c>, if the command buffer is a primary command buffer.</param>
-		explicit VulkanCommandBuffer(const VulkanQueue& queue, bool begin = false, bool primary = true);
-		VulkanCommandBuffer(const VulkanCommandBuffer&) = delete;
-		VulkanCommandBuffer(VulkanCommandBuffer&&) = delete;
-		virtual ~VulkanCommandBuffer() noexcept;
-
-		// Vulkan Command Buffer interface.
-	public:
-		/// <summary>
-		/// Begins the command buffer as a secondary command buffer that inherits the state of <paramref name="renderPass" />.
-		/// </summary>
-		/// <param name="renderPass">The render pass state to inherit.</param>
-		virtual void begin(const VulkanRenderPass& renderPass) const noexcept;
-
-		// CommandBuffer interface.
-	public:
-		/// <inheritdoc />
-		void begin() const override;
-
-		/// <inheritdoc />
-		void end() const override;
-
-		/// <inheritdoc />
-		bool isSecondary() const noexcept override;
-
-		/// <inheritdoc />
-		void setViewports(Span<const IViewport*> viewports) const noexcept override;
-
-		/// <inheritdoc />
-		void setViewports(const IViewport* viewport) const noexcept override;
-
-		/// <inheritdoc />
-		void setScissors(Span<const IScissor*> scissors) const noexcept override;
-
-		/// <inheritdoc />
-		void setScissors(const IScissor* scissor) const noexcept override;
-
-		/// <inheritdoc />
-		void setBlendFactors(const Vector4f& blendFactors) const noexcept override;
-
-		/// <inheritdoc />
-		void setStencilRef(UInt32 stencilRef) const noexcept override;
-
-		/// <inheritdoc />
-		void generateMipMaps(IVulkanImage& image) noexcept override;
-
-		/// <inheritdoc />
-		void barrier(const VulkanBarrier& barrier) const noexcept override;
-
-		/// <inheritdoc />
-		void transfer(IVulkanBuffer& source, IVulkanBuffer& target, UInt32 sourceElement = 0, UInt32 targetElement = 0, UInt32 elements = 1) const override;
-
-		/// <inheritdoc />
-		void transfer(IVulkanBuffer& source, IVulkanImage& target, UInt32 sourceElement = 0, UInt32 firstSubresource = 0, UInt32 elements = 1) const override;
-
-		/// <inheritdoc />
-		void transfer(IVulkanImage& source, IVulkanImage& target, UInt32 sourceSubresource = 0, UInt32 targetSubresource = 0, UInt32 subresources = 1) const override;
-
-		/// <inheritdoc />
-		void transfer(IVulkanImage& source, IVulkanBuffer& target, UInt32 firstSubresource = 0, UInt32 targetElement = 0, UInt32 subresources = 1) const override;
-
-		/// <inheritdoc />
-		void transfer(SharedPtr<IVulkanBuffer> source, IVulkanBuffer& target, UInt32 sourceElement = 0, UInt32 targetElement = 0, UInt32 elements = 1) const override;
-
-		/// <inheritdoc />
-		void transfer(SharedPtr<IVulkanBuffer> source, IVulkanImage& target, UInt32 sourceElement = 0, UInt32 firstSubresource = 0, UInt32 elements = 1) const override;
-
-		/// <inheritdoc />
-		void transfer(SharedPtr<IVulkanImage> source, IVulkanImage& target, UInt32 sourceSubresource = 0, UInt32 targetSubresource = 0, UInt32 subresources = 1) const override;
-
-		/// <inheritdoc />
-		void transfer(SharedPtr<IVulkanImage> source, IVulkanBuffer& target, UInt32 firstSubresource = 0, UInt32 targetElement = 0, UInt32 subresources = 1) const override;
-
-		/// <inheritdoc />
-		void use(const VulkanPipelineState& pipeline) const noexcept override;
-
-		/// <inheritdoc />
-		void bind(const VulkanDescriptorSet& descriptorSet, const VulkanPipelineState& pipeline) const noexcept override;
-
-		/// <inheritdoc />
-		void bind(const IVulkanVertexBuffer& buffer) const noexcept override;
-
-		/// <inheritdoc />
-		void bind(const IVulkanIndexBuffer& buffer) const noexcept override;
-
-		/// <inheritdoc />
-		void dispatch(const Vector3u& threadCount) const noexcept override;
-
-		/// <inheritdoc />
-		void draw(UInt32 vertices, UInt32 instances = 1, UInt32 firstVertex = 0, UInt32 firstInstance = 0) const noexcept override;
-
-		/// <inheritdoc />
-		void drawIndexed(UInt32 indices, UInt32 instances = 1, UInt32 firstIndex = 0, Int32 vertexOffset = 0, UInt32 firstInstance = 0) const noexcept override;
-
-		/// <inheritdoc />
-		void pushConstants(const VulkanPushConstantsLayout& layout, const void* const memory) const noexcept override;
-
-		/// <inheritdoc />
-		void writeTimingEvent(SharedPtr<const TimingEvent> timingEvent) const override;
-
-		/// <inheritdoc />
-		void execute(SharedPtr<const VulkanCommandBuffer> commandBuffer) const override;
-
-		/// <inheritdoc />
-		void execute(Enumerable<SharedPtr<const VulkanCommandBuffer>> commandBuffers) const override;
-
-	private:
-		void releaseSharedState() const override;
-	};
-
-	/// <summary>
-	/// Implements a Vulkan <see cref="RenderPipeline" />.
-	/// </summary>
-	/// <seealso cref="VulkanComputePipeline" />
-	/// <seealso cref="VulkanRenderPipelineBuilder" />
-	class LITEFX_VULKAN_API VulkanRenderPipeline final : public RenderPipeline<VulkanPipelineLayout, VulkanShaderProgram, VulkanInputAssembler, VulkanRasterizer>, public VulkanPipelineState {
-		LITEFX_IMPLEMENTATION(VulkanRenderPipelineImpl);
-		LITEFX_BUILDER(VulkanRenderPipelineBuilder);
-
-	public:
-		/// <summary>
-		/// Initializes a new Vulkan render pipeline.
-		/// </summary>
-		/// <param name="renderPass">The parent render pass.</param>
-		/// <param name="shaderProgram">The shader program used by the pipeline.</param>
-		/// <param name="layout">The layout of the pipeline.</param>
-		/// <param name="inputAssembler">The input assembler state of the pipeline.</param>
-		/// <param name="rasterizer">The rasterizer state of the pipeline.</param>
-		/// <param name="name">The optional name of the render pipeline.</param>
-		/// <param name="enableAlphaToCoverage">Whether or not to enable Alpha-to-Coverage multi-sampling.</param>
-		explicit VulkanRenderPipeline(const VulkanRenderPass& renderPass, SharedPtr<VulkanShaderProgram> shaderProgram, SharedPtr<VulkanPipelineLayout> layout, SharedPtr<VulkanInputAssembler> inputAssembler, SharedPtr<VulkanRasterizer> rasterizer, bool enableAlphaToCoverage = false, const String& name = "");
-		VulkanRenderPipeline(VulkanRenderPipeline&&) noexcept = delete;
-		VulkanRenderPipeline(const VulkanRenderPipeline&) noexcept = delete;
-		virtual ~VulkanRenderPipeline() noexcept;
-
-	private:
-		/// <summary>
-		/// Initializes a new Vulkan render pipeline.
-		/// </summary>
-		/// <param name="renderPass">The parent render pass.</param>
-		/// <param name="name">The optional name of the render pipeline.</param>
-		VulkanRenderPipeline(const VulkanRenderPass& renderPass, const String& name = "") noexcept;
-
-		// Pipeline interface.
-	public:
-		/// <inheritdoc />
-		SharedPtr<const VulkanShaderProgram> program() const noexcept override;
-
-		/// <inheritdoc />
-		SharedPtr<const VulkanPipelineLayout> layout() const noexcept override;
-
-		// RenderPipeline interface.
-	public:
-		/// <inheritdoc />
-		SharedPtr<VulkanInputAssembler> inputAssembler() const noexcept override;
-
-		/// <inheritdoc />
-		SharedPtr<VulkanRasterizer> rasterizer() const noexcept override;
-
-		/// <inheritdoc />
-		bool alphaToCoverage() const noexcept override;
-
-		// VulkanPipelineState interface.
-	public:
-		/// <inheritdoc />
-		void use(const VulkanCommandBuffer& commandBuffer) const noexcept override;
-
-		/// <inheritdoc />
-		void bind(const VulkanCommandBuffer& commandBuffer, const VulkanDescriptorSet& descriptorSet) const noexcept override;
-	};
-
-	/// <summary>
-	/// Implements a Vulkan <see cref="ComputePipeline" />.
-	/// </summary>
-	/// <seealso cref="VulkanRenderPipeline" />
-	/// <seealso cref="VulkanComputePipelineBuilder" />
-	class LITEFX_VULKAN_API VulkanComputePipeline final : public ComputePipeline<VulkanPipelineLayout, VulkanShaderProgram>, public VulkanPipelineState {
-		LITEFX_IMPLEMENTATION(VulkanComputePipelineImpl);
-		LITEFX_BUILDER(VulkanComputePipelineBuilder);
-
-	public:
-		/// <summary>
-		/// Initializes a new Vulkan compute pipeline.
-		/// </summary>
-		/// <param name="device">The parent device.</param>
-		/// <param name="shaderProgram">The shader program used by the pipeline.</param>
-		/// <param name="layout">The layout of the pipeline.</param>
-		/// <param name="name">The optional debug name of the render pipeline.</param>
-		explicit VulkanComputePipeline(const VulkanDevice& device, SharedPtr<VulkanShaderProgram> shaderProgram, SharedPtr<VulkanPipelineLayout> layout, const String& name = "");
-		VulkanComputePipeline(VulkanComputePipeline&&) noexcept = delete;
-		VulkanComputePipeline(const VulkanComputePipeline&) noexcept = delete;
-		virtual ~VulkanComputePipeline() noexcept;
-
-	private:
-		/// <summary>
-		/// Initializes a new Vulkan compute pipeline.
-		/// </summary>
-		/// <param name="device">The parent device.</param>
-		VulkanComputePipeline(const VulkanDevice& device) noexcept;
-
-		// Pipeline interface.
-	public:
-		/// <inheritdoc />
-		SharedPtr<const VulkanShaderProgram> program() const noexcept override;
-
-		/// <inheritdoc />
-		SharedPtr<const VulkanPipelineLayout> layout() const noexcept override;
-
-		// VulkanPipelineState interface.
-	public:
-		/// <inheritdoc />
-		void use(const VulkanCommandBuffer& commandBuffer) const noexcept override;
-
-		/// <inheritdoc />
-		void bind(const VulkanCommandBuffer& commandBuffer, const VulkanDescriptorSet& descriptorSet) const noexcept override;
-	};
-
-	/// <summary>
-	/// Implements a Vulkan frame buffer.
-	/// </summary>
-	/// <seealso cref="VulkanRenderPass" />
-	class LITEFX_VULKAN_API VulkanFrameBuffer final : public FrameBuffer<VulkanCommandBuffer>, public Resource<VkFramebuffer> {
-		LITEFX_IMPLEMENTATION(VulkanFrameBufferImpl);
-
-	public:
-		/// <summary>
-		/// Initializes a Vulkan frame buffer.
-		/// </summary>
-		/// <param name="renderPass">The parent render pass of the frame buffer.</param>
-		/// <param name="bufferIndex">The index of the frame buffer within the parent render pass.</param>
-		/// <param name="renderArea">The initial size of the render area.</param>
-		/// <param name="commandBuffers">The number of command buffers, the frame buffer stores.</param>
-		VulkanFrameBuffer(const VulkanRenderPass& renderPass, UInt32 bufferIndex, const Size2d& renderArea, UInt32 commandBuffers = 1);
-		VulkanFrameBuffer(const VulkanFrameBuffer&) noexcept = delete;
-		VulkanFrameBuffer(VulkanFrameBuffer&&) noexcept = delete;
-		virtual ~VulkanFrameBuffer() noexcept;
-
-		// Vulkan frame buffer interface.
-	public:
-		/// <summary>
-		/// Returns a reference of the semaphore, that can be used to signal, that the frame buffer is finished.
-		/// </summary>
-		/// <returns>A reference of the semaphore, that can be used to signal, that the frame buffer is finished.</returns>
-		virtual const VkSemaphore& semaphore() const noexcept;
-
-		/// <summary>
-		/// Returns a reference of the last fence value for the frame buffer.
-		/// </summary>
-		/// <remarks>
-		/// The frame buffer must only be re-used, if this fence is reached in the graphics queue.
-		/// </remarks>
-		/// <returns>A reference of the last fence value for the frame buffer.</returns>
-		virtual UInt64& lastFence() const noexcept;
-
-		// FrameBuffer interface.
-	public:
-		/// <inheritdoc />
-		UInt32 bufferIndex() const noexcept override;
-
-		/// <inheritdoc />
-		const Size2d& size() const noexcept override;
-
-		/// <inheritdoc />
-		size_t getWidth() const noexcept override;
-
-		/// <inheritdoc />
-		size_t getHeight() const noexcept override;
-
-		/// <inheritdoc />
-		SharedPtr<const VulkanCommandBuffer> commandBuffer(UInt32 index) const override;
-
-		/// <inheritdoc />
-		Enumerable<SharedPtr<const VulkanCommandBuffer>> commandBuffers() const noexcept override;
-
-		/// <inheritdoc />
-		Enumerable<const IVulkanImage*> images() const noexcept override;
-
-		/// <inheritdoc />
-		const IVulkanImage& image(UInt32 location) const override;
-
-	public:
-		/// <inheritdoc />
-		void resize(const Size2d& renderArea) override;
-	};
-
-	/// <summary>
-	/// Implements a Vulkan render pass.
-	/// </summary>
-	/// <seealso cref="VulkanRenderPassBuilder" />
-	class LITEFX_VULKAN_API VulkanRenderPass final : public RenderPass<VulkanRenderPipeline, VulkanFrameBuffer, VulkanInputAttachmentMapping>, public Resource<VkRenderPass> {
-		LITEFX_IMPLEMENTATION(VulkanRenderPassImpl);
-		LITEFX_BUILDER(VulkanRenderPassBuilder);
-
-	public:
-		using base_type = RenderPass<VulkanRenderPipeline, VulkanFrameBuffer, VulkanInputAttachmentMapping>;
-		using base_type::updateAttachments;
-
-	public:
-		/// <summary>
-		/// Creates and initializes a new Vulkan render pass instance.
-		/// </summary>
-		/// <param name="device">The parent device instance.</param>
-		/// <param name="commandBuffers">The number of command buffers in each frame buffer.</param>
-		/// <param name="renderTargets">The render targets that are output by the render pass.</param>
-		/// <param name="samples">The number of samples for the render targets in this render pass.</param>
-		/// <param name="inputAttachments">The input attachments that are read by the render pass.</param>
-		explicit VulkanRenderPass(const VulkanDevice& device, Span<RenderTarget> renderTargets, UInt32 commandBuffers = 1, MultiSamplingLevel samples = MultiSamplingLevel::x1, Span<VulkanInputAttachmentMapping> inputAttachments = { });
-
-		/// <summary>
-		/// Creates and initializes a new Vulkan render pass instance.
-		/// </summary>
-		/// <param name="device">The parent device instance.</param>
-		/// <param name="name">The name of the render pass state resource.</param>
-		/// <param name="commandBuffers">The number of command buffers in each frame buffer.</param>
-		/// <param name="renderTargets">The render targets that are output by the render pass.</param>
-		/// <param name="samples">The number of samples for the render targets in this render pass.</param>
-		/// <param name="inputAttachments">The input attachments that are read by the render pass.</param>
-		explicit VulkanRenderPass(const VulkanDevice& device, const String& name, Span<RenderTarget> renderTargets, UInt32 commandBuffers = 1, MultiSamplingLevel samples = MultiSamplingLevel::x1, Span<VulkanInputAttachmentMapping> inputAttachments = { });
-		
-		VulkanRenderPass(const VulkanRenderPass&) = delete;
-		VulkanRenderPass(VulkanRenderPass&&) = delete;
-		virtual ~VulkanRenderPass() noexcept;
-
-	private:
-		/// <summary>
-		/// Creates an uninitialized Vulkan render pass instance.
-		/// </summary>
-		/// <remarks>
-		/// This constructor is called by the <see cref="VulkanRenderPassBuilder" /> in order to create a render pass instance without initializing it. The instance 
-		/// is only initialized after calling <see cref="VulkanRenderPassBuilder::go" />.
-		/// </remarks>
-		/// <param name="device">The parent device of the render pass.</param>
-		/// <param name="name">The name of the render pass state resource.</param>
-		explicit VulkanRenderPass(const VulkanDevice& device, const String& name = "") noexcept;
-
-		// IInputAttachmentMappingSource interface.
-	public:
-		/// <inheritdoc />
-		const VulkanFrameBuffer& frameBuffer(UInt32 buffer) const override;
-
-		// RenderPass interface.
-	public:
-		/// <summary>
-		/// Returns a reference to the device that provides this queue.
-		/// </summary>
-		/// <returns>A reference to the queue's parent device.</returns>
-		virtual const VulkanDevice& device() const noexcept;
-
-		/// <inheritdoc />
-		const VulkanFrameBuffer& activeFrameBuffer() const override;
-
-		/// <inheritdoc />
-		Enumerable<const VulkanFrameBuffer*> frameBuffers() const noexcept override;
-
-		/// <inheritdoc />
-		Enumerable<const VulkanRenderPipeline*> pipelines() const noexcept override;
-
-		/// <inheritdoc />
-		const RenderTarget& renderTarget(UInt32 location) const override;
-
-		/// <inheritdoc />
-		Span<const RenderTarget> renderTargets() const noexcept override;
-
-		/// <inheritdoc />
-		bool hasPresentTarget() const noexcept override;
-
-		/// <inheritdoc />
-		Span<const VulkanInputAttachmentMapping> inputAttachments() const noexcept override;
-
-		/// <inheritdoc />
-		MultiSamplingLevel multiSamplingLevel() const noexcept override;
-
-	public:
-		/// <inheritdoc />
-		void begin(UInt32 buffer) override;
-		
-		/// <inheritdoc />
-		void end() const override;
-
-		/// <inheritdoc />
-		void resizeFrameBuffers(const Size2d& renderArea) override;
-
-		/// <inheritdoc />
-		void changeMultiSamplingLevel(MultiSamplingLevel samples) override;
-
-		/// <inheritdoc />
-		void updateAttachments(const VulkanDescriptorSet& descriptorSet) const override;
-	};
-
-	/// <summary>
-	/// Implements a <see cref="IInputAttachmentMapping" />.
-	/// </summary>
-	/// <seealso cref="VulkanRenderPass" />
-	/// <seealso cref="VulkanRenderPassBuilder" />
-	class LITEFX_VULKAN_API VulkanInputAttachmentMapping final : public IInputAttachmentMapping<VulkanRenderPass> {
-		LITEFX_IMPLEMENTATION(VulkanInputAttachmentMappingImpl);
-
-	public:
-		/// <summary>
-		/// Creates a new Vulkan input attachment mapping.
-		/// </summary>
-		VulkanInputAttachmentMapping() noexcept;
-
-		/// <summary>
-		/// Creates a new Vulkan input attachment mapping.
-		/// </summary>
-		/// <param name="renderPass">The render pass to fetch the input attachment from.</param>
-		/// <param name="renderTarget">The render target of the <paramref name="renderPass"/> that is used for the input attachment.</param>
-		/// <param name="location">The location to bind the input attachment to.</param>
-		VulkanInputAttachmentMapping(const VulkanRenderPass& renderPass, const RenderTarget& renderTarget, UInt32 location);
-
-		/// <summary>
-		/// Copies another input attachment mapping.
-		/// </summary>
-		VulkanInputAttachmentMapping(const VulkanInputAttachmentMapping&) noexcept;
-
-		/// <summary>
-		/// Takes over another input attachment mapping.
-		/// </summary>
-		VulkanInputAttachmentMapping(VulkanInputAttachmentMapping&&) noexcept;
-
-		virtual ~VulkanInputAttachmentMapping() noexcept;
-
-	public:
-		/// <summary>
-		/// Copies another input attachment mapping.
-		/// </summary>
-		inline VulkanInputAttachmentMapping& operator=(const VulkanInputAttachmentMapping&) noexcept;
-
-		/// <summary>
-		/// Takes over another input attachment mapping.
-		/// </summary>
-		inline VulkanInputAttachmentMapping& operator=(VulkanInputAttachmentMapping&&) noexcept;
-
-	public:
-		/// <inheritdoc />
-		const VulkanRenderPass* inputAttachmentSource() const noexcept override;
-
-		/// <inheritdoc />
-		const RenderTarget& renderTarget() const noexcept override;
-
-		/// <inheritdoc />
-		UInt32 location() const noexcept override;
-	};
-
-	/// <summary>
-	/// Implements a Vulkan swap chain.
-	/// </summary>
-	class LITEFX_VULKAN_API VulkanSwapChain final : public SwapChain<IVulkanImage, VulkanFrameBuffer> {
-		LITEFX_IMPLEMENTATION(VulkanSwapChainImpl);
-
-	public:
-		using base_type = SwapChain<IVulkanImage, VulkanFrameBuffer>;
-		using base_type::present;
-
-	public:
-		/// <summary>
-		/// Initializes a Vulkan swap chain.
-		/// </summary>
-		/// <param name="device">The device that owns the swap chain.</param>
-		/// <param name="format">The initial surface format.</param>
-		/// <param name="renderArea">The initial size of the render area.</param>
-		/// <param name="buffers">The initial number of buffers.</param>
-		explicit VulkanSwapChain(const VulkanDevice& device, Format surfaceFormat = Format::B8G8R8A8_SRGB, const Size2d& renderArea = { 800, 600 }, UInt32 buffers = 3);
-		VulkanSwapChain(const VulkanSwapChain&) = delete;
-		VulkanSwapChain(VulkanSwapChain&&) = delete;
-		virtual ~VulkanSwapChain() noexcept;
-
-		// Vulkan Swap Chain interface.
-	public:
-		/// <summary>
-		/// Returns a reference of the current swap semaphore, a command queue can wait on for presenting.
-		/// </summary>
-		/// <returns>A reference of the current swap semaphore, a command queue can wait on for presenting.</returns>
-		virtual const VkSemaphore& semaphore() const noexcept;
-
-		/// <summary>
-		/// Returns the query pool for the current frame.
-		/// </summary>
-		/// <returns>A reference of the query pool for the current frame.</returns>
-		virtual const VkQueryPool& timestampQueryPool() const noexcept;
-
-		// SwapChain interface.
-	public:
-		/// <inheritdoc />
-		Enumerable<SharedPtr<TimingEvent>> timingEvents() const noexcept override;
-
-		/// <inheritdoc />
-		SharedPtr<TimingEvent> timingEvent(UInt32 queryId) const override;
-
-		/// <inheritdoc />
-		UInt64 readTimingEvent(SharedPtr<const TimingEvent> timingEvent) const override;
-
-		/// <inheritdoc />
-		UInt32 resolveQueryId(SharedPtr<const TimingEvent> timingEvent) const override;
-
-		/// <inheritdoc />
-		Format surfaceFormat() const noexcept override;
-
-		/// <inheritdoc />
-		UInt32 buffers() const noexcept override;
-
-		/// <inheritdoc />
-		const Size2d& renderArea() const noexcept override;
-
-		/// <inheritdoc />
-		const IVulkanImage* image(UInt32 backBuffer) const override;
-
-		/// <inheritdoc />
-		Enumerable<const IVulkanImage*> images() const noexcept override;
-
-		/// <inheritdoc />
-		void present(const VulkanFrameBuffer& frameBuffer) const override;
-
-	public:
-		/// <inheritdoc />
-		Enumerable<Format> getSurfaceFormats() const noexcept override;
-
-		/// <inheritdoc />
-		void addTimingEvent(SharedPtr<TimingEvent> timingEvent) override;
-
-		/// <inheritdoc />
-		void reset(Format surfaceFormat, const Size2d& renderArea, UInt32 buffers) override;
-
-		/// <inheritdoc />
-		[[nodiscard]] UInt32 swapBackBuffer() const override;
-	};
-
-	/// <summary>
-	/// Implements a Vulkan command queue.
-	/// </summary>
-	/// <seealso cref="VulkanCommandBuffer" />
-	class LITEFX_VULKAN_API VulkanQueue final : public CommandQueue<VulkanCommandBuffer>, public Resource<VkQueue> {
-		LITEFX_IMPLEMENTATION(VulkanQueueImpl);
-
-	public:
-		using base_type = CommandQueue<VulkanCommandBuffer>;
-		using base_type::submit;
-
-	public:
-		/// <summary>
-		/// Initializes the Vulkan command queue.
-		/// </summary>
-		/// <param name="device">The device, commands get send to.</param>
-		/// <param name="type">The type of the command queue.</param>
-		/// <param name="priority">The priority, of which commands are issued on the device.</param>
-		/// <param name="familyId">The ID of the queue family.</param>
-		/// <param name="queueId">The ID of the queue.</param>
-		explicit VulkanQueue(const VulkanDevice& device, QueueType type, QueuePriority priority, UInt32 familyId, UInt32 queueId);
-		VulkanQueue(const VulkanQueue&) = delete;
-		VulkanQueue(VulkanQueue&&) = delete;
-		virtual ~VulkanQueue() noexcept;
-
-		// VulkanQueue interface.
-	public:
-		/// <summary>
-		/// Returns a reference to the device that provides this queue.
-		/// </summary>
-		/// <returns>A reference to the queue's parent device.</returns>
-		virtual const VulkanDevice& device() const noexcept;
-
-		/// <summary>
-		/// Returns a reference of the command pool that is used to allocate commands.
-		/// </summary>
-		/// <remarks>
-		/// Note that the command pool does only exist, if the queue is bound on a device.
-		/// </remarks>
-		/// <seealso cref="isBound" />
-		/// <seealso cref="bind" />
-		/// <seealso cref="release" />
-		/// <returns>A reference of the command pool that is used to allocate commands</returns>
-		virtual const VkCommandPool& commandPool() const noexcept;
-
-		/// <summary>
-		/// Returns the queue family ID.
-		/// </summary>
-		/// <returns>The queue family ID.</returns>
-		virtual UInt32 familyId() const noexcept;
-
-		/// <summary>
-		/// Returns the queue ID.
-		/// </summary>
-		/// <returns>The queue ID.</returns>
-		virtual UInt32 queueId() const noexcept;
-
-		/// <summary>
-		/// Returns the internal timeline semaphore used to synchronize the queue execution.
-		/// </summary>
-		/// <returns>The internal timeline semaphore.</returns>
-		virtual const VkSemaphore& timelineSemaphore() const noexcept;
-
-		/// <summary>
-		/// Submits a single command buffer and inserts a fence to wait for it.
-		/// </summary>
-		/// <remarks>
+    using namespace LiteFX::Math;
+    using namespace LiteFX::Rendering;
+
+    /// <summary>
+    /// Implements a Vulkan vertex buffer layout.
+    /// </summary>
+    /// <seealso cref="VulkanVertexBuffer" />
+    /// <seealso cref="VulkanIndexBufferLayout" />
+    /// <seealso cref="VulkanVertexBufferLayoutBuilder" />
+    class LITEFX_VULKAN_API VulkanVertexBufferLayout final : public IVertexBufferLayout {
+        LITEFX_IMPLEMENTATION(VulkanVertexBufferLayoutImpl);
+        LITEFX_BUILDER(VulkanVertexBufferLayoutBuilder);
+
+    public:
+        /// <summary>
+        /// Initializes a new vertex buffer layout.
+        /// </summary>
+        /// <param name="vertexSize">The size of a single vertex.</param>
+        /// <param name="binding">The binding point of the vertex buffers using this layout.</param>
+        explicit VulkanVertexBufferLayout(size_t vertexSize, UInt32 binding = 0);
+        VulkanVertexBufferLayout(VulkanVertexBufferLayout&&) = delete;
+        VulkanVertexBufferLayout(const VulkanVertexBufferLayout&) = delete;
+        virtual ~VulkanVertexBufferLayout() noexcept;
+
+        // IVertexBufferLayout interface.
+    public:
+        /// <inheritdoc />
+        Enumerable<const BufferAttribute*> attributes() const noexcept override;
+
+        // IBufferLayout interface.
+    public:
+        /// <inheritdoc />
+        size_t elementSize() const noexcept override;
+
+        /// <inheritdoc />
+        UInt32 binding() const noexcept override;
+
+        /// <inheritdoc />
+        BufferType type() const noexcept override;
+    };
+
+    /// <summary>
+    /// Implements a Vulkan index buffer layout.
+    /// </summary>
+    /// <seealso cref="VulkanIndexBuffer" />
+    /// <seealso cref="VulkanVertexBufferLayout" />
+    class LITEFX_VULKAN_API VulkanIndexBufferLayout final : public IIndexBufferLayout {
+        LITEFX_IMPLEMENTATION(VulkanIndexBufferLayoutImpl);
+
+    public:
+        /// <summary>
+        /// Initializes a new index buffer layout
+        /// </summary>
+        /// <param name="type">The type of the indices within the index buffer.</param>
+        explicit VulkanIndexBufferLayout(IndexType type);
+        VulkanIndexBufferLayout(VulkanIndexBufferLayout&&) = delete;
+        VulkanIndexBufferLayout(const VulkanIndexBufferLayout&) = delete;
+        virtual ~VulkanIndexBufferLayout() noexcept;
+
+        // IIndexBufferLayout interface.
+    public:
+        /// <inheritdoc />
+        IndexType indexType() const noexcept override;
+
+        // IBufferLayout interface.
+    public:
+        /// <inheritdoc />
+        size_t elementSize() const noexcept override;
+
+        /// <inheritdoc />
+        UInt32 binding() const noexcept override;
+
+        /// <inheritdoc />
+        BufferType type() const noexcept override;
+    };
+
+    /// <summary>
+    /// Represents the base interface for a Vulkan buffer implementation.
+    /// </summary>
+    /// <seealso cref="VulkanDescriptorSet" />
+    /// <seealso cref="IVulkanImage" />
+    /// <seealso cref="IVulkanVertexBuffer" />
+    /// <seealso cref="IVulkanIndexBuffer" />
+    class LITEFX_VULKAN_API IVulkanBuffer : public virtual IBuffer, public virtual IResource<VkBuffer> {
+    public:
+        virtual ~IVulkanBuffer() noexcept = default;
+    };
+
+    /// <summary>
+    /// Represents a Vulkan vertex buffer.
+    /// </summary>
+    /// <seealso cref="VulkanVertexBufferLayout" />
+    /// <seealso cref="IVulkanBuffer" />
+    class LITEFX_VULKAN_API IVulkanVertexBuffer : public virtual VertexBuffer<VulkanVertexBufferLayout>, public virtual IVulkanBuffer {
+    public:
+        virtual ~IVulkanVertexBuffer() noexcept = default;
+    };
+
+    /// <summary>
+    /// Represents a Vulkan index buffer.
+    /// </summary>
+    /// <seealso cref="VulkanIndexBufferLayout" />
+    /// <seealso cref="IVulkanBuffer" />
+    class LITEFX_VULKAN_API IVulkanIndexBuffer : public virtual IndexBuffer<VulkanIndexBufferLayout>, public virtual IVulkanBuffer {
+    public:
+        virtual ~IVulkanIndexBuffer() noexcept = default;
+    };
+
+    /// <summary>
+    /// Represents a Vulkan sampled image or the base interface for a texture.
+    /// </summary>
+    /// <seealso cref="VulkanDescriptorLayout" />
+    /// <seealso cref="VulkanDescriptorSet" />
+    /// <seealso cref="VulkanDescriptorSetLayout" />
+    /// <seealso cref="IVulkanBuffer" />
+    /// <seealso cref="IVulkanSampler" />
+    class LITEFX_VULKAN_API IVulkanImage : public virtual IImage, public virtual IResource<VkImage> {
+    public:
+        friend class VulkanBarrier;
+
+    public:
+        virtual ~IVulkanImage() noexcept = default;
+
+    public:
+        /// <summary>
+        /// Returns the image resource aspect mask for all sub-resources.
+        /// </summary>
+        /// <returns>The image resource aspect mask.</returns>
+        virtual VkImageAspectFlags aspectMask() const noexcept = 0;
+
+        /// <summary>
+        /// Returns the image resource aspect mask for a single sub-resource.
+        /// </summary>
+        /// <param name="plane">The sub-resource identifier to query the aspect mask from.</param>
+        /// <returns>The image resource aspect mask.</returns>
+        virtual VkImageAspectFlags aspectMask(UInt32 plane) const = 0;
+
+        /// <summary>
+        /// Returns the image view for a sub-resource.
+        /// </summary>
+        /// <param name="plane">The sub-resource index to return the image view for.</param>
+        /// <returns>The image view for the sub-resource.</returns>
+        virtual const VkImageView& imageView(UInt32 plane = 0) const = 0;
+        
+    private:
+        virtual ImageLayout& layout(UInt32 subresource) = 0;
+    };
+
+    /// <summary>
+    /// Represents a Vulkan sampler.
+    /// </summary>
+    /// <seealso cref="VulkanDescriptorLayout" />
+    /// <seealso cref="VulkanDescriptorSet" />
+    /// <seealso cref="VulkanDescriptorSetLayout" />
+    /// <seealso cref="IVulkanImage" />
+    class LITEFX_VULKAN_API IVulkanSampler : public virtual ISampler, public virtual IResource<VkSampler> {
+    public:
+        virtual ~IVulkanSampler() noexcept = default;
+    };
+
+    /// <summary>
+    /// Implements a Vulkan resource barrier.
+    /// </summary>
+    /// <seealso cref="VulkanCommandBuffer" />
+    /// <seealso cref="IVulkanBuffer" />
+    /// <seealso cref="IVulkanImage" />
+    /// <seealso cref="Barrier" />
+    class LITEFX_VULKAN_API VulkanBarrier final : public Barrier<IVulkanBuffer, IVulkanImage> {
+        LITEFX_IMPLEMENTATION(VulkanBarrierImpl);
+        LITEFX_BUILDER(VulkanBarrierBuilder);
+
+    public:
+        using base_type = Barrier<IVulkanBuffer, IVulkanImage>;
+        using base_type::transition;
+
+    public:
+        /// <summary>
+        /// Initializes a new Vulkan barrier.
+        /// </summary>
+        /// <param name="syncBefore">The pipeline stage(s) all previous commands have to finish before the barrier is executed.</param>
+        /// <param name="syncAfter">The pipeline stage(s) all subsequent commands are blocked at until the barrier is executed.</param>
+        constexpr inline explicit VulkanBarrier(PipelineStage syncBefore, PipelineStage syncAfter) noexcept;
+        VulkanBarrier(const VulkanBarrier&) = delete;
+        VulkanBarrier(VulkanBarrier&&) = delete;
+        constexpr inline virtual ~VulkanBarrier() noexcept;
+
+    private:
+        constexpr inline explicit VulkanBarrier() noexcept;
+        constexpr inline PipelineStage& syncBefore() noexcept;
+        constexpr inline PipelineStage& syncAfter() noexcept;
+
+        // Barrier interface.
+    public:
+        /// <inheritdoc />
+        constexpr inline PipelineStage syncBefore() const noexcept override;
+
+        /// <inheritdoc />
+        constexpr inline PipelineStage syncAfter() const noexcept override;
+
+        /// <inheritdoc />
+        constexpr inline void wait(ResourceAccess accessBefore, ResourceAccess accessAfter) noexcept override;
+
+        /// <inheritdoc />
+        constexpr inline void transition(IVulkanBuffer& buffer, ResourceAccess accessBefore, ResourceAccess accessAfter) override;
+
+        /// <inheritdoc />
+        constexpr inline void transition(IVulkanBuffer& buffer, UInt32 element, ResourceAccess accessBefore, ResourceAccess accessAfter) override;
+
+        /// <inheritdoc />
+        constexpr inline void transition(IVulkanImage& image, ResourceAccess accessBefore, ResourceAccess accessAfter, ImageLayout layout) override;
+
+        /// <inheritdoc />
+        constexpr inline void transition(IVulkanImage& image, ResourceAccess accessBefore, ResourceAccess accessAfter, ImageLayout fromLayout, ImageLayout toLayout) override;
+
+        /// <inheritdoc />
+        constexpr inline void transition(IVulkanImage& image, UInt32 level, UInt32 levels, UInt32 layer, UInt32 layers, UInt32 plane, ResourceAccess accessBefore, ResourceAccess accessAfter, ImageLayout layout) override;
+
+        /// <inheritdoc />
+        constexpr inline void transition(IVulkanImage& image, UInt32 level, UInt32 levels, UInt32 layer, UInt32 layers, UInt32 plane, ResourceAccess accessBefore, ResourceAccess accessAfter, ImageLayout fromLayout, ImageLayout toLayout) override;
+
+    public:
+        /// <summary>
+        /// Adds the barrier to a command buffer and updates the resource target states.
+        /// </summary>
+        /// <param name="commandBuffer">The command buffer to add the barriers to.</param>
+        /// <exception cref="RuntimeException">Thrown, if any of the contained barriers is a image barrier that targets a sub-resource range that does not share the same <see cref="ImageLayout" /> in all sub-resources.</exception>
+        inline void execute(const VulkanCommandBuffer& commandBuffer) const noexcept;
+    };
+
+    /// <summary>
+    /// Implements a Vulkan <see cref="IShaderModule" />.
+    /// </summary>
+    /// <seealso cref="VulkanShaderProgram" />
+    /// <seealso cref="VulkanDevice" />
+    /// <seealso href="https://github.com/crud89/LiteFX/wiki/Shader-Development" />
+    class LITEFX_VULKAN_API VulkanShaderModule final : public IShaderModule, public Resource<VkShaderModule> {
+        LITEFX_IMPLEMENTATION(VulkanShaderModuleImpl);
+
+    public:
+        /// <summary>
+        /// Initializes a new Vulkan shader module.
+        /// </summary>
+        /// <param name="device">The parent device, this shader module has been created from.</param>
+        /// <param name="type">The shader stage, this module is used in.</param>
+        /// <param name="fileName">The file name of the module source.</param>
+        /// <param name="entryPoint">The name of the module entry point.</param>
+        explicit VulkanShaderModule(const VulkanDevice& device, ShaderStage type, const String& fileName, const String& entryPoint = "main");
+
+        /// <summary>
+        /// Initializes a new Vulkan shader module.
+        /// </summary>
+        /// <param name="device">The parent device, this shader module has been created from.</param>
+        /// <param name="type">The shader stage, this module is used in.</param>
+        /// <param name="stream">The file stream of the module source.</param>
+        /// <param name="name">The file name of the module source.</param>
+        /// <param name="entryPoint">The name of the module entry point.</param>
+        explicit VulkanShaderModule(const VulkanDevice& device, ShaderStage type, std::istream& stream, const String& name, const String& entryPoint = "main");
+        VulkanShaderModule(const VulkanShaderModule&) noexcept = delete;
+        VulkanShaderModule(VulkanShaderModule&&) noexcept = delete;
+        virtual ~VulkanShaderModule() noexcept;
+
+        // ShaderModule interface.
+    public:
+        /// <inheritdoc />
+        const String& fileName() const noexcept override;
+
+        /// <inheritdoc />
+        const String& entryPoint() const noexcept override;
+
+        /// <inheritdoc />
+        ShaderStage type() const noexcept override;
+
+    public:
+        /// <summary>
+        /// Returns the shader byte code.
+        /// </summary>
+        /// <returns>The shader byte code.</returns>
+        virtual const String& bytecode() const noexcept;
+
+        /// <summary>
+        /// Returns the shader stage creation info for convenience.
+        /// </summary>
+        /// <returns>The shader stage creation info for convenience.</returns>
+        virtual VkPipelineShaderStageCreateInfo shaderStageDefinition() const;
+    };
+
+    /// <summary>
+    /// Implements a Vulkan <see cref="ShaderProgram" />.
+    /// </summary>
+    /// <seealso cref="VulkanShaderProgramBuilder" />
+    /// <seealso cref="VulkanShaderModule" />
+    /// <seealso href="https://github.com/crud89/LiteFX/wiki/Shader-Development" />
+    class LITEFX_VULKAN_API VulkanShaderProgram final : public ShaderProgram<VulkanShaderModule> {
+        LITEFX_IMPLEMENTATION(VulkanShaderProgramImpl);
+        LITEFX_BUILDER(VulkanShaderProgramBuilder);
+
+    public:
+        /// <summary>
+        /// Initializes a new Vulkan shader program.
+        /// </summary>
+        /// <param name="device">The parent device of the shader program.</param>
+        /// <param name="modules">The shader modules used by the shader program.</param>
+        explicit VulkanShaderProgram(const VulkanDevice& device, Enumerable<UniquePtr<VulkanShaderModule>>&& modules);
+        VulkanShaderProgram(VulkanShaderProgram&&) noexcept = delete;
+        VulkanShaderProgram(const VulkanShaderProgram&) noexcept = delete;
+        virtual ~VulkanShaderProgram() noexcept;
+
+    private:
+        /// <summary>
+        /// Initializes a new Vulkan shader program.
+        /// </summary>
+        /// <param name="device">The parent device of the shader program.</param>
+        explicit VulkanShaderProgram(const VulkanDevice& device) noexcept;
+
+    public:
+        /// <inheritdoc />
+        Enumerable<const VulkanShaderModule*> modules() const noexcept override;
+
+        /// <inheritdoc />
+        virtual SharedPtr<VulkanPipelineLayout> reflectPipelineLayout() const;
+
+    private:
+        SharedPtr<IPipelineLayout> parsePipelineLayout() const override {
+            return std::static_pointer_cast<IPipelineLayout>(this->reflectPipelineLayout());
+        }
+    };
+
+    /// <summary>
+    /// Implements a Vulkan <see cref="DescriptorSet" />.
+    /// </summary>
+    /// <seealso cref="VulkanDescriptorSetLayout" />
+    class LITEFX_VULKAN_API VulkanDescriptorSet final : public DescriptorSet<IVulkanBuffer, IVulkanImage, IVulkanSampler>, public Resource<VkDescriptorSet> {
+        LITEFX_IMPLEMENTATION(VulkanDescriptorSetImpl);
+
+    public:
+        using base_type = DescriptorSet<IVulkanBuffer, IVulkanImage, IVulkanSampler>;
+        using base_type::update;
+        using base_type::attach;
+
+    public:
+        /// <summary>
+        /// Initializes a new descriptor set.
+        /// </summary>
+        /// <param name="layout">The parent descriptor set layout.</param>
+        /// <param name="descriptorSet">The descriptor set handle.</param>
+        explicit VulkanDescriptorSet(const VulkanDescriptorSetLayout& layout, VkDescriptorSet descriptorSet);
+        VulkanDescriptorSet(VulkanDescriptorSet&&) = delete;
+        VulkanDescriptorSet(const VulkanDescriptorSet&) = delete;
+        virtual ~VulkanDescriptorSet() noexcept;
+
+    public:
+        /// <summary>
+        /// Returns the parent descriptor set layout.
+        /// </summary>
+        /// <returns>The parent descriptor set layout.</returns>
+        virtual const VulkanDescriptorSetLayout& layout() const noexcept;
+
+    public:
+        /// <inheritdoc />
+        void update(UInt32 binding, const IVulkanBuffer& buffer, UInt32 bufferElement = 0, UInt32 elements = 0, UInt32 firstDescriptor = 0) const override;
+
+        /// <inheritdoc />
+        void update(UInt32 binding, const IVulkanImage& texture, UInt32 descriptor = 0, UInt32 firstLevel = 0, UInt32 levels = 0, UInt32 firstLayer = 0, UInt32 layers = 0) const override;
+
+        /// <inheritdoc />
+        void update(UInt32 binding, const IVulkanSampler& sampler, UInt32 descriptor = 0) const override;
+
+        /// <inheritdoc />
+        void attach(UInt32 binding, const IVulkanImage& image) const override;
+    };
+
+    /// <summary>
+    /// Implements a Vulkan <see cref="IDescriptorLayout" />
+    /// </summary>
+    /// <seealso cref="IVulkanBuffer" />
+    /// <seealso cref="IVulkanImage" />
+    /// <seealso cref="IVulkanSampler" />
+    /// <seealso cref="VulkanDescriptorSet" />
+    /// <seealso cref="VulkanDescriptorSetLayout" />
+    class LITEFX_VULKAN_API VulkanDescriptorLayout final : public IDescriptorLayout {
+        LITEFX_IMPLEMENTATION(VulkanDescriptorLayoutImpl);
+
+    public:
+        /// <summary>
+        /// Initializes a new Vulkan descriptor layout.
+        /// </summary>
+        /// <param name="type">The type of the descriptor.</param>
+        /// <param name="binding">The binding point for the descriptor.</param>
+        /// <param name="elementSize">The size of the descriptor.</param>
+        /// <param name="descriptors">The number of descriptors in the descriptor array. If set to `-1`, the descriptor will be unbounded.</param>
+        /// <seealso cref="descriptors" />
+        explicit VulkanDescriptorLayout(DescriptorType type, UInt32 binding, size_t elementSize, UInt32 descriptors = 1);
+
+        /// <summary>
+        /// Initializes a new Vulkan descriptor layout for a static sampler.
+        /// </summary>
+        /// <param name="staticSampler">The static sampler to initialize the state with.</param>
+        /// <param name="binding">The binding point for the descriptor.</param>
+        explicit VulkanDescriptorLayout(UniquePtr<IVulkanSampler>&& staticSampler, UInt32 binding);
+
+        VulkanDescriptorLayout(VulkanDescriptorLayout&&) = delete;
+        VulkanDescriptorLayout(const VulkanDescriptorLayout&) = delete;
+        virtual ~VulkanDescriptorLayout() noexcept;
+
+        // IDescriptorLayout interface.
+    public:
+        /// <inheritdoc />
+        DescriptorType descriptorType() const noexcept override;
+
+        /// <inheritdoc />
+        UInt32 descriptors() const noexcept override;
+
+        /// <inheritdoc />
+        const IVulkanSampler* staticSampler() const noexcept override;
+
+        // IBufferLayout interface.
+    public:
+        /// <inheritdoc />
+        size_t elementSize() const noexcept override;
+
+        /// <inheritdoc />
+        UInt32 binding() const noexcept override;
+
+        /// <inheritdoc />
+        BufferType type() const noexcept override;
+    };
+
+    /// <summary>
+    /// Implements a Vulkan <see cref="DescriptorSetLayout" />.
+    /// </summary>
+    /// <seealso cref="VulkanDescriptorSet" />
+    /// <seealso cref="VulkanDescriptorSetLayoutBuilder" />
+    class LITEFX_VULKAN_API VulkanDescriptorSetLayout final : public DescriptorSetLayout<VulkanDescriptorLayout, VulkanDescriptorSet>, public Resource<VkDescriptorSetLayout> {
+        LITEFX_IMPLEMENTATION(VulkanDescriptorSetLayoutImpl);
+        LITEFX_BUILDER(VulkanDescriptorSetLayoutBuilder);
+
+    public:
+        using base_type = DescriptorSetLayout<VulkanDescriptorLayout, VulkanDescriptorSet>;
+        using base_type::free;
+
+    public:
+        /// <summary>
+        /// Initializes a Vulkan descriptor set layout.
+        /// </summary>
+        /// <remarks>
+        /// If the descriptor set contains an unbounded array, it still is not truly unbounded. Instead, only maximum number of descriptors can be allocated from the descriptor set. This
+        /// number is defined by the device limits and depends on the descriptor type. If you need more descriptors in one array, increase the <paramref name="maxUnboundedArraySize" />
+        /// parameter. Keep in mind that you may be only able to use less or smaller unbounded descriptor arrays in other descriptor sets as a result.
+        /// </remarks>
+        /// <param name="device">The parent device, the pipeline layout has been created from.</param>
+        /// <param name="descriptorLayouts">The descriptor layouts of the descriptors within the descriptor set.</param>
+        /// <param name="space">The space or set id of the descriptor set.</param>
+        /// <param name="stages">The shader stages, the descriptor sets are bound to.</param>
+        /// <param name="poolSize">The size of a descriptor pool.</param>
+        /// <param name="maxUnboundedArraySize">The maximum number of descriptors in an unbounded array.</param>
+        explicit VulkanDescriptorSetLayout(const VulkanDevice& device, Enumerable<UniquePtr<VulkanDescriptorLayout>>&& descriptorLayouts, UInt32 space, ShaderStage stages, UInt32 poolSize = 1024, UInt32 maxUnboundedArraySize = 104857);
+        VulkanDescriptorSetLayout(VulkanDescriptorSetLayout&&) = delete;
+        VulkanDescriptorSetLayout(const VulkanDescriptorSetLayout&) = delete;
+        virtual ~VulkanDescriptorSetLayout() noexcept;
+
+    private:
+        /// <summary>
+        /// Initializes a Vulkan descriptor set layout.
+        /// </summary>
+        /// <param name="device">The parent device, the pipeline layout has been created from.</param>
+        explicit VulkanDescriptorSetLayout(const VulkanDevice& device) noexcept;
+
+    public:
+        /// <summary>
+        /// Returns the device, the pipeline layout has been created from.
+        /// </summary>
+        /// <returns>A reference of the device, the pipeline layout has been created from.</returns>
+        virtual const VulkanDevice& device() const noexcept;
+
+    public:
+        /// <inheritdoc />
+        Enumerable<const VulkanDescriptorLayout*> descriptors() const noexcept override;
+
+        /// <inheritdoc />
+        const VulkanDescriptorLayout& descriptor(UInt32 binding) const override;
+
+        /// <inheritdoc />
+        UInt32 space() const noexcept override;
+
+        /// <inheritdoc />
+        ShaderStage shaderStages() const noexcept override;
+
+        /// <inheritdoc />
+        UInt32 uniforms() const noexcept override;
+
+        /// <inheritdoc />
+        UInt32 storages() const noexcept override;
+
+        /// <inheritdoc />
+        UInt32 images() const noexcept override;
+
+        /// <inheritdoc />
+        UInt32 buffers() const noexcept override;
+
+        /// <inheritdoc />
+        UInt32 samplers() const noexcept override;
+
+        /// <inheritdoc />
+        UInt32 staticSamplers() const noexcept override;
+
+        /// <inheritdoc />
+        UInt32 inputAttachments() const noexcept override;
+
+    public:
+        /// <inheritdoc />
+        UniquePtr<VulkanDescriptorSet> allocate(const Enumerable<DescriptorBinding>& bindings = { }) const override;
+
+        /// <inheritdoc />
+        UniquePtr<VulkanDescriptorSet> allocate(UInt32 descriptors, const Enumerable<DescriptorBinding>& bindings = { }) const override;
+
+        /// <inheritdoc />
+        Enumerable<UniquePtr<VulkanDescriptorSet>> allocateMultiple(UInt32 descriptorSets, const Enumerable<Enumerable<DescriptorBinding>>& bindings = { }) const override;
+
+        /// <inheritdoc />
+        Enumerable<UniquePtr<VulkanDescriptorSet>> allocateMultiple(UInt32 descriptorSets, std::function<Enumerable<DescriptorBinding>(UInt32)> bindingFactory) const override;
+
+        /// <inheritdoc />
+        Enumerable<UniquePtr<VulkanDescriptorSet>> allocateMultiple(UInt32 descriptorSets, UInt32 descriptors, const Enumerable<Enumerable<DescriptorBinding>>& bindings = { }) const override;
+
+        /// <inheritdoc />
+        Enumerable<UniquePtr<VulkanDescriptorSet>> allocateMultiple(UInt32 descriptorSets, UInt32 descriptors, std::function<Enumerable<DescriptorBinding>(UInt32)> bindingFactory) const override;
+
+        /// <inheritdoc />
+        void free(const VulkanDescriptorSet& descriptorSet) const noexcept override;
+
+    public:
+        /// <summary>
+        /// The size of each descriptor pool.
+        /// </summary>
+        /// <remarks>
+        /// Descriptors are allocated from descriptor pools in Vulkan. Each descriptor pool has a number of descriptor sets it can hand out. Before allocating a new descriptor set
+        /// the layout tries to find an unused descriptor set, that it can hand out. If there are no free descriptor sets, the layout tries to allocate a new one. This is only possible
+        /// if the descriptor pool is not yet full, in which case a new pool needs to be created. All created pools are cached and destroyed, if the layout itself gets destroyed, 
+        /// causing all descriptor sets allocated from the layout to be invalidated. 
+        /// 
+        /// In general, if the number of required descriptor sets can be pre-calculated, it should be used as a pool size. Otherwise there is a trade-off to be made, based on the 
+        /// frequency of which new descriptor sets are required. A small pool size is more memory efficient, but can have a significant runtime cost, as long as new allocations happen
+        /// and no descriptor sets can be reused. A large pool size on the other hand is faster, whilst it may leave a large chunk of descriptor sets unallocated. Keep in mind, that the 
+        /// layout might not be the only active layout, hence a large portion of descriptor sets might end up not being used.
+        /// </remarks>
+        /// <returns>The size of one descriptor pool.</returns>
+        /// <seealso cref="allocate" />
+        /// <seealso cref="free" />
+        /// <seealso cref="pools" />
+        virtual UInt32 poolSize() const noexcept;
+
+        /// <summary>
+        /// Returns the number of active descriptor pools.
+        /// </summary>
+        /// <returns>The number of active descriptor pools.</returns>
+        /// <seealso cref="allocate" />
+        /// <seealso cref="free" />
+        /// <seealso cref="poolSize" />
+        virtual size_t pools() const noexcept;
+    };
+
+    /// <summary>
+    /// Implements the Vulkan <see cref="IPushConstantsRange" />.
+    /// </summary>
+    /// <seealso cref="VulkanPushConstantsLayout" />
+    class LITEFX_VULKAN_API VulkanPushConstantsRange final : public IPushConstantsRange {
+        LITEFX_IMPLEMENTATION(VulkanPushConstantsRangeImpl);
+
+    public:
+        /// <summary>
+        /// Initializes a new push constants range.
+        /// </summary>
+        /// <param name="shaderStage">The shader stage, that access the push constants from the range.</param>
+        /// <param name="offset">The offset relative to the parent push constants backing memory that marks the beginning of the range.</param>
+        /// <param name="size">The size of the push constants range.</param>
+        /// <param name="space">The space from which the push constants of the range will be accessible in the shader.</param>
+        /// <param name="binding">The register from which the push constants of the range will be accessible in the shader.</param>
+        explicit VulkanPushConstantsRange(ShaderStage shaderStage, UInt32 offset, UInt32 size, UInt32 space, UInt32 binding);
+        VulkanPushConstantsRange(const VulkanPushConstantsRange&) = delete;
+        VulkanPushConstantsRange(VulkanPushConstantsRange&&) = delete;
+        virtual ~VulkanPushConstantsRange() noexcept;
+
+    public:
+        /// <inheritdoc />
+        UInt32 space() const noexcept override;
+
+        /// <inheritdoc />
+        UInt32 binding() const noexcept override;
+
+        /// <inheritdoc />
+        UInt32 offset() const noexcept override;
+
+        /// <inheritdoc />
+        UInt32 size() const noexcept override;
+
+        /// <inheritdoc />
+        ShaderStage stage() const noexcept override;
+    };
+
+    /// <summary>
+    /// Implements the Vulkan <see cref="PushConstantsLayout" />.
+    /// </summary>
+    /// <seealso cref="VulkanPushConstantsRange" />
+    /// <seealso cref="VulkanPushConstantsLayoutBuilder" />
+    /// <seealso cref="VulkanPushConstantsLayoutBuilder" />
+    class LITEFX_VULKAN_API VulkanPushConstantsLayout final : public PushConstantsLayout<VulkanPushConstantsRange> {
+        LITEFX_IMPLEMENTATION(VulkanPushConstantsLayoutImpl);
+        LITEFX_BUILDER(VulkanPushConstantsLayoutBuilder);
+        friend class VulkanPipelineLayout;
+
+    public:
+        /// <summary>
+        /// Initializes a new push constants layout.
+        /// </summary>
+        /// <param name="ranges">The ranges contained by the layout.</param>
+        /// <param name="size">The overall size (in bytes) of the push constants backing memory.</param>
+        explicit VulkanPushConstantsLayout(Enumerable<UniquePtr<VulkanPushConstantsRange>>&& ranges, UInt32 size);
+        VulkanPushConstantsLayout(const VulkanPushConstantsLayout&) = delete;
+        VulkanPushConstantsLayout(VulkanPushConstantsLayout&&) = delete;
+        virtual ~VulkanPushConstantsLayout() noexcept;
+
+    private:
+        /// <summary>
+        /// Initializes a new push constants layout.
+        /// </summary>
+        /// <param name="size">The overall size (in bytes) of the push constants backing memory.</param>
+        explicit VulkanPushConstantsLayout(UInt32 size);
+
+    public:
+        /// <summary>
+        /// Returns the parent pipeline layout, the push constants are described for.
+        /// </summary>
+        /// <returns>A reference of the parent pipeline layout.</returns>
+        virtual const VulkanPipelineLayout& pipelineLayout() const;
+
+    private:
+        /// <summary>
+        /// Sets the parent pipeline layout, the push constants are described for.
+        /// </summary>
+        /// <param name="pipelineLayout">The parent pipeline layout.</param>
+        virtual void pipelineLayout(const VulkanPipelineLayout& pipelineLayout);
+    
+    public:
+        /// <inheritdoc />
+        UInt32 size() const noexcept override;
+
+        /// <inheritdoc />
+        const VulkanPushConstantsRange& range(ShaderStage stage) const override;
+
+        /// <inheritdoc />
+        Enumerable<const VulkanPushConstantsRange*> ranges() const noexcept override;
+    };
+
+    /// <summary>
+    /// Implements a Vulkan <see cref="PipelineLayout" />.
+    /// </summary>
+    /// <seealso cref="VulkanPipelineLayoutBuilder" />
+    class LITEFX_VULKAN_API VulkanPipelineLayout final : public PipelineLayout<VulkanDescriptorSetLayout, VulkanPushConstantsLayout>, public Resource<VkPipelineLayout> {
+        LITEFX_IMPLEMENTATION(VulkanPipelineLayoutImpl);
+        LITEFX_BUILDER(VulkanPipelineLayoutBuilder);
+
+    public:
+        /// <summary>
+        /// Initializes a new Vulkan render pipeline layout.
+        /// </summary>
+        /// <param name="device">The parent device, the layout is created from.</param>
+        /// <param name="descriptorSetLayouts">The descriptor set layouts used by the pipeline.</param>
+        /// <param name="pushConstantsLayout">The push constants layout used by the pipeline.</param>
+        explicit VulkanPipelineLayout(const VulkanDevice& device, Enumerable<UniquePtr<VulkanDescriptorSetLayout>>&& descriptorSetLayouts, UniquePtr<VulkanPushConstantsLayout>&& pushConstantsLayout);
+        VulkanPipelineLayout(VulkanPipelineLayout&&) noexcept = delete;
+        VulkanPipelineLayout(const VulkanPipelineLayout&) noexcept = delete;
+        virtual ~VulkanPipelineLayout() noexcept;
+
+    private:
+        /// <summary>
+        /// Initializes a new Vulkan render pipeline layout.
+        /// </summary>
+        /// <param name="device">The parent device, the layout is created from.</param>
+        explicit VulkanPipelineLayout(const VulkanDevice& device) noexcept;
+
+    public:
+        /// <summary>
+        /// Returns a reference to the device that provides this layout.
+        /// </summary>
+        /// <returns>A reference to the layouts parent device.</returns>
+        virtual const VulkanDevice& device() const noexcept;
+
+        // PipelineLayout interface.
+    public:
+        /// <inheritdoc />
+        const VulkanDescriptorSetLayout& descriptorSet(UInt32 space) const override;
+
+        /// <inheritdoc />
+        Enumerable<const VulkanDescriptorSetLayout*> descriptorSets() const noexcept override;
+
+        /// <inheritdoc />
+        const VulkanPushConstantsLayout* pushConstants() const noexcept override;
+    };
+
+    /// <summary>
+    /// Implements the Vulkan input assembler state.
+    /// </summary>
+    /// <seealso cref="VulkanInputAssemblerBuilder" />
+    class LITEFX_VULKAN_API VulkanInputAssembler final : public InputAssembler<VulkanVertexBufferLayout, VulkanIndexBufferLayout> {
+        LITEFX_IMPLEMENTATION(VulkanInputAssemblerImpl);
+        LITEFX_BUILDER(VulkanInputAssemblerBuilder);
+
+    public:
+        /// <summary>
+        /// Initializes a new Vulkan input assembler state.
+        /// </summary>
+        /// <param name="vertexBufferLayouts">The vertex buffer layouts supported by the input assembler state. Each layout must have a unique binding.</param>
+        /// <param name="indexBufferLayout">The index buffer layout.</param>
+        /// <param name="primitiveTopology">The primitive topology.</param>
+        explicit VulkanInputAssembler(Enumerable<UniquePtr<VulkanVertexBufferLayout>>&& vertexBufferLayouts, UniquePtr<VulkanIndexBufferLayout>&& indexBufferLayout, PrimitiveTopology primitiveTopology = PrimitiveTopology::TriangleList);
+        VulkanInputAssembler(VulkanInputAssembler&&) noexcept = delete;
+        VulkanInputAssembler(const VulkanInputAssembler&) noexcept = delete;
+        virtual ~VulkanInputAssembler() noexcept;
+
+    private:
+        /// <summary>
+        /// Initializes a new Vulkan input assembler state.
+        /// </summary>
+        explicit VulkanInputAssembler() noexcept;
+
+    public:
+        /// <inheritdoc />
+        Enumerable<const VulkanVertexBufferLayout*> vertexBufferLayouts() const noexcept override;
+
+        /// <inheritdoc />
+        const VulkanVertexBufferLayout& vertexBufferLayout(UInt32 binding) const override;
+
+        /// <inheritdoc />
+        const VulkanIndexBufferLayout& indexBufferLayout() const override;
+
+        /// <inheritdoc />
+        PrimitiveTopology topology() const noexcept override;
+    };
+
+    /// <summary>
+    /// Implements a Vulkan <see cref="IRasterizer" />.
+    /// </summary>
+    /// <seealso cref="VulkanRasterizerBuilder" />
+    class LITEFX_VULKAN_API VulkanRasterizer final : public Rasterizer {
+        LITEFX_BUILDER(VulkanRasterizerBuilder);
+
+    public:
+        /// <summary>
+        /// Initializes a new Vulkan rasterizer state.
+        /// </summary>
+        /// <param name="polygonMode">The polygon mode used by the pipeline.</param>
+        /// <param name="cullMode">The cull mode used by the pipeline.</param>
+        /// <param name="cullOrder">The cull order used by the pipeline.</param>
+        /// <param name="lineWidth">The line width used by the pipeline.</param>
+        /// <param name="depthStencilState">The rasterizer depth/stencil state.</param>
+        explicit VulkanRasterizer(PolygonMode polygonMode, CullMode cullMode, CullOrder cullOrder, Float lineWidth = 1.f, const DepthStencilState& depthStencilState = {}) noexcept;
+        VulkanRasterizer(VulkanRasterizer&&) noexcept = delete;
+        VulkanRasterizer(const VulkanRasterizer&) noexcept = delete;
+        virtual ~VulkanRasterizer() noexcept;
+
+    private:
+        /// <summary>
+        /// Initializes a new Vulkan rasterizer state.
+        /// </summary>
+        explicit VulkanRasterizer() noexcept;
+
+    public:
+        /// <summary>
+        /// Sets the line width on the rasterizer.
+        /// </summary>
+        /// <remarks>
+        /// Note that updating the line width requires the "wide lines" feature to be available. If it is not, the line width **must** be `1.0`. This
+        /// constraint is not enforced by the engine and you are responsible of making sure that it is fulfilled.
+        /// 
+        /// Furthermore, note that the DirectX 12 back-end does have any representation for the line width concept. Thus you should only use the line 
+        /// width, if you plan to only support Vulkan.
+        /// </remarks>
+        /// <returns>A reference to the line width.</returns>
+        /// <seealso href="https://www.khronos.org/registry/vulkan/specs/1.2-extensions/html/vkspec.html#features-wideLines" />
+        virtual void updateLineWidth(Float lineWidth) noexcept;
+    };
+
+    /// <summary>
+    /// Defines the base class for Vulkan pipeline state objects.
+    /// </summary>
+    /// <seealso cref="VulkanRenderPipeline" />
+    /// <seealso cref="VulkanComputePipeline" />
+    class LITEFX_VULKAN_API VulkanPipelineState : public virtual Pipeline<VulkanPipelineLayout, VulkanShaderProgram>, public Resource<VkPipeline> {
+    public:
+        using Resource<VkPipeline>::Resource;
+        virtual ~VulkanPipelineState() noexcept = default;
+
+    public:
+        /// <summary>
+        /// Sets the current pipeline state on the <paramref name="commandBuffer" />.
+        /// </summary>
+        /// <param name="commandBuffer">The command buffer to set the current pipeline state on.</param>
+        virtual void use(const VulkanCommandBuffer& commandBuffer) const noexcept = 0;
+
+        /// <summary>
+        /// Binds a descriptor set on a command buffer.
+        /// </summary>
+        /// <param name="commandBuffer">The command buffer to issue the bind command on.</param>
+        /// <param name="descriptorSet">The descriptor set to bind.</param>
+        virtual void bind(const VulkanCommandBuffer& commandBuffer, const VulkanDescriptorSet& descriptorSet) const noexcept = 0;
+    };
+
+    /// <summary>
+    /// Records commands for a <see cref="VulkanCommandQueue" />
+    /// </summary>
+    /// <seealso cref="VulkanQueue" />
+    class LITEFX_VULKAN_API VulkanCommandBuffer final : public CommandBuffer<VulkanCommandBuffer, IVulkanBuffer, IVulkanVertexBuffer, IVulkanIndexBuffer, IVulkanImage, VulkanBarrier, VulkanPipelineState>, public Resource<VkCommandBuffer> {
+        LITEFX_IMPLEMENTATION(VulkanCommandBufferImpl);
+
+    public:
+        using base_type = CommandBuffer<VulkanCommandBuffer, IVulkanBuffer, IVulkanVertexBuffer, IVulkanIndexBuffer, IVulkanImage, VulkanBarrier, VulkanPipelineState>;
+        using base_type::dispatch;
+        using base_type::draw;
+        using base_type::drawIndexed;
+        using base_type::barrier;
+        using base_type::transfer;
+        using base_type::generateMipMaps;
+        using base_type::bind;
+        using base_type::use;
+        using base_type::pushConstants;
+
+    public:
+        /// <summary>
+        /// Initializes a command buffer from a command queue.
+        /// </summary>
+        /// <param name="queue">The parent command queue, the buffer gets submitted to.</param>
+        /// <param name="begin">If set to <c>true</c>, the command buffer automatically starts recording by calling <see cref="begin" />.</param>
+        /// <param name="primary"><c>true</c>, if the command buffer is a primary command buffer.</param>
+        explicit VulkanCommandBuffer(const VulkanQueue& queue, bool begin = false, bool primary = true);
+        VulkanCommandBuffer(const VulkanCommandBuffer&) = delete;
+        VulkanCommandBuffer(VulkanCommandBuffer&&) = delete;
+        virtual ~VulkanCommandBuffer() noexcept;
+
+        // Vulkan Command Buffer interface.
+    public:
+        /// <summary>
+        /// Begins the command buffer as a secondary command buffer that inherits the state of <paramref name="renderPass" />.
+        /// </summary>
+        /// <param name="renderPass">The render pass state to inherit.</param>
+        virtual void begin(const VulkanRenderPass& renderPass) const noexcept;
+
+        // CommandBuffer interface.
+    public:
+        /// <inheritdoc />
+        void begin() const override;
+
+        /// <inheritdoc />
+        void end() const override;
+
+        /// <inheritdoc />
+        bool isSecondary() const noexcept override;
+
+        /// <inheritdoc />
+        void setViewports(Span<const IViewport*> viewports) const noexcept override;
+
+        /// <inheritdoc />
+        void setViewports(const IViewport* viewport) const noexcept override;
+
+        /// <inheritdoc />
+        void setScissors(Span<const IScissor*> scissors) const noexcept override;
+
+        /// <inheritdoc />
+        void setScissors(const IScissor* scissor) const noexcept override;
+
+        /// <inheritdoc />
+        void setBlendFactors(const Vector4f& blendFactors) const noexcept override;
+
+        /// <inheritdoc />
+        void setStencilRef(UInt32 stencilRef) const noexcept override;
+
+        /// <inheritdoc />
+        void generateMipMaps(IVulkanImage& image) noexcept override;
+
+        /// <inheritdoc />
+        void barrier(const VulkanBarrier& barrier) const noexcept override;
+
+        /// <inheritdoc />
+        void transfer(IVulkanBuffer& source, IVulkanBuffer& target, UInt32 sourceElement = 0, UInt32 targetElement = 0, UInt32 elements = 1) const override;
+
+        /// <inheritdoc />
+        void transfer(IVulkanBuffer& source, IVulkanImage& target, UInt32 sourceElement = 0, UInt32 firstSubresource = 0, UInt32 elements = 1) const override;
+
+        /// <inheritdoc />
+        void transfer(IVulkanImage& source, IVulkanImage& target, UInt32 sourceSubresource = 0, UInt32 targetSubresource = 0, UInt32 subresources = 1) const override;
+
+        /// <inheritdoc />
+        void transfer(IVulkanImage& source, IVulkanBuffer& target, UInt32 firstSubresource = 0, UInt32 targetElement = 0, UInt32 subresources = 1) const override;
+
+        /// <inheritdoc />
+        void transfer(SharedPtr<IVulkanBuffer> source, IVulkanBuffer& target, UInt32 sourceElement = 0, UInt32 targetElement = 0, UInt32 elements = 1) const override;
+
+        /// <inheritdoc />
+        void transfer(SharedPtr<IVulkanBuffer> source, IVulkanImage& target, UInt32 sourceElement = 0, UInt32 firstSubresource = 0, UInt32 elements = 1) const override;
+
+        /// <inheritdoc />
+        void transfer(SharedPtr<IVulkanImage> source, IVulkanImage& target, UInt32 sourceSubresource = 0, UInt32 targetSubresource = 0, UInt32 subresources = 1) const override;
+
+        /// <inheritdoc />
+        void transfer(SharedPtr<IVulkanImage> source, IVulkanBuffer& target, UInt32 firstSubresource = 0, UInt32 targetElement = 0, UInt32 subresources = 1) const override;
+
+        /// <inheritdoc />
+        void use(const VulkanPipelineState& pipeline) const noexcept override;
+
+        /// <inheritdoc />
+        void bind(const VulkanDescriptorSet& descriptorSet, const VulkanPipelineState& pipeline) const noexcept override;
+
+        /// <inheritdoc />
+        void bind(const IVulkanVertexBuffer& buffer) const noexcept override;
+
+        /// <inheritdoc />
+        void bind(const IVulkanIndexBuffer& buffer) const noexcept override;
+
+        /// <inheritdoc />
+        void dispatch(const Vector3u& threadCount) const noexcept override;
+
+        /// <inheritdoc />
+        void draw(UInt32 vertices, UInt32 instances = 1, UInt32 firstVertex = 0, UInt32 firstInstance = 0) const noexcept override;
+
+        /// <inheritdoc />
+        void drawIndexed(UInt32 indices, UInt32 instances = 1, UInt32 firstIndex = 0, Int32 vertexOffset = 0, UInt32 firstInstance = 0) const noexcept override;
+
+        /// <inheritdoc />
+        void pushConstants(const VulkanPushConstantsLayout& layout, const void* const memory) const noexcept override;
+
+        /// <inheritdoc />
+        void writeTimingEvent(SharedPtr<const TimingEvent> timingEvent) const override;
+
+        /// <inheritdoc />
+        void execute(SharedPtr<const VulkanCommandBuffer> commandBuffer) const override;
+
+        /// <inheritdoc />
+        void execute(Enumerable<SharedPtr<const VulkanCommandBuffer>> commandBuffers) const override;
+
+    private:
+        void releaseSharedState() const override;
+    };
+
+    /// <summary>
+    /// Implements a Vulkan <see cref="RenderPipeline" />.
+    /// </summary>
+    /// <seealso cref="VulkanComputePipeline" />
+    /// <seealso cref="VulkanRenderPipelineBuilder" />
+    class LITEFX_VULKAN_API VulkanRenderPipeline final : public RenderPipeline<VulkanPipelineLayout, VulkanShaderProgram, VulkanInputAssembler, VulkanRasterizer>, public VulkanPipelineState {
+        LITEFX_IMPLEMENTATION(VulkanRenderPipelineImpl);
+        LITEFX_BUILDER(VulkanRenderPipelineBuilder);
+
+    public:
+        /// <summary>
+        /// Initializes a new Vulkan render pipeline.
+        /// </summary>
+        /// <param name="renderPass">The parent render pass.</param>
+        /// <param name="shaderProgram">The shader program used by the pipeline.</param>
+        /// <param name="layout">The layout of the pipeline.</param>
+        /// <param name="inputAssembler">The input assembler state of the pipeline.</param>
+        /// <param name="rasterizer">The rasterizer state of the pipeline.</param>
+        /// <param name="name">The optional name of the render pipeline.</param>
+        /// <param name="enableAlphaToCoverage">Whether or not to enable Alpha-to-Coverage multi-sampling.</param>
+        explicit VulkanRenderPipeline(const VulkanRenderPass& renderPass, SharedPtr<VulkanShaderProgram> shaderProgram, SharedPtr<VulkanPipelineLayout> layout, SharedPtr<VulkanInputAssembler> inputAssembler, SharedPtr<VulkanRasterizer> rasterizer, bool enableAlphaToCoverage = false, const String& name = "");
+        VulkanRenderPipeline(VulkanRenderPipeline&&) noexcept = delete;
+        VulkanRenderPipeline(const VulkanRenderPipeline&) noexcept = delete;
+        virtual ~VulkanRenderPipeline() noexcept;
+
+    private:
+        /// <summary>
+        /// Initializes a new Vulkan render pipeline.
+        /// </summary>
+        /// <param name="renderPass">The parent render pass.</param>
+        /// <param name="name">The optional name of the render pipeline.</param>
+        VulkanRenderPipeline(const VulkanRenderPass& renderPass, const String& name = "") noexcept;
+
+        // Pipeline interface.
+    public:
+        /// <inheritdoc />
+        SharedPtr<const VulkanShaderProgram> program() const noexcept override;
+
+        /// <inheritdoc />
+        SharedPtr<const VulkanPipelineLayout> layout() const noexcept override;
+
+        // RenderPipeline interface.
+    public:
+        /// <inheritdoc />
+        SharedPtr<VulkanInputAssembler> inputAssembler() const noexcept override;
+
+        /// <inheritdoc />
+        SharedPtr<VulkanRasterizer> rasterizer() const noexcept override;
+
+        /// <inheritdoc />
+        bool alphaToCoverage() const noexcept override;
+
+        // VulkanPipelineState interface.
+    public:
+        /// <inheritdoc />
+        void use(const VulkanCommandBuffer& commandBuffer) const noexcept override;
+
+        /// <inheritdoc />
+        void bind(const VulkanCommandBuffer& commandBuffer, const VulkanDescriptorSet& descriptorSet) const noexcept override;
+    };
+
+    /// <summary>
+    /// Implements a Vulkan <see cref="ComputePipeline" />.
+    /// </summary>
+    /// <seealso cref="VulkanRenderPipeline" />
+    /// <seealso cref="VulkanComputePipelineBuilder" />
+    class LITEFX_VULKAN_API VulkanComputePipeline final : public ComputePipeline<VulkanPipelineLayout, VulkanShaderProgram>, public VulkanPipelineState {
+        LITEFX_IMPLEMENTATION(VulkanComputePipelineImpl);
+        LITEFX_BUILDER(VulkanComputePipelineBuilder);
+
+    public:
+        /// <summary>
+        /// Initializes a new Vulkan compute pipeline.
+        /// </summary>
+        /// <param name="device">The parent device.</param>
+        /// <param name="shaderProgram">The shader program used by the pipeline.</param>
+        /// <param name="layout">The layout of the pipeline.</param>
+        /// <param name="name">The optional debug name of the render pipeline.</param>
+        explicit VulkanComputePipeline(const VulkanDevice& device, SharedPtr<VulkanShaderProgram> shaderProgram, SharedPtr<VulkanPipelineLayout> layout, const String& name = "");
+        VulkanComputePipeline(VulkanComputePipeline&&) noexcept = delete;
+        VulkanComputePipeline(const VulkanComputePipeline&) noexcept = delete;
+        virtual ~VulkanComputePipeline() noexcept;
+
+    private:
+        /// <summary>
+        /// Initializes a new Vulkan compute pipeline.
+        /// </summary>
+        /// <param name="device">The parent device.</param>
+        VulkanComputePipeline(const VulkanDevice& device) noexcept;
+
+        // Pipeline interface.
+    public:
+        /// <inheritdoc />
+        SharedPtr<const VulkanShaderProgram> program() const noexcept override;
+
+        /// <inheritdoc />
+        SharedPtr<const VulkanPipelineLayout> layout() const noexcept override;
+
+        // VulkanPipelineState interface.
+    public:
+        /// <inheritdoc />
+        void use(const VulkanCommandBuffer& commandBuffer) const noexcept override;
+
+        /// <inheritdoc />
+        void bind(const VulkanCommandBuffer& commandBuffer, const VulkanDescriptorSet& descriptorSet) const noexcept override;
+    };
+
+    /// <summary>
+    /// Implements a Vulkan frame buffer.
+    /// </summary>
+    /// <seealso cref="VulkanRenderPass" />
+    class LITEFX_VULKAN_API VulkanFrameBuffer final : public FrameBuffer<VulkanCommandBuffer>, public Resource<VkFramebuffer> {
+        LITEFX_IMPLEMENTATION(VulkanFrameBufferImpl);
+
+    public:
+        /// <summary>
+        /// Initializes a Vulkan frame buffer.
+        /// </summary>
+        /// <param name="renderPass">The parent render pass of the frame buffer.</param>
+        /// <param name="bufferIndex">The index of the frame buffer within the parent render pass.</param>
+        /// <param name="renderArea">The initial size of the render area.</param>
+        /// <param name="commandBuffers">The number of command buffers, the frame buffer stores.</param>
+        VulkanFrameBuffer(const VulkanRenderPass& renderPass, UInt32 bufferIndex, const Size2d& renderArea, UInt32 commandBuffers = 1);
+        VulkanFrameBuffer(const VulkanFrameBuffer&) noexcept = delete;
+        VulkanFrameBuffer(VulkanFrameBuffer&&) noexcept = delete;
+        virtual ~VulkanFrameBuffer() noexcept;
+
+        // Vulkan frame buffer interface.
+    public:
+        /// <summary>
+        /// Returns a reference of the semaphore, that can be used to signal, that the frame buffer is finished.
+        /// </summary>
+        /// <returns>A reference of the semaphore, that can be used to signal, that the frame buffer is finished.</returns>
+        virtual const VkSemaphore& semaphore() const noexcept;
+
+        /// <summary>
+        /// Returns a reference of the last fence value for the frame buffer.
+        /// </summary>
+        /// <remarks>
+        /// The frame buffer must only be re-used, if this fence is reached in the graphics queue.
+        /// </remarks>
+        /// <returns>A reference of the last fence value for the frame buffer.</returns>
+        virtual UInt64& lastFence() const noexcept;
+
+        // FrameBuffer interface.
+    public:
+        /// <inheritdoc />
+        UInt32 bufferIndex() const noexcept override;
+
+        /// <inheritdoc />
+        const Size2d& size() const noexcept override;
+
+        /// <inheritdoc />
+        size_t getWidth() const noexcept override;
+
+        /// <inheritdoc />
+        size_t getHeight() const noexcept override;
+
+        /// <inheritdoc />
+        SharedPtr<const VulkanCommandBuffer> commandBuffer(UInt32 index) const override;
+
+        /// <inheritdoc />
+        Enumerable<SharedPtr<const VulkanCommandBuffer>> commandBuffers() const noexcept override;
+
+        /// <inheritdoc />
+        Enumerable<const IVulkanImage*> images() const noexcept override;
+
+        /// <inheritdoc />
+        const IVulkanImage& image(UInt32 location) const override;
+
+    public:
+        /// <inheritdoc />
+        void resize(const Size2d& renderArea) override;
+    };
+
+    /// <summary>
+    /// Implements a Vulkan render pass.
+    /// </summary>
+    /// <seealso cref="VulkanRenderPassBuilder" />
+    class LITEFX_VULKAN_API VulkanRenderPass final : public RenderPass<VulkanRenderPipeline, VulkanFrameBuffer, VulkanInputAttachmentMapping>, public Resource<VkRenderPass> {
+        LITEFX_IMPLEMENTATION(VulkanRenderPassImpl);
+        LITEFX_BUILDER(VulkanRenderPassBuilder);
+
+    public:
+        using base_type = RenderPass<VulkanRenderPipeline, VulkanFrameBuffer, VulkanInputAttachmentMapping>;
+        using base_type::updateAttachments;
+
+    public:
+        /// <summary>
+        /// Creates and initializes a new Vulkan render pass instance.
+        /// </summary>
+        /// <param name="device">The parent device instance.</param>
+        /// <param name="commandBuffers">The number of command buffers in each frame buffer.</param>
+        /// <param name="renderTargets">The render targets that are output by the render pass.</param>
+        /// <param name="samples">The number of samples for the render targets in this render pass.</param>
+        /// <param name="inputAttachments">The input attachments that are read by the render pass.</param>
+        explicit VulkanRenderPass(const VulkanDevice& device, Span<RenderTarget> renderTargets, UInt32 commandBuffers = 1, MultiSamplingLevel samples = MultiSamplingLevel::x1, Span<VulkanInputAttachmentMapping> inputAttachments = { });
+
+        /// <summary>
+        /// Creates and initializes a new Vulkan render pass instance.
+        /// </summary>
+        /// <param name="device">The parent device instance.</param>
+        /// <param name="name">The name of the render pass state resource.</param>
+        /// <param name="commandBuffers">The number of command buffers in each frame buffer.</param>
+        /// <param name="renderTargets">The render targets that are output by the render pass.</param>
+        /// <param name="samples">The number of samples for the render targets in this render pass.</param>
+        /// <param name="inputAttachments">The input attachments that are read by the render pass.</param>
+        explicit VulkanRenderPass(const VulkanDevice& device, const String& name, Span<RenderTarget> renderTargets, UInt32 commandBuffers = 1, MultiSamplingLevel samples = MultiSamplingLevel::x1, Span<VulkanInputAttachmentMapping> inputAttachments = { });
+        
+        VulkanRenderPass(const VulkanRenderPass&) = delete;
+        VulkanRenderPass(VulkanRenderPass&&) = delete;
+        virtual ~VulkanRenderPass() noexcept;
+
+    private:
+        /// <summary>
+        /// Creates an uninitialized Vulkan render pass instance.
+        /// </summary>
+        /// <remarks>
+        /// This constructor is called by the <see cref="VulkanRenderPassBuilder" /> in order to create a render pass instance without initializing it. The instance 
+        /// is only initialized after calling <see cref="VulkanRenderPassBuilder::go" />.
+        /// </remarks>
+        /// <param name="device">The parent device of the render pass.</param>
+        /// <param name="name">The name of the render pass state resource.</param>
+        explicit VulkanRenderPass(const VulkanDevice& device, const String& name = "") noexcept;
+
+        // IInputAttachmentMappingSource interface.
+    public:
+        /// <inheritdoc />
+        const VulkanFrameBuffer& frameBuffer(UInt32 buffer) const override;
+
+        // RenderPass interface.
+    public:
+        /// <summary>
+        /// Returns a reference to the device that provides this queue.
+        /// </summary>
+        /// <returns>A reference to the queue's parent device.</returns>
+        virtual const VulkanDevice& device() const noexcept;
+
+        /// <inheritdoc />
+        const VulkanFrameBuffer& activeFrameBuffer() const override;
+
+        /// <inheritdoc />
+        Enumerable<const VulkanFrameBuffer*> frameBuffers() const noexcept override;
+
+        /// <inheritdoc />
+        Enumerable<const VulkanRenderPipeline*> pipelines() const noexcept override;
+
+        /// <inheritdoc />
+        const RenderTarget& renderTarget(UInt32 location) const override;
+
+        /// <inheritdoc />
+        Span<const RenderTarget> renderTargets() const noexcept override;
+
+        /// <inheritdoc />
+        bool hasPresentTarget() const noexcept override;
+
+        /// <inheritdoc />
+        Span<const VulkanInputAttachmentMapping> inputAttachments() const noexcept override;
+
+        /// <inheritdoc />
+        MultiSamplingLevel multiSamplingLevel() const noexcept override;
+
+    public:
+        /// <inheritdoc />
+        void begin(UInt32 buffer) override;
+        
+        /// <inheritdoc />
+        void end() const override;
+
+        /// <inheritdoc />
+        void resizeFrameBuffers(const Size2d& renderArea) override;
+
+        /// <inheritdoc />
+        void changeMultiSamplingLevel(MultiSamplingLevel samples) override;
+
+        /// <inheritdoc />
+        void updateAttachments(const VulkanDescriptorSet& descriptorSet) const override;
+    };
+
+    /// <summary>
+    /// Implements a <see cref="IInputAttachmentMapping" />.
+    /// </summary>
+    /// <seealso cref="VulkanRenderPass" />
+    /// <seealso cref="VulkanRenderPassBuilder" />
+    class LITEFX_VULKAN_API VulkanInputAttachmentMapping final : public IInputAttachmentMapping<VulkanRenderPass> {
+        LITEFX_IMPLEMENTATION(VulkanInputAttachmentMappingImpl);
+
+    public:
+        /// <summary>
+        /// Creates a new Vulkan input attachment mapping.
+        /// </summary>
+        VulkanInputAttachmentMapping() noexcept;
+
+        /// <summary>
+        /// Creates a new Vulkan input attachment mapping.
+        /// </summary>
+        /// <param name="renderPass">The render pass to fetch the input attachment from.</param>
+        /// <param name="renderTarget">The render target of the <paramref name="renderPass"/> that is used for the input attachment.</param>
+        /// <param name="location">The location to bind the input attachment to.</param>
+        VulkanInputAttachmentMapping(const VulkanRenderPass& renderPass, const RenderTarget& renderTarget, UInt32 location);
+
+        /// <summary>
+        /// Copies another input attachment mapping.
+        /// </summary>
+        VulkanInputAttachmentMapping(const VulkanInputAttachmentMapping&) noexcept;
+
+        /// <summary>
+        /// Takes over another input attachment mapping.
+        /// </summary>
+        VulkanInputAttachmentMapping(VulkanInputAttachmentMapping&&) noexcept;
+
+        virtual ~VulkanInputAttachmentMapping() noexcept;
+
+    public:
+        /// <summary>
+        /// Copies another input attachment mapping.
+        /// </summary>
+        inline VulkanInputAttachmentMapping& operator=(const VulkanInputAttachmentMapping&) noexcept;
+
+        /// <summary>
+        /// Takes over another input attachment mapping.
+        /// </summary>
+        inline VulkanInputAttachmentMapping& operator=(VulkanInputAttachmentMapping&&) noexcept;
+
+    public:
+        /// <inheritdoc />
+        const VulkanRenderPass* inputAttachmentSource() const noexcept override;
+
+        /// <inheritdoc />
+        const RenderTarget& renderTarget() const noexcept override;
+
+        /// <inheritdoc />
+        UInt32 location() const noexcept override;
+    };
+
+    /// <summary>
+    /// Implements a Vulkan swap chain.
+    /// </summary>
+    class LITEFX_VULKAN_API VulkanSwapChain final : public SwapChain<IVulkanImage, VulkanFrameBuffer> {
+        LITEFX_IMPLEMENTATION(VulkanSwapChainImpl);
+
+    public:
+        using base_type = SwapChain<IVulkanImage, VulkanFrameBuffer>;
+        using base_type::present;
+
+    public:
+        /// <summary>
+        /// Initializes a Vulkan swap chain.
+        /// </summary>
+        /// <param name="device">The device that owns the swap chain.</param>
+        /// <param name="format">The initial surface format.</param>
+        /// <param name="renderArea">The initial size of the render area.</param>
+        /// <param name="buffers">The initial number of buffers.</param>
+        explicit VulkanSwapChain(const VulkanDevice& device, Format surfaceFormat = Format::B8G8R8A8_SRGB, const Size2d& renderArea = { 800, 600 }, UInt32 buffers = 3);
+        VulkanSwapChain(const VulkanSwapChain&) = delete;
+        VulkanSwapChain(VulkanSwapChain&&) = delete;
+        virtual ~VulkanSwapChain() noexcept;
+
+        // Vulkan Swap Chain interface.
+    public:
+        /// <summary>
+        /// Returns a reference of the current swap semaphore, a command queue can wait on for presenting.
+        /// </summary>
+        /// <returns>A reference of the current swap semaphore, a command queue can wait on for presenting.</returns>
+        virtual const VkSemaphore& semaphore() const noexcept;
+
+        /// <summary>
+        /// Returns the query pool for the current frame.
+        /// </summary>
+        /// <returns>A reference of the query pool for the current frame.</returns>
+        virtual const VkQueryPool& timestampQueryPool() const noexcept;
+
+        // SwapChain interface.
+    public:
+        /// <inheritdoc />
+        Enumerable<SharedPtr<TimingEvent>> timingEvents() const noexcept override;
+
+        /// <inheritdoc />
+        SharedPtr<TimingEvent> timingEvent(UInt32 queryId) const override;
+
+        /// <inheritdoc />
+        UInt64 readTimingEvent(SharedPtr<const TimingEvent> timingEvent) const override;
+
+        /// <inheritdoc />
+        UInt32 resolveQueryId(SharedPtr<const TimingEvent> timingEvent) const override;
+
+        /// <inheritdoc />
+        Format surfaceFormat() const noexcept override;
+
+        /// <inheritdoc />
+        UInt32 buffers() const noexcept override;
+
+        /// <inheritdoc />
+        const Size2d& renderArea() const noexcept override;
+
+        /// <inheritdoc />
+        const IVulkanImage* image(UInt32 backBuffer) const override;
+
+        /// <inheritdoc />
+        Enumerable<const IVulkanImage*> images() const noexcept override;
+
+        /// <inheritdoc />
+        void present(const VulkanFrameBuffer& frameBuffer) const override;
+
+    public:
+        /// <inheritdoc />
+        Enumerable<Format> getSurfaceFormats() const noexcept override;
+
+        /// <inheritdoc />
+        void addTimingEvent(SharedPtr<TimingEvent> timingEvent) override;
+
+        /// <inheritdoc />
+        void reset(Format surfaceFormat, const Size2d& renderArea, UInt32 buffers) override;
+
+        /// <inheritdoc />
+        [[nodiscard]] UInt32 swapBackBuffer() const override;
+    };
+
+    /// <summary>
+    /// Implements a Vulkan command queue.
+    /// </summary>
+    /// <seealso cref="VulkanCommandBuffer" />
+    class LITEFX_VULKAN_API VulkanQueue final : public CommandQueue<VulkanCommandBuffer>, public Resource<VkQueue> {
+        LITEFX_IMPLEMENTATION(VulkanQueueImpl);
+
+    public:
+        using base_type = CommandQueue<VulkanCommandBuffer>;
+        using base_type::submit;
+
+    public:
+        /// <summary>
+        /// Initializes the Vulkan command queue.
+        /// </summary>
+        /// <param name="device">The device, commands get send to.</param>
+        /// <param name="type">The type of the command queue.</param>
+        /// <param name="priority">The priority, of which commands are issued on the device.</param>
+        /// <param name="familyId">The ID of the queue family.</param>
+        /// <param name="queueId">The ID of the queue.</param>
+        explicit VulkanQueue(const VulkanDevice& device, QueueType type, QueuePriority priority, UInt32 familyId, UInt32 queueId);
+        VulkanQueue(const VulkanQueue&) = delete;
+        VulkanQueue(VulkanQueue&&) = delete;
+        virtual ~VulkanQueue() noexcept;
+
+        // VulkanQueue interface.
+    public:
+        /// <summary>
+        /// Returns a reference to the device that provides this queue.
+        /// </summary>
+        /// <returns>A reference to the queue's parent device.</returns>
+        virtual const VulkanDevice& device() const noexcept;
+
+        /// <summary>
+        /// Returns the queue family ID.
+        /// </summary>
+        /// <returns>The queue family ID.</returns>
+        virtual UInt32 familyId() const noexcept;
+
+        /// <summary>
+        /// Returns the queue ID.
+        /// </summary>
+        /// <returns>The queue ID.</returns>
+        virtual UInt32 queueId() const noexcept;
+
+        /// <summary>
+        /// Returns the internal timeline semaphore used to synchronize the queue execution.
+        /// </summary>
+        /// <returns>The internal timeline semaphore.</returns>
+        virtual const VkSemaphore& timelineSemaphore() const noexcept;
+
+        /// <summary>
+        /// Submits a single command buffer and inserts a fence to wait for it.
+        /// </summary>
+        /// <remarks>
         /// By calling this method, the queue takes shared ownership over the <paramref name="commandBuffers" /> until the fence is passed. The reference will be released
         /// during a <see cref="waitFor" />, if the awaited fence is inserted after the associated one.
         /// 
-		/// Note that submitting a command buffer that is currently recording will implicitly close the command buffer.
-		/// </remarks>
-		/// <param name="commandBuffer">The command buffer to submit to the command queue.</param>
-		/// <param name="waitForSemaphores">The semaphores to wait for on each pipeline stage. There must be a semaphore for each entry in the <see cref="waitForStages" /> array.</param>
-		/// <param name="waitForStages">The pipeline stages of the current render pass to wait for before submitting the command buffer.</param>
-		/// <param name="signalSemaphores">The semaphores to signal, when the command buffer is executed.</param>
-		/// <returns>The value of the fence, inserted after the command buffer.</returns>
-		/// <seealso cref="waitFor" />
-		virtual UInt64 submit(SharedPtr<const VulkanCommandBuffer> commandBuffer, Span<VkSemaphore> waitForSemaphores, Span<VkPipelineStageFlags> waitForStages, Span<VkSemaphore> signalSemaphores = { }) const;
+        /// Note that submitting a command buffer that is currently recording will implicitly close the command buffer.
+        /// </remarks>
+        /// <param name="commandBuffer">The command buffer to submit to the command queue.</param>
+        /// <param name="waitForSemaphores">The semaphores to wait for on each pipeline stage. There must be a semaphore for each entry in the <see cref="waitForStages" /> array.</param>
+        /// <param name="waitForStages">The pipeline stages of the current render pass to wait for before submitting the command buffer.</param>
+        /// <param name="signalSemaphores">The semaphores to signal, when the command buffer is executed.</param>
+        /// <returns>The value of the fence, inserted after the command buffer.</returns>
+        /// <seealso cref="waitFor" />
+        virtual UInt64 submit(SharedPtr<const VulkanCommandBuffer> commandBuffer, Span<VkSemaphore> waitForSemaphores, Span<VkPipelineStageFlags> waitForStages, Span<VkSemaphore> signalSemaphores = { }) const;
 
-		/// <summary>
-		/// Submits a set of command buffers and inserts a fence to wait for them.
-		/// </summary>
-		/// <remarks>
+        /// <summary>
+        /// Submits a set of command buffers and inserts a fence to wait for them.
+        /// </summary>
+        /// <remarks>
         /// By calling this method, the queue takes shared ownership over the <paramref name="commandBuffers" /> until the fence is passed. The reference will be released
         /// during a <see cref="waitFor" />, if the awaited fence is inserted after the associated one.
         /// 
-		/// Note that submitting a command buffer that is currently recording will implicitly close the command buffer.
-		/// </remarks>
-		/// <param name="commandBuffers">The command buffers to submit to the command queue.</param>
-		/// <param name="waitForSemaphores">The semaphores to wait for on each pipeline stage. There must be a semaphore for each entry in the <see cref="waitForStages" /> array.</param>
-		/// <param name="waitForStages">The pipeline stages of the current render pass to wait for before submitting the command buffer.</param>
-		/// <param name="signalSemaphores">The semaphores to signal, when the command buffer is executed.</param>
-		/// <returns>The value of the fence, inserted after the command buffers.</returns>
-		/// <seealso cref="waitFor" />
-		virtual UInt64 submit(const Enumerable<SharedPtr<const VulkanCommandBuffer>>& commandBuffers, Span<VkSemaphore> waitForSemaphores, Span<VkPipelineStageFlags> waitForStages, Span<VkSemaphore> signalSemaphores = { }) const;
+        /// Note that submitting a command buffer that is currently recording will implicitly close the command buffer.
+        /// </remarks>
+        /// <param name="commandBuffers">The command buffers to submit to the command queue.</param>
+        /// <param name="waitForSemaphores">The semaphores to wait for on each pipeline stage. There must be a semaphore for each entry in the <see cref="waitForStages" /> array.</param>
+        /// <param name="waitForStages">The pipeline stages of the current render pass to wait for before submitting the command buffer.</param>
+        /// <param name="signalSemaphores">The semaphores to signal, when the command buffer is executed.</param>
+        /// <returns>The value of the fence, inserted after the command buffers.</returns>
+        /// <seealso cref="waitFor" />
+        virtual UInt64 submit(const Enumerable<SharedPtr<const VulkanCommandBuffer>>& commandBuffers, Span<VkSemaphore> waitForSemaphores, Span<VkPipelineStageFlags> waitForStages, Span<VkSemaphore> signalSemaphores = { }) const;
 
-		// CommandQueue interface.
-	public:
-		/// <inheritdoc />
-		bool isBound() const noexcept override;
+        // CommandQueue interface.
+    public:
+        /// <inheritdoc />
+        QueuePriority priority() const noexcept override;
 
-		/// <inheritdoc />
-		QueuePriority priority() const noexcept override;
-
-		/// <inheritdoc />
-		QueueType type() const noexcept override;
+        /// <inheritdoc />
+        QueueType type() const noexcept override;
 
 #ifndef NDEBUG
-	public:
-		/// <inheritdoc />
-		void BeginDebugRegion(const String& label, const Vectors::ByteVector3& color = { 128_b, 128_b, 128_b }) const noexcept override;
+    public:
+        /// <inheritdoc />
+        void BeginDebugRegion(const String& label, const Vectors::ByteVector3& color = { 128_b, 128_b, 128_b }) const noexcept override;
 
-		/// <inheritdoc />
-		void EndDebugRegion() const noexcept override;
+        /// <inheritdoc />
+        void EndDebugRegion() const noexcept override;
 
-		/// <inheritdoc />
-		void SetDebugMarker(const String& label, const Vectors::ByteVector3& color = { 128_b, 128_b, 128_b }) const noexcept override;
+        /// <inheritdoc />
+        void SetDebugMarker(const String& label, const Vectors::ByteVector3& color = { 128_b, 128_b, 128_b }) const noexcept override;
 #endif
 
-	public:
-		/// <inheritdoc />
-		void bind() override;
+    public:
+        /// <inheritdoc />
+        SharedPtr<VulkanCommandBuffer> createCommandBuffer(bool beginRecording = false, bool secondary = false) const override;
 
-		/// <inheritdoc />
-		void release() override;
+        /// <inheritdoc />
+        UInt64 submit(SharedPtr<const VulkanCommandBuffer> commandBuffer) const override;
 
-		/// <inheritdoc />
-		SharedPtr<VulkanCommandBuffer> createCommandBuffer(bool beginRecording = false, bool secondary = false) const override;
+        /// <inheritdoc />
+        UInt64 submit(const Enumerable<SharedPtr<const VulkanCommandBuffer>>& commandBuffers) const override;
 
-		/// <inheritdoc />
-		UInt64 submit(SharedPtr<const VulkanCommandBuffer> commandBuffer) const override;
+        /// <inheritdoc />
+        void waitFor(UInt64 fence) const noexcept override;
 
-		/// <inheritdoc />
-		UInt64 submit(const Enumerable<SharedPtr<const VulkanCommandBuffer>>& commandBuffers) const override;
+        /// <inheritdoc />
+        UInt64 currentFence() const noexcept override;
+    };
 
-		/// <inheritdoc />
-		void waitFor(UInt64 fence) const noexcept override;
+    /// <summary>
+    /// A graphics factory that produces objects for a <see cref="VulkanDevice" />.
+    /// </summary>
+    /// <remarks>
+    /// Internally this factory implementation is based on <a href="https://gpuopen.com/vulkan-memory-allocator/" target="_blank">Vulkan Memory Allocator</a>.
+    /// </remarks>
+    class LITEFX_VULKAN_API VulkanGraphicsFactory final : public GraphicsFactory<VulkanDescriptorLayout, IVulkanBuffer, IVulkanVertexBuffer, IVulkanIndexBuffer, IVulkanImage, IVulkanSampler> {
+        LITEFX_IMPLEMENTATION(VulkanGraphicsFactoryImpl);
 
-		/// <inheritdoc />
-		UInt64 currentFence() const noexcept override;
-	};
+    public:
+        using base_type = GraphicsFactory<VulkanDescriptorLayout, IVulkanBuffer, IVulkanVertexBuffer, IVulkanIndexBuffer, IVulkanImage, IVulkanSampler>;
+        using base_type::createBuffer;
+        using base_type::createVertexBuffer;
+        using base_type::createIndexBuffer;
+        using base_type::createAttachment;
+        using base_type::createTexture;
+        using base_type::createTextures;
+        using base_type::createSampler;
+        using base_type::createSamplers;
 
-	/// <summary>
-	/// A graphics factory that produces objects for a <see cref="VulkanDevice" />.
-	/// </summary>
-	/// <remarks>
-	/// Internally this factory implementation is based on <a href="https://gpuopen.com/vulkan-memory-allocator/" target="_blank">Vulkan Memory Allocator</a>.
-	/// </remarks>
-	class LITEFX_VULKAN_API VulkanGraphicsFactory final : public GraphicsFactory<VulkanDescriptorLayout, IVulkanBuffer, IVulkanVertexBuffer, IVulkanIndexBuffer, IVulkanImage, IVulkanSampler> {
-		LITEFX_IMPLEMENTATION(VulkanGraphicsFactoryImpl);
+    public:
+        /// <summary>
+        /// Creates a new graphics factory.
+        /// </summary>
+        /// <param name="device">The device the factory should produce objects for.</param>
+        explicit VulkanGraphicsFactory(const VulkanDevice& device);
+        VulkanGraphicsFactory(const VulkanGraphicsFactory&) = delete;
+        VulkanGraphicsFactory(VulkanGraphicsFactory&&) = delete;
+        virtual ~VulkanGraphicsFactory() noexcept;
 
-	public:
-		using base_type = GraphicsFactory<VulkanDescriptorLayout, IVulkanBuffer, IVulkanVertexBuffer, IVulkanIndexBuffer, IVulkanImage, IVulkanSampler>;
-		using base_type::createBuffer;
-		using base_type::createVertexBuffer;
-		using base_type::createIndexBuffer;
-		using base_type::createAttachment;
-		using base_type::createTexture;
-		using base_type::createTextures;
-		using base_type::createSampler;
-		using base_type::createSamplers;
+    public:
+        /// <inheritdoc />
+        UniquePtr<IVulkanBuffer> createBuffer(BufferType type, BufferUsage usage, size_t elementSize, UInt32 elements = 1, bool allowWrite = false) const override;
 
-	public:
-		/// <summary>
-		/// Creates a new graphics factory.
-		/// </summary>
-		/// <param name="device">The device the factory should produce objects for.</param>
-		explicit VulkanGraphicsFactory(const VulkanDevice& device);
-		VulkanGraphicsFactory(const VulkanGraphicsFactory&) = delete;
-		VulkanGraphicsFactory(VulkanGraphicsFactory&&) = delete;
-		virtual ~VulkanGraphicsFactory() noexcept;
+        /// <inheritdoc />
+        UniquePtr<IVulkanBuffer> createBuffer(const String& name, BufferType type, BufferUsage usage, size_t elementSize, UInt32 elements = 1, bool allowWrite = false) const override;
 
-	public:
-		/// <inheritdoc />
-		UniquePtr<IVulkanBuffer> createBuffer(BufferType type, BufferUsage usage, size_t elementSize, UInt32 elements = 1, bool allowWrite = false) const override;
+        /// <inheritdoc />
+        UniquePtr<IVulkanVertexBuffer> createVertexBuffer(const VulkanVertexBufferLayout& layout, BufferUsage usage, UInt32 elements = 1) const override;
 
-		/// <inheritdoc />
-		UniquePtr<IVulkanBuffer> createBuffer(const String& name, BufferType type, BufferUsage usage, size_t elementSize, UInt32 elements = 1, bool allowWrite = false) const override;
+        /// <inheritdoc />
+        UniquePtr<IVulkanVertexBuffer> createVertexBuffer(const String& name, const VulkanVertexBufferLayout& layout, BufferUsage usage, UInt32 elements = 1) const override;
 
-		/// <inheritdoc />
-		UniquePtr<IVulkanVertexBuffer> createVertexBuffer(const VulkanVertexBufferLayout& layout, BufferUsage usage, UInt32 elements = 1) const override;
+        /// <inheritdoc />
+        UniquePtr<IVulkanIndexBuffer> createIndexBuffer(const VulkanIndexBufferLayout& layout, BufferUsage usage, UInt32 elements) const override;
 
-		/// <inheritdoc />
-		UniquePtr<IVulkanVertexBuffer> createVertexBuffer(const String& name, const VulkanVertexBufferLayout& layout, BufferUsage usage, UInt32 elements = 1) const override;
+        /// <inheritdoc />
+        UniquePtr<IVulkanIndexBuffer> createIndexBuffer(const String& name, const VulkanIndexBufferLayout& layout, BufferUsage usage, UInt32 elements) const override;
 
-		/// <inheritdoc />
-		UniquePtr<IVulkanIndexBuffer> createIndexBuffer(const VulkanIndexBufferLayout& layout, BufferUsage usage, UInt32 elements) const override;
+        /// <inheritdoc />
+        UniquePtr<IVulkanImage> createAttachment(Format format, const Size2d& size, MultiSamplingLevel samples = MultiSamplingLevel::x1) const override;
 
-		/// <inheritdoc />
-		UniquePtr<IVulkanIndexBuffer> createIndexBuffer(const String& name, const VulkanIndexBufferLayout& layout, BufferUsage usage, UInt32 elements) const override;
+        /// <inheritdoc />
+        UniquePtr<IVulkanImage> createAttachment(const String& name, Format format, const Size2d& size, MultiSamplingLevel samples = MultiSamplingLevel::x1) const override;
 
-		/// <inheritdoc />
-		UniquePtr<IVulkanImage> createAttachment(Format format, const Size2d& size, MultiSamplingLevel samples = MultiSamplingLevel::x1) const override;
+        /// <inheritdoc />
+        UniquePtr<IVulkanImage> createTexture(Format format, const Size3d& size, ImageDimensions dimension = ImageDimensions::DIM_2, UInt32 levels = 1, UInt32 layers = 1, MultiSamplingLevel samples = MultiSamplingLevel::x1, bool allowWrite = false) const override;
 
-		/// <inheritdoc />
-		UniquePtr<IVulkanImage> createAttachment(const String& name, Format format, const Size2d& size, MultiSamplingLevel samples = MultiSamplingLevel::x1) const override;
+        /// <inheritdoc />
+        UniquePtr<IVulkanImage> createTexture(const String& name, Format format, const Size3d& size, ImageDimensions dimension = ImageDimensions::DIM_2, UInt32 levels = 1, UInt32 layers = 1, MultiSamplingLevel samples = MultiSamplingLevel::x1, bool allowWrite = false) const override;
 
-		/// <inheritdoc />
-		UniquePtr<IVulkanImage> createTexture(Format format, const Size3d& size, ImageDimensions dimension = ImageDimensions::DIM_2, UInt32 levels = 1, UInt32 layers = 1, MultiSamplingLevel samples = MultiSamplingLevel::x1, bool allowWrite = false) const override;
+        /// <inheritdoc />
+        Enumerable<UniquePtr<IVulkanImage>> createTextures(UInt32 elements, Format format, const Size3d& size, ImageDimensions dimension = ImageDimensions::DIM_2, UInt32 levels = 1, UInt32 layers = 1, MultiSamplingLevel samples = MultiSamplingLevel::x1, bool allowWrite = false) const override;
 
-		/// <inheritdoc />
-		UniquePtr<IVulkanImage> createTexture(const String& name, Format format, const Size3d& size, ImageDimensions dimension = ImageDimensions::DIM_2, UInt32 levels = 1, UInt32 layers = 1, MultiSamplingLevel samples = MultiSamplingLevel::x1, bool allowWrite = false) const override;
+        /// <inheritdoc />
+        UniquePtr<IVulkanSampler> createSampler(FilterMode magFilter = FilterMode::Nearest, FilterMode minFilter = FilterMode::Nearest, BorderMode borderU = BorderMode::Repeat, BorderMode borderV = BorderMode::Repeat, BorderMode borderW = BorderMode::Repeat, MipMapMode mipMapMode = MipMapMode::Nearest, Float mipMapBias = 0.f, Float maxLod = std::numeric_limits<Float>::max(), Float minLod = 0.f, Float anisotropy = 0.f) const override;
 
-		/// <inheritdoc />
-		Enumerable<UniquePtr<IVulkanImage>> createTextures(UInt32 elements, Format format, const Size3d& size, ImageDimensions dimension = ImageDimensions::DIM_2, UInt32 levels = 1, UInt32 layers = 1, MultiSamplingLevel samples = MultiSamplingLevel::x1, bool allowWrite = false) const override;
+        /// <inheritdoc />
+        UniquePtr<IVulkanSampler> createSampler(const String& name, FilterMode magFilter = FilterMode::Nearest, FilterMode minFilter = FilterMode::Nearest, BorderMode borderU = BorderMode::Repeat, BorderMode borderV = BorderMode::Repeat, BorderMode borderW = BorderMode::Repeat, MipMapMode mipMapMode = MipMapMode::Nearest, Float mipMapBias = 0.f, Float maxLod = std::numeric_limits<Float>::max(), Float minLod = 0.f, Float anisotropy = 0.f) const override;
 
-		/// <inheritdoc />
-		UniquePtr<IVulkanSampler> createSampler(FilterMode magFilter = FilterMode::Nearest, FilterMode minFilter = FilterMode::Nearest, BorderMode borderU = BorderMode::Repeat, BorderMode borderV = BorderMode::Repeat, BorderMode borderW = BorderMode::Repeat, MipMapMode mipMapMode = MipMapMode::Nearest, Float mipMapBias = 0.f, Float maxLod = std::numeric_limits<Float>::max(), Float minLod = 0.f, Float anisotropy = 0.f) const override;
+        /// <inheritdoc />
+        Enumerable<UniquePtr<IVulkanSampler>> createSamplers(UInt32 elements, FilterMode magFilter = FilterMode::Nearest, FilterMode minFilter = FilterMode::Nearest, BorderMode borderU = BorderMode::Repeat, BorderMode borderV = BorderMode::Repeat, BorderMode borderW = BorderMode::Repeat, MipMapMode mipMapMode = MipMapMode::Nearest, Float mipMapBias = 0.f, Float maxLod = std::numeric_limits<Float>::max(), Float minLod = 0.f, Float anisotropy = 0.f) const override;
+    };
 
-		/// <inheritdoc />
-		UniquePtr<IVulkanSampler> createSampler(const String& name, FilterMode magFilter = FilterMode::Nearest, FilterMode minFilter = FilterMode::Nearest, BorderMode borderU = BorderMode::Repeat, BorderMode borderV = BorderMode::Repeat, BorderMode borderW = BorderMode::Repeat, MipMapMode mipMapMode = MipMapMode::Nearest, Float mipMapBias = 0.f, Float maxLod = std::numeric_limits<Float>::max(), Float minLod = 0.f, Float anisotropy = 0.f) const override;
+    /// <summary>
+    /// Implements a Vulkan graphics device.
+    /// </summary>
+    class LITEFX_VULKAN_API VulkanDevice final : public GraphicsDevice<VulkanGraphicsFactory, VulkanSurface, VulkanGraphicsAdapter, VulkanSwapChain, VulkanQueue, VulkanRenderPass, VulkanComputePipeline, VulkanBarrier>, public Resource<VkDevice> {
+        LITEFX_IMPLEMENTATION(VulkanDeviceImpl);
 
-		/// <inheritdoc />
-		Enumerable<UniquePtr<IVulkanSampler>> createSamplers(UInt32 elements, FilterMode magFilter = FilterMode::Nearest, FilterMode minFilter = FilterMode::Nearest, BorderMode borderU = BorderMode::Repeat, BorderMode borderV = BorderMode::Repeat, BorderMode borderW = BorderMode::Repeat, MipMapMode mipMapMode = MipMapMode::Nearest, Float mipMapBias = 0.f, Float maxLod = std::numeric_limits<Float>::max(), Float minLod = 0.f, Float anisotropy = 0.f) const override;
-	};
+    public:
+        /// <summary>
+        /// Creates a new device instance.
+        /// </summary>
+        /// <param name="backend">The backend from which the device is created.</param>
+        /// <param name="adapter">The adapter the device uses for drawing.</param>
+        /// <param name="surface">The surface, the device should draw to.</param>
+        /// <param name="extensions">The required extensions the device gets initialized with.</param>
+        explicit VulkanDevice(const VulkanBackend& backend, const VulkanGraphicsAdapter& adapter, UniquePtr<VulkanSurface>&& surface, Span<String> extensions = { });
 
-	/// <summary>
-	/// Implements a Vulkan graphics device.
-	/// </summary>
-	class LITEFX_VULKAN_API VulkanDevice final : public GraphicsDevice<VulkanGraphicsFactory, VulkanSurface, VulkanGraphicsAdapter, VulkanSwapChain, VulkanQueue, VulkanRenderPass, VulkanComputePipeline, VulkanBarrier>, public Resource<VkDevice> {
-		LITEFX_IMPLEMENTATION(VulkanDeviceImpl);
+        /// <summary>
+        /// Creates a new device instance.
+        /// </summary>
+        /// <param name="backend">The backend from which the device is created.</param>
+        /// <param name="adapter">The adapter the device uses for drawing.</param>
+        /// <param name="surface">The surface, the device should draw to.</param>
+        /// <param name="format">The initial surface format, device uses for drawing.</param>
+        /// <param name="frameBufferSize">The initial size of the frame buffers.</param>
+        /// <param name="frameBuffers">The initial number of frame buffers.</param>
+        /// <param name="extensions">The required extensions the device gets initialized with.</param>
+        explicit VulkanDevice(const VulkanBackend& backend, const VulkanGraphicsAdapter& adapter, UniquePtr<VulkanSurface>&& surface, Format format, const Size2d& frameBufferSize, UInt32 frameBuffers, Span<String> extensions = { });
 
-	public:
-		/// <summary>
-		/// Creates a new device instance.
-		/// </summary>
-		/// <param name="backend">The backend from which the device is created.</param>
-		/// <param name="adapter">The adapter the device uses for drawing.</param>
-		/// <param name="surface">The surface, the device should draw to.</param>
-		/// <param name="extensions">The required extensions the device gets initialized with.</param>
-		explicit VulkanDevice(const VulkanBackend& backend, const VulkanGraphicsAdapter& adapter, UniquePtr<VulkanSurface>&& surface, Span<String> extensions = { });
+        VulkanDevice(const VulkanDevice&) = delete;
+        VulkanDevice(VulkanDevice&&) = delete;
+        virtual ~VulkanDevice() noexcept;
 
-		/// <summary>
-		/// Creates a new device instance.
-		/// </summary>
-		/// <param name="backend">The backend from which the device is created.</param>
-		/// <param name="adapter">The adapter the device uses for drawing.</param>
-		/// <param name="surface">The surface, the device should draw to.</param>
-		/// <param name="format">The initial surface format, device uses for drawing.</param>
-		/// <param name="frameBufferSize">The initial size of the frame buffers.</param>
-		/// <param name="frameBuffers">The initial number of frame buffers.</param>
-		/// <param name="extensions">The required extensions the device gets initialized with.</param>
-		explicit VulkanDevice(const VulkanBackend& backend, const VulkanGraphicsAdapter& adapter, UniquePtr<VulkanSurface>&& surface, Format format, const Size2d& frameBufferSize, UInt32 frameBuffers, Span<String> extensions = { });
+        // Vulkan Device interface.
+    public:
+        /// <summary>
+        /// Returns the array that stores the extensions that were used to initialize the device.
+        /// </summary>
+        /// <returns>A reference to the array that stores the extensions that were used to initialize the device.</returns>
+        Span<const String> enabledExtensions() const noexcept;
 
-		VulkanDevice(const VulkanDevice&) = delete;
-		VulkanDevice(VulkanDevice&&) = delete;
-		virtual ~VulkanDevice() noexcept;
+        /// <summary>
+        /// Sets the debug name for an object.
+        /// </summary>
+        /// <remarks>
+        /// This function sets the debug name for an object to make it easier to identify when using an external debugger. This function will do nothing
+        /// in release mode or if the device extension VK_EXT_debug_marker is not available.
+        /// </remarks>
+        /// <param name="objectHandle">The handle of the object casted to an integer.</param>
+        /// <param name="objectType">The type of the object.</param>
+        /// <param name="name">The debug name of the object.</param>
+        void setDebugName(UInt64 objectHandle, VkDebugReportObjectTypeEXT objectType, StringView name) const noexcept;
 
-		// Vulkan Device interface.
-	public:
-		/// <summary>
-		/// Returns the array that stores the extensions that were used to initialize the device.
-		/// </summary>
-		/// <returns>A reference to the array that stores the extensions that were used to initialize the device.</returns>
-		Span<const String> enabledExtensions() const noexcept;
+        /// <summary>
+        /// Returns the indices of all queue families with support for <paramref name="type" />.
+        /// </summary>
+        /// <param name="type">The type of workload that must be supported by the family in order for it to be returned. Specifying <see cref="QueueType::None" /> will return all available queue families.</param>
+        /// <returns>The indices of the queue families that support queue workloads specified by <paramref name="type" />.</returns>
+        Enumerable<UInt32> queueFamilyIndices(QueueType type = QueueType::None) const noexcept;
 
-		/// <summary>
-		/// Sets the debug name for an object.
-		/// </summary>
-		/// <remarks>
-		/// This function sets the debug name for an object to make it easier to identify when using an external debugger. This function will do nothing
-		/// in release mode or if the device extension VK_EXT_debug_marker is not available.
-		/// </remarks>
-		/// <param name="objectHandle">The handle of the object casted to an integer.</param>
-		/// <param name="objectType">The type of the object.</param>
-		/// <param name="name">The debug name of the object.</param>
-		void setDebugName(UInt64 objectHandle, VkDebugReportObjectTypeEXT objectType, StringView name) const noexcept;
+        // GraphicsDevice interface.
+    public:
+        /// <inheritdoc />
+        DeviceState& state() const noexcept override;
 
-		/// <summary>
-		/// Returns the indices of all queue families with support for <paramref name="type" />.
-		/// </summary>
-		/// <param name="type">The type of workload that must be supported by the family in order for it to be returned. Specifying <see cref="QueueType::None" /> will return all available queue families.</param>
-		/// <returns>The indices of the queue families that support queue workloads specified by <paramref name="type" />.</returns>
-		Enumerable<UInt32> queueFamilyIndices(QueueType type = QueueType::None) const noexcept;
+        /// <inheritdoc />
+        const VulkanSwapChain& swapChain() const noexcept override;
 
-		// GraphicsDevice interface.
-	public:
-		/// <inheritdoc />
-		DeviceState& state() const noexcept override;
+        /// <inheritdoc />
+        VulkanSwapChain& swapChain() noexcept override;
 
-		/// <inheritdoc />
-		const VulkanSwapChain& swapChain() const noexcept override;
+        /// <inheritdoc />
+        const VulkanSurface& surface() const noexcept override;
 
-		/// <inheritdoc />
-		VulkanSwapChain& swapChain() noexcept override;
+        /// <inheritdoc />
+        const VulkanGraphicsAdapter& adapter() const noexcept override;
 
-		/// <inheritdoc />
-		const VulkanSurface& surface() const noexcept override;
+        /// <inheritdoc />
+        const VulkanGraphicsFactory& factory() const noexcept override;
 
-		/// <inheritdoc />
-		const VulkanGraphicsAdapter& adapter() const noexcept override;
+        /// <inheritdoc />
+        const VulkanQueue& defaultQueue(QueueType type) const override;
 
-		/// <inheritdoc />
-		const VulkanGraphicsFactory& factory() const noexcept override;
-		
-		/// <inheritdoc />
-		const VulkanQueue& graphicsQueue() const noexcept override;
-		
-		/// <inheritdoc />
-		const VulkanQueue& transferQueue() const noexcept override;
+        /// <inheritdoc />
+        const VulkanQueue* createQueue(QueueType type, QueuePriority priority = QueuePriority::Normal) noexcept override;
 
-		/// <inheritdoc />
-		const VulkanQueue& bufferQueue() const noexcept override;
+        /// <inheritdoc />
+        [[nodiscard]] UniquePtr<VulkanBarrier> makeBarrier(PipelineStage syncBefore, PipelineStage syncAfter) const noexcept override;
 
-		/// <inheritdoc />
-		const VulkanQueue& computeQueue() const noexcept override;
+        /// <inheritdoc />
+        MultiSamplingLevel maximumMultiSamplingLevel(Format format) const noexcept override;
 
-		/// <inheritdoc />
-		[[nodiscard]] UniquePtr<VulkanBarrier> makeBarrier(PipelineStage syncBefore, PipelineStage syncAfter) const noexcept override;
+        /// <inheritdoc />
+        double ticksPerMillisecond() const noexcept override;
 
-		/// <inheritdoc />
-		MultiSamplingLevel maximumMultiSamplingLevel(Format format) const noexcept override;
-
-		/// <inheritdoc />
-		double ticksPerMillisecond() const noexcept override;
-
-		/// <inheritdoc />
-		void wait() const override;
+        /// <inheritdoc />
+        void wait() const override;
 
 #if defined(BUILD_DEFINE_BUILDERS)
-	public:
-		/// <inheritdoc />
-		[[nodiscard]] VulkanRenderPassBuilder buildRenderPass(MultiSamplingLevel samples = MultiSamplingLevel::x1, UInt32 commandBuffers = 1) const override;
+    public:
+        /// <inheritdoc />
+        [[nodiscard]] VulkanRenderPassBuilder buildRenderPass(MultiSamplingLevel samples = MultiSamplingLevel::x1, UInt32 commandBuffers = 1) const override;
 
-		/// <inheritdoc />
-		[[nodiscard]] VulkanRenderPassBuilder buildRenderPass(const String& name, MultiSamplingLevel samples = MultiSamplingLevel::x1, UInt32 commandBuffers = 1) const override;
+        /// <inheritdoc />
+        [[nodiscard]] VulkanRenderPassBuilder buildRenderPass(const String& name, MultiSamplingLevel samples = MultiSamplingLevel::x1, UInt32 commandBuffers = 1) const override;
 
-		/// <inheritdoc />
-		//[[nodiscard]] VulkanRenderPipelineBuilder buildRenderPipeline(const String& name) const override;
+        /// <inheritdoc />
+        //[[nodiscard]] VulkanRenderPipelineBuilder buildRenderPipeline(const String& name) const override;
 
-		/// <inheritdoc />
-		[[nodiscard]] VulkanRenderPipelineBuilder buildRenderPipeline(const VulkanRenderPass& renderPass, const String& name) const override;
+        /// <inheritdoc />
+        [[nodiscard]] VulkanRenderPipelineBuilder buildRenderPipeline(const VulkanRenderPass& renderPass, const String& name) const override;
 
-		/// <inheritdoc />
-		[[nodiscard]] VulkanComputePipelineBuilder buildComputePipeline(const String& name) const override;
-		
-		/// <inheritdoc />
-		[[nodiscard]] VulkanPipelineLayoutBuilder buildPipelineLayout() const override;
+        /// <inheritdoc />
+        [[nodiscard]] VulkanComputePipelineBuilder buildComputePipeline(const String& name) const override;
+        
+        /// <inheritdoc />
+        [[nodiscard]] VulkanPipelineLayoutBuilder buildPipelineLayout() const override;
 
-		/// <inheritdoc />
-		[[nodiscard]] VulkanInputAssemblerBuilder buildInputAssembler() const override;
+        /// <inheritdoc />
+        [[nodiscard]] VulkanInputAssemblerBuilder buildInputAssembler() const override;
 
-		/// <inheritdoc />
-		[[nodiscard]] VulkanRasterizerBuilder buildRasterizer() const override;
+        /// <inheritdoc />
+        [[nodiscard]] VulkanRasterizerBuilder buildRasterizer() const override;
 
-		/// <inheritdoc />
-		[[nodiscard]] VulkanShaderProgramBuilder buildShaderProgram() const override;
+        /// <inheritdoc />
+        [[nodiscard]] VulkanShaderProgramBuilder buildShaderProgram() const override;
 
-		/// <inheritdoc />
-		[[nodiscard]] VulkanBarrierBuilder buildBarrier() const override;
+        /// <inheritdoc />
+        [[nodiscard]] VulkanBarrierBuilder buildBarrier() const override;
 #endif // defined(BUILD_DEFINE_BUILDERS)
-	};
+    };
 
-	/// <summary>
-	/// Defines a rendering backend that creates a Vulkan device.
-	/// </summary>
-	class LITEFX_VULKAN_API VulkanBackend final : public RenderBackend<VulkanDevice>, public Resource<VkInstance> {
-		LITEFX_IMPLEMENTATION(VulkanBackendImpl);
+    /// <summary>
+    /// Defines a rendering backend that creates a Vulkan device.
+    /// </summary>
+    class LITEFX_VULKAN_API VulkanBackend final : public RenderBackend<VulkanDevice>, public Resource<VkInstance> {
+        LITEFX_IMPLEMENTATION(VulkanBackendImpl);
 
-	public:
-		/// <summary>
-		/// Initializes a new vulkan rendering backend.
-		/// </summary>
-		/// <param name="app">An instance of the app that owns the backend.</param>
-		/// <param name="extensions">A set of instance extensions to enable on the backend instance.</param>
-		/// <param name="validationLayers">A set of validation layers to enable on the rendering backend.</param>
-		explicit VulkanBackend(const App& app, const Span<String> extensions = { }, const Span<String> validationLayers = { });
-		VulkanBackend(const VulkanBackend&) noexcept = delete;
-		VulkanBackend(VulkanBackend&&) noexcept = delete;
-		virtual ~VulkanBackend() noexcept;
+    public:
+        /// <summary>
+        /// Initializes a new vulkan rendering backend.
+        /// </summary>
+        /// <param name="app">An instance of the app that owns the backend.</param>
+        /// <param name="extensions">A set of instance extensions to enable on the backend instance.</param>
+        /// <param name="validationLayers">A set of validation layers to enable on the rendering backend.</param>
+        explicit VulkanBackend(const App& app, const Span<String> extensions = { }, const Span<String> validationLayers = { });
+        VulkanBackend(const VulkanBackend&) noexcept = delete;
+        VulkanBackend(VulkanBackend&&) noexcept = delete;
+        virtual ~VulkanBackend() noexcept;
 
 
-	public:
-		/// <summary>
-		/// Returns the validation layers that are enabled on the backend.
-		/// </summary>
-		/// <returns>An array of validation layers that are enabled on the backend.</returns>
-		virtual Span<const String> getEnabledValidationLayers() const noexcept;
+    public:
+        /// <summary>
+        /// Returns the validation layers that are enabled on the backend.
+        /// </summary>
+        /// <returns>An array of validation layers that are enabled on the backend.</returns>
+        virtual Span<const String> getEnabledValidationLayers() const noexcept;
 
 #ifdef VK_USE_PLATFORM_WIN32_KHR
-		/// <summary>
-		/// Creates a surface on a window handle.
-		/// </summary>
-		/// <param name="hwnd">The window handle on which the surface should be created.</param>
-		/// <returns>The instance of the created surface.</returns>
-		UniquePtr<VulkanSurface> createSurface(const HWND& hwnd) const;
+        /// <summary>
+        /// Creates a surface on a window handle.
+        /// </summary>
+        /// <param name="hwnd">The window handle on which the surface should be created.</param>
+        /// <returns>The instance of the created surface.</returns>
+        UniquePtr<VulkanSurface> createSurface(const HWND& hwnd) const;
 #else
-		/// <summary>
-		/// A callback that creates a surface from a Vulkan instance.
-		/// </summary>
-		typedef std::function<VkSurfaceKHR(const VkInstance&)> surface_callback;
+        /// <summary>
+        /// A callback that creates a surface from a Vulkan instance.
+        /// </summary>
+        typedef std::function<VkSurfaceKHR(const VkInstance&)> surface_callback;
 
-		/// <summary>
-		/// Creates a surface using the <paramref name="predicate" /> callback.
-		/// </summary>
-		/// <param name="predicate">A callback that gets called with the backend instance handle and creates the surface instance</param>
-		/// <returns>The instance of the created surface.</returns>
-		/// <seealso cref="surface_callback" />
-		UniquePtr<VulkanSurface> createSurface(surface_callback predicate) const;
+        /// <summary>
+        /// Creates a surface using the <paramref name="predicate" /> callback.
+        /// </summary>
+        /// <param name="predicate">A callback that gets called with the backend instance handle and creates the surface instance</param>
+        /// <returns>The instance of the created surface.</returns>
+        /// <seealso cref="surface_callback" />
+        UniquePtr<VulkanSurface> createSurface(surface_callback predicate) const;
 #endif // VK_USE_PLATFORM_WIN32_KHR
 
-	public:
-		/// <summary>
-		/// Returns <c>true</c>, if all elements of <paramref cref="extensions" /> are contained by the a list of available extensions.
-		/// </summary>
-		/// <returns><c>true</c>, if all elements of <paramref cref="extensions" /> are contained by the a list of available extensions.</returns>
-		/// <seealso cref="getAvailableInstanceExtensions" />
-		static bool validateInstanceExtensions(Span<const String> extensions) noexcept;
+    public:
+        /// <summary>
+        /// Returns <c>true</c>, if all elements of <paramref cref="extensions" /> are contained by the a list of available extensions.
+        /// </summary>
+        /// <returns><c>true</c>, if all elements of <paramref cref="extensions" /> are contained by the a list of available extensions.</returns>
+        /// <seealso cref="getAvailableInstanceExtensions" />
+        static bool validateInstanceExtensions(Span<const String> extensions) noexcept;
 
-		/// <summary>
-		/// Returns a list of available extensions.
-		/// </summary>
-		/// <returns>A list of available extensions.</returns>
-		/// <seealso cref="validateInstanceExtensions" />
-		static Enumerable<String> getAvailableInstanceExtensions() noexcept;
+        /// <summary>
+        /// Returns a list of available extensions.
+        /// </summary>
+        /// <returns>A list of available extensions.</returns>
+        /// <seealso cref="validateInstanceExtensions" />
+        static Enumerable<String> getAvailableInstanceExtensions() noexcept;
 
-		/// <summary>
-		/// Returns <c>true</c>, if all elements of <paramref cref="validationLayers" /> are contained by the a list of available validation layers.
-		/// </summary>
-		/// <returns><c>true</c>, if all elements of <paramref cref="validationLayers" /> are contained by the a list of available validation layers.</returns>
-		/// <seealso cref="getInstanceValidationLayers" />
-		static bool validateInstanceLayers(const Span<const String> validationLayers) noexcept;
+        /// <summary>
+        /// Returns <c>true</c>, if all elements of <paramref cref="validationLayers" /> are contained by the a list of available validation layers.
+        /// </summary>
+        /// <returns><c>true</c>, if all elements of <paramref cref="validationLayers" /> are contained by the a list of available validation layers.</returns>
+        /// <seealso cref="getInstanceValidationLayers" />
+        static bool validateInstanceLayers(const Span<const String> validationLayers) noexcept;
 
-		/// <summary>
-		/// Returns a list of available validation layers.
-		/// </summary>
-		/// <returns>A list of available validation layers.</returns>
-		/// <seealso cref="validateInstanceLayers" />
-		static Enumerable<String> getInstanceValidationLayers() noexcept;
+        /// <summary>
+        /// Returns a list of available validation layers.
+        /// </summary>
+        /// <returns>A list of available validation layers.</returns>
+        /// <seealso cref="validateInstanceLayers" />
+        static Enumerable<String> getInstanceValidationLayers() noexcept;
 
-		// IBackend interface.
-	public:
-		/// <inheritdoc />
-		BackendType type() const noexcept override;
+        // IBackend interface.
+    public:
+        /// <inheritdoc />
+        BackendType type() const noexcept override;
 
-		/// <inheritdoc />
-		String name() const noexcept override;
+        /// <inheritdoc />
+        String name() const noexcept override;
 
-	protected:
-		/// <inheritdoc />
-		void activate() override;
+    protected:
+        /// <inheritdoc />
+        void activate() override;
 
-		/// <inheritdoc />
-		void deactivate() override;
+        /// <inheritdoc />
+        void deactivate() override;
 
-		// RenderBackend interface.
-	public:
-		/// <inheritdoc />
-		Enumerable<const VulkanGraphicsAdapter*> listAdapters() const override;
+        // RenderBackend interface.
+    public:
+        /// <inheritdoc />
+        Enumerable<const VulkanGraphicsAdapter*> listAdapters() const override;
 
-		/// <inheritdoc />
-		const VulkanGraphicsAdapter* findAdapter(const Optional<UInt64>& adapterId = std::nullopt) const override;
+        /// <inheritdoc />
+        const VulkanGraphicsAdapter* findAdapter(const Optional<UInt64>& adapterId = std::nullopt) const override;
 
-		/// <inheritdoc />
-		void registerDevice(String name, UniquePtr<VulkanDevice>&& device) override;
+        /// <inheritdoc />
+        void registerDevice(String name, UniquePtr<VulkanDevice>&& device) override;
 
-		/// <inheritdoc />
-		void releaseDevice(const String& name) override;
+        /// <inheritdoc />
+        void releaseDevice(const String& name) override;
 
-		/// <inheritdoc />
-		VulkanDevice* device(const String& name) noexcept override;
+        /// <inheritdoc />
+        VulkanDevice* device(const String& name) noexcept override;
 
-		/// <inheritdoc />
-		const VulkanDevice* device(const String& name) const noexcept override;
-	};
+        /// <inheritdoc />
+        const VulkanDevice* device(const String& name) const noexcept override;
+    };
 
 }

--- a/src/Backends/Vulkan/include/litefx/backends/vulkan.hpp
+++ b/src/Backends/Vulkan/include/litefx/backends/vulkan.hpp
@@ -1621,7 +1621,7 @@ namespace LiteFX::Rendering::Backends {
 		/// Returns the array that stores the extensions that were used to initialize the device.
 		/// </summary>
 		/// <returns>A reference to the array that stores the extensions that were used to initialize the device.</returns>
-		virtual Span<const String> enabledExtensions() const noexcept;
+		Span<const String> enabledExtensions() const noexcept;
 
 		/// <summary>
 		/// Sets the debug name for an object.
@@ -1633,7 +1633,14 @@ namespace LiteFX::Rendering::Backends {
 		/// <param name="objectHandle">The handle of the object casted to an integer.</param>
 		/// <param name="objectType">The type of the object.</param>
 		/// <param name="name">The debug name of the object.</param>
-		virtual void setDebugName(UInt64 objectHandle, VkDebugReportObjectTypeEXT objectType, StringView name) const noexcept;
+		void setDebugName(UInt64 objectHandle, VkDebugReportObjectTypeEXT objectType, StringView name) const noexcept;
+
+		/// <summary>
+		/// Returns the indices of all queue families with support for <paramref name="type" />.
+		/// </summary>
+		/// <param name="type">The type of workload that must be supported by the family in order for it to be returned. Specifying <see cref="QueueType::None" /> will return all available queue families.</param>
+		/// <returns>The indices of the queue families that support queue workloads specified by <paramref name="type" />.</returns>
+		Enumerable<UInt32> queueFamilyIndices(QueueType type = QueueType::None) const noexcept;
 
 		// GraphicsDevice interface.
 	public:

--- a/src/Backends/Vulkan/include/litefx/backends/vulkan.hpp
+++ b/src/Backends/Vulkan/include/litefx/backends/vulkan.hpp
@@ -1485,7 +1485,20 @@ namespace LiteFX::Rendering::Backends {
         void waitFor(UInt64 fence) const noexcept override;
 
         /// <inheritdoc />
+        void waitFor(const VulkanQueue& queue, UInt64 fence) const noexcept;
+
+        /// <inheritdoc />
         UInt64 currentFence() const noexcept override;
+
+    private:
+        inline void waitForQueue(const ICommandQueue& queue, UInt64 fence) const override {
+            auto vkQueue = dynamic_cast<const VulkanQueue*>(&queue);
+
+            if (vkQueue == nullptr) [[unlikely]]
+                throw InvalidArgumentException("Cannot wait for queues from other backends.");
+
+            this->waitFor(*vkQueue, fence);
+        }
     };
 
     /// <summary>

--- a/src/Backends/Vulkan/src/command_buffer.cpp
+++ b/src/Backends/Vulkan/src/command_buffer.cpp
@@ -172,6 +172,14 @@ void VulkanCommandBuffer::setStencilRef(UInt32 stencilRef) const noexcept
 	::vkCmdSetStencilReference(this->handle(), VK_STENCIL_FACE_FRONT_AND_BACK, stencilRef);
 }
 
+UInt64 VulkanCommandBuffer::submit() const 
+{
+	if (this->isSecondary())
+		throw RuntimeException("A secondary command buffer cannot be directly submitted to a command queue and must be executed on a primary command buffer instead.");
+
+	return m_impl->m_queue.submit(this->shared_from_this());
+}
+
 void VulkanCommandBuffer::generateMipMaps(IVulkanImage& image) noexcept
 {
 	VulkanBarrier startBarrier(PipelineStage::None, PipelineStage::Transfer);

--- a/src/Backends/Vulkan/src/command_buffer.cpp
+++ b/src/Backends/Vulkan/src/command_buffer.cpp
@@ -13,7 +13,7 @@ public:
 private:
 	const VulkanQueue& m_queue;
 	bool m_recording{ false }, m_secondary{ false };
-	Optional<VkCommandPool> m_commandPool;
+	VkCommandPool m_commandPool;
 	Array<SharedPtr<const IStateResource>> m_sharedResources;
 	const VulkanPipelineState* m_lastPipeline = nullptr;
 

--- a/src/Backends/Vulkan/src/command_buffer.cpp
+++ b/src/Backends/Vulkan/src/command_buffer.cpp
@@ -13,39 +13,49 @@ public:
 private:
 	const VulkanQueue& m_queue;
 	bool m_recording{ false }, m_secondary{ false };
-	Optional<VkCommandPool> m_commandPool;
-	Array<SharedPtr<const IStateResource>> m_sharedResources;
+	VkCommandPool m_commandPool{ };
+	Array<SharedPtr<const IStateResource>> m_sharedResources{ };
 
 public:
-	VulkanCommandBufferImpl(VulkanCommandBuffer* parent, const VulkanQueue& queue) :
-		base(parent), m_queue(queue)
+	VulkanCommandBufferImpl(VulkanCommandBuffer* parent, const VulkanQueue& queue, bool primary) :
+		base(parent), m_queue(queue), m_secondary(!primary)
 	{
 	}
 
-public:
-	VkCommandBuffer initialize(bool primary)
+	~VulkanCommandBufferImpl() 
 	{
-		// Secondary command buffers have their own command pool.
-		if (!primary)
-		{
-			VkCommandPoolCreateInfo poolInfo = {
-				.sType = VK_STRUCTURE_TYPE_COMMAND_POOL_CREATE_INFO,
-				.flags = VK_COMMAND_POOL_CREATE_RESET_COMMAND_BUFFER_BIT,
-				.queueFamilyIndex = m_queue.queueId()
-			};
+		this->release();
+	}
 
-			VkCommandPool commandPool;
-			raiseIfFailed<RuntimeException>(::vkCreateCommandPool(m_queue.device().handle(), &poolInfo, nullptr, &commandPool), "Unable to create command pool.");
-			m_commandPool = commandPool;
-			m_secondary = true;
-		}
+public:
+	void release() 
+	{
+		::vkFreeCommandBuffers(m_queue.device().handle(), m_commandPool, 1, &m_parent->handle());
+		::vkDestroyCommandPool(m_queue.device().handle(), m_commandPool, nullptr);
+	}
+
+	VkCommandBuffer initialize()
+	{
+		// Create command pool.
+		VkCommandPoolCreateInfo poolInfo = {
+			.sType = VK_STRUCTURE_TYPE_COMMAND_POOL_CREATE_INFO,
+			.flags = VK_COMMAND_POOL_CREATE_RESET_COMMAND_BUFFER_BIT,
+			.queueFamilyIndex = m_queue.familyId(),
+		};
+
+		// Primary command buffers are frequently reset and re-allocated, whilst secondary command buffers must be recorded once and never reset.
+		if (!m_secondary)
+			poolInfo.flags |= VK_COMMAND_POOL_CREATE_TRANSIENT_BIT;
+
+		raiseIfFailed<RuntimeException>(::vkCreateCommandPool(m_queue.device().handle(), &poolInfo, nullptr, &m_commandPool), "Unable to create command pool.");
 
 		// Create the command buffer.
-		VkCommandBufferAllocateInfo bufferInfo{};
-		bufferInfo.sType = VK_STRUCTURE_TYPE_COMMAND_BUFFER_ALLOCATE_INFO;
-		bufferInfo.level = primary ? VK_COMMAND_BUFFER_LEVEL_PRIMARY : VK_COMMAND_BUFFER_LEVEL_SECONDARY;
-		bufferInfo.commandPool = primary ? m_queue.commandPool() : m_commandPool.value();
-		bufferInfo.commandBufferCount = 1;
+		VkCommandBufferAllocateInfo bufferInfo = {
+			.sType = VK_STRUCTURE_TYPE_COMMAND_BUFFER_ALLOCATE_INFO,
+			.commandPool = m_commandPool,
+			.level = m_secondary ? VK_COMMAND_BUFFER_LEVEL_SECONDARY : VK_COMMAND_BUFFER_LEVEL_PRIMARY,
+			.commandBufferCount = 1
+		};
 
 		VkCommandBuffer buffer;
 		raiseIfFailed<RuntimeException>(::vkAllocateCommandBuffers(m_queue.device().handle(), &bufferInfo, &buffer), "Unable to allocate command buffer.");
@@ -59,27 +69,15 @@ public:
 // ------------------------------------------------------------------------------------------------
 
 VulkanCommandBuffer::VulkanCommandBuffer(const VulkanQueue& queue, bool begin, bool primary) :
-	m_impl(makePimpl<VulkanCommandBufferImpl>(this, queue)), Resource<VkCommandBuffer>(nullptr)
+	m_impl(makePimpl<VulkanCommandBufferImpl>(this, queue, primary)), Resource<VkCommandBuffer>(nullptr)
 {
-	if (!queue.isBound())
-		throw InvalidArgumentException("You must bind the queue before creating a command buffer from it.");
-
-	this->handle() = m_impl->initialize(primary);
+	this->handle() = m_impl->initialize();
 
 	if (begin)
 		this->begin();
 }
 
-VulkanCommandBuffer::~VulkanCommandBuffer() noexcept
-{
-	if (!m_impl->m_commandPool.has_value())
-		::vkFreeCommandBuffers(m_impl->m_queue.device().handle(), m_impl->m_queue.commandPool(), 1, &this->handle());
-	else
-	{
-		::vkFreeCommandBuffers(m_impl->m_queue.device().handle(), m_impl->m_commandPool.value(), 1, &this->handle());
-		::vkDestroyCommandPool(m_impl->m_queue.device().handle(), m_impl->m_commandPool.value(), nullptr);
-	}
-}
+VulkanCommandBuffer::~VulkanCommandBuffer() noexcept = default
 
 void VulkanCommandBuffer::begin() const
 {

--- a/src/Backends/Vulkan/src/command_buffer.cpp
+++ b/src/Backends/Vulkan/src/command_buffer.cpp
@@ -77,7 +77,7 @@ VulkanCommandBuffer::VulkanCommandBuffer(const VulkanQueue& queue, bool begin, b
 		this->begin();
 }
 
-VulkanCommandBuffer::~VulkanCommandBuffer() noexcept = default
+VulkanCommandBuffer::~VulkanCommandBuffer() noexcept = default;
 
 void VulkanCommandBuffer::begin() const
 {

--- a/src/Backends/Vulkan/src/device.cpp
+++ b/src/Backends/Vulkan/src/device.cpp
@@ -9,317 +9,298 @@ using namespace LiteFX::Rendering::Backends;
 
 class VulkanDevice::VulkanDeviceImpl : public Implement<VulkanDevice> {
 public:
-	friend class VulkanDevice;
+    friend class VulkanDevice;
 
 private:
-	class QueueFamily {
-	private:
-		Array<UniquePtr<VulkanQueue>> m_queues;
-		UInt32 m_id, m_queueCount;
-		QueueType m_type;
+    class QueueFamily {
+    private:
+        Array<UniquePtr<VulkanQueue>> m_queues;
+        UInt32 m_id, m_queueCount;
+        QueueType m_type;
 
-	public:
-		QueueType type() const noexcept { return m_type; }
-		UInt32 total() const noexcept { return m_queueCount; }
-		const UInt32 active() const noexcept { return static_cast<UInt32>(m_queues.size()); }
-		UInt32 id() const noexcept { return m_id; }
-		const Array<UniquePtr<VulkanQueue>>& queues() const noexcept { return m_queues; }
+    public:
+        QueueType type() const noexcept { return m_type; }
+        UInt32 total() const noexcept { return m_queueCount; }
+        UInt32 active() const noexcept { return static_cast<UInt32>(m_queues.size()); }
+        UInt32 id() const noexcept { return m_id; }
+        const Array<UniquePtr<VulkanQueue>>& queues() const noexcept { return m_queues; }
 
-	public:
-		QueueFamily(UInt32 id, UInt32 queueCount, QueueType type) :
-			m_id(id), m_queueCount(queueCount), m_type(type) { 
-		}
-		QueueFamily(const QueueFamily& _other) = delete;
-		QueueFamily(QueueFamily&& _other) noexcept {
-			m_queues = std::move(_other.m_queues);
-			m_id = std::move(_other.m_id);
-			m_queueCount = std::move(_other.m_queueCount);
-			m_type = std::move(_other.m_type);
-		}
-		~QueueFamily() noexcept {
-			m_queues.clear();
-		}
+    public:
+        QueueFamily(UInt32 id, UInt32 queueCount, QueueType type) :
+            m_id(id), m_queueCount(queueCount), m_type(type) { 
+        }
+        QueueFamily(const QueueFamily& _other) = delete;
+        QueueFamily(QueueFamily&& _other) noexcept {
+            m_queues = std::move(_other.m_queues);
+            m_id = std::move(_other.m_id);
+            m_queueCount = std::move(_other.m_queueCount);
+            m_type = std::move(_other.m_type);
+        }
+        ~QueueFamily() noexcept {
+            m_queues.clear();
+        }
 
-	public:
-		VulkanQueue* createQueue(const VulkanDevice& device, QueuePriority priority) {
-			if (this->active() >= this->total())
-			{
-				LITEFX_ERROR(VULKAN_LOG, "Unable to create another queue for family {0}, since all {1} queues are already created.", m_id, m_queueCount);
-				return nullptr;
-			}
+    public:
+        VulkanQueue* createQueue(const VulkanDevice& device, QueuePriority priority) {
+            if (this->active() >= this->total())
+            {
+                LITEFX_ERROR(VULKAN_LOG, "Unable to create another queue for family {0}, since all {1} queues are already created.", m_id, m_queueCount);
+                return nullptr;
+            }
 
-			auto queue = makeUnique<VulkanQueue>(device, m_type, priority, m_id, this->active());
-			auto queuePointer = queue.get();
-			m_queues.push_back(std::move(queue));
-			return queuePointer;
-		}
-	};
+            auto queue = makeUnique<VulkanQueue>(device, m_type, priority, m_id, this->active());
+            auto queuePointer = queue.get();
+            m_queues.push_back(std::move(queue));
+            return queuePointer;
+        }
+    };
 
-	DeviceState m_deviceState;
+    DeviceState m_deviceState;
 
-	Array<QueueFamily> m_families;
-	VulkanQueue* m_graphicsQueue;
-	VulkanQueue* m_transferQueue;
-	VulkanQueue* m_bufferQueue;
-	VulkanQueue* m_computeQueue;
+    Array<QueueFamily> m_families;
+    VulkanQueue* m_graphicsQueue;
+    VulkanQueue* m_transferQueue;
+    VulkanQueue* m_computeQueue;
 
-	VkCommandPool m_commandPool;
-	UniquePtr<VulkanSwapChain> m_swapChain;
-	Array<String> m_extensions;
+    VkCommandPool m_commandPool;
+    UniquePtr<VulkanSwapChain> m_swapChain;
+    Array<String> m_extensions;
 
-	const VulkanGraphicsAdapter& m_adapter;
-	UniquePtr<VulkanSurface> m_surface;
-	UniquePtr<VulkanGraphicsFactory> m_factory;
+    const VulkanGraphicsAdapter& m_adapter;
+    UniquePtr<VulkanSurface> m_surface;
+    UniquePtr<VulkanGraphicsFactory> m_factory;
 
 #ifndef NDEBUG
-	PFN_vkDebugMarkerSetObjectNameEXT debugMarkerSetObjectName = nullptr;
+    PFN_vkDebugMarkerSetObjectNameEXT debugMarkerSetObjectName = nullptr;
 #endif
 
 public:
-	VulkanDeviceImpl(VulkanDevice* parent, const VulkanGraphicsAdapter& adapter, UniquePtr<VulkanSurface>&& surface, Span<String> extensions) :
-		base(parent), m_adapter(adapter), m_surface(std::move(surface))
-	{
-		if (m_surface == nullptr)
-			throw ArgumentNotInitializedException("The surface must be initialized.");
+    VulkanDeviceImpl(VulkanDevice* parent, const VulkanGraphicsAdapter& adapter, UniquePtr<VulkanSurface>&& surface, Span<String> extensions) :
+        base(parent), m_adapter(adapter), m_surface(std::move(surface))
+    {
+        if (m_surface == nullptr)
+            throw ArgumentNotInitializedException("The surface must be initialized.");
 
-		m_extensions.assign(std::begin(extensions), std::end(extensions));
+        m_extensions.assign(std::begin(extensions), std::end(extensions));
 
-		this->defineMandatoryExtensions();
-		this->loadQueueFamilies();
-	}
+        this->defineMandatoryExtensions();
+        this->loadQueueFamilies();
+    }
 
-	~VulkanDeviceImpl()
-	{
-		// Clear the device state.
-		m_deviceState.clear();
+    ~VulkanDeviceImpl()
+    {
+        // Clear the device state.
+        m_deviceState.clear();
 
-		// This will also cause all queue instances to be automatically released (graphicsQueue, transferQueue, bufferQueue).
-		m_families.clear();
+        // This will also cause all queue instances to be automatically released (graphicsQueue, transferQueue, bufferQueue).
+        m_families.clear();
 
-		// Release the swap chain.
-		m_swapChain = nullptr;
+        // Release the swap chain.
+        m_swapChain = nullptr;
 
-		// Destroy the surface.
-		m_surface = nullptr;
-	}
+        // Destroy the surface.
+        m_surface = nullptr;
+    }
 
 private:
-	void defineMandatoryExtensions() noexcept
-	{
-		m_extensions.push_back(VK_KHR_GET_MEMORY_REQUIREMENTS_2_EXTENSION_NAME);
+    void defineMandatoryExtensions() noexcept
+    {
+        m_extensions.push_back(VK_KHR_GET_MEMORY_REQUIREMENTS_2_EXTENSION_NAME);
 
 #ifdef BUILD_DIRECTX_12_BACKEND
-		// Interop swap chain requires external memory access.
-		m_extensions.push_back(VK_KHR_EXTERNAL_MEMORY_EXTENSION_NAME);
-		m_extensions.push_back(VK_KHR_EXTERNAL_MEMORY_WIN32_EXTENSION_NAME);
-		m_extensions.push_back(VK_KHR_DEDICATED_ALLOCATION_EXTENSION_NAME);
+        // Interop swap chain requires external memory access.
+        m_extensions.push_back(VK_KHR_EXTERNAL_MEMORY_EXTENSION_NAME);
+        m_extensions.push_back(VK_KHR_EXTERNAL_MEMORY_WIN32_EXTENSION_NAME);
+        m_extensions.push_back(VK_KHR_DEDICATED_ALLOCATION_EXTENSION_NAME);
 #else
-		m_extensions.push_back(VK_KHR_SWAPCHAIN_EXTENSION_NAME);
+        m_extensions.push_back(VK_KHR_SWAPCHAIN_EXTENSION_NAME);
 #endif // BUILD_DIRECTX_12_BACKEND
 
 #ifndef NDEBUG
-		auto availableExtensions = m_adapter.getAvailableDeviceExtensions();
+        auto availableExtensions = m_adapter.getAvailableDeviceExtensions();
 
-		if (auto match = std::ranges::find_if(availableExtensions, [](const String& extension) { return extension == VK_EXT_DEBUG_MARKER_EXTENSION_NAME; }); match != availableExtensions.end())
-			m_extensions.push_back(VK_EXT_DEBUG_MARKER_EXTENSION_NAME);
+        if (auto match = std::ranges::find_if(availableExtensions, [](const String& extension) { return extension == VK_EXT_DEBUG_MARKER_EXTENSION_NAME; }); match != availableExtensions.end())
+            m_extensions.push_back(VK_EXT_DEBUG_MARKER_EXTENSION_NAME);
 #endif
-	}
+    }
 
 public:
-	void loadQueueFamilies()
-	{
-		// Find an available command queues.
-		uint32_t queueFamilies = 0;
-		::vkGetPhysicalDeviceQueueFamilyProperties(m_adapter.handle(), &queueFamilies, nullptr);
+    void loadQueueFamilies()
+    {
+        // Find an available command queues.
+        uint32_t queueFamilies = 0;
+        ::vkGetPhysicalDeviceQueueFamilyProperties(m_adapter.handle(), &queueFamilies, nullptr);
 
-		Array<VkQueueFamilyProperties> familyProperties(queueFamilies);
-		::vkGetPhysicalDeviceQueueFamilyProperties(m_adapter.handle(), &queueFamilies, familyProperties.data());
+        Array<VkQueueFamilyProperties> familyProperties(queueFamilies);
+        ::vkGetPhysicalDeviceQueueFamilyProperties(m_adapter.handle(), &queueFamilies, familyProperties.data());
 
-		m_families = familyProperties | 
-			std::views::transform([i = 0](const VkQueueFamilyProperties& familyProperty) mutable {
-				QueueType type = QueueType::None;
+        m_families = familyProperties | 
+            std::views::transform([i = 0](const VkQueueFamilyProperties& familyProperty) mutable {
+                QueueType type = QueueType::None;
 
-				if (familyProperty.queueFlags & VK_QUEUE_COMPUTE_BIT)
-					type |= QueueType::Compute;
-				if (familyProperty.queueFlags & VK_QUEUE_GRAPHICS_BIT)
-					type |= QueueType::Graphics;
-				if (familyProperty.queueFlags & VK_QUEUE_TRANSFER_BIT)
-					type |= QueueType::Transfer;
+                if (familyProperty.queueFlags & VK_QUEUE_COMPUTE_BIT)
+                    type |= QueueType::Compute;
+                if (familyProperty.queueFlags & VK_QUEUE_GRAPHICS_BIT)
+                    type |= QueueType::Graphics;
+                if (familyProperty.queueFlags & VK_QUEUE_TRANSFER_BIT)
+                    type |= QueueType::Transfer;
 
-				return QueueFamily(i++, familyProperty.queueCount, type);
-			}) |
-			std::ranges::to<Array<QueueFamily>>();
-	}
+                return QueueFamily(i++, familyProperty.queueCount, type);
+            }) | std::ranges::to<Array<QueueFamily>>();
+    }
 
-	VkDevice initialize()
-	{
-		if (!m_adapter.validateDeviceExtensions(m_extensions))
-			throw InvalidArgumentException("Some required device extensions are not supported by the system.");
+    VkDevice initialize()
+    {
+        if (!m_adapter.validateDeviceExtensions(m_extensions))
+            throw InvalidArgumentException("Some required device extensions are not supported by the system.");
 
-		auto const requiredExtensions = m_extensions | std::views::transform([](const auto& extension) { return extension.c_str(); }) | std::ranges::to<Array<const char*>>();
+        auto const requiredExtensions = m_extensions | std::views::transform([](const auto& extension) { return extension.c_str(); }) | std::ranges::to<Array<const char*>>();
 
-		// Create graphics and transfer queue.
-		m_graphicsQueue = this->createQueue(QueueType::Graphics, QueuePriority::Realtime, std::as_const(*m_surface).handle());
-		m_transferQueue = this->createQueue(QueueType::Transfer, QueuePriority::Normal);
-		m_bufferQueue = this->createQueue(QueueType::Transfer, QueuePriority::Normal);
-		m_computeQueue = this->createQueue(QueueType::Compute, QueuePriority::Normal);
+        // Initialize default queues.
+        m_graphicsQueue = this->createQueue(QueueType::Graphics, QueuePriority::Realtime, std::as_const(*m_surface).handle());
+        m_transferQueue = this->createQueue(QueueType::Transfer, QueuePriority::Normal);
+        m_computeQueue = this->createQueue(QueueType::Compute, QueuePriority::Normal);
 
-		if (m_graphicsQueue == nullptr)
-			throw RuntimeException("Unable to find a fitting command queue to present the specified surface.");
+        if (m_graphicsQueue == nullptr)
+            throw RuntimeException("Unable to find a fitting command queue to present the specified surface.");
 
-		if (m_transferQueue == nullptr)
-		{
-			LITEFX_WARNING(VULKAN_LOG, "Unable to find dedicated transfer queue for device-device transfer. Using graphics queue instead.");
-			m_transferQueue = m_graphicsQueue;
-		}
+        if (m_transferQueue == nullptr)
+        {
+            LITEFX_INFO(VULKAN_LOG, "Unable to find dedicated transfer queue for device-device transfer. Using graphics queue instead.");
+            m_transferQueue = m_graphicsQueue;
+        }
 
-		if (m_bufferQueue == nullptr)
-		{
-			// NOTE: Default transfer queue can be a fallback, too.
-			LITEFX_WARNING(VULKAN_LOG, "Unable to find dedicated transfer queue for host-device transfer. Using default transfer queue instead.");
-			m_bufferQueue = m_transferQueue;
-		}
+        if (m_computeQueue == nullptr)
+        {
+            LITEFX_INFO(VULKAN_LOG, "Unable to find dedicated compute queue for host-device transfer. Using graphics queue instead.");
+            m_computeQueue = m_graphicsQueue;
+        }
 
-		if (m_computeQueue == nullptr)
-		{
-			// NOTE: Default compute queue can be a fallback, too.
-			LITEFX_WARNING(VULKAN_LOG, "Unable to find dedicated compute queue for host-device transfer. Using graphics queue instead.");
-			m_computeQueue = m_graphicsQueue;
-		}
+        // Define used queue families.
+        Array<Array<Float>> queuePriorities;
+        auto const queueCreateInfos = m_families |
+            std::views::filter([](const QueueFamily& family) { return family.active() > 0; }) |
+            std::views::transform([&queuePriorities](const QueueFamily& family) {
+                auto const priorities = family.queues() | 
+                    std::views::transform([](const UniquePtr<VulkanQueue>& queue) { return static_cast<Float>(queue->priority()) / 100.f; }) |
+                    std::ranges::to<Array<Float>>();
+                queuePriorities.push_back(priorities);
 
-		// Define used queue families.
-		Array<Array<Float>> queuePriorities;
-		auto const queueCreateInfos = m_families |
-			std::views::filter([](const QueueFamily& family) { return family.active() > 0; }) |
-			std::views::transform([&queuePriorities](const QueueFamily& family) {
-				auto const priorities = family.queues() | 
-					std::views::transform([](const UniquePtr<VulkanQueue>& queue) { return static_cast<Float>(queue->priority()) / 100.f; }) |
-					std::ranges::to<Array<Float>>();
-				queuePriorities.push_back(priorities);
+                VkDeviceQueueCreateInfo queueCreateInfo = {};
+                queueCreateInfo.sType = VK_STRUCTURE_TYPE_DEVICE_QUEUE_CREATE_INFO;
+                queueCreateInfo.queueFamilyIndex = family.id();
+                queueCreateInfo.queueCount = family.active();
+                queueCreateInfo.pQueuePriorities = queuePriorities.back().data();
 
-				VkDeviceQueueCreateInfo queueCreateInfo = {};
-				queueCreateInfo.sType = VK_STRUCTURE_TYPE_DEVICE_QUEUE_CREATE_INFO;
-				queueCreateInfo.queueFamilyIndex = family.id();
-				queueCreateInfo.queueCount = family.active();
-				queueCreateInfo.pQueuePriorities = queuePriorities.back().data();
+                return queueCreateInfo;
+            }) | std::ranges::to<Array<VkDeviceQueueCreateInfo>>();
 
-				return queueCreateInfo;
-			}) | std::ranges::to<Array<VkDeviceQueueCreateInfo>>();
+        // Allow geometry and tessellation shader stages.
+        VkPhysicalDeviceFeatures deviceFeatures = {
+            .geometryShader = true,
+            .tessellationShader = true,
+            .samplerAnisotropy = true
+        };
 
-		// Allow geometry and tessellation shader stages.
-		VkPhysicalDeviceFeatures deviceFeatures = {
-			.geometryShader = true,
-			.tessellationShader = true,
-			.samplerAnisotropy = true
-		};
+        VkPhysicalDeviceVulkan13Features deviceFeatures13 = {
+            .sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_VULKAN_1_3_FEATURES,
+            .synchronization2 = true
+        };
 
-		VkPhysicalDeviceVulkan13Features deviceFeatures13 = {
-			.sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_VULKAN_1_3_FEATURES,
-			.synchronization2 = true
-		};
+        VkPhysicalDeviceVulkan12Features deviceFeatures12 = {
+            .sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_VULKAN_1_2_FEATURES,
+            .pNext = &deviceFeatures13,
+            .descriptorIndexing = true,
+            .shaderInputAttachmentArrayDynamicIndexing = true,
+            .shaderUniformTexelBufferArrayDynamicIndexing = true,
+            .shaderStorageTexelBufferArrayDynamicIndexing = true,
+            .shaderUniformBufferArrayNonUniformIndexing = true,
+            .shaderSampledImageArrayNonUniformIndexing = true,
+            .shaderStorageBufferArrayNonUniformIndexing = true,
+            .shaderStorageImageArrayNonUniformIndexing = true,
+            .shaderInputAttachmentArrayNonUniformIndexing = true,
+            .shaderUniformTexelBufferArrayNonUniformIndexing = true,
+            .shaderStorageTexelBufferArrayNonUniformIndexing = true,
+            //.descriptorBindingUniformBufferUpdateAfterBind = true,	// Causes problems on some NVidia cards.
+            .descriptorBindingSampledImageUpdateAfterBind = true,
+            .descriptorBindingStorageImageUpdateAfterBind = true,
+            .descriptorBindingStorageBufferUpdateAfterBind = true,
+            .descriptorBindingUniformTexelBufferUpdateAfterBind = true,
+            .descriptorBindingStorageTexelBufferUpdateAfterBind = true,
+            .descriptorBindingUpdateUnusedWhilePending = true,
+            .descriptorBindingPartiallyBound = true,
+            .descriptorBindingVariableDescriptorCount = true,
+            .runtimeDescriptorArray = true,
+            .hostQueryReset = true,
+            .timelineSemaphore = true
+        };
 
-		VkPhysicalDeviceVulkan12Features deviceFeatures12 = {
-			.sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_VULKAN_1_2_FEATURES,
-			.pNext = &deviceFeatures13,
-			.descriptorIndexing = true,
-			.shaderInputAttachmentArrayDynamicIndexing = true,
-			.shaderUniformTexelBufferArrayDynamicIndexing = true,
-			.shaderStorageTexelBufferArrayDynamicIndexing = true,
-			.shaderUniformBufferArrayNonUniformIndexing = true,
-			.shaderSampledImageArrayNonUniformIndexing = true,
-			.shaderStorageBufferArrayNonUniformIndexing = true,
-			.shaderStorageImageArrayNonUniformIndexing = true,
-			.shaderInputAttachmentArrayNonUniformIndexing = true,
-			.shaderUniformTexelBufferArrayNonUniformIndexing = true,
-			.shaderStorageTexelBufferArrayNonUniformIndexing = true,
-			//.descriptorBindingUniformBufferUpdateAfterBind = true,	// Causes problems on some NVidia cards.
-			.descriptorBindingSampledImageUpdateAfterBind = true,
-			.descriptorBindingStorageImageUpdateAfterBind = true,
-			.descriptorBindingStorageBufferUpdateAfterBind = true,
-			.descriptorBindingUniformTexelBufferUpdateAfterBind = true,
-			.descriptorBindingStorageTexelBufferUpdateAfterBind = true,
-			.descriptorBindingUpdateUnusedWhilePending = true,
-			.descriptorBindingPartiallyBound = true,
-			.descriptorBindingVariableDescriptorCount = true,
-			.runtimeDescriptorArray = true,
-			.hostQueryReset = true,
-			.timelineSemaphore = true
-		};
+        // Enable extended dynamic state.
+        VkPhysicalDeviceExtendedDynamicStateFeaturesEXT extendedDynamicStateFeatures = {
+            .sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_EXTENDED_DYNAMIC_STATE_FEATURES_EXT,
+            .pNext = &deviceFeatures12,
+            .extendedDynamicState = true
+        };
 
-		// Enable extended dynamic state.
-		VkPhysicalDeviceExtendedDynamicStateFeaturesEXT extendedDynamicStateFeatures = {
-			.sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_EXTENDED_DYNAMIC_STATE_FEATURES_EXT,
-			.pNext = &deviceFeatures12,
-			.extendedDynamicState = true
-		};
+        // Define the device itself.
+        VkDeviceCreateInfo createInfo = {};
+        createInfo.sType = VK_STRUCTURE_TYPE_DEVICE_CREATE_INFO;
+        createInfo.pNext = &extendedDynamicStateFeatures;
+        createInfo.queueCreateInfoCount = static_cast<UInt32>(queueCreateInfos.size());
+        createInfo.pQueueCreateInfos = queueCreateInfos.data();
+        createInfo.pEnabledFeatures = &deviceFeatures;
+        createInfo.enabledExtensionCount = static_cast<UInt32>(requiredExtensions.size());
+        createInfo.ppEnabledExtensionNames = requiredExtensions.data();
 
-		// Define the device itself.
-		VkDeviceCreateInfo createInfo = {};
-		createInfo.sType = VK_STRUCTURE_TYPE_DEVICE_CREATE_INFO;
-		createInfo.pNext = &extendedDynamicStateFeatures;
-		createInfo.queueCreateInfoCount = static_cast<UInt32>(queueCreateInfos.size());
-		createInfo.pQueueCreateInfos = queueCreateInfos.data();
-		createInfo.pEnabledFeatures = &deviceFeatures;
-		createInfo.enabledExtensionCount = static_cast<UInt32>(requiredExtensions.size());
-		createInfo.ppEnabledExtensionNames = requiredExtensions.data();
-
-		// Create the device.
-		// NOTE: This can time-out under very mysterious circumstances, in which case the event log shows a TDR error. Unfortunately, the only way I found
-		//       to fix this is rebooting the entire system.
-		VkDevice device;
-		raiseIfFailed<RuntimeException>(::vkCreateDevice(m_adapter.handle(), &createInfo, nullptr, &device), "Unable to create Vulkan device.");
+        // Create the device.
+        // NOTE: This can time-out under very mysterious circumstances, in which case the event log shows a TDR error. Unfortunately, the only way I found
+        //       to fix this is rebooting the entire system.
+        VkDevice device;
+        raiseIfFailed<RuntimeException>(::vkCreateDevice(m_adapter.handle(), &createInfo, nullptr, &device), "Unable to create Vulkan device.");
 
 #ifndef NDEBUG
-		debugMarkerSetObjectName = reinterpret_cast<PFN_vkDebugMarkerSetObjectNameEXT>(::vkGetDeviceProcAddr(device, "vkDebugMarkerSetObjectNameEXT"));
+        debugMarkerSetObjectName = reinterpret_cast<PFN_vkDebugMarkerSetObjectNameEXT>(::vkGetDeviceProcAddr(device, "vkDebugMarkerSetObjectNameEXT"));
 #endif
 
-		return device;
-	}
+        return device;
+    }
 
-	void createFactory()
-	{
-		m_factory = makeUnique<VulkanGraphicsFactory>(*m_parent);
-	}
+    void createFactory()
+    {
+        m_factory = makeUnique<VulkanGraphicsFactory>(*m_parent);
+    }
 
-	void createSwapChain(Format format, const Size2d& frameBufferSize, UInt32 frameBuffers)
-	{
-		m_swapChain = makeUnique<VulkanSwapChain>(*m_parent, format, frameBufferSize, frameBuffers);
-	}
-
-	void createQueues()
-	{
-		m_graphicsQueue->bind();
-		m_transferQueue->bind();
-		m_bufferQueue->bind();
-		m_computeQueue->bind();
-	}
+    void createSwapChain(Format format, const Size2d& frameBufferSize, UInt32 frameBuffers)
+    {
+        m_swapChain = makeUnique<VulkanSwapChain>(*m_parent, format, frameBufferSize, frameBuffers);
+    }
 
 public:
-	VulkanQueue* createQueue(QueueType type, QueuePriority priority)
-	{
-		// If a transfer queue is requested, look up only dedicated transfer queues. If none is available, fallbacks need to be handled manually. Every queue implicitly handles transfer.
-		auto match = type == QueueType::Transfer ?
-			std::ranges::find_if(m_families, [](const auto& family) { return family.type() == QueueType::Transfer; }) :
-			std::ranges::find_if(m_families, [&type](const auto& family) { return LITEFX_FLAG_IS_SET(family.type(), type); });
+    VulkanQueue* createQueue(QueueType type, QueuePriority priority)
+    {
+        // If a transfer queue is requested, look up only dedicated transfer queues. If none is available, fallbacks need to be handled manually. Every queue implicitly handles transfer.
+        auto match = type == QueueType::Transfer ?
+            std::ranges::find_if(m_families, [](const auto& family) { return family.type() == QueueType::Transfer; }) :
+            std::ranges::find_if(m_families, [&type](const auto& family) { return LITEFX_FLAG_IS_SET(family.type(), type); });
 
-		return match == m_families.end() ? nullptr : match->createQueue(*m_parent, priority);
-	}
+        return match == m_families.end() ? nullptr : match->createQueue(*m_parent, priority);
+    }
 
-	VulkanQueue* createQueue(QueueType type, QueuePriority priority, const VkSurfaceKHR& surface)
-	{
-		if (auto match = std::ranges::find_if(m_families, [&](const auto& family) {
-				if (!LITEFX_FLAG_IS_SET(family.type(), type))
-					return false;
+    VulkanQueue* createQueue(QueueType type, QueuePriority priority, const VkSurfaceKHR& surface)
+    {
+        if (auto match = std::ranges::find_if(m_families, [&](const auto& family) {
+                if (!LITEFX_FLAG_IS_SET(family.type(), type))
+                    return false;
 
-				VkBool32 canPresent = VK_FALSE;
-				::vkGetPhysicalDeviceSurfaceSupportKHR(m_adapter.handle(), family.id(), surface, &canPresent);
+                VkBool32 canPresent = VK_FALSE;
+                ::vkGetPhysicalDeviceSurfaceSupportKHR(m_adapter.handle(), family.id(), surface, &canPresent);
 
-				return static_cast<bool>(canPresent);
-			}); match != m_families.end()) [[likely]]
-			return match->createQueue(*m_parent, priority);
-		
-		return nullptr;
-	}
+                return static_cast<bool>(canPresent);
+            }); match != m_families.end()) [[likely]]
+            return match->createQueue(*m_parent, priority);
+        
+        return nullptr;
+    }
 };
 
 // ------------------------------------------------------------------------------------------------
@@ -327,209 +308,205 @@ public:
 // ------------------------------------------------------------------------------------------------
 
 VulkanDevice::VulkanDevice(const VulkanBackend& backend, const VulkanGraphicsAdapter& adapter, UniquePtr<VulkanSurface>&& surface, Span<String> extensions) :
-	VulkanDevice(backend, adapter, std::move(surface), Format::B8G8R8A8_SRGB, { 800, 600 }, 3, extensions)
+    VulkanDevice(backend, adapter, std::move(surface), Format::B8G8R8A8_SRGB, { 800, 600 }, 3, extensions)
 {
 }
 
 VulkanDevice::VulkanDevice(const VulkanBackend& /*backend*/, const VulkanGraphicsAdapter& adapter, UniquePtr<VulkanSurface>&& surface, Format format, const Size2d& frameBufferSize, UInt32 frameBuffers, Span<String> extensions) :
-	Resource<VkDevice>(nullptr), m_impl(makePimpl<VulkanDeviceImpl>(this, adapter, std::move(surface), extensions))
+    Resource<VkDevice>(nullptr), m_impl(makePimpl<VulkanDeviceImpl>(this, adapter, std::move(surface), extensions))
 {
-	LITEFX_DEBUG(VULKAN_LOG, "Creating Vulkan device {{ Surface: {0}, Adapter: {1}, Extensions: {2} }}...", fmt::ptr(reinterpret_cast<const void*>(m_impl->m_surface.get())), adapter.deviceId(), Join(this->enabledExtensions(), ", "));
-	LITEFX_DEBUG(VULKAN_LOG, "--------------------------------------------------------------------------");
-	LITEFX_DEBUG(VULKAN_LOG, "Vendor: {0:#0x}", adapter.vendorId());
-	LITEFX_DEBUG(VULKAN_LOG, "Driver Version: {0:#0x}", adapter.driverVersion());
-	LITEFX_DEBUG(VULKAN_LOG, "API Version: {0:#0x}", adapter.apiVersion());
-	LITEFX_DEBUG(VULKAN_LOG, "Dedicated Memory: {0} Bytes", adapter.dedicatedMemory());
-	LITEFX_DEBUG(VULKAN_LOG, "--------------------------------------------------------------------------");
-	LITEFX_DEBUG(VULKAN_LOG, "Available extensions: {0}", Join(adapter.getAvailableDeviceExtensions(), ", "));
-	LITEFX_DEBUG(VULKAN_LOG, "Validation layers: {0}", Join(adapter.deviceValidationLayers(), ", "));
-	LITEFX_DEBUG(VULKAN_LOG, "--------------------------------------------------------------------------");
+    LITEFX_DEBUG(VULKAN_LOG, "Creating Vulkan device {{ Surface: {0}, Adapter: {1}, Extensions: {2} }}...", fmt::ptr(reinterpret_cast<const void*>(m_impl->m_surface.get())), adapter.deviceId(), Join(this->enabledExtensions(), ", "));
+    LITEFX_DEBUG(VULKAN_LOG, "--------------------------------------------------------------------------");
+    LITEFX_DEBUG(VULKAN_LOG, "Vendor: {0:#0x}", adapter.vendorId());
+    LITEFX_DEBUG(VULKAN_LOG, "Driver Version: {0:#0x}", adapter.driverVersion());
+    LITEFX_DEBUG(VULKAN_LOG, "API Version: {0:#0x}", adapter.apiVersion());
+    LITEFX_DEBUG(VULKAN_LOG, "Dedicated Memory: {0} Bytes", adapter.dedicatedMemory());
+    LITEFX_DEBUG(VULKAN_LOG, "--------------------------------------------------------------------------");
+    LITEFX_DEBUG(VULKAN_LOG, "Available extensions: {0}", Join(adapter.getAvailableDeviceExtensions(), ", "));
+    LITEFX_DEBUG(VULKAN_LOG, "Validation layers: {0}", Join(adapter.deviceValidationLayers(), ", "));
+    LITEFX_DEBUG(VULKAN_LOG, "--------------------------------------------------------------------------");
 
-	if (extensions.size() > 0)
-		LITEFX_INFO(VULKAN_LOG, "Enabled validation layers: {0}", Join(extensions, ", "));
+    if (extensions.size() > 0)
+        LITEFX_INFO(VULKAN_LOG, "Enabled validation layers: {0}", Join(extensions, ", "));
 
-	this->handle() = m_impl->initialize();
-	m_impl->createQueues();
-	m_impl->createFactory();
-	m_impl->createSwapChain(format, frameBufferSize, frameBuffers);
+    this->handle() = m_impl->initialize();
+    m_impl->createFactory();
+    m_impl->createSwapChain(format, frameBufferSize, frameBuffers);
 }
 
 VulkanDevice::~VulkanDevice() noexcept
 {
-	// Destroy the implementation.
-	m_impl.destroy();
+    // Destroy the implementation.
+    m_impl.destroy();
 
-	// Destroy the device.
-	::vkDestroyDevice(this->handle(), nullptr);
+    // Destroy the device.
+    ::vkDestroyDevice(this->handle(), nullptr);
 }
 
 Span<const String> VulkanDevice::enabledExtensions() const noexcept
 {
-	return m_impl->m_extensions;
+    return m_impl->m_extensions;
 }
 
 void VulkanDevice::setDebugName(UInt64 handle, VkDebugReportObjectTypeEXT type, StringView name) const noexcept
 {
 #ifndef NDEBUG
-	if (m_impl->debugMarkerSetObjectName != nullptr)
-	{
-		VkDebugMarkerObjectNameInfoEXT nameInfo = {
-			.sType = VK_STRUCTURE_TYPE_DEBUG_MARKER_OBJECT_NAME_INFO_EXT,
-			.objectType = type,
-			.object = handle,
-			.pObjectName = name.data()
-		};
-		
-		if (m_impl->debugMarkerSetObjectName(this->handle(), &nameInfo) != VK_SUCCESS)
-			LITEFX_WARNING(VULKAN_LOG, "Unable to set object name for object handle {0}.", fmt::ptr(reinterpret_cast<void*>(handle)));
-	}
+    if (m_impl->debugMarkerSetObjectName != nullptr)
+    {
+        VkDebugMarkerObjectNameInfoEXT nameInfo = {
+            .sType = VK_STRUCTURE_TYPE_DEBUG_MARKER_OBJECT_NAME_INFO_EXT,
+            .objectType = type,
+            .object = handle,
+            .pObjectName = name.data()
+        };
+        
+        if (m_impl->debugMarkerSetObjectName(this->handle(), &nameInfo) != VK_SUCCESS)
+            LITEFX_WARNING(VULKAN_LOG, "Unable to set object name for object handle {0}.", fmt::ptr(reinterpret_cast<void*>(handle)));
+    }
 #endif
 }
 
 Enumerable<UInt32> VulkanDevice::queueFamilyIndices(QueueType type) const noexcept
 {
-	return m_impl->m_families | 
-		std::views::filter([type](const auto& family) { return type == QueueType::None || LITEFX_FLAG_IS_SET(family.type(), type); }) |
-		std::views::transform([](const auto& family) { return family.id(); }) | 
-		std::ranges::to<Enumerable<UInt32>>();
+    return m_impl->m_families | 
+        std::views::filter([type](const auto& family) { return type == QueueType::None || LITEFX_FLAG_IS_SET(family.type(), type); }) |
+        std::views::transform([](const auto& family) { return family.id(); }) | 
+        std::ranges::to<Enumerable<UInt32>>();
 }
 
 VulkanSwapChain& VulkanDevice::swapChain() noexcept
 {
-	return *m_impl->m_swapChain;
+    return *m_impl->m_swapChain;
 }
 
 #if defined(BUILD_DEFINE_BUILDERS)
 VulkanRenderPassBuilder VulkanDevice::buildRenderPass(MultiSamplingLevel samples, UInt32 commandBuffers) const
 {
-	return VulkanRenderPassBuilder(*this, commandBuffers, samples);
+    return VulkanRenderPassBuilder(*this, commandBuffers, samples);
 }
 
 VulkanRenderPassBuilder VulkanDevice::buildRenderPass(const String& name, MultiSamplingLevel samples, UInt32 commandBuffers) const
 {
-	return VulkanRenderPassBuilder(*this, commandBuffers, samples, name);
+    return VulkanRenderPassBuilder(*this, commandBuffers, samples, name);
 }
 
 VulkanRenderPipelineBuilder VulkanDevice::buildRenderPipeline(const VulkanRenderPass& renderPass, const String& name) const
 {
-	return VulkanRenderPipelineBuilder(renderPass, name);
+    return VulkanRenderPipelineBuilder(renderPass, name);
 }
 
 VulkanComputePipelineBuilder VulkanDevice::buildComputePipeline(const String& name) const
 {
-	return VulkanComputePipelineBuilder(*this, name);
+    return VulkanComputePipelineBuilder(*this, name);
 }
 
 VulkanPipelineLayoutBuilder VulkanDevice::buildPipelineLayout() const
 {
-	return VulkanPipelineLayoutBuilder(*this);
+    return VulkanPipelineLayoutBuilder(*this);
 }
 
 VulkanInputAssemblerBuilder VulkanDevice::buildInputAssembler() const
 {
-	return VulkanInputAssemblerBuilder();
+    return VulkanInputAssemblerBuilder();
 }
 
 VulkanRasterizerBuilder VulkanDevice::buildRasterizer() const
 {
-	return VulkanRasterizerBuilder();
+    return VulkanRasterizerBuilder();
 }
 
 VulkanShaderProgramBuilder VulkanDevice::buildShaderProgram() const
 {
-	return VulkanShaderProgramBuilder(*this);
+    return VulkanShaderProgramBuilder(*this);
 }
 
 VulkanBarrierBuilder VulkanDevice::buildBarrier() const
 {
-	return VulkanBarrierBuilder();
+    return VulkanBarrierBuilder();
 }
 #endif // defined(BUILD_DEFINE_BUILDERS)
 
 DeviceState& VulkanDevice::state() const noexcept
 {
-	return m_impl->m_deviceState;
+    return m_impl->m_deviceState;
 }
 
 const VulkanSwapChain& VulkanDevice::swapChain() const noexcept
 {
-	return *m_impl->m_swapChain;
+    return *m_impl->m_swapChain;
 }
 
 const VulkanSurface& VulkanDevice::surface() const noexcept
 {
-	return *m_impl->m_surface;
+    return *m_impl->m_surface;
 }
 
 const VulkanGraphicsAdapter& VulkanDevice::adapter() const noexcept
 {
-	return m_impl->m_adapter;
+    return m_impl->m_adapter;
 }
 
 const VulkanGraphicsFactory& VulkanDevice::factory() const noexcept
 {
-	return *m_impl->m_factory;
+    return *m_impl->m_factory;
 }
 
-const VulkanQueue& VulkanDevice::graphicsQueue() const noexcept
+const VulkanQueue& VulkanDevice::defaultQueue(QueueType type) const
 {
-	return *m_impl->m_graphicsQueue;
+    // If the type contains the graphics flag, always return the graphics queue.
+    if (LITEFX_FLAG_IS_SET(type, QueueType::Graphics))
+        return *m_impl->m_graphicsQueue;
+    else if (LITEFX_FLAG_IS_SET(type, QueueType::Compute))
+        return *m_impl->m_computeQueue;
+    else if (LITEFX_FLAG_IS_SET(type, QueueType::Transfer))
+        return *m_impl->m_transferQueue;
+    else
+        throw InvalidArgumentException("No default queue for the provided queue type has was found.");
 }
 
-const VulkanQueue& VulkanDevice::transferQueue() const noexcept
-{
-	return *m_impl->m_transferQueue;
-}
-
-const VulkanQueue& VulkanDevice::bufferQueue() const noexcept
-{
-	return *m_impl->m_bufferQueue;
-}
-
-const VulkanQueue& VulkanDevice::computeQueue() const noexcept
-{
-	return *m_impl->m_computeQueue;
+const VulkanQueue* VulkanDevice::createQueue(QueueType type, QueuePriority priority) noexcept {
+    return m_impl->createQueue(type, priority);
 }
 
 UniquePtr<VulkanBarrier> VulkanDevice::makeBarrier(PipelineStage syncBefore, PipelineStage syncAfter) const noexcept
 {
-	return makeUnique<VulkanBarrier>(syncBefore, syncAfter);
+    return makeUnique<VulkanBarrier>(syncBefore, syncAfter);
 }
 
 MultiSamplingLevel VulkanDevice::maximumMultiSamplingLevel(Format format) const noexcept
 {
-	auto limits = m_impl->m_adapter.limits();
-	VkSampleCountFlags sampleCounts = limits.framebufferColorSampleCounts;
+    auto limits = m_impl->m_adapter.limits();
+    VkSampleCountFlags sampleCounts = limits.framebufferColorSampleCounts;
 
-	if (::hasDepth(format) && ::hasStencil(format))
-		sampleCounts = limits.framebufferDepthSampleCounts & limits.framebufferStencilSampleCounts;
-	else if (::hasDepth(format))
-		sampleCounts = limits.framebufferDepthSampleCounts;
-	else if (::hasStencil(format))
-		sampleCounts = limits.framebufferStencilSampleCounts;
+    if (::hasDepth(format) && ::hasStencil(format))
+        sampleCounts = limits.framebufferDepthSampleCounts & limits.framebufferStencilSampleCounts;
+    else if (::hasDepth(format))
+        sampleCounts = limits.framebufferDepthSampleCounts;
+    else if (::hasStencil(format))
+        sampleCounts = limits.framebufferStencilSampleCounts;
 
-	if (sampleCounts & VK_SAMPLE_COUNT_64_BIT)
-		return MultiSamplingLevel::x64;
-	else if (sampleCounts & VK_SAMPLE_COUNT_32_BIT)
-		return MultiSamplingLevel::x32;
-	else if (sampleCounts & VK_SAMPLE_COUNT_16_BIT)
-		return MultiSamplingLevel::x16;
-	else if (sampleCounts & VK_SAMPLE_COUNT_8_BIT)
-		return MultiSamplingLevel::x8;
-	else if (sampleCounts & VK_SAMPLE_COUNT_4_BIT)
-		return MultiSamplingLevel::x4;
-	else if (sampleCounts & VK_SAMPLE_COUNT_2_BIT)
-		return MultiSamplingLevel::x2;
-	else
-		return MultiSamplingLevel::x1;
+    if (sampleCounts & VK_SAMPLE_COUNT_64_BIT)
+        return MultiSamplingLevel::x64;
+    else if (sampleCounts & VK_SAMPLE_COUNT_32_BIT)
+        return MultiSamplingLevel::x32;
+    else if (sampleCounts & VK_SAMPLE_COUNT_16_BIT)
+        return MultiSamplingLevel::x16;
+    else if (sampleCounts & VK_SAMPLE_COUNT_8_BIT)
+        return MultiSamplingLevel::x8;
+    else if (sampleCounts & VK_SAMPLE_COUNT_4_BIT)
+        return MultiSamplingLevel::x4;
+    else if (sampleCounts & VK_SAMPLE_COUNT_2_BIT)
+        return MultiSamplingLevel::x2;
+    else
+        return MultiSamplingLevel::x1;
 }
 
 double VulkanDevice::ticksPerMillisecond() const noexcept
 {
-	return 1000000.0 / static_cast<double>(this->adapter().limits().timestampPeriod);
+    return 1000000.0 / static_cast<double>(this->adapter().limits().timestampPeriod);
 }
 
 void VulkanDevice::wait() const
 {
-	raiseIfFailed<RuntimeException>(::vkDeviceWaitIdle(this->handle()), "Unable to wait for the device.");
+    raiseIfFailed<RuntimeException>(::vkDeviceWaitIdle(this->handle()), "Unable to wait for the device.");
 }

--- a/src/Backends/Vulkan/src/device.cpp
+++ b/src/Backends/Vulkan/src/device.cpp
@@ -92,7 +92,7 @@ private:
                 std::views::transform([this](auto i) { return std::make_tuple(i, std::ranges::count_if(m_queues, [i](const auto& q) { return q->queueId() == i; })); });
             auto [queueId, refCount] = *std::ranges::min_element(indices, {}, [](const auto& i) { return std::get<1>(i); });
 
-            LITEFX_DEBUG(VULKAN_LOG, "Creating queue with id {0} (referenced {1} times).", queueId, refCount);
+            LITEFX_DEBUG(VULKAN_LOG, "Creating queue with id {0} of type {2} (referenced {1} times).", queueId, refCount, m_type);
 
             // Create a queue instance with the queue id.
             auto queue = makeUnique<VulkanQueue>(device, m_type, priority, m_id, static_cast<UInt32>(queueId));

--- a/src/Backends/Vulkan/src/device.cpp
+++ b/src/Backends/Vulkan/src/device.cpp
@@ -386,6 +386,14 @@ void VulkanDevice::setDebugName(UInt64 handle, VkDebugReportObjectTypeEXT type, 
 #endif
 }
 
+Enumerable<UInt32> VulkanDevice::queueFamilyIndices(QueueType type) const noexcept
+{
+	return m_impl->m_families | 
+		std::views::filter([type](const auto& family) { return type == QueueType::None || LITEFX_FLAG_IS_SET(family.type(), type); }) |
+		std::views::transform([](const auto& family) { return family.id(); }) | 
+		std::ranges::to<Enumerable<UInt32>>();
+}
+
 VulkanSwapChain& VulkanDevice::swapChain() noexcept
 {
 	return *m_impl->m_swapChain;

--- a/src/Backends/Vulkan/src/device.cpp
+++ b/src/Backends/Vulkan/src/device.cpp
@@ -95,7 +95,7 @@ private:
             LITEFX_DEBUG(VULKAN_LOG, "Creating queue with id {0} (referenced {1} times).", queueId, refCount);
 
             // Create a queue instance with the queue id.
-            auto queue = makeUnique<VulkanQueue>(device, m_type, priority, m_id, queueId);
+            auto queue = makeUnique<VulkanQueue>(device, m_type, priority, m_id, static_cast<UInt32>(queueId));
             auto queuePointer = queue.get();
             m_queues.push_back(std::move(queue));
             return queuePointer;

--- a/src/Backends/Vulkan/src/device.cpp
+++ b/src/Backends/Vulkan/src/device.cpp
@@ -464,7 +464,8 @@ const VulkanQueue& VulkanDevice::defaultQueue(QueueType type) const
         throw InvalidArgumentException("No default queue for the provided queue type has was found.");
 }
 
-const VulkanQueue* VulkanDevice::createQueue(QueueType type, QueuePriority priority) noexcept {
+const VulkanQueue* VulkanDevice::createQueue(QueueType type, QueuePriority priority) noexcept 
+{
     return m_impl->createQueue(type, priority);
 }
 

--- a/src/Backends/Vulkan/src/frame_buffer.cpp
+++ b/src/Backends/Vulkan/src/frame_buffer.cpp
@@ -33,7 +33,7 @@ public:
 
         // Retrieve a command buffer from the graphics queue.
         m_commandBuffers.resize(commandBuffers);
-        std::ranges::generate(m_commandBuffers, [this, &device]() { return device.graphicsQueue().createCommandBuffer(false, true); });
+        std::ranges::generate(m_commandBuffers, [this]() { return m_renderPass.commandQueue().createCommandBuffer(false, true); });
 	}
 
 	~VulkanFrameBufferImpl()

--- a/src/Backends/Vulkan/src/pipeline_layout.cpp
+++ b/src/Backends/Vulkan/src/pipeline_layout.cpp
@@ -46,7 +46,9 @@ public:
                 throw InvalidArgumentException("Two layouts defined for the same descriptor set {}. Each descriptor set must use it's own space.", a);
             
             while (i != a)
-                emptySets.push_back(i++);
+                emptySets.push_back(i);
+
+            ++i;
         }
 
         // Add empty sets.

--- a/src/Backends/Vulkan/src/queue.cpp
+++ b/src/Backends/Vulkan/src/queue.cpp
@@ -110,7 +110,7 @@ QueueType VulkanQueue::type() const noexcept
 }
 
 #ifndef NDEBUG
-void VulkanQueue::BeginDebugRegion(const String& label, const Vectors::ByteVector3& color) const noexcept
+void VulkanQueue::beginDebugRegion(const String& label, const Vectors::ByteVector3& color) const noexcept
 {
 	VkDebugUtilsLabelEXT labelInfo {
 		.sType = VK_STRUCTURE_TYPE_DEBUG_UTILS_LABEL_EXT,
@@ -121,12 +121,12 @@ void VulkanQueue::BeginDebugRegion(const String& label, const Vectors::ByteVecto
 	::vkQueueBeginDebugUtilsLabel(this->handle(), &labelInfo);
 }
 
-void VulkanQueue::EndDebugRegion() const noexcept
+void VulkanQueue::endDebugRegion() const noexcept
 {
 	::vkQueueEndDebugUtilsLabel(this->handle());
 }
 
-void VulkanQueue::SetDebugMarker(const String& label, const Vectors::ByteVector3& color) const noexcept
+void VulkanQueue::setDebugMarker(const String& label, const Vectors::ByteVector3& color) const noexcept
 {
 	VkDebugUtilsLabelEXT labelInfo{
 		.sType = VK_STRUCTURE_TYPE_DEBUG_UTILS_LABEL_EXT,

--- a/src/Backends/Vulkan/src/queue.cpp
+++ b/src/Backends/Vulkan/src/queue.cpp
@@ -16,24 +16,22 @@ public:
 	friend class VulkanQueue;
 
 private:
-	VkCommandPool m_commandPool{};
 	QueueType m_type;
 	QueuePriority m_priority;
 	UInt32 m_familyId, m_queueId;
 	VkSemaphore m_timelineSemaphore{};
 	UInt64 m_fenceValue{ 0 };
 	mutable std::mutex m_mutex;
-	bool m_bound;
 	const VulkanDevice& m_device;
 	Array<Tuple<UInt64, SharedPtr<const VulkanCommandBuffer>>> m_submittedCommandBuffers;
 
 public:
 	VulkanQueueImpl(VulkanQueue* parent, const VulkanDevice& device, QueueType type, QueuePriority priority, UInt32 familyId, UInt32 queueId) :
-		base(parent), m_type(type), m_priority(priority), m_familyId(familyId), m_queueId(queueId), m_bound(false), m_device(device)
+		base(parent), m_type(type), m_priority(priority), m_familyId(familyId), m_queueId(queueId), m_device(device)
 	{
 	}
 
-	~VulkanQueueImpl()
+	~VulkanQueueImpl() 
 	{
 		this->release();
 	}
@@ -46,51 +44,31 @@ public:
 		if (m_timelineSemaphore != nullptr)
 			::vkDestroySemaphore(m_device.handle(), m_timelineSemaphore, nullptr);
 
-		if (m_bound)
-			::vkDestroyCommandPool(m_device.handle(), m_commandPool, nullptr);
-
-		m_bound = false;
-		m_commandPool = {};
 		m_timelineSemaphore = {};
 	}
 
-	void bind()
+	VkQueue initialize()
 	{
-		if (m_bound)
-			return;
-
-		// Store the queue handle, if not done in previous binds.
-		if (m_parent->handle() == nullptr)
-			::vkGetDeviceQueue(m_device.handle(), m_familyId, m_queueId, &m_parent->handle());
-
-		// Create command pool.
-		VkCommandPoolCreateInfo poolInfo = {};
-		poolInfo.sType = VK_STRUCTURE_TYPE_COMMAND_POOL_CREATE_INFO;
-		poolInfo.queueFamilyIndex = m_familyId;
-
-		// Transfer pools can be transient.
-		poolInfo.flags = VK_COMMAND_POOL_CREATE_RESET_COMMAND_BUFFER_BIT;
-
-		if (m_type == QueueType::Transfer)
-			poolInfo.flags |= VK_COMMAND_POOL_CREATE_TRANSIENT_BIT;
-
-		raiseIfFailed<RuntimeException>(::vkCreateCommandPool(m_device.handle(), &poolInfo, nullptr, &m_commandPool), "Unable to create command pool.");
+		// Create the queue instance.
+		VkQueue queue;
+		::vkGetDeviceQueue(m_device.handle(), m_familyId, m_queueId, &queue);
 
 		// Create a timeline semaphore for queue synchronization.
-		VkSemaphoreTypeCreateInfo timelineCreateInfo;
-		timelineCreateInfo.sType = VK_STRUCTURE_TYPE_SEMAPHORE_TYPE_CREATE_INFO;
-		timelineCreateInfo.pNext = NULL;
-		timelineCreateInfo.semaphoreType = VK_SEMAPHORE_TYPE_TIMELINE;
-		timelineCreateInfo.initialValue = m_fenceValue;
+		VkSemaphoreTypeCreateInfo timelineCreateInfo = {
+			.sType = VK_STRUCTURE_TYPE_SEMAPHORE_TYPE_CREATE_INFO,
+			.semaphoreType = VK_SEMAPHORE_TYPE_TIMELINE,
+			.initialValue = m_fenceValue
+		};
 
-		VkSemaphoreCreateInfo createInfo;
-		createInfo.sType = VK_STRUCTURE_TYPE_SEMAPHORE_CREATE_INFO;
-		createInfo.pNext = &timelineCreateInfo;
-		createInfo.flags = 0;
+		VkSemaphoreCreateInfo createInfo = {
+			.sType = VK_STRUCTURE_TYPE_SEMAPHORE_CREATE_INFO,
+			.pNext = &timelineCreateInfo,
+			.flags = 0
+		};
 
-		raiseIfFailed<RuntimeException>(::vkCreateSemaphore(m_device.handle(), &createInfo, NULL, &m_timelineSemaphore), "Unable to create queue synchronization semaphore.");
+		raiseIfFailed<RuntimeException>(::vkCreateSemaphore(m_device.handle(), &createInfo, nullptr, &m_timelineSemaphore), "Unable to create queue synchronization semaphore.");
 
-		m_bound = true;
+		return queue;
 	}
 };
 
@@ -101,6 +79,7 @@ public:
 VulkanQueue::VulkanQueue(const VulkanDevice& device, QueueType type, QueuePriority priority, UInt32 familyId, UInt32 queueId) :
 	Resource<VkQueue>(nullptr), m_impl(makePimpl<VulkanQueueImpl>(this, device, type, priority, familyId, queueId))
 {
+	this->handle() = m_impl->initialize();
 }
 
 VulkanQueue::~VulkanQueue() noexcept = default;
@@ -108,11 +87,6 @@ VulkanQueue::~VulkanQueue() noexcept = default;
 const VulkanDevice& VulkanQueue::device() const noexcept
 {
 	return m_impl->m_device;
-}
-
-const VkCommandPool& VulkanQueue::commandPool() const noexcept
-{
-	return m_impl->m_commandPool;
 }
 
 UInt32 VulkanQueue::familyId() const noexcept
@@ -128,11 +102,6 @@ UInt32 VulkanQueue::queueId() const noexcept
 const VkSemaphore& VulkanQueue::timelineSemaphore() const noexcept
 {
 	return m_impl->m_timelineSemaphore;
-}
-
-bool VulkanQueue::isBound() const noexcept
-{
-	return m_impl->m_bound;
 }
 
 QueueType VulkanQueue::type() const noexcept
@@ -172,18 +141,6 @@ void VulkanQueue::SetDebugMarker(const String& label, const Vectors::ByteVector3
 QueuePriority VulkanQueue::priority() const noexcept
 {
 	return m_impl->m_priority;
-}
-
-void VulkanQueue::bind()
-{
-	m_impl->bind();
-	this->bound(this, { });
-}
-
-void VulkanQueue::release()
-{
-	m_impl->release();
-	this->released(this, { });
 }
 
 SharedPtr<VulkanCommandBuffer> VulkanQueue::createCommandBuffer(bool beginRecording, bool secondary) const

--- a/src/Backends/Vulkan/src/queue.cpp
+++ b/src/Backends/Vulkan/src/queue.cpp
@@ -312,6 +312,24 @@ void VulkanQueue::waitFor(UInt64 fence) const noexcept
 	m_impl->m_submittedCommandBuffers.erase(from, to);
 }
 
+void VulkanQueue::waitFor(const VulkanQueue& queue, UInt64 fence) const noexcept
+{
+	VkTimelineSemaphoreSubmitInfo timelineInfo {
+		.sType = VK_STRUCTURE_TYPE_TIMELINE_SEMAPHORE_SUBMIT_INFO,
+		.waitSemaphoreValueCount = 1,
+		.pWaitSemaphoreValues = &fence
+	};
+
+	VkSubmitInfo submitInfo{
+		.sType = VK_STRUCTURE_TYPE_SUBMIT_INFO,
+		.pNext = &timelineInfo,
+		.waitSemaphoreCount = 1,
+		.pWaitSemaphores = &queue.m_impl->m_timelineSemaphore
+	};
+
+	::vkQueueSubmit(this->handle(), 1, &submitInfo, VK_NULL_HANDLE);
+}
+
 UInt64 VulkanQueue::currentFence() const noexcept
 {
 	return m_impl->m_fenceValue;

--- a/src/Backends/Vulkan/src/queue.cpp
+++ b/src/Backends/Vulkan/src/queue.cpp
@@ -145,7 +145,7 @@ QueuePriority VulkanQueue::priority() const noexcept
 
 SharedPtr<VulkanCommandBuffer> VulkanQueue::createCommandBuffer(bool beginRecording, bool secondary) const
 {
-	return makeShared<VulkanCommandBuffer>(*this, beginRecording, !secondary);
+	return VulkanCommandBuffer::create(*this, beginRecording, !secondary);
 }
 
 UInt64 VulkanQueue::submit(SharedPtr<const VulkanCommandBuffer> commandBuffer) const

--- a/src/Backends/Vulkan/src/render_pass.cpp
+++ b/src/Backends/Vulkan/src/render_pass.cpp
@@ -542,7 +542,10 @@ constexpr VulkanRenderPassBuilder::~VulkanRenderPassBuilder() noexcept = default
 void VulkanRenderPassBuilder::build()
 {
     auto instance = this->instance();
-    instance->m_impl->m_queue = m_state.commandQueue;
+    
+    if (m_state.commandQueue != nullptr)
+        instance->m_impl->m_queue = m_state.commandQueue;
+    
     instance->m_impl->mapRenderTargets(m_state.renderTargets);
     instance->m_impl->mapInputAttachments(m_state.inputAttachments);
     instance->m_impl->m_samples = m_state.multiSamplingLevel;

--- a/src/Rendering/include/litefx/rendering.hpp
+++ b/src/Rendering/include/litefx/rendering.hpp
@@ -235,23 +235,23 @@ namespace LiteFX::Rendering {
         virtual void free(const descriptor_set_type& descriptorSet) const noexcept = 0;
 
     private:
-        Enumerable<const IDescriptorLayout*> getDescriptors() const noexcept override {
+        inline Enumerable<const IDescriptorLayout*> getDescriptors() const noexcept override {
             return this->descriptors();
         }
 
-        UniquePtr<IDescriptorSet> getDescriptorSet(UInt32 descriptors, const Enumerable<DescriptorBinding>& bindings = { }) const override {
+        inline UniquePtr<IDescriptorSet> getDescriptorSet(UInt32 descriptors, const Enumerable<DescriptorBinding>& bindings = { }) const override {
             return this->allocate(descriptors, bindings);
         }
 
-        Enumerable<UniquePtr<IDescriptorSet>> getDescriptorSets(UInt32 descriptorSets, UInt32 descriptors, const Enumerable<Enumerable<DescriptorBinding>>& bindings = { }) const override {
+        inline Enumerable<UniquePtr<IDescriptorSet>> getDescriptorSets(UInt32 descriptorSets, UInt32 descriptors, const Enumerable<Enumerable<DescriptorBinding>>& bindings = { }) const override {
             return this->allocateMultiple(descriptorSets, descriptors, bindings) | std::views::as_rvalue;
         }
 
-        Enumerable<UniquePtr<IDescriptorSet>> getDescriptorSets(UInt32 descriptorSets, UInt32 descriptors, std::function<Enumerable<DescriptorBinding>(UInt32)> bindingFactory) const override {
+        inline Enumerable<UniquePtr<IDescriptorSet>> getDescriptorSets(UInt32 descriptorSets, UInt32 descriptors, std::function<Enumerable<DescriptorBinding>(UInt32)> bindingFactory) const override {
             return this->allocateMultiple(descriptorSets, descriptors, bindingFactory) | std::views::as_rvalue;
         }
 
-        void releaseDescriptorSet(const IDescriptorSet& descriptorSet) const noexcept override {
+        inline void releaseDescriptorSet(const IDescriptorSet& descriptorSet) const noexcept override {
             this->releaseDescriptorSet(dynamic_cast<const descriptor_set_type&>(descriptorSet));
         }
     };
@@ -293,7 +293,7 @@ namespace LiteFX::Rendering {
         virtual Enumerable<const push_constants_range_type*> ranges() const noexcept = 0;
 
     private:
-        Enumerable<const IPushConstantsRange*> getRanges() const noexcept override {
+        inline Enumerable<const IPushConstantsRange*> getRanges() const noexcept override {
             return this->ranges();
         }
     };
@@ -317,7 +317,7 @@ namespace LiteFX::Rendering {
         virtual Enumerable<const shader_module_type*> modules() const noexcept = 0;
 
     private:
-        virtual Enumerable<const IShaderModule*> getModules() const noexcept {
+        inline virtual Enumerable<const IShaderModule*> getModules() const noexcept {
             return this->modules();
         }
     };
@@ -349,7 +349,7 @@ namespace LiteFX::Rendering {
         virtual const push_constants_layout_type* pushConstants() const noexcept = 0;
 
     private:
-        Enumerable<const IDescriptorSetLayout*> getDescriptorSets() const noexcept override {
+        inline Enumerable<const IDescriptorSetLayout*> getDescriptorSets() const noexcept override {
             return this->descriptorSets();
         }
     };
@@ -417,7 +417,7 @@ namespace LiteFX::Rendering {
         virtual const index_buffer_layout_type& indexBufferLayout() const = 0;
 
     private:
-        Enumerable<const IVertexBufferLayout*> getVertexBufferLayouts() const noexcept override {
+        inline Enumerable<const IVertexBufferLayout*> getVertexBufferLayouts() const noexcept override {
             return this->vertexBufferLayouts();
         }
     };
@@ -448,11 +448,11 @@ namespace LiteFX::Rendering {
         virtual SharedPtr<const pipeline_layout_type> layout() const noexcept = 0;
 
     private:
-        SharedPtr<const IShaderProgram> getProgram() const noexcept override {
+        inline SharedPtr<const IShaderProgram> getProgram() const noexcept override {
             return std::static_pointer_cast<const IShaderProgram>(this->program());
         }
 
-        SharedPtr<const IPipelineLayout> getLayout() const noexcept override {
+        inline SharedPtr<const IPipelineLayout> getLayout() const noexcept override {
             return std::static_pointer_cast<const IPipelineLayout>(this->layout());
         }
     };
@@ -546,19 +546,19 @@ namespace LiteFX::Rendering {
         virtual void pushConstants(const push_constants_layout_type& layout, const void* const memory) const noexcept = 0;
 
         /// <inheritdoc />
-        virtual void draw(const vertex_buffer_type& vertexBuffer, UInt32 instances = 1, UInt32 firstVertex = 0, UInt32 firstInstance = 0) const {
+        inline virtual void draw(const vertex_buffer_type& vertexBuffer, UInt32 instances = 1, UInt32 firstVertex = 0, UInt32 firstInstance = 0) const {
             this->bind(vertexBuffer);
             this->draw(vertexBuffer.elements(), instances, firstVertex, firstInstance);
         }
 
         /// <inheritdoc />
-        virtual void drawIndexed(const index_buffer_type& indexBuffer, UInt32 instances = 1, UInt32 firstIndex = 0, Int32 vertexOffset = 0, UInt32 firstInstance = 0) const {
+        inline virtual void drawIndexed(const index_buffer_type& indexBuffer, UInt32 instances = 1, UInt32 firstIndex = 0, Int32 vertexOffset = 0, UInt32 firstInstance = 0) const {
             this->bind(indexBuffer);
             this->drawIndexed(indexBuffer.elements(), instances, firstIndex, vertexOffset, firstInstance);
         }
 
         /// <inheritdoc />
-        virtual void drawIndexed(const vertex_buffer_type& vertexBuffer, const index_buffer_type& indexBuffer, UInt32 instances = 1, UInt32 firstIndex = 0, Int32 vertexOffset = 0, UInt32 firstInstance = 0) const {
+        inline virtual void drawIndexed(const vertex_buffer_type& vertexBuffer, const index_buffer_type& indexBuffer, UInt32 instances = 1, UInt32 firstIndex = 0, Int32 vertexOffset = 0, UInt32 firstInstance = 0) const {
             this->bind(vertexBuffer);
             this->bind(indexBuffer);
             this->drawIndexed(indexBuffer.elements(), instances, firstIndex, vertexOffset, firstInstance);
@@ -571,86 +571,85 @@ namespace LiteFX::Rendering {
         virtual void execute(Enumerable<SharedPtr<const command_buffer_type>> commandBuffers) const = 0;
 
     private:
-        void cmdBarrier(const IBarrier& barrier) const noexcept override { 
+        inline void cmdBarrier(const IBarrier& barrier) const noexcept override {
             this->barrier(dynamic_cast<const barrier_type&>(barrier));
         }
 
-        void cmdGenerateMipMaps(IImage& image) noexcept override { 
+        inline void cmdGenerateMipMaps(IImage& image) noexcept override {
             this->generateMipMaps(dynamic_cast<image_type&>(image));
         }
 
-        void cmdTransfer(IBuffer& source, IBuffer& target, UInt32 sourceElement, UInt32 targetElement, UInt32 elements) const override { 
+        inline void cmdTransfer(IBuffer& source, IBuffer& target, UInt32 sourceElement, UInt32 targetElement, UInt32 elements) const override {
             this->transfer(dynamic_cast<buffer_type&>(source), dynamic_cast<buffer_type&>(target), sourceElement, targetElement, elements);
         }
         
-        void cmdTransfer(IBuffer& source, IImage& target, UInt32 sourceElement, UInt32 firstSubresource, UInt32 elements) const override { 
+        inline void cmdTransfer(IBuffer& source, IImage& target, UInt32 sourceElement, UInt32 firstSubresource, UInt32 elements) const override {
             this->transfer(dynamic_cast<buffer_type&>(source), dynamic_cast<image_type&>(target), sourceElement, firstSubresource, elements);
         }
         
-        void cmdTransfer(IImage& source, IImage& target, UInt32 sourceSubresource, UInt32 targetSubresource, UInt32 subresources) const override {
+        inline void cmdTransfer(IImage& source, IImage& target, UInt32 sourceSubresource, UInt32 targetSubresource, UInt32 subresources) const override {
             this->transfer(dynamic_cast<image_type&>(source), dynamic_cast<image_type&>(target), sourceSubresource, targetSubresource, subresources);
         }
 
-        void cmdTransfer(IImage& source, IBuffer& target, UInt32 firstSubresource, UInt32 targetElement, UInt32 subresources) const override {
+        inline void cmdTransfer(IImage& source, IBuffer& target, UInt32 firstSubresource, UInt32 targetElement, UInt32 subresources) const override {
             this->transfer(dynamic_cast<image_type&>(source), dynamic_cast<buffer_type&>(target), firstSubresource, targetElement, subresources);
         }
 
-        void cmdTransfer(SharedPtr<IBuffer> source, IBuffer& target, UInt32 sourceElement, UInt32 targetElement, UInt32 elements) const override {
+        inline void cmdTransfer(SharedPtr<IBuffer> source, IBuffer& target, UInt32 sourceElement, UInt32 targetElement, UInt32 elements) const override {
             this->transfer(std::dynamic_pointer_cast<buffer_type>(source), dynamic_cast<buffer_type&>(target), sourceElement, targetElement, elements);
         }
         
-        void cmdTransfer(SharedPtr<IBuffer> source, IImage& target, UInt32 sourceElement, UInt32 firstSubresource, UInt32 elements) const override {
+        inline void cmdTransfer(SharedPtr<IBuffer> source, IImage& target, UInt32 sourceElement, UInt32 firstSubresource, UInt32 elements) const override {
             this->transfer(std::dynamic_pointer_cast<buffer_type>(source), dynamic_cast<image_type&>(target), sourceElement, firstSubresource, elements);
         }
         
-        void cmdTransfer(SharedPtr<IImage> source, IImage& target, UInt32 sourceSubresource, UInt32 targetSubresource, UInt32 subresources) const override {
+        inline void cmdTransfer(SharedPtr<IImage> source, IImage& target, UInt32 sourceSubresource, UInt32 targetSubresource, UInt32 subresources) const override {
             this->transfer(std::dynamic_pointer_cast<image_type>(source), dynamic_cast<image_type&>(target), sourceSubresource, targetSubresource, subresources);
         }
         
-        void cmdTransfer(SharedPtr<IImage> source, IBuffer& target, UInt32 firstSubresource, UInt32 targetElement, UInt32 subresources) const override {
+        inline void cmdTransfer(SharedPtr<IImage> source, IBuffer& target, UInt32 firstSubresource, UInt32 targetElement, UInt32 subresources) const override {
             this->transfer(std::dynamic_pointer_cast<image_type>(source), dynamic_cast<buffer_type&>(target), firstSubresource, targetElement, subresources);
         }
 
-        void cmdUse(const IPipeline& pipeline) const noexcept override { 
+        inline void cmdUse(const IPipeline& pipeline) const noexcept override {
             this->use(dynamic_cast<const pipeline_type&>(pipeline));
         }
 
-        void cmdBind(const IDescriptorSet& descriptorSet, const IPipeline& pipeline) const noexcept override { 
+        inline void cmdBind(const IDescriptorSet& descriptorSet, const IPipeline& pipeline) const noexcept override {
             this->bind(dynamic_cast<const descriptor_set_type&>(descriptorSet), dynamic_cast<const pipeline_type&>(pipeline));
         }
         
-        void cmdBind(const IVertexBuffer& buffer) const noexcept override { 
+        inline void cmdBind(const IVertexBuffer& buffer) const noexcept override {
             this->bind(dynamic_cast<const vertex_buffer_type&>(buffer));
         }
 
-        void cmdBind(const IIndexBuffer& buffer) const noexcept override { 
+        inline void cmdBind(const IIndexBuffer& buffer) const noexcept override {
             this->bind(dynamic_cast<const index_buffer_type&>(buffer));
         }
         
-        void cmdPushConstants(const IPushConstantsLayout& layout, const void* const memory) const noexcept override { 
+        inline void cmdPushConstants(const IPushConstantsLayout& layout, const void* const memory) const noexcept override {
             this->pushConstants(dynamic_cast<const push_constants_layout_type&>(layout), memory);
         }
         
-        void cmdDraw(const IVertexBuffer& vertexBuffer, UInt32 instances, UInt32 firstVertex, UInt32 firstInstance) const override { 
+        inline void cmdDraw(const IVertexBuffer& vertexBuffer, UInt32 instances, UInt32 firstVertex, UInt32 firstInstance) const override {
             this->draw(dynamic_cast<const vertex_buffer_type&>(vertexBuffer), instances, firstVertex, firstInstance);
         }
         
-        void cmdDrawIndexed(const IIndexBuffer& indexBuffer, UInt32 instances, UInt32 firstIndex, Int32 vertexOffset, UInt32 firstInstance) const override { 
+        inline void cmdDrawIndexed(const IIndexBuffer& indexBuffer, UInt32 instances, UInt32 firstIndex, Int32 vertexOffset, UInt32 firstInstance) const override {
             this->drawIndexed(dynamic_cast<const index_buffer_type&>(indexBuffer), instances, firstIndex, vertexOffset, firstInstance);
         }
         
-        void cmdDrawIndexed(const IVertexBuffer& vertexBuffer, const IIndexBuffer& indexBuffer, UInt32 instances, UInt32 firstIndex, Int32 vertexOffset, UInt32 firstInstance) const override { 
+        inline void cmdDrawIndexed(const IVertexBuffer& vertexBuffer, const IIndexBuffer& indexBuffer, UInt32 instances, UInt32 firstIndex, Int32 vertexOffset, UInt32 firstInstance) const override {
             this->drawIndexed(dynamic_cast<const vertex_buffer_type&>(vertexBuffer), dynamic_cast<const index_buffer_type&>(indexBuffer), instances, firstIndex, vertexOffset, firstInstance);
         }
 
-        void cmdExecute(SharedPtr<const ICommandBuffer> commandBuffer) const override {
+        inline void cmdExecute(SharedPtr<const ICommandBuffer> commandBuffer) const override {
             this->execute(std::dynamic_pointer_cast<const command_buffer_type>(commandBuffer));
         }
         
-        void cmdExecute(Enumerable<SharedPtr<const ICommandBuffer>> commandBuffers) const override {
+        inline void cmdExecute(Enumerable<SharedPtr<const ICommandBuffer>> commandBuffers) const override {
             return this->execute(commandBuffers | std::views::transform([](auto buffer) { return std::dynamic_pointer_cast<const command_buffer_type>(buffer); }));
         }
-
     };
 
     /// <summary>
@@ -680,11 +679,11 @@ namespace LiteFX::Rendering {
         virtual SharedPtr<rasterizer_type> rasterizer() const noexcept = 0;
 
     private:
-        SharedPtr<IInputAssembler> getInputAssembler() const noexcept override {
+        inline SharedPtr<IInputAssembler> getInputAssembler() const noexcept override {
             return this->inputAssembler();
         }
 
-        SharedPtr<IRasterizer> getRasterizer() const noexcept override {
+        inline SharedPtr<IRasterizer> getRasterizer() const noexcept override {
             return this->rasterizer();
         }
     };
@@ -730,15 +729,15 @@ namespace LiteFX::Rendering {
         virtual const image_type& image(UInt32 location) const = 0;
 
     private:
-        SharedPtr<const ICommandBuffer> getCommandBuffer(UInt32 index) const noexcept override {
+        inline SharedPtr<const ICommandBuffer> getCommandBuffer(UInt32 index) const noexcept override {
             return this->commandBuffer(index);
         }
 
-        Enumerable<SharedPtr<const ICommandBuffer>> getCommandBuffers() const noexcept override {
+        inline Enumerable<SharedPtr<const ICommandBuffer>> getCommandBuffers() const noexcept override {
             return this->commandBuffers();
         }
 
-        Enumerable<const IImage*> getImages() const noexcept override {
+        inline Enumerable<const IImage*> getImages() const noexcept override {
             return this->images();
         }
     };
@@ -852,15 +851,15 @@ namespace LiteFX::Rendering {
         virtual void updateAttachments(const descriptor_set_type& descriptorSet) const = 0;
 
     private:
-        Enumerable<const IFrameBuffer*> getFrameBuffers() const noexcept override {
+        inline Enumerable<const IFrameBuffer*> getFrameBuffers() const noexcept override {
             return this->frameBuffers();
         }
 
-        Enumerable<const IRenderPipeline*> getPipelines() const noexcept override {
+        inline Enumerable<const IRenderPipeline*> getPipelines() const noexcept override {
             return this->pipelines();
         }
 
-        void setAttachments(const IDescriptorSet& descriptorSet) const override {
+        inline void setAttachments(const IDescriptorSet& descriptorSet) const override {
             this->updateAttachments(dynamic_cast<const descriptor_set_type&>(descriptorSet));
         }
     };
@@ -891,12 +890,12 @@ namespace LiteFX::Rendering {
         virtual void present(const frame_buffer_type& frameBuffer) const = 0;
 
         /// <inheritdoc />
-        void present(const IFrameBuffer& frameBuffer) const override {
+        inline void present(const IFrameBuffer& frameBuffer) const override {
             this->present(dynamic_cast<const frame_buffer_type&>(frameBuffer));
         }
 
     private:
-        Enumerable<const IImage*> getImages() const noexcept override {
+        inline Enumerable<const IImage*> getImages() const noexcept override {
             return this->images();
         }
     };
@@ -921,7 +920,7 @@ namespace LiteFX::Rendering {
         virtual SharedPtr<command_buffer_type> createCommandBuffer(bool beginRecording = false, bool secondary = false) const = 0;
 
         /// <inheritdoc />
-        virtual UInt64 submit(SharedPtr<command_buffer_type> commandBuffer) const {
+        inline virtual UInt64 submit(SharedPtr<command_buffer_type> commandBuffer) const {
             return this->submit(std::static_pointer_cast<const command_buffer_type>(commandBuffer));
         }
 
@@ -929,7 +928,7 @@ namespace LiteFX::Rendering {
         virtual UInt64 submit(SharedPtr<const command_buffer_type> commandBuffer) const = 0;
 
         /// <inheritdoc />
-        virtual UInt64 submit(const Enumerable<SharedPtr<command_buffer_type>>& commandBuffers) const {
+        inline virtual UInt64 submit(const Enumerable<SharedPtr<command_buffer_type>>& commandBuffers) const {
             return this->submit(commandBuffers | std::ranges::to<Enumerable<SharedPtr<const command_buffer_type>>>());
         }
 
@@ -937,15 +936,15 @@ namespace LiteFX::Rendering {
         virtual UInt64 submit(const Enumerable<SharedPtr<const command_buffer_type>>& commandBuffers) const = 0;
 
     private:
-        SharedPtr<ICommandBuffer> getCommandBuffer(bool beginRecording, bool secondary) const override {
+        inline SharedPtr<ICommandBuffer> getCommandBuffer(bool beginRecording, bool secondary) const override {
             return this->createCommandBuffer(beginRecording, secondary);
         }
 
-        UInt64 submitCommandBuffer(SharedPtr<const ICommandBuffer> commandBuffer) const override {
+        inline UInt64 submitCommandBuffer(SharedPtr<const ICommandBuffer> commandBuffer) const override {
             return this->submit(std::dynamic_pointer_cast<const command_buffer_type>(commandBuffer));
         }
 
-        UInt64 submitCommandBuffers(const Enumerable<SharedPtr<const ICommandBuffer>>& commandBuffers) const override {
+        inline UInt64 submitCommandBuffers(const Enumerable<SharedPtr<const ICommandBuffer>>& commandBuffers) const override {
             return this->submit(commandBuffers | std::views::transform([](auto buffer) { return std::dynamic_pointer_cast<const command_buffer_type>(buffer); }) | std::ranges::to<Enumerable<SharedPtr<const command_buffer_type>>>());
         }
     };
@@ -1033,59 +1032,59 @@ namespace LiteFX::Rendering {
         virtual Enumerable<UniquePtr<TSampler>> createSamplers(UInt32 elements, FilterMode magFilter = FilterMode::Nearest, FilterMode minFilter = FilterMode::Nearest, BorderMode borderU = BorderMode::Repeat, BorderMode borderV = BorderMode::Repeat, BorderMode borderW = BorderMode::Repeat, MipMapMode mipMapMode = MipMapMode::Nearest, Float mipMapBias = 0.f, Float maxLod = std::numeric_limits<Float>::max(), Float minLod = 0.f, Float anisotropy = 0.f) const = 0;
 
     private:
-        UniquePtr<IBuffer> getBuffer(BufferType type, BufferUsage usage, size_t elementSize, UInt32 elements, bool allowWrite) const override { 
+        inline UniquePtr<IBuffer> getBuffer(BufferType type, BufferUsage usage, size_t elementSize, UInt32 elements, bool allowWrite) const override {
             return this->createBuffer(type, usage, elementSize, elements, allowWrite);
         }
 
-        UniquePtr<IBuffer> getBuffer(const String& name, BufferType type, BufferUsage usage, size_t elementSize, UInt32 elements, bool allowWrite) const override {
+        inline UniquePtr<IBuffer> getBuffer(const String& name, BufferType type, BufferUsage usage, size_t elementSize, UInt32 elements, bool allowWrite) const override {
             return this->createBuffer(name, type, usage, elementSize, elements, allowWrite);
         }
 
-        UniquePtr<IVertexBuffer> getVertexBuffer(const IVertexBufferLayout& layout, BufferUsage usage, UInt32 elements) const override { 
+        inline UniquePtr<IVertexBuffer> getVertexBuffer(const IVertexBufferLayout& layout, BufferUsage usage, UInt32 elements) const override {
             return this->createVertexBuffer(dynamic_cast<const vertex_buffer_layout_type&>(layout), usage, elements);
         }
 
-        UniquePtr<IVertexBuffer> getVertexBuffer(const String& name, const IVertexBufferLayout& layout, BufferUsage usage, UInt32 elements) const override {
+        inline UniquePtr<IVertexBuffer> getVertexBuffer(const String& name, const IVertexBufferLayout& layout, BufferUsage usage, UInt32 elements) const override {
             return this->createVertexBuffer(name, dynamic_cast<const vertex_buffer_layout_type&>(layout), usage, elements);
         }
         
-        UniquePtr<IIndexBuffer> getIndexBuffer(const IIndexBufferLayout& layout, BufferUsage usage, UInt32 elements) const override {
+        inline UniquePtr<IIndexBuffer> getIndexBuffer(const IIndexBufferLayout& layout, BufferUsage usage, UInt32 elements) const override {
             return this->createIndexBuffer(dynamic_cast<const index_buffer_layout_type&>(layout), usage, elements);
         }
 
-        UniquePtr<IIndexBuffer> getIndexBuffer(const String& name, const IIndexBufferLayout& layout, BufferUsage usage, UInt32 elements) const override {
+        inline UniquePtr<IIndexBuffer> getIndexBuffer(const String& name, const IIndexBufferLayout& layout, BufferUsage usage, UInt32 elements) const override {
             return this->createIndexBuffer(name, dynamic_cast<const index_buffer_layout_type&>(layout), usage, elements);
         }
 
-        UniquePtr<IImage> getAttachment(Format format, const Size2d& size, MultiSamplingLevel samples) const override { 
+        inline UniquePtr<IImage> getAttachment(Format format, const Size2d& size, MultiSamplingLevel samples) const override {
             return this->createAttachment(format, size, samples);
         }
 
-        UniquePtr<IImage> getAttachment(const String& name, Format format, const Size2d& size, MultiSamplingLevel samples) const override {
+        inline UniquePtr<IImage> getAttachment(const String& name, Format format, const Size2d& size, MultiSamplingLevel samples) const override {
             return this->createAttachment(name, format, size, samples);
         }
         
-        UniquePtr<IImage> getTexture(Format format, const Size3d& size, ImageDimensions dimension, UInt32 levels, UInt32 layers, MultiSamplingLevel samples, bool allowWrite) const override { 
+        inline UniquePtr<IImage> getTexture(Format format, const Size3d& size, ImageDimensions dimension, UInt32 levels, UInt32 layers, MultiSamplingLevel samples, bool allowWrite) const override {
             return this->createTexture(format, size, dimension, levels, layers, samples, allowWrite);
         }
 
-        UniquePtr<IImage> getTexture(const String& name, Format format, const Size3d& size, ImageDimensions dimension, UInt32 levels, UInt32 layers, MultiSamplingLevel samples, bool allowWrite) const override {
+        inline UniquePtr<IImage> getTexture(const String& name, Format format, const Size3d& size, ImageDimensions dimension, UInt32 levels, UInt32 layers, MultiSamplingLevel samples, bool allowWrite) const override {
             return this->createTexture(name, format, size, dimension, levels, layers, samples, allowWrite);
         }
 
-        Enumerable<UniquePtr<IImage>> getTextures(UInt32 elements, Format format, const Size3d& size, ImageDimensions dimension, UInt32 layers, UInt32 levels, MultiSamplingLevel samples, bool allowWrite) const override {
+        inline Enumerable<UniquePtr<IImage>> getTextures(UInt32 elements, Format format, const Size3d& size, ImageDimensions dimension, UInt32 layers, UInt32 levels, MultiSamplingLevel samples, bool allowWrite) const override {
             return this->getTextures(elements, format, size, dimension, layers, levels, samples, allowWrite) | std::views::as_rvalue;
         }
         
-        UniquePtr<ISampler> getSampler(FilterMode magFilter, FilterMode minFilter, BorderMode borderU, BorderMode borderV, BorderMode borderW, MipMapMode mipMapMode, Float mipMapBias, Float maxLod, Float minLod, Float anisotropy) const override { 
+        inline UniquePtr<ISampler> getSampler(FilterMode magFilter, FilterMode minFilter, BorderMode borderU, BorderMode borderV, BorderMode borderW, MipMapMode mipMapMode, Float mipMapBias, Float maxLod, Float minLod, Float anisotropy) const override {
             return this->createSampler(magFilter, minFilter, borderU, borderV, borderW, mipMapMode, mipMapBias, maxLod, minLod, anisotropy);
         }
 
-        UniquePtr<ISampler> getSampler(const String& name, FilterMode magFilter, FilterMode minFilter, BorderMode borderU, BorderMode borderV, BorderMode borderW, MipMapMode mipMapMode, Float mipMapBias, Float maxLod, Float minLod, Float anisotropy) const override {
+        inline UniquePtr<ISampler> getSampler(const String& name, FilterMode magFilter, FilterMode minFilter, BorderMode borderU, BorderMode borderV, BorderMode borderW, MipMapMode mipMapMode, Float mipMapBias, Float maxLod, Float minLod, Float anisotropy) const override {
             return this->createSampler(name, magFilter, minFilter, borderU, borderV, borderW, mipMapMode, mipMapBias, maxLod, minLod, anisotropy);
         }
         
-        Enumerable<UniquePtr<ISampler>> getSamplers(UInt32 elements, FilterMode magFilter, FilterMode minFilter, BorderMode borderU, BorderMode borderV, BorderMode borderW, MipMapMode mipMapMode, Float mipMapBias, Float maxLod, Float minLod, Float anisotropy) const override {
+        inline Enumerable<UniquePtr<ISampler>> getSamplers(UInt32 elements, FilterMode magFilter, FilterMode minFilter, BorderMode borderU, BorderMode borderV, BorderMode borderW, MipMapMode mipMapMode, Float mipMapBias, Float maxLod, Float minLod, Float anisotropy) const override {
             return this->createSamplers(elements, magFilter, minFilter, borderU, borderV, borderW, mipMapMode, mipMapBias, maxLod, minLod, anisotropy) | std::views::as_rvalue;
         }
     };
@@ -1160,23 +1159,25 @@ namespace LiteFX::Rendering {
         virtual const factory_type& factory() const noexcept = 0;
 
         /// <inheritdoc />
-        virtual const command_queue_type& graphicsQueue() const noexcept = 0;
+        virtual const command_queue_type& defaultQueue(QueueType type) const = 0;
 
         /// <inheritdoc />
-        virtual const command_queue_type& transferQueue() const noexcept = 0;
-
-        /// <inheritdoc />
-        virtual const command_queue_type& bufferQueue() const noexcept = 0;
-
-        /// <inheritdoc />
-        virtual const command_queue_type& computeQueue() const noexcept = 0;
+        virtual const command_queue_type* createQueue(QueueType type, QueuePriority priority = QueuePriority::Normal) noexcept = 0;
 
         /// <inheritdoc />
         [[nodiscard]] virtual UniquePtr<barrier_type> makeBarrier(PipelineStage syncBefore, PipelineStage syncAfter) const noexcept = 0;
 
     private:
-        UniquePtr<IBarrier> getNewBarrier(PipelineStage syncBefore, PipelineStage syncAfter) const noexcept override {
+        inline UniquePtr<IBarrier> getNewBarrier(PipelineStage syncBefore, PipelineStage syncAfter) const noexcept override {
             return this->makeBarrier(syncBefore, syncAfter);
+        }
+
+        inline const ICommandQueue& getDefaultQueue(QueueType type) const {
+            return this->defaultQueue(type);
+        }
+
+        inline const ICommandQueue* getNewQueue(QueueType type, QueuePriority priority) noexcept {
+            return this->createQueue(type, priority);
         }
 
 #if defined(BUILD_DEFINE_BUILDERS)
@@ -1311,7 +1312,7 @@ namespace LiteFX::Rendering {
         /// <param name="_args">The arguments that are passed to the graphics device constructor.</param>
         /// <returns>A pointer of the created graphics device instance.</returns>
         template <typename TSelf, typename ...TArgs>
-        device_type* createDevice(this TSelf&& self, String name, const adapter_type& adapter, UniquePtr<surface_type>&& surface, TArgs&&... _args) {
+        inline device_type* createDevice(this TSelf&& self, String name, const adapter_type& adapter, UniquePtr<surface_type>&& surface, TArgs&&... _args) {
             auto device = makeUnique<device_type>(self, adapter, std::move(surface), std::forward<TArgs>(_args)...);
             auto devicePointer = device.get();
             self.registerDevice(name, std::move(device));
@@ -1331,18 +1332,18 @@ namespace LiteFX::Rendering {
         virtual const device_type* device(const String& name) const noexcept = 0;
 
         /// <inheritdoc />
-        virtual const device_type* operator[](const String& name) const noexcept {
+        inline virtual const device_type* operator[](const String& name) const noexcept {
             return this->device(name);
         };
 
         /// <inheritdoc />
-        virtual device_type* operator[](const String& name) noexcept {
+        inline virtual device_type* operator[](const String& name) noexcept {
             return this->device(name);
         };
 
         // IRenderBackend interface
     private:
-        Enumerable<const IGraphicsAdapter*> getAdapters() const override {
+        inline Enumerable<const IGraphicsAdapter*> getAdapters() const override {
             return this->listAdapters();
         }
     };

--- a/src/Rendering/include/litefx/rendering_api.hpp
+++ b/src/Rendering/include/litefx/rendering_api.hpp
@@ -4339,6 +4339,12 @@ namespace LiteFX::Rendering {
         virtual void setStencilRef(UInt32 stencilRef) const noexcept = 0;
 
         /// <summary>
+        /// Submits the command buffer to parent command
+        /// </summary>
+        /// <exception cref="RuntimeException">Thrown, if the command buffer is a secondary command buffer.</exception>
+        virtual UInt64 submit() const = 0;
+
+        /// <summary>
         /// Writes the current GPU time stamp value for the timing event.
         /// </summary>
         /// <param name="timingEvent">The timing event for which the time stamp is written.</param>

--- a/src/Rendering/include/litefx/rendering_api.hpp
+++ b/src/Rendering/include/litefx/rendering_api.hpp
@@ -4959,7 +4959,7 @@ namespace LiteFX::Rendering {
         /// </remarks>
         /// <param name="label">The name of the debug region.</param>
         /// <param name="color">The color of the debug region.</param>
-        virtual void BeginDebugRegion(const String& label, const Vectors::ByteVector3& color = { 128_b, 128_b, 128_b }) const noexcept { };
+        virtual void beginDebugRegion(const String& label, const Vectors::ByteVector3& color = { 128_b, 128_b, 128_b }) const noexcept { };
         
         /// <summary>
         /// Ends the current debug region.
@@ -4967,7 +4967,7 @@ namespace LiteFX::Rendering {
         /// <remarks>
         /// This is a debug helper, that is not required to be implemented. In the built-in backends, it will no-op by default in non-debug builds.
         /// </remarks>
-        virtual void EndDebugRegion() const noexcept { };
+        virtual void endDebugRegion() const noexcept { };
 
         /// <summary>
         /// Inserts a debug marker.
@@ -4977,7 +4977,7 @@ namespace LiteFX::Rendering {
         /// </remarks>
         /// <param name="label">The name of the debug marker.</param>
         /// <param name="color">The color of the debug marker.</param>
-        virtual void SetDebugMarker(const String& label, const Vectors::ByteVector3& color = { 128_b, 128_b, 128_b }) const noexcept { };
+        virtual void setDebugMarker(const String& label, const Vectors::ByteVector3& color = { 128_b, 128_b, 128_b }) const noexcept { };
 
     public:
         /// <summary>

--- a/src/Rendering/include/litefx/rendering_api.hpp
+++ b/src/Rendering/include/litefx/rendering_api.hpp
@@ -4569,6 +4569,15 @@ namespace LiteFX::Rendering {
         virtual const IFrameBuffer& activeFrameBuffer() const = 0;
 
         /// <summary>
+        /// Returns the command queue, the render pass is executing on.
+        /// </summary>
+        /// <returns>A reference of the command queue, the render pass is executing on.</returns>
+        inline const ICommandQueue& commandQueue() const noexcept {
+            // NOTE: This should be a covariant, though?!
+            return this->getCommandQueue();
+        }
+
+        /// <summary>
         /// Returns a list of all frame buffers.
         /// </summary>
         /// <returns>A list of all frame buffers. </returns>
@@ -4680,6 +4689,7 @@ namespace LiteFX::Rendering {
         virtual Enumerable<const IFrameBuffer*> getFrameBuffers() const noexcept = 0;
         virtual Enumerable<const IRenderPipeline*> getPipelines() const noexcept = 0;
         virtual void setAttachments(const IDescriptorSet& descriptorSet) const = 0;
+        virtual const ICommandQueue& getCommandQueue() const noexcept = 0;
     };
 
     /// <summary>

--- a/src/Rendering/include/litefx/rendering_api.hpp
+++ b/src/Rendering/include/litefx/rendering_api.hpp
@@ -103,7 +103,7 @@ namespace LiteFX::Rendering {
     /// graphics queue, you do not need to synchronize in order to wait for the result, however this also means that no rendering can take place until the workloads have
     /// finished.
     /// </remarks>
-    enum class LITEFX_RENDERING_API QueueType {
+    enum class LITEFX_RENDERING_API QueueType : UInt32 {
         /// <summary>
         /// Describes an unspecified command queue. It is not valid to create a queue instance with this type.
         /// </summary>
@@ -123,6 +123,22 @@ namespace LiteFX::Rendering {
         /// Represents a queue that can execute only transfer workloads.
         /// </summary>
         Transfer = 0x00000004,
+
+        /// <summary>
+        /// Represents a queue that can perform hardware video decoding.
+        /// </summary>
+        /// <remarks>
+        /// Video encoding/decoding is currently not a supported feature, but knowing all the capabilities of a queue is useful to select the best queue family for a particular task.
+        /// </remarks>
+        VideoDecode = 0x00000010,
+
+        /// <summary>
+        /// Represents a queue that can perform hardware video encoding.
+        /// </summary>
+        /// <remarks>
+        /// Video encoding/decoding is currently a supported feature, but knowing all the capabilities of a queue is useful to select the best queue family for a particular task.
+        /// </remarks>
+        VideoEncode = 0x00000020,
 
         /// <summary>
         /// Represents an invalid queue type.
@@ -147,6 +163,9 @@ namespace LiteFX::Rendering {
         /// <summary>
         /// The highest possible queue priority. Submitting work to this queue might block other queues.
         /// </summary>
+        /// <remarks>
+        /// Do not use this queue priority when creating queues, as it is reserved for the default (builtin) queues.
+        /// </remarks>
         Realtime = 100
     };
 

--- a/src/Rendering/include/litefx/rendering_api.hpp
+++ b/src/Rendering/include/litefx/rendering_api.hpp
@@ -2527,7 +2527,7 @@ namespace LiteFX::Rendering {
         /// Returns a pointer with shared ownership to the current instance.
         /// </summary>
         /// <returns>A pointer with shared ownership to the current instance.</returns>
-        std::shared_ptr<TimingEvent> getptr() {
+        inline std::shared_ptr<TimingEvent> getptr() {
             return shared_from_this();
         }
 
@@ -3401,7 +3401,7 @@ namespace LiteFX::Rendering {
         /// Returns the layouts of the descriptors within the descriptor set.
         /// </summary>
         /// <returns>The layouts of the descriptors within the descriptor set.</returns>
-        Enumerable<const IDescriptorLayout*> descriptors() const noexcept {
+        inline Enumerable<const IDescriptorLayout*> descriptors() const noexcept {
             return this->getDescriptors();
         }
 
@@ -3498,7 +3498,7 @@ namespace LiteFX::Rendering {
         /// </remarks>
         /// <returns>The instance of the descriptor set.</returns>
         /// <seealso cref="IDescriptorLayout" />
-        UniquePtr<IDescriptorSet> allocate(const Enumerable<DescriptorBinding>& bindings = { }) const {
+        inline UniquePtr<IDescriptorSet> allocate(const Enumerable<DescriptorBinding>& bindings = { }) const {
             return this->allocate(0, bindings);
         }
 
@@ -3509,7 +3509,7 @@ namespace LiteFX::Rendering {
         /// <param name="bindings">Optional default bindings for descriptors in the descriptor set.</param>
         /// <returns>The instance of the descriptor set.</returns>
         /// <seealso cref="IDescriptorLayout" />
-        UniquePtr<IDescriptorSet> allocate(UInt32 descriptors, const Enumerable<DescriptorBinding>& bindings = { }) const {
+        inline UniquePtr<IDescriptorSet> allocate(UInt32 descriptors, const Enumerable<DescriptorBinding>& bindings = { }) const {
             return this->getDescriptorSet(descriptors, bindings);
         }
 
@@ -3520,7 +3520,7 @@ namespace LiteFX::Rendering {
         /// <param name="bindings">Optional default bindings for descriptors in each descriptor set.</param>
         /// <returns>The array of descriptor set instances.</returns>
         /// <seealso cref="allocate" />
-        Enumerable<UniquePtr<IDescriptorSet>> allocateMultiple(UInt32 descriptorSets, const Enumerable<Enumerable<DescriptorBinding>>& bindings = { }) const {
+        inline Enumerable<UniquePtr<IDescriptorSet>> allocateMultiple(UInt32 descriptorSets, const Enumerable<Enumerable<DescriptorBinding>>& bindings = { }) const {
             return this->allocateMultiple(descriptorSets, 0, bindings);
         }
 
@@ -3531,7 +3531,7 @@ namespace LiteFX::Rendering {
         /// <param name="bindingFactory">A factory function that is called for each descriptor set in order to provide the default bindings.</param>
         /// <returns>The array of descriptor set instances.</returns>
         /// <seealso cref="allocate" />
-        Enumerable<UniquePtr<IDescriptorSet>> allocateMultiple(UInt32 descriptorSets, std::function<Enumerable<DescriptorBinding>(UInt32)> bindingFactory) const {
+        inline Enumerable<UniquePtr<IDescriptorSet>> allocateMultiple(UInt32 descriptorSets, std::function<Enumerable<DescriptorBinding>(UInt32)> bindingFactory) const {
             return this->allocateMultiple(descriptorSets, 0, bindingFactory);
         }
 
@@ -3543,7 +3543,7 @@ namespace LiteFX::Rendering {
         /// <param name="bindings">Optional default bindings for descriptors in each descriptor set.</param>
         /// <returns>The array of descriptor set instances.</returns>
         /// <seealso cref="allocate" />
-        Enumerable<UniquePtr<IDescriptorSet>> allocateMultiple(UInt32 descriptorSets, UInt32 descriptors, const Enumerable<Enumerable<DescriptorBinding>>& bindings = { }) const {
+        inline Enumerable<UniquePtr<IDescriptorSet>> allocateMultiple(UInt32 descriptorSets, UInt32 descriptors, const Enumerable<Enumerable<DescriptorBinding>>& bindings = { }) const {
             return this->getDescriptorSets(descriptorSets, descriptors, bindings);
         }
 
@@ -3555,7 +3555,7 @@ namespace LiteFX::Rendering {
         /// <param name="bindingFactory">A factory function that is called for each descriptor set in order to provide the default bindings.</param>
         /// <returns>The array of descriptor set instances.</returns>
         /// <seealso cref="allocate" />
-        Enumerable<UniquePtr<IDescriptorSet>> allocateMultiple(UInt32 descriptorSets, UInt32 descriptors, std::function<Enumerable<DescriptorBinding>(UInt32)> bindingFactory) const {
+        inline Enumerable<UniquePtr<IDescriptorSet>> allocateMultiple(UInt32 descriptorSets, UInt32 descriptors, std::function<Enumerable<DescriptorBinding>(UInt32)> bindingFactory) const {
             return this->getDescriptorSets(descriptorSets, descriptors, bindingFactory);
         }
 
@@ -3563,7 +3563,7 @@ namespace LiteFX::Rendering {
         /// Marks a descriptor set as unused, so that it can be handed out again instead of allocating a new one.
         /// </summary>
         /// <seealso cref="allocate" />
-        void free(const IDescriptorSet& descriptorSet) const noexcept {
+        inline void free(const IDescriptorSet& descriptorSet) const noexcept {
             this->releaseDescriptorSet(descriptorSet);
         }
 
@@ -3645,7 +3645,7 @@ namespace LiteFX::Rendering {
         /// </summary>
         /// <returns>All push constant ranges.</returns>
         /// <seealso cref="range" />
-        Enumerable<const IPushConstantsRange*> ranges() const noexcept {
+        inline Enumerable<const IPushConstantsRange*> ranges() const noexcept {
             return this->getRanges();
         }
 
@@ -3666,7 +3666,7 @@ namespace LiteFX::Rendering {
         /// Returns the modules, the shader program is build from.
         /// </summary>
         /// <returns>The modules, the shader program is build from.</returns>
-        Enumerable<const IShaderModule*> modules() const noexcept {
+        inline Enumerable<const IShaderModule*> modules() const noexcept {
             return this->getModules();
         }
 
@@ -3694,7 +3694,7 @@ namespace LiteFX::Rendering {
         /// </remarks>
         /// <returns>The pipeline layout extracted from shader reflection.</returns>
         /// <seealso href="https://github.com/crud89/LiteFX/wiki/Shader-Development" />
-        SharedPtr<IPipelineLayout> reflectPipelineLayout() const {
+        inline SharedPtr<IPipelineLayout> reflectPipelineLayout() const {
             return this->parsePipelineLayout();
         };
 
@@ -3722,7 +3722,7 @@ namespace LiteFX::Rendering {
         /// Returns all descriptor set layouts, the pipeline has been initialized with.
         /// </summary>
         /// <returns>All descriptor set layouts, the pipeline has been initialized with.</returns>
-        Enumerable<const IDescriptorSetLayout*> descriptorSets() const noexcept {
+        inline Enumerable<const IDescriptorSetLayout*> descriptorSets() const noexcept {
             return this->getDescriptorSets();
         }
 
@@ -3778,7 +3778,7 @@ namespace LiteFX::Rendering {
         /// Returns all vertex buffer layouts of the input assembly.
         /// </summary>
         /// <returns>All vertex buffer layouts of the input assembly.</returns>
-        Enumerable<const IVertexBufferLayout*> vertexBufferLayouts() const noexcept {
+        inline Enumerable<const IVertexBufferLayout*> vertexBufferLayouts() const noexcept {
             return this->getVertexBufferLayouts();
         }
 
@@ -3817,7 +3817,7 @@ namespace LiteFX::Rendering {
         /// Returns the shader program used by the pipeline.
         /// </summary>
         /// <returns>The shader program used by the pipeline.</returns>
-        SharedPtr<const IShaderProgram> program() const noexcept {
+        inline SharedPtr<const IShaderProgram> program() const noexcept {
             return this->getProgram();
         }
 
@@ -3825,7 +3825,7 @@ namespace LiteFX::Rendering {
         /// Returns the layout of the render pipeline.
         /// </summary>
         /// <returns>The layout of the render pipeline.</returns>
-        SharedPtr<const IPipelineLayout> layout() const noexcept {
+        inline SharedPtr<const IPipelineLayout> layout() const noexcept {
             return this->getLayout();
         }
 
@@ -3880,7 +3880,7 @@ namespace LiteFX::Rendering {
         /// order. You might have to manually synchronize barrier execution.
         /// </remarks>
         /// <param name="barrier">The barrier containing the transitions to perform.</param>
-        void barrier(const IBarrier& barrier) const noexcept {
+        inline void barrier(const IBarrier& barrier) const noexcept {
             this->cmdBarrier(barrier);
         }
 
@@ -3897,7 +3897,7 @@ namespace LiteFX::Rendering {
         /// Note that generating mip maps might require the texture to be writable. You can transfer the texture into a non-writable resource afterwards to improve performance.
         /// </remarks>
         /// <param name="commandBuffer">The command buffer used to issue the transition and transfer operations.</param>
-        void generateMipMaps(IImage& image) noexcept {
+        inline void generateMipMaps(IImage& image) noexcept {
             this->cmdGenerateMipMaps(image);
         }
 
@@ -3915,7 +3915,7 @@ namespace LiteFX::Rendering {
         /// <param name="elements">The number of elements to copy from the source buffer into the target buffer.</param>
         /// <exception cref="ArgumentOutOfRangeException">Thrown, if the number of either the source buffer or the target buffer has not enough elements for the specified <paramref name="elements" /> parameter.</exception>
         /// <seealso cref="IBarrier" />
-        void transfer(IBuffer& source, IBuffer& target, UInt32 sourceElement = 0, UInt32 targetElement = 0, UInt32 elements = 1) const {
+        inline void transfer(IBuffer& source, IBuffer& target, UInt32 sourceElement = 0, UInt32 targetElement = 0, UInt32 elements = 1) const {
             this->cmdTransfer(source, target, sourceElement, targetElement, elements);
         }
         
@@ -3939,7 +3939,7 @@ namespace LiteFX::Rendering {
         /// <param name="targetElement">The index of the first element in the target buffer to copy to.</param>
         /// <param name="elements">The number of elements to copy from the source buffer into the target buffer.</param>
         /// <exception cref="ArgumentOutOfRangeException">Thrown, if the number of either the source buffer or the target buffer has not enough elements for the specified <paramref name="elements" /> parameter.</exception>
-        void transfer(SharedPtr<IBuffer> source, IBuffer& target, UInt32 sourceElement = 0, UInt32 targetElement = 0, UInt32 elements = 1) const {
+        inline void transfer(SharedPtr<IBuffer> source, IBuffer& target, UInt32 sourceElement = 0, UInt32 targetElement = 0, UInt32 elements = 1) const {
             this->cmdTransfer(source, target, sourceElement, targetElement, elements);
         }
 
@@ -3978,7 +3978,7 @@ namespace LiteFX::Rendering {
         /// <param name="firstSubresource">The index of the first sub-resource of the target image to receive data.</param>
         /// <param name="elements">The number of elements to copy from the source buffer into the target image sub-resources.</param>
         /// <exception cref="ArgumentOutOfRangeException">Thrown, if the number of either the source buffer or the target buffer has not enough elements for the specified <paramref name="elements" /> parameter.</exception>
-        void transfer(IBuffer& source, IImage& target, UInt32 sourceElement = 0, UInt32 firstSubresource = 0, UInt32 elements = 1) const {
+        inline void transfer(IBuffer& source, IImage& target, UInt32 sourceElement = 0, UInt32 firstSubresource = 0, UInt32 elements = 1) const {
             this->cmdTransfer(source, target, sourceElement, firstSubresource, elements);
         }
 
@@ -4024,7 +4024,7 @@ namespace LiteFX::Rendering {
         /// <param name="firstSubresource">The index of the first sub-resource of the target image to receive data.</param>
         /// <param name="elements">The number of elements to copy from the source buffer into the target image sub-resources.</param>
         /// <exception cref="ArgumentOutOfRangeException">Thrown, if the number of either the source buffer or the target buffer has not enough elements for the specified <paramref name="elements" /> parameter.</exception>
-        void transfer(SharedPtr<IBuffer> source, IImage& target, UInt32 sourceElement = 0, UInt32 firstSubresource = 0, UInt32 elements = 1) const {
+        inline void transfer(SharedPtr<IBuffer> source, IImage& target, UInt32 sourceElement = 0, UInt32 firstSubresource = 0, UInt32 elements = 1) const {
             this->cmdTransfer(source, target, sourceElement, firstSubresource, elements);
         }
 
@@ -4041,7 +4041,7 @@ namespace LiteFX::Rendering {
         /// <param name="targetSubresource">The image of the first sub-resource in the target image to receive data.</param>
         /// <param name="subresources">The number of sub-resources to copy between the images.</param>
         /// <exception cref="ArgumentOutOfRangeException">Thrown, if the number of either the source buffer or the target buffer has not enough elements for the specified <paramref name="elements" /> parameter.</exception>
-        void transfer(IImage& source, IImage& target, UInt32 sourceSubresource = 0, UInt32 targetSubresource = 0, UInt32 subresources = 1) const {
+        inline void transfer(IImage& source, IImage& target, UInt32 sourceSubresource = 0, UInt32 targetSubresource = 0, UInt32 subresources = 1) const {
             this->cmdTransfer(source, target, sourceSubresource, targetSubresource, subresources);
         }
 
@@ -4065,7 +4065,7 @@ namespace LiteFX::Rendering {
         /// <param name="targetSubresource">The image of the first sub-resource in the target image to receive data.</param>
         /// <param name="subresources">The number of sub-resources to copy between the images.</param>
         /// <exception cref="ArgumentOutOfRangeException">Thrown, if the number of either the source buffer or the target buffer has not enough elements for the specified <paramref name="elements" /> parameter.</exception>
-        void transfer(SharedPtr<IImage> source, IImage& target, UInt32 sourceSubresource = 0, UInt32 targetSubresource = 0, UInt32 subresources = 1) const {
+        inline void transfer(SharedPtr<IImage> source, IImage& target, UInt32 sourceSubresource = 0, UInt32 targetSubresource = 0, UInt32 subresources = 1) const {
             this->cmdTransfer(source, target, sourceSubresource, targetSubresource, subresources);
         }
 
@@ -4104,7 +4104,7 @@ namespace LiteFX::Rendering {
         /// <param name="targetElement">The index of the first target element to receive data.</param>
         /// <param name="subresources">The number of sub-resources to copy.</param>
         /// <exception cref="ArgumentOutOfRangeException">Thrown, if the number of either the source buffer or the target buffer has not enough elements for the specified <paramref name="elements" /> parameter.</exception>
-        void transfer(IImage& source, IBuffer& target, UInt32 firstSubresource = 0, UInt32 targetElement = 0, UInt32 subresources = 1) const {
+        inline void transfer(IImage& source, IBuffer& target, UInt32 firstSubresource = 0, UInt32 targetElement = 0, UInt32 subresources = 1) const {
             this->cmdTransfer(source, target, firstSubresource, targetElement, subresources);
         }
 
@@ -4150,14 +4150,14 @@ namespace LiteFX::Rendering {
         /// <param name="targetElement">The index of the first target element to receive data.</param>
         /// <param name="subresources">The number of sub-resources to copy.</param>
         /// <exception cref="ArgumentOutOfRangeException">Thrown, if the number of either the source buffer or the target buffer has not enough elements for the specified <paramref name="elements" /> parameter.</exception>
-        void transfer(SharedPtr<IImage> source, IBuffer& target, UInt32 firstSubresource = 0, UInt32 targetElement = 0, UInt32 subresources = 1) const {
+        inline void transfer(SharedPtr<IImage> source, IBuffer& target, UInt32 firstSubresource = 0, UInt32 targetElement = 0, UInt32 subresources = 1) const {
             this->cmdTransfer(source, target, firstSubresource, targetElement, subresources);
         }
 
         /// <summary>
         /// Sets the active pipeline state.
         /// </summary>
-        void use(const IPipeline& pipeline) const noexcept {
+        inline void use(const IPipeline& pipeline) const noexcept {
             this->cmdUse(pipeline);
         }
 
@@ -4169,7 +4169,7 @@ namespace LiteFX::Rendering {
         /// </summary>
         /// <param name="descriptorSet">The descriptor set to bind.</param>
         /// <param name="pipeline">The pipeline to bind the descriptor set to.</param>
-        void bind(const IDescriptorSet& descriptorSet, const IPipeline& pipeline) const noexcept {
+        inline void bind(const IDescriptorSet& descriptorSet, const IPipeline& pipeline) const noexcept {
             this->cmdBind(descriptorSet, pipeline);
         }
 
@@ -4183,7 +4183,7 @@ namespace LiteFX::Rendering {
         /// <seealso cref="VertexBuffer" />
         /// <seealso cref="draw" />
         /// <seealso cref="drawIndexed" />
-        void bind(const IVertexBuffer& buffer) const noexcept {
+        inline void bind(const IVertexBuffer& buffer) const noexcept {
             this->cmdBind(buffer);
         }
 
@@ -4196,7 +4196,7 @@ namespace LiteFX::Rendering {
         /// <param name="buffer">The index buffer to bind to the pipeline.</param>
         /// <seealso cref="IndexBuffer" />
         /// <seealso cref="drawIndexed" />
-        void bind(const IIndexBuffer& buffer) const noexcept {
+        inline void bind(const IIndexBuffer& buffer) const noexcept {
             this->cmdBind(buffer);
         }
 
@@ -4230,7 +4230,7 @@ namespace LiteFX::Rendering {
         /// </summary>
         /// <param name="layout">The layout of the push constants to update.</param>
         /// <param name="memory">A pointer to the source memory.</param>
-        void pushConstants(const IPushConstantsLayout& layout, const void* const memory) const noexcept {
+        inline void pushConstants(const IPushConstantsLayout& layout, const void* const memory) const noexcept {
             this->cmdPushConstants(layout, memory);
         }
 
@@ -4244,7 +4244,7 @@ namespace LiteFX::Rendering {
         /// <param name="instances">The number of instances to draw.</param>
         /// <param name="firstVertex">The index of the first vertex to start drawing from.</param>
         /// <param name="firstInstance">The index of the first instance to draw.</param>
-        void draw(const IVertexBuffer& vertexBuffer, UInt32 instances = 1, UInt32 firstVertex = 0, UInt32 firstInstance = 0) const {
+        inline void draw(const IVertexBuffer& vertexBuffer, UInt32 instances = 1, UInt32 firstVertex = 0, UInt32 firstInstance = 0) const {
             this->cmdDraw(vertexBuffer, instances, firstVertex, firstInstance);
         }
 
@@ -4259,7 +4259,7 @@ namespace LiteFX::Rendering {
         /// <param name="firstIndex">The index of the first element of the index buffer to start drawing from.</param>
         /// <param name="vertexOffset">The offset added to each index to find the corresponding vertex.</param>
         /// <param name="firstInstance">The index of the first instance to draw.</param>
-        void drawIndexed(const IIndexBuffer& indexBuffer, UInt32 instances = 1, UInt32 firstIndex = 0, Int32 vertexOffset = 0, UInt32 firstInstance = 0) const {
+        inline void drawIndexed(const IIndexBuffer& indexBuffer, UInt32 instances = 1, UInt32 firstIndex = 0, Int32 vertexOffset = 0, UInt32 firstInstance = 0) const {
             this->cmdDrawIndexed(indexBuffer, instances, firstIndex, vertexOffset, firstInstance);
         }
 
@@ -4275,7 +4275,7 @@ namespace LiteFX::Rendering {
         /// <param name="firstIndex">The index of the first element of the index buffer to start drawing from.</param>
         /// <param name="vertexOffset">The offset added to each index to find the corresponding vertex.</param>
         /// <param name="firstInstance">The index of the first instance to draw.</param>
-        void drawIndexed(const IVertexBuffer& vertexBuffer, const IIndexBuffer& indexBuffer, UInt32 instances = 1, UInt32 firstIndex = 0, Int32 vertexOffset = 0, UInt32 firstInstance = 0) const {
+        inline void drawIndexed(const IVertexBuffer& vertexBuffer, const IIndexBuffer& indexBuffer, UInt32 instances = 1, UInt32 firstIndex = 0, Int32 vertexOffset = 0, UInt32 firstInstance = 0) const {
             this->cmdDrawIndexed(vertexBuffer, indexBuffer, instances, firstIndex, vertexOffset, firstInstance);
         }
 
@@ -4329,7 +4329,7 @@ namespace LiteFX::Rendering {
         /// Executes a secondary command buffer/bundle.
         /// </summary>
         /// <param name="commandBuffer">The secondary command buffer/bundle to execute.</param>
-        void execute(SharedPtr<const ICommandBuffer> commandBuffer) const {
+        inline void execute(SharedPtr<const ICommandBuffer> commandBuffer) const {
             this->cmdExecute(commandBuffer);
         }
 
@@ -4337,7 +4337,7 @@ namespace LiteFX::Rendering {
         /// Executes a series of secondary command buffers/bundles.
         /// </summary>
         /// <param name="commandBuffers">The command buffers to execute.</param>
-        void execute(Enumerable<SharedPtr<const ICommandBuffer>> commandBuffers) const {
+        inline void execute(Enumerable<SharedPtr<const ICommandBuffer>> commandBuffers) const {
             this->cmdExecute(commandBuffers);
         }
 
@@ -4381,7 +4381,7 @@ namespace LiteFX::Rendering {
         /// Returns the input assembler state used by the render pipeline.
         /// </summary>
         /// <returns>The input assembler state used by the render pipeline.</returns>
-        SharedPtr<IInputAssembler> inputAssembler() const noexcept {
+        inline SharedPtr<IInputAssembler> inputAssembler() const noexcept {
             return this->getInputAssembler();
         }
 
@@ -4389,7 +4389,7 @@ namespace LiteFX::Rendering {
         /// Returns the rasterizer state used by the render pipeline.
         /// </summary>
         /// <returns>The rasterizer state used by the render pipeline.</returns>
-        SharedPtr<IRasterizer> rasterizer() const noexcept {
+        inline SharedPtr<IRasterizer> rasterizer() const noexcept {
             return this->getRasterizer();
         }
 
@@ -4471,7 +4471,7 @@ namespace LiteFX::Rendering {
         /// </summary>
         /// <returns>All command buffers, the frame buffer stores.</returns>
         /// <seealso cref="commandBuffer" />
-        Enumerable<SharedPtr<const ICommandBuffer>> commandBuffers() const noexcept {
+        inline Enumerable<SharedPtr<const ICommandBuffer>> commandBuffers() const noexcept {
             return this->getCommandBuffers();
         }
 
@@ -4482,7 +4482,7 @@ namespace LiteFX::Rendering {
         /// <returns>A command buffer that records draw commands for the frame buffer</returns>
         /// <exception cref="ArgumentOutOfRangeException">Thrown, if the frame buffer does not store a command buffer at <paramref name="index" />.</exception>
         /// <seealso cref="commandBuffers" />
-        SharedPtr<const ICommandBuffer> commandBuffer(UInt32 index) const {
+        inline SharedPtr<const ICommandBuffer> commandBuffer(UInt32 index) const {
             return this->getCommandBuffer(index);
         }
 
@@ -4490,7 +4490,7 @@ namespace LiteFX::Rendering {
         /// Returns the images that store the output attachments for the render targets of the <see cref="RenderPass" />.
         /// </summary>
         /// <returns>The images that store the output attachments for the render targets of the <see cref="RenderPass" />.</returns>
-        Enumerable<const IImage*> images() const noexcept {
+        inline Enumerable<const IImage*> images() const noexcept {
             return this->getImages();
         }
 
@@ -4548,7 +4548,7 @@ namespace LiteFX::Rendering {
             /// Gets the index of the next back-buffer used in the render pass.
             /// </summary>
             /// <returns>The index of the next back-buffer used in the render pass.</returns>
-            UInt32 backBuffer() const noexcept {
+            inline UInt32 backBuffer() const noexcept {
                 return m_backBuffer;
             }
         };
@@ -4572,7 +4572,7 @@ namespace LiteFX::Rendering {
         /// Returns a list of all frame buffers.
         /// </summary>
         /// <returns>A list of all frame buffers. </returns>
-        Enumerable<const IFrameBuffer*> frameBuffers() const noexcept {
+        inline Enumerable<const IFrameBuffer*> frameBuffers() const noexcept {
             return this->getFrameBuffers();
         }
 
@@ -4581,7 +4581,7 @@ namespace LiteFX::Rendering {
         /// </summary>
         /// <returns>An array of all render pipelines, owned by the render pass.</returns>
         /// <seealso cref="IRenderPipeline" />
-        Enumerable<const IRenderPipeline*> pipelines() const noexcept {
+        inline Enumerable<const IRenderPipeline*> pipelines() const noexcept {
             return this->getPipelines();
         }
 
@@ -4672,7 +4672,7 @@ namespace LiteFX::Rendering {
         /// Resolves the input attachments mapped to the render pass and updates them on the descriptor set provided with <see cref="descriptorSet" />.
         /// </summary>
         /// <param name="descriptorSet">The descriptor set to update the input attachments on.</param>
-        void updateAttachments(const IDescriptorSet& descriptorSet) const {
+        inline void updateAttachments(const IDescriptorSet& descriptorSet) const {
             this->setAttachments(descriptorSet);
         }
 
@@ -4712,7 +4712,7 @@ namespace LiteFX::Rendering {
             /// Gets the new surface format of the swap chain back-buffers.
             /// </summary>
             /// <returns>The new surface format of the swap chain back-buffers.</returns>
-            Format surfaceFormat() const noexcept {
+            inline Format surfaceFormat() const noexcept {
                 return m_surfaceFormat;
             }
 
@@ -4720,7 +4720,7 @@ namespace LiteFX::Rendering {
             /// Gets the new render area of the swap chain back-buffers.
             /// </summary>
             /// <returns>The size of the new render area of the swap chain back-buffers.</returns>
-            const Size2d& renderArea() const noexcept {
+            inline const Size2d& renderArea() const noexcept {
                 return m_renderArea;
             }
 
@@ -4728,7 +4728,7 @@ namespace LiteFX::Rendering {
             /// Gets the number of back-buffers in the swap chain.
             /// </summary>
             /// <returns>The number of back-buffers in the swap chain.</returns>
-            UInt32 buffers() const noexcept {
+            inline UInt32 buffers() const noexcept {
                 return m_buffers;
             }
         };
@@ -4746,7 +4746,7 @@ namespace LiteFX::Rendering {
         /// </remarks>
         /// <param name="name">The name of the timing event.</param>
         /// <returns>A pointer with shared ownership to the newly created timing event instance.</returns>
-        [[nodiscard]] std::shared_ptr<TimingEvent> registerTimingEvent(StringView name = "") noexcept {
+        [[nodiscard]] inline std::shared_ptr<TimingEvent> registerTimingEvent(StringView name = "") noexcept {
             auto timingEvent = SharedPtr<TimingEvent>(new TimingEvent(*this, name));
             this->addTimingEvent(timingEvent);
             return timingEvent;
@@ -4815,7 +4815,7 @@ namespace LiteFX::Rendering {
         /// Returns an array of the swap chain present images.
         /// </summary>
         /// <returns>Returns an array of the swap chain present images.</returns>
-        Enumerable<const IImage*> images() const noexcept {
+        inline Enumerable<const IImage*> images() const noexcept {
             return this->getImages();
         };
 
@@ -4901,7 +4901,7 @@ namespace LiteFX::Rendering {
             /// Gets the command buffers that are about to be submitted to the queue.
             /// </summary>
             /// <returns>An array containing the command buffers that are about to be submitted to the queue.</returns>
-            const Enumerable<SharedPtr<const ICommandBuffer>>& commandBuffers() const noexcept {
+            inline const Enumerable<SharedPtr<const ICommandBuffer>>& commandBuffers() const noexcept {
                 return m_commandBuffers;
             }
         };
@@ -4929,7 +4929,7 @@ namespace LiteFX::Rendering {
             /// Gets the fence that is triggered, if the command buffers have been executed.
             /// </summary>
             /// <returns>The fence that is triggered, if the command buffers have been executed.</returns>
-            UInt64 fence() const noexcept {
+            inline UInt64 fence() const noexcept {
                 return m_fence;
             }
         };
@@ -4938,18 +4938,6 @@ namespace LiteFX::Rendering {
         virtual ~ICommandQueue() noexcept = default;
 
     public:
-        /// <summary>
-        /// Returns <c>true</c>, if the command queue is bound on the parent device.
-        /// </summary>
-        /// <remarks>
-        /// Before a command queue can receive commands, it needs to be bound to a device. This ensures, that the queue is actually able to allocate commands. A 
-        /// command queue starts in unbound state until <see cref="bind" /> gets called. Destroying the queue also releases it by calling <see cref="release" />.
-        /// </remarks>
-        /// <seealso cref="bind" />
-        /// <seealso cref="release" />
-        /// <returns><c>true</c>, if the command queue is bound on a device.</returns>
-        virtual bool isBound() const noexcept = 0;
-
         /// <summary>
         /// Returns the priority of the queue.
         /// </summary>
@@ -4993,16 +4981,6 @@ namespace LiteFX::Rendering {
 
     public:
         /// <summary>
-        /// Invoked, when the queue has been bound on the parent device.
-        /// </summary>
-        mutable Event<EventArgs> bound;
-
-        /// <summary>
-        /// Invoked, when the queue is released from the parent device.
-        /// </summary>
-        mutable Event<EventArgs> released;
-
-        /// <summary>
         /// Invoked, when one or more command buffers are submitted to the queue.
         /// </summary>
         mutable Event<QueueSubmittingEventArgs> submitting;
@@ -5011,17 +4989,6 @@ namespace LiteFX::Rendering {
         /// Invoked, after one or more command buffers have been submitted to the queue.
         /// </summary>
         mutable Event<QueueSubmittedEventArgs> submitted;
-
-        /// <summary>
-        /// Binds the queue on the parent device.
-        /// </summary>
-        /// <seealso cref="isBound" />
-        virtual void bind() = 0;
-
-        /// <summary>
-        /// Releases the queue from the parent device.
-        /// </summary>
-        virtual void release() = 0;
 
         /// <summary>
         /// Creates a command buffer that can be used to allocate commands on the queue.
@@ -5036,7 +5003,7 @@ namespace LiteFX::Rendering {
         /// <param name="beginRecording">If set to <c>true</c>, the command buffer will be initialized in recording state and can receive commands straight away.</param>
         /// <param name="secondary">If set to `true`, the method will create a secondary command buffer/bundle.</param>
         /// <returns>The instance of the command buffer.</returns>
-        SharedPtr<ICommandBuffer> createCommandBuffer(bool beginRecording = false, bool secondary = false) const {
+        inline SharedPtr<ICommandBuffer> createCommandBuffer(bool beginRecording = false, bool secondary = false) const {
             return this->getCommandBuffer(beginRecording, secondary);
         }
 
@@ -5052,7 +5019,7 @@ namespace LiteFX::Rendering {
         /// <param name="commandBuffer">The command buffer to submit to the command queue.</param>
         /// <returns>The value of the fence, inserted after the command buffer.</returns>
         /// <seealso cref="waitFor" />
-        UInt64 submit(SharedPtr<const ICommandBuffer> commandBuffer) const {
+        inline UInt64 submit(SharedPtr<const ICommandBuffer> commandBuffer) const {
             return this->submitCommandBuffer(commandBuffer);
         }
 
@@ -5068,7 +5035,7 @@ namespace LiteFX::Rendering {
         /// <param name="commandBuffer">The command buffer to submit to the command queue.</param>
         /// <returns>The value of the fence, inserted after the command buffer.</returns>
         /// <seealso cref="waitFor" />
-        UInt64 submit(SharedPtr<ICommandBuffer> commandBuffer) const {
+        inline UInt64 submit(SharedPtr<ICommandBuffer> commandBuffer) const {
             return this->submitCommandBuffer(commandBuffer);
         }
 
@@ -5084,7 +5051,7 @@ namespace LiteFX::Rendering {
         /// <param name="commandBuffers">The command buffers to submit to the command queue.</param>
         /// <returns>The value of the fence, inserted after the command buffers.</returns>
         /// <seealso cref="waitFor" />
-        UInt64 submit(const Enumerable<SharedPtr<const ICommandBuffer>>& commandBuffers) const {
+        inline UInt64 submit(const Enumerable<SharedPtr<const ICommandBuffer>>& commandBuffers) const {
             return this->submitCommandBuffers(commandBuffers);
         }
 
@@ -5100,7 +5067,7 @@ namespace LiteFX::Rendering {
         /// <param name="commandBuffers">The command buffers to submit to the command queue.</param>
         /// <returns>The value of the fence, inserted after the command buffers.</returns>
         /// <seealso cref="waitFor" />
-        UInt64 submit(const Enumerable<SharedPtr<ICommandBuffer>>& commandBuffers) const {
+        inline UInt64 submit(const Enumerable<SharedPtr<ICommandBuffer>>& commandBuffers) const {
             return this->submitCommandBuffers(commandBuffers | std::ranges::to<Enumerable<SharedPtr<const ICommandBuffer>>>());
         }
 
@@ -5134,7 +5101,7 @@ namespace LiteFX::Rendering {
         virtual UInt64 submitCommandBuffers(const Enumerable<SharedPtr<const ICommandBuffer>>& commandBuffers) const = 0;
         
     protected:
-        void releaseSharedState(const ICommandBuffer& commandBuffer) const {
+        inline void releaseSharedState(const ICommandBuffer& commandBuffer) const {
             commandBuffer.releaseSharedState();
         }
     };
@@ -5156,7 +5123,7 @@ namespace LiteFX::Rendering {
         /// <param name="elements">The number of elements in the buffer (in case the buffer is an array).</param>
         /// <param name="allowWrite">Allows the resource to be bound to a read/write descriptor.</param>
         /// <returns>The instance of the buffer.</returns>
-        UniquePtr<IBuffer> createBuffer(BufferType type, BufferUsage usage, size_t elementSize, UInt32 elements = 1, bool allowWrite = false) const {
+        inline UniquePtr<IBuffer> createBuffer(BufferType type, BufferUsage usage, size_t elementSize, UInt32 elements = 1, bool allowWrite = false) const {
             return this->getBuffer(type, usage, elementSize, elements, allowWrite);
         };
 
@@ -5169,7 +5136,7 @@ namespace LiteFX::Rendering {
         /// <param name="elements">The number of elements in the buffer (in case the buffer is an array).</param>
         /// <param name="allowWrite">Allows the resource to be bound to a read/write descriptor.</param>
         /// <returns>The instance of the buffer.</returns>
-        UniquePtr<IBuffer> createBuffer(const IDescriptorSetLayout& descriptorSet, UInt32 binding, BufferUsage usage, UInt32 elements = 1, bool allowWrite = false) const {
+        inline UniquePtr<IBuffer> createBuffer(const IDescriptorSetLayout& descriptorSet, UInt32 binding, BufferUsage usage, UInt32 elements = 1, bool allowWrite = false) const {
             auto& descriptor = descriptorSet.descriptor(binding);
             return this->createBuffer(descriptor.type(), usage, descriptor.elementSize(), elements, allowWrite);
         };
@@ -5183,7 +5150,7 @@ namespace LiteFX::Rendering {
         /// <param name="elements">The number of elements in the buffer (in case the buffer is an array).</param>
         /// <param name="allowWrite">Allows the resource to be bound to a read/write descriptor.</param>
         /// <returns>The instance of the buffer.</returns>
-        UniquePtr<IBuffer> createBuffer(const IDescriptorSetLayout& descriptorSet, UInt32 binding, BufferUsage usage, UInt32 elementSize, UInt32 elements, bool allowWrite = false) const {
+        inline UniquePtr<IBuffer> createBuffer(const IDescriptorSetLayout& descriptorSet, UInt32 binding, BufferUsage usage, UInt32 elementSize, UInt32 elements, bool allowWrite = false) const {
             auto& descriptor = descriptorSet.descriptor(binding);
             return this->createBuffer(descriptor.type(), usage, elementSize, elements, allowWrite);
         };
@@ -5198,7 +5165,7 @@ namespace LiteFX::Rendering {
         /// <param name="elements">The number of elements in the buffer (in case the buffer is an array).</param>
         /// <param name="allowWrite">Allows the resource to be bound to a read/write descriptor.</param>
         /// <returns>The instance of the buffer.</returns>
-        UniquePtr<IBuffer> createBuffer(const IPipeline& pipeline, UInt32 space, UInt32 binding, BufferUsage usage, UInt32 elementSize, UInt32 elements, bool allowWrite = false) const {
+        inline UniquePtr<IBuffer> createBuffer(const IPipeline& pipeline, UInt32 space, UInt32 binding, BufferUsage usage, UInt32 elementSize, UInt32 elements, bool allowWrite = false) const {
             return this->createBuffer(pipeline.layout()->descriptorSet(space), binding, usage, elementSize, elements, allowWrite);
         };
 
@@ -5212,7 +5179,7 @@ namespace LiteFX::Rendering {
         /// <param name="elements">The number of elements in the buffer (in case the buffer is an array).</param>
         /// <param name="allowWrite">Allows the resource to be bound to a read/write descriptor.</param>
         /// <returns>The instance of the buffer.</returns>
-        UniquePtr<IBuffer> createBuffer(const IPipeline& pipeline, UInt32 space, UInt32 binding, BufferUsage usage, UInt32 elements = 1, bool allowWrite = false) const {
+        inline UniquePtr<IBuffer> createBuffer(const IPipeline& pipeline, UInt32 space, UInt32 binding, BufferUsage usage, UInt32 elements = 1, bool allowWrite = false) const {
             return this->createBuffer(pipeline.layout()->descriptorSet(space), binding, usage, elements, allowWrite);
         };
 
@@ -5226,7 +5193,7 @@ namespace LiteFX::Rendering {
         /// <param name="elements">The number of elements in the buffer (in case the buffer is an array).</param>
         /// <param name="allowWrite">Allows the resource to be bound to a read/write descriptor.</param>
         /// <returns>The instance of the buffer.</returns>
-        UniquePtr<IBuffer> createBuffer(const String& name, BufferType type, BufferUsage usage, size_t elementSize, UInt32 elements, bool allowWrite = false) const {
+        inline UniquePtr<IBuffer> createBuffer(const String& name, BufferType type, BufferUsage usage, size_t elementSize, UInt32 elements, bool allowWrite = false) const {
             return this->getBuffer(name, type, usage, elementSize, elements, allowWrite);
         };
 
@@ -5240,7 +5207,7 @@ namespace LiteFX::Rendering {
         /// <param name="elements">The number of elements in the buffer (in case the buffer is an array).</param>
         /// <param name="allowWrite">Allows the resource to be bound to a read/write descriptor.</param>
         /// <returns>The instance of the buffer.</returns>
-        UniquePtr<IBuffer> createBuffer(const String& name, const IDescriptorSetLayout& descriptorSet, UInt32 binding, BufferUsage usage, UInt32 elements = 1, bool allowWrite = false) const {
+        inline UniquePtr<IBuffer> createBuffer(const String& name, const IDescriptorSetLayout& descriptorSet, UInt32 binding, BufferUsage usage, UInt32 elements = 1, bool allowWrite = false) const {
             auto& descriptor = descriptorSet.descriptor(binding);
             return this->createBuffer(name, descriptor.type(), usage, descriptor.elementSize(), elements, allowWrite);
         };
@@ -5256,7 +5223,7 @@ namespace LiteFX::Rendering {
         /// <param name="elements">The number of elements in the buffer (in case the buffer is an array).</param>
         /// <param name="allowWrite">Allows the resource to be bound to a read/write descriptor.</param>
         /// <returns>The instance of the buffer.</returns>
-        UniquePtr<IBuffer> createBuffer(const String& name, const IDescriptorSetLayout& descriptorSet, UInt32 binding, BufferUsage usage, size_t elementSize, UInt32 elements, bool allowWrite = false) const {
+        inline UniquePtr<IBuffer> createBuffer(const String& name, const IDescriptorSetLayout& descriptorSet, UInt32 binding, BufferUsage usage, size_t elementSize, UInt32 elements, bool allowWrite = false) const {
             auto& descriptor = descriptorSet.descriptor(binding);
             return this->createBuffer(name, descriptor.type(), usage, elementSize, elements, allowWrite);
         };
@@ -5272,7 +5239,7 @@ namespace LiteFX::Rendering {
         /// <param name="elements">The number of elements in the buffer (in case the buffer is an array).</param>
         /// <param name="allowWrite">Allows the resource to be bound to a read/write descriptor.</param>
         /// <returns>The instance of the buffer.</returns>
-        UniquePtr<IBuffer> createBuffer(const String& name, const IPipeline& pipeline, UInt32 space, UInt32 binding, BufferUsage usage, UInt32 elements = 1, bool allowWrite = false) const {
+        inline UniquePtr<IBuffer> createBuffer(const String& name, const IPipeline& pipeline, UInt32 space, UInt32 binding, BufferUsage usage, UInt32 elements = 1, bool allowWrite = false) const {
             return this->createBuffer(name, pipeline.layout()->descriptorSet(space), binding, usage, elements, allowWrite);
         };
 
@@ -5288,7 +5255,7 @@ namespace LiteFX::Rendering {
         /// <param name="elements">The number of elements in the buffer (in case the buffer is an array).</param>
         /// <param name="allowWrite">Allows the resource to be bound to a read/write descriptor.</param>
         /// <returns>The instance of the buffer.</returns>
-        UniquePtr<IBuffer> createBuffer(const String& name, const IPipeline& pipeline, UInt32 space, UInt32 binding, BufferUsage usage, size_t elementSize, UInt32 elements = 1, bool allowWrite = false) const {
+        inline UniquePtr<IBuffer> createBuffer(const String& name, const IPipeline& pipeline, UInt32 space, UInt32 binding, BufferUsage usage, size_t elementSize, UInt32 elements = 1, bool allowWrite = false) const {
             return this->createBuffer(name, pipeline.layout()->descriptorSet(space), binding, usage, elementSize, elements, allowWrite);
         };
 
@@ -5304,7 +5271,7 @@ namespace LiteFX::Rendering {
         /// <param name="usage">The buffer usage.</param>
         /// <param name="elements">The number of elements within the vertex buffer (i.e. the number of vertices).</param>
         /// <returns>The instance of the vertex buffer.</returns>
-        UniquePtr<IVertexBuffer> createVertexBuffer(const IVertexBufferLayout& layout, BufferUsage usage, UInt32 elements = 1) const {
+        inline UniquePtr<IVertexBuffer> createVertexBuffer(const IVertexBufferLayout& layout, BufferUsage usage, UInt32 elements = 1) const {
             return this->getVertexBuffer(layout, usage, elements);
         }
 
@@ -5321,7 +5288,7 @@ namespace LiteFX::Rendering {
         /// <param name="usage">The buffer usage.</param>
         /// <param name="elements">The number of elements within the vertex buffer (i.e. the number of vertices).</param>
         /// <returns>The instance of the vertex buffer.</returns>
-        UniquePtr<IVertexBuffer> createVertexBuffer(const String& name, const IVertexBufferLayout& layout, BufferUsage usage, UInt32 elements = 1) const {
+        inline UniquePtr<IVertexBuffer> createVertexBuffer(const String& name, const IVertexBufferLayout& layout, BufferUsage usage, UInt32 elements = 1) const {
             return this->getVertexBuffer(name, layout, usage, elements);
         }
 
@@ -5337,7 +5304,7 @@ namespace LiteFX::Rendering {
         /// <param name="usage">The buffer usage.</param>
         /// <param name="elements">The number of elements within the vertex buffer (i.e. the number of indices).</param>
         /// <returns>The instance of the index buffer.</returns>
-        UniquePtr<IIndexBuffer> createIndexBuffer(const IIndexBufferLayout& layout, BufferUsage usage, UInt32 elements) const {
+        inline UniquePtr<IIndexBuffer> createIndexBuffer(const IIndexBufferLayout& layout, BufferUsage usage, UInt32 elements) const {
             return this->getIndexBuffer(layout, usage, elements);
         }
 
@@ -5354,7 +5321,7 @@ namespace LiteFX::Rendering {
         /// <param name="usage">The buffer usage.</param>
         /// <param name="elements">The number of elements within the vertex buffer (i.e. the number of indices).</param>
         /// <returns>The instance of the index buffer.</returns>
-        UniquePtr<IIndexBuffer> createIndexBuffer(const String& name, const IIndexBufferLayout& layout, BufferUsage usage, UInt32 elements) const {
+        inline UniquePtr<IIndexBuffer> createIndexBuffer(const String& name, const IIndexBufferLayout& layout, BufferUsage usage, UInt32 elements) const {
             return this->getIndexBuffer(name, layout, usage, elements);
         }
 
@@ -5365,7 +5332,7 @@ namespace LiteFX::Rendering {
         /// <param name="size">The extent of the image.</param>
         /// <param name="samples">The number of samples, the image should be sampled with.</param>
         /// <returns>The instance of the attachment image.</returns>
-        UniquePtr<IImage> createAttachment(Format format, const Size2d& size, MultiSamplingLevel samples = MultiSamplingLevel::x1) const {
+        inline UniquePtr<IImage> createAttachment(Format format, const Size2d& size, MultiSamplingLevel samples = MultiSamplingLevel::x1) const {
             return this->getAttachment(format, size, samples);
         }
 
@@ -5377,7 +5344,7 @@ namespace LiteFX::Rendering {
         /// <param name="size">The extent of the image.</param>
         /// <param name="samples">The number of samples, the image should be sampled with.</param>
         /// <returns>The instance of the attachment image.</returns>
-        UniquePtr<IImage> createAttachment(const String& name, Format format, const Size2d& size, MultiSamplingLevel samples = MultiSamplingLevel::x1) const {
+        inline UniquePtr<IImage> createAttachment(const String& name, Format format, const Size2d& size, MultiSamplingLevel samples = MultiSamplingLevel::x1) const {
             return this->getAttachment(name, format, size, samples);
         }
 
@@ -5397,7 +5364,7 @@ namespace LiteFX::Rendering {
         /// <param name="allowWrite">Allows the resource to be bound to a read/write descriptor.</param>
         /// <returns>The instance of the texture.</returns>
         /// <seealso cref="createTextures" />
-        UniquePtr<IImage> createTexture(Format format, const Size3d& size, ImageDimensions dimension = ImageDimensions::DIM_2, UInt32 levels = 1, UInt32 layers = 1, MultiSamplingLevel samples = MultiSamplingLevel::x1, bool allowWrite = false) const {
+        inline UniquePtr<IImage> createTexture(Format format, const Size3d& size, ImageDimensions dimension = ImageDimensions::DIM_2, UInt32 levels = 1, UInt32 layers = 1, MultiSamplingLevel samples = MultiSamplingLevel::x1, bool allowWrite = false) const {
             return this->getTexture(format, size, dimension, levels, layers, samples, allowWrite);
         }
 
@@ -5418,7 +5385,7 @@ namespace LiteFX::Rendering {
         /// <param name="allowWrite">Allows the resource to be bound to a read/write descriptor.</param>
         /// <returns>The instance of the texture.</returns>
         /// <seealso cref="createTextures" />
-        UniquePtr<IImage> createTexture(const String& name, Format format, const Size3d& size, ImageDimensions dimension = ImageDimensions::DIM_2, UInt32 levels = 1, UInt32 layers = 1, MultiSamplingLevel samples = MultiSamplingLevel::x1, bool allowWrite = false) const {
+        inline UniquePtr<IImage> createTexture(const String& name, Format format, const Size3d& size, ImageDimensions dimension = ImageDimensions::DIM_2, UInt32 levels = 1, UInt32 layers = 1, MultiSamplingLevel samples = MultiSamplingLevel::x1, bool allowWrite = false) const {
             return this->getTexture(name, format, size, dimension, levels, layers, samples, allowWrite);
         }
 
@@ -5435,7 +5402,7 @@ namespace LiteFX::Rendering {
         /// <param name="allowWrite">Allows the resource to be bound to a read/write descriptor.</param>
         /// <returns>An array of texture instances.</returns>
         /// <seealso cref="createTexture" />
-        Enumerable<UniquePtr<IImage>> createTextures(UInt32 elements, Format format, const Size3d& size, ImageDimensions dimension = ImageDimensions::DIM_2, UInt32 layers = 1, UInt32 levels = 1, MultiSamplingLevel samples = MultiSamplingLevel::x1, bool allowWrite = false) const {
+        inline Enumerable<UniquePtr<IImage>> createTextures(UInt32 elements, Format format, const Size3d& size, ImageDimensions dimension = ImageDimensions::DIM_2, UInt32 layers = 1, UInt32 levels = 1, MultiSamplingLevel samples = MultiSamplingLevel::x1, bool allowWrite = false) const {
             return this->getTextures(elements, format, size, dimension, layers, levels, samples, allowWrite);
         }
 
@@ -5454,7 +5421,7 @@ namespace LiteFX::Rendering {
         /// <param name="anisotropy">The level of anisotropic filtering.</param>
         /// <returns>The instance of the sampler.</returns>
         /// <seealso cref="createSamplers" />
-        UniquePtr<ISampler> createSampler(FilterMode magFilter = FilterMode::Nearest, FilterMode minFilter = FilterMode::Nearest, BorderMode borderU = BorderMode::Repeat, BorderMode borderV = BorderMode::Repeat, BorderMode borderW = BorderMode::Repeat, MipMapMode mipMapMode = MipMapMode::Nearest, Float mipMapBias = 0.f, Float maxLod = std::numeric_limits<Float>::max(), Float minLod = 0.f, Float anisotropy = 0.f) const {
+        inline UniquePtr<ISampler> createSampler(FilterMode magFilter = FilterMode::Nearest, FilterMode minFilter = FilterMode::Nearest, BorderMode borderU = BorderMode::Repeat, BorderMode borderV = BorderMode::Repeat, BorderMode borderW = BorderMode::Repeat, MipMapMode mipMapMode = MipMapMode::Nearest, Float mipMapBias = 0.f, Float maxLod = std::numeric_limits<Float>::max(), Float minLod = 0.f, Float anisotropy = 0.f) const {
             return this->getSampler(magFilter, minFilter, borderU, borderV, borderW, mipMapMode, mipMapBias, maxLod, minLod, anisotropy);
         }
 
@@ -5474,7 +5441,7 @@ namespace LiteFX::Rendering {
         /// <param name="anisotropy">The level of anisotropic filtering.</param>
         /// <returns>The instance of the sampler.</returns>
         /// <seealso cref="createSamplers" />
-        UniquePtr<ISampler> createSampler(const String& name, FilterMode magFilter = FilterMode::Nearest, FilterMode minFilter = FilterMode::Nearest, BorderMode borderU = BorderMode::Repeat, BorderMode borderV = BorderMode::Repeat, BorderMode borderW = BorderMode::Repeat, MipMapMode mipMapMode = MipMapMode::Nearest, Float mipMapBias = 0.f, Float maxLod = std::numeric_limits<Float>::max(), Float minLod = 0.f, Float anisotropy = 0.f) const {
+        inline UniquePtr<ISampler> createSampler(const String& name, FilterMode magFilter = FilterMode::Nearest, FilterMode minFilter = FilterMode::Nearest, BorderMode borderU = BorderMode::Repeat, BorderMode borderV = BorderMode::Repeat, BorderMode borderW = BorderMode::Repeat, MipMapMode mipMapMode = MipMapMode::Nearest, Float mipMapBias = 0.f, Float maxLod = std::numeric_limits<Float>::max(), Float minLod = 0.f, Float anisotropy = 0.f) const {
             return this->getSampler(name, magFilter, minFilter, borderU, borderV, borderW, mipMapMode, mipMapBias, maxLod, minLod, anisotropy);
         }
 
@@ -5494,7 +5461,7 @@ namespace LiteFX::Rendering {
         /// <param name="anisotropy">The level of anisotropic filtering.</param>
         /// <returns>An array of sampler instances.</returns>
         /// <seealso cref="createSampler" />
-        Enumerable<UniquePtr<ISampler>> createSamplers(UInt32 elements, FilterMode magFilter = FilterMode::Nearest, FilterMode minFilter = FilterMode::Nearest, BorderMode borderU = BorderMode::Repeat, BorderMode borderV = BorderMode::Repeat, BorderMode borderW = BorderMode::Repeat, MipMapMode mipMapMode = MipMapMode::Nearest, Float mipMapBias = 0.f, Float maxLod = std::numeric_limits<Float>::max(), Float minLod = 0.f, Float anisotropy = 0.f) const {
+        inline Enumerable<UniquePtr<ISampler>> createSamplers(UInt32 elements, FilterMode magFilter = FilterMode::Nearest, FilterMode minFilter = FilterMode::Nearest, BorderMode borderU = BorderMode::Repeat, BorderMode borderV = BorderMode::Repeat, BorderMode borderW = BorderMode::Repeat, MipMapMode mipMapMode = MipMapMode::Nearest, Float mipMapBias = 0.f, Float maxLod = std::numeric_limits<Float>::max(), Float minLod = 0.f, Float anisotropy = 0.f) const {
             return this->getSamplers(elements, magFilter, minFilter, borderU, borderV, borderW, mipMapMode, mipMapBias, maxLod, minLod, anisotropy);
         }
 
@@ -5560,45 +5527,48 @@ namespace LiteFX::Rendering {
         virtual const IGraphicsFactory& factory() const noexcept = 0;
 
         /// <summary>
-        /// Returns the instance of the queue, used to process draw calls.
+        /// Returns the instance of the default <see cref="ICommandQueue" /> that supports the combination of queue types specified by the <paramref name="type" /> parameter.
         /// </summary>
+        /// <remarks>
+        /// When the device is created, it attempts to create a queue for each singular queue type. Each GPU is expected to provide at least one queue that is capable of supporting all
+        /// queue types. This queue is used as a fallback queue, if no dedicated queue for a certain type is supported. For example, if no dedicated <see cref="QueueType::Transfer" />
+        /// queue can be created, calling this method for the default transfer queue will return the same queue instance as the default graphics queue, which implicitly always supports
+        /// transfer operations. The same is true for compute queues. This default graphics queue is ensured to support presentation and is also created with the highest queue priority.
+        /// </remarks>
+        /// <param name="type">The type or a combination of types that specifies the operation the queue should support.</param>
+        /// <exception cref="InvalidArgumentException">Thrown, if no default queue for the combination of queue types specified with the <paramref name="type" /> parameter has been created.</exception>
         /// <returns>The instance of the queue, used to process draw calls.</returns>
-        virtual const ICommandQueue& graphicsQueue() const noexcept = 0;
+        /// <seealso cref="createQueue" />
+        inline const ICommandQueue& defaultQueue(QueueType type) const {
+            return this->getDefaultQueue(type);
+        }
 
         /// <summary>
-        /// Returns the instance of the queue used for device-device transfers (e.g. between render-passes).
+        /// Attempts to create a new queue that supports the combination of queue types specified by the <paramref name="type" /> parameter.
         /// </summary>
         /// <remarks>
-        /// Note that this can be the same as <see cref="graphicsQueue" />, if no dedicated transfer queues are supported on the device.
+        /// Note that a queue is not guaranteed to represent an *actual* hardware queue that runs in parallel to other hardware queues. Backends might create *virtual* queues, that map
+        /// the same hardware queue. In this case, creating a new queue is always possible but might not yield performance benefits. As a good practice, it is advised to create only as
+        /// few queues as required.
+        /// 
+        /// If this method is not able to create a new queue (i.e., it returns `nullptr`), you can either fall back to the default queue (<see cref="defaultQueue" />) or use any queue
+        /// that you created earlier instead.
         /// </remarks>
-        /// <returns>The instance of the queue used for device-device transfers (e.g. between render-passes).</returns>
-        virtual const ICommandQueue& transferQueue() const noexcept = 0;
-
-        /// <summary>
-        /// Returns the instance of the queue used for host-device transfers.
-        /// </summary>
-        /// <remarks>
-        /// Note that this can be the same as <see cref="graphicsQueue" />, if no dedicated transfer queues are supported on the device.
-        /// </remarks>
-        /// <returns>The instance of the queue used for host-device transfers.</returns>
-        virtual const ICommandQueue& bufferQueue() const noexcept = 0;
-
-        /// <summary>
-        /// Returns the instance of the queue used for compute calls.
-        /// </summary>
-        /// <remarks>
-        /// Note that this can be the same as <see cref="graphicsQueue" />, if no dedicated compute queues are supported on the device.
-        /// </remarks>
-        /// <returns>The instance of the queue used for compute calls.</returns>
-        virtual const ICommandQueue& computeQueue() const noexcept = 0;
+        /// <param name="type"></param>
+        /// <param name="priority"></param>
+        /// <returns>A pointer to the newly created queue, or `nullptr`, if no queue could be created.</returns>
+        /// <seealso cref="defaultQueue" />
+        inline const ICommandQueue* createQueue(QueueType type, QueuePriority priority = QueuePriority::Normal) noexcept {
+            return this->getNewQueue(type, priority);
+        }
 
         /// <summary>
         /// Creates a memory barrier instance.
         /// </summary>
-		/// <param name="syncBefore">The pipeline stage(s) all previous commands have to finish before the barrier is executed.</param>
-		/// <param name="syncAfter">The pipeline stage(s) all subsequent commands are blocked at until the barrier is executed.</param>
+        /// <param name="syncBefore">The pipeline stage(s) all previous commands have to finish before the barrier is executed.</param>
+        /// <param name="syncAfter">The pipeline stage(s) all subsequent commands are blocked at until the barrier is executed.</param>
         /// <returns>The instance of the memory barrier.</returns>
-        UniquePtr<IBarrier> makeBarrier(PipelineStage syncBefore, PipelineStage syncAfter) const noexcept {
+        inline UniquePtr<IBarrier> makeBarrier(PipelineStage syncBefore, PipelineStage syncAfter) const noexcept {
             return this->getNewBarrier(syncBefore, syncAfter);
         }
 
@@ -5632,6 +5602,8 @@ namespace LiteFX::Rendering {
 
     private:
         virtual UniquePtr<IBarrier> getNewBarrier(PipelineStage syncBefore, PipelineStage syncAfter) const noexcept = 0;
+        virtual const ICommandQueue& getDefaultQueue(QueueType type) const = 0;
+        virtual const ICommandQueue* getNewQueue(QueueType type, QueuePriority priority) noexcept = 0;
     };
 
     /// <summary>
@@ -5646,7 +5618,7 @@ namespace LiteFX::Rendering {
         /// Lists all available graphics adapters.
         /// </summary>
         /// <returns>An array of pointers to all available graphics adapters.</returns>
-        Enumerable<const IGraphicsAdapter*> listAdapters() const {
+        inline Enumerable<const IGraphicsAdapter*> listAdapters() const {
             return this->getAdapters();
         }
 
@@ -5682,7 +5654,7 @@ namespace LiteFX::Rendering {
         /// </summary>
         /// <param name="name">The name of the device.</param>
         /// <returns>A pointer to the device or <c>nullptr</c>, if no device could be found.</returns>
-        virtual const IGraphicsDevice* operator[](const String& name) const noexcept {
+        virtual inline const IGraphicsDevice* operator[](const String& name) const noexcept {
             return this->device(name);
         };
 
@@ -5691,7 +5663,7 @@ namespace LiteFX::Rendering {
         /// </summary>
         /// <param name="name">The name of the device.</param>
         /// <returns>A pointer to the device or <c>nullptr</c>, if no device could be found.</returns>
-        virtual IGraphicsDevice* operator[](const String& name) noexcept {
+        virtual inline IGraphicsDevice* operator[](const String& name) noexcept {
             return this->device(name);
         };
 

--- a/src/Rendering/include/litefx/rendering_api.hpp
+++ b/src/Rendering/include/litefx/rendering_api.hpp
@@ -5570,9 +5570,12 @@ namespace LiteFX::Rendering {
         /// 
         /// If this method is not able to create a new queue (i.e., it returns `nullptr`), you can either fall back to the default queue (<see cref="defaultQueue" />) or use any queue
         /// that you created earlier instead.
+        /// 
+        /// The <paramref name="priority" /> parameter can be specified to request a queue with a certain priority. However, the backend is not required to return a queue with that 
+        /// actual priority. The default queues are always prioritized highest.
         /// </remarks>
-        /// <param name="type"></param>
-        /// <param name="priority"></param>
+        /// <param name="type">The type of the queue or a combination of capabilities the queue is required to support.</param>
+        /// <param name="priority">The preferred priority of the queue.</param>
         /// <returns>A pointer to the newly created queue, or `nullptr`, if no queue could be created.</returns>
         /// <seealso cref="defaultQueue" />
         inline const ICommandQueue* createQueue(QueueType type, QueuePriority priority = QueuePriority::Normal) noexcept {
@@ -5609,11 +5612,11 @@ namespace LiteFX::Rendering {
 
     public:
         /// <summary>
-        /// Waits until the device is idle.
+        /// Waits until all queues allocated from the device have finished the work issued prior to this point.
         /// </summary>
         /// <remarks>
-        /// The complexity of this operation may depend on the graphics API that implements this method. Calling this method guarantees, that the device resources are in an unused state and 
-        /// may safely be released.
+        /// Note that you must synchronize calls to this method, i.e., you have to ensure no other thread is submitting work on any queue while waiting. Calling this method only 
+        /// guarantees that all *prior* work is finished after returning. If any other thread submits work to any queue after calling this method, this workload is not waited on.
         /// </remarks>
         virtual void wait() const = 0;
 

--- a/src/Samples/BasicRendering/src/sample.cpp
+++ b/src/Samples/BasicRendering/src/sample.cpp
@@ -92,7 +92,7 @@ void initRenderGraph(TRenderBackend* backend, SharedPtr<IInputAssembler>& inputA
 void SampleApp::initBuffers(IRenderBackend* backend)
 {
     // Get a command buffer
-    auto commandBuffer = m_device->bufferQueue().createCommandBuffer(true);
+    auto commandBuffer = m_device->defaultQueue(QueueType::Transfer).createCommandBuffer(true);
 
     // Create the staging buffer.
     // NOTE: The mapping works, because vertex and index buffers have an alignment of 0, so we can treat the whole buffer as a single element the size of the 
@@ -133,7 +133,7 @@ void SampleApp::initBuffers(IRenderBackend* backend)
     });
     
     // End and submit the command buffer.
-    m_transferFence = m_device->bufferQueue().submit(commandBuffer);
+    m_transferFence = commandBuffer->submit();
     
     // Add everything to the state.
     m_device->state().add(std::move(vertexBuffer));
@@ -261,9 +261,9 @@ void SampleApp::onResize(const void* sender, ResizeEventArgs e)
 
     // Also update the camera.
     auto& cameraBuffer = m_device->state().buffer("Camera");
-    auto commandBuffer = m_device->bufferQueue().createCommandBuffer(true);
+    auto commandBuffer = m_device->defaultQueue(QueueType::Transfer).createCommandBuffer(true);
     this->updateCamera(*commandBuffer, cameraBuffer);
-    m_transferFence = m_device->bufferQueue().submit(commandBuffer);
+    m_transferFence = commandBuffer->submit();
 }
 
 void SampleApp::keyDown(int key, int scancode, int action, int mods)
@@ -372,7 +372,7 @@ void SampleApp::drawFrame()
     auto& indexBuffer = m_device->state().indexBuffer("Index Buffer");
 
     // Wait for all transfers to finish.
-    m_device->bufferQueue().waitFor(m_transferFence);
+    renderPass.commandQueue().waitFor(m_device->defaultQueue(QueueType::Transfer), m_transferFence);
 
     // Begin rendering on the render pass and use the only pipeline we've created for it.
     renderPass.begin(backBuffer);

--- a/src/Samples/Bindless/src/sample.cpp
+++ b/src/Samples/Bindless/src/sample.cpp
@@ -122,8 +122,8 @@ void initRenderGraph(TRenderBackend* backend, SharedPtr<IInputAssembler>& inputA
 
 void SampleApp::initBuffers(IRenderBackend* backend)
 {
-    // Get a command buffer
-    auto commandBuffer = m_device->bufferQueue().createCommandBuffer(true);
+    // Get a command buffer.
+    auto commandBuffer = m_device->defaultQueue(QueueType::Transfer).createCommandBuffer(true);
 
     // Create the staging buffer.
     // NOTE: The mapping works, because vertex and index buffers have an alignment of 0, so we can treat the whole buffer as a single element the size of the 
@@ -178,7 +178,7 @@ void SampleApp::initBuffers(IRenderBackend* backend)
     commandBuffer->transfer(asShared(std::move(instanceStagingBuffer)), *instanceBuffer, 0, 0, NUM_INSTANCES);
 
     // End and submit the command buffer.
-    m_transferFence = m_device->bufferQueue().submit(commandBuffer);
+    m_transferFence = commandBuffer->submit();
 
     // Add everything to the state.
     m_device->state().add(std::move(vertexBuffer));
@@ -311,9 +311,9 @@ void SampleApp::onResize(const void* sender, ResizeEventArgs e)
 
     // Also update the camera.
     auto& cameraBuffer = m_device->state().buffer("Camera");
-    auto commandBuffer = m_device->bufferQueue().createCommandBuffer(true);
+    auto commandBuffer = m_device->defaultQueue(QueueType::Transfer).createCommandBuffer(true);
     this->updateCamera(*commandBuffer, cameraBuffer);
-    m_transferFence = m_device->bufferQueue().submit(commandBuffer);
+    m_transferFence = commandBuffer->submit();
 }
 
 void SampleApp::keyDown(int key, int scancode, int action, int mods)
@@ -423,7 +423,8 @@ void SampleApp::drawFrame()
     auto& indexBuffer = m_device->state().indexBuffer("Index Buffer");
 
     // Wait for all transfers to finish.
-    m_device->bufferQueue().waitFor(m_transferFence);
+    renderPass.commandQueue().waitFor(m_device->defaultQueue(QueueType::Transfer),
+ m_transferFence);
 
     // Begin rendering on the render pass and use the only pipeline we've created for it.
     renderPass.begin(backBuffer);

--- a/src/Samples/Multisampling/src/sample.cpp
+++ b/src/Samples/Multisampling/src/sample.cpp
@@ -92,7 +92,7 @@ void initRenderGraph(TRenderBackend* backend, SharedPtr<IInputAssembler>& inputA
 void SampleApp::initBuffers(IRenderBackend* backend)
 {
     // Get a command buffer
-    auto commandBuffer = m_device->bufferQueue().createCommandBuffer(true);
+    auto commandBuffer = m_device->defaultQueue(QueueType::Transfer).createCommandBuffer(true);
 
     // Create the staging buffer.
     // NOTE: The mapping works, because vertex and index buffers have an alignment of 0, so we can treat the whole buffer as a single element the size of the 
@@ -133,7 +133,7 @@ void SampleApp::initBuffers(IRenderBackend* backend)
     });
 
     // End and submit the command buffer.
-    m_transferFence = m_device->bufferQueue().submit(commandBuffer);
+    m_transferFence = commandBuffer->submit();
 
     // Add everything to the state.
     m_device->state().add(std::move(vertexBuffer));
@@ -261,9 +261,9 @@ void SampleApp::onResize(const void* sender, ResizeEventArgs e)
 
     // Also update the camera.
     auto& cameraBuffer = m_device->state().buffer("Camera");
-    auto commandBuffer = m_device->bufferQueue().createCommandBuffer(true);
+    auto commandBuffer = m_device->defaultQueue(QueueType::Transfer).createCommandBuffer(true);
     this->updateCamera(*commandBuffer, cameraBuffer);
-    m_transferFence = m_device->bufferQueue().submit(commandBuffer);
+    m_transferFence = commandBuffer->submit();
 }
 
 void SampleApp::keyDown(int key, int scancode, int action, int mods)
@@ -372,7 +372,7 @@ void SampleApp::drawFrame()
     auto& indexBuffer = m_device->state().indexBuffer("Index Buffer");
 
     // Wait for all transfers to finish.
-    m_device->bufferQueue().waitFor(m_transferFence);
+    renderPass.commandQueue().waitFor(m_device->defaultQueue(QueueType::Transfer), m_transferFence);
 
     // Begin rendering on the render pass and use the only pipeline we've created for it.
     renderPass.begin(backBuffer);

--- a/src/Samples/Multithreading/src/sample.cpp
+++ b/src/Samples/Multithreading/src/sample.cpp
@@ -106,7 +106,7 @@ void initRenderGraph(TRenderBackend* backend, SharedPtr<IInputAssembler>& inputA
 void SampleApp::initBuffers(IRenderBackend* backend)
 {
     // Get a command buffer
-    auto commandBuffer = m_device->bufferQueue().createCommandBuffer(true);
+    auto commandBuffer = m_device->defaultQueue(QueueType::Transfer).createCommandBuffer(true);
 
     // Create the staging buffer.
     // NOTE: The mapping works, because vertex and index buffers have an alignment of 0, so we can treat the whole buffer as a single element the size of the 
@@ -148,7 +148,7 @@ void SampleApp::initBuffers(IRenderBackend* backend)
     });
     
     // End and submit the command buffer.
-    m_transferFence = m_device->bufferQueue().submit(commandBuffer);
+    m_transferFence = commandBuffer->submit();
 
     // Add everything to the state.
     m_device->state().add(std::move(vertexBuffer));
@@ -276,9 +276,9 @@ void SampleApp::onResize(const void* sender, ResizeEventArgs e)
 
     // Also update the camera.
     auto& cameraBuffer = m_device->state().buffer("Camera");
-    auto commandBuffer = m_device->bufferQueue().createCommandBuffer(true);
+    auto commandBuffer = m_device->defaultQueue(QueueType::Transfer).createCommandBuffer(true);
     this->updateCamera(*commandBuffer, cameraBuffer);
-    m_transferFence = m_device->bufferQueue().submit(commandBuffer);
+    m_transferFence = commandBuffer->submit();
 }
 
 void SampleApp::keyDown(int key, int scancode, int action, int mods)
@@ -408,14 +408,14 @@ void SampleApp::drawFrame()
     // Store the initial time this method has been called first.
     static auto start = std::chrono::high_resolution_clock::now();
 
+    // Query state. For performance reasons, those state variables should be cached for more complex applications, instead of looking them up every frame.
+    auto& renderPass = m_device->state().renderPass("Opaque");
+
     // Wait for all transfers to finish.
-    m_device->bufferQueue().waitFor(m_transferFence);
+    renderPass.commandQueue().waitFor(m_device->defaultQueue(QueueType::Transfer), m_transferFence);
 
     // Swap the back buffers for the next frame.
     auto backBuffer = m_device->swapChain().swapBackBuffer();
-
-    // Query state. For performance reasons, those state variables should be cached for more complex applications, instead of looking them up every frame.
-    auto& renderPass = m_device->state().renderPass("Opaque");
 
     // Begin rendering on the render pass and use the only pipeline we've created for it.
     renderPass.begin(backBuffer);

--- a/src/Samples/RenderPasses/src/sample.cpp
+++ b/src/Samples/RenderPasses/src/sample.cpp
@@ -126,7 +126,7 @@ void initRenderGraph(TRenderBackend* backend, SharedPtr<IInputAssembler>& inputA
 void SampleApp::initBuffers(IRenderBackend* backend)
 {
     // Get a command buffer
-    auto commandBuffer = m_device->bufferQueue().createCommandBuffer(true);
+    auto commandBuffer = m_device->defaultQueue(QueueType::Transfer).createCommandBuffer(true);
 
     // Create the staging buffer.
     // NOTE: The mapping works, because vertex and index buffers have an alignment of 0, so we can treat the whole buffer as a single element the size of the 
@@ -182,7 +182,7 @@ void SampleApp::initBuffers(IRenderBackend* backend)
     auto gBufferBindings = lightingPipeline.layout()->descriptorSet(0).allocateMultiple(3);
 
     // End and submit the command buffer.
-    m_transferFence = m_device->bufferQueue().submit(commandBuffer);
+    m_transferFence = commandBuffer->submit();
 
     // Add everything to the state.
     m_device->state().add(std::move(vertexBuffer));
@@ -311,9 +311,9 @@ void SampleApp::onResize(const void* sender, ResizeEventArgs e)
 
     // Also update the camera.
     auto& cameraBuffer = m_device->state().buffer("Camera");
-    auto commandBuffer = m_device->bufferQueue().createCommandBuffer(true);
+    auto commandBuffer = m_device->defaultQueue(QueueType::Transfer).createCommandBuffer(true);
     this->updateCamera(*commandBuffer, cameraBuffer);
-    m_transferFence = m_device->bufferQueue().submit(commandBuffer);
+    m_transferFence = commandBuffer->submit();
 }
 
 void SampleApp::keyDown(int key, int scancode, int action, int mods)
@@ -409,9 +409,6 @@ void SampleApp::drawFrame()
     // Store the initial time this method has been called first.
     static auto start = std::chrono::high_resolution_clock::now();
 
-    // Wait for all transfers to finish.
-    m_device->bufferQueue().waitFor(m_transferFence);
-
     // Swap the back buffers for the next frame.
     auto backBuffer = m_device->swapChain().swapBackBuffer();
 
@@ -424,6 +421,9 @@ void SampleApp::drawFrame()
         auto& transformBindings = m_device->state().descriptorSet(fmt::format("Transform Bindings {0}", backBuffer));
         auto& vertexBuffer = m_device->state().vertexBuffer("Vertex Buffer");
         auto& indexBuffer = m_device->state().indexBuffer("Index Buffer");
+
+        // Wait for all transfers to finish.
+        geometryPass.commandQueue().waitFor(m_device->defaultQueue(QueueType::Transfer), m_transferFence);
 
         // Begin rendering on the render pass and use the only pipeline we've created for it.
         geometryPass.begin(backBuffer);

--- a/src/Samples/Textures/src/sample.cpp
+++ b/src/Samples/Textures/src/sample.cpp
@@ -61,9 +61,9 @@ void initRenderGraph(TRenderBackend* backend, SharedPtr<IInputAssembler>& inputA
         .topology(PrimitiveTopology::TriangleList)
         .indexType(IndexType::UInt16)
         .vertexBuffer(sizeof(Vertex), 0)
-        .withAttribute(0, BufferFormat::XYZ32F, offsetof(Vertex, Position), AttributeSemantic::Position)
-        .withAttribute(1, BufferFormat::XYZW32F, offsetof(Vertex, Color), AttributeSemantic::Color)
-        .withAttribute(2, BufferFormat::XY32F, offsetof(Vertex, TextureCoordinate0), AttributeSemantic::TextureCoordinate, 0)
+            .withAttribute(0, BufferFormat::XYZ32F, offsetof(Vertex, Position), AttributeSemantic::Position)
+            .withAttribute(1, BufferFormat::XYZW32F, offsetof(Vertex, Color), AttributeSemantic::Color)
+            .withAttribute(2, BufferFormat::XY32F, offsetof(Vertex, TextureCoordinate0), AttributeSemantic::TextureCoordinate, 0)
         .add();
 
     inputAssemblerState = std::static_pointer_cast<IInputAssembler>(inputAssembler);

--- a/src/Samples/Textures/src/sample.cpp
+++ b/src/Samples/Textures/src/sample.cpp
@@ -96,7 +96,7 @@ void initRenderGraph(TRenderBackend* backend, SharedPtr<IInputAssembler>& inputA
 
 template<typename TDevice> requires
     rtti::implements<TDevice, IGraphicsDevice>
-UInt64 loadTexture(TDevice& device, UniquePtr<IImage>& texture, UniquePtr<ISampler>& sampler)
+void loadTexture(TDevice& device, UniquePtr<IImage>& texture, UniquePtr<ISampler>& sampler)
 {
     using TBarrier = typename TDevice::barrier_type;
 
@@ -118,8 +118,8 @@ UInt64 loadTexture(TDevice& device, UniquePtr<IImage>& texture, UniquePtr<ISampl
     auto stagedTexture = device.factory().createBuffer(BufferType::Other, BufferUsage::Staging, texture->size(0));
     stagedTexture->map(imageData.get(), texture->size(0), 0);
 
-    // Transfer the texture using the compute queue (since we want to be able to generate mip maps, which is done on the compute queue).
-    auto commandBuffer = device.graphicsQueue().createCommandBuffer(true);
+    // Transfer the texture using the graphics queue (since we want to be able to generate mip maps, which is done on the graphics queue in Vulkan and a compute-capable queue in D3D12).
+    auto commandBuffer = device.defaultQueue(QueueType::Graphics).createCommandBuffer(true);
     commandBuffer->transfer(asShared(std::move(stagedTexture)), *texture);
 
     // Generate the rest of the mip maps.
@@ -134,12 +134,10 @@ UInt64 loadTexture(TDevice& device, UniquePtr<IImage>& texture, UniquePtr<ISampl
 
     // Submit the command buffer and wait for it to execute. Note that it is possible to do the waiting later when we actually use the texture during rendering. This
     // would not block earlier draw calls, if the texture would be streamed in at run-time.
-    auto transferFence = device.graphicsQueue().submit(commandBuffer);
+    auto transferFence = commandBuffer->submit();
 
     // Create a sampler state for the texture.
     sampler = device.factory().createSampler("Sampler", FilterMode::Linear, FilterMode::Linear, BorderMode::Repeat, BorderMode::Repeat, BorderMode::Repeat, MipMapMode::Linear, 0.f, std::numeric_limits<Float>::max(), 0.f, 16.f);
-
-    return transferFence;
 }
 
 template<typename TDevice> requires
@@ -147,7 +145,7 @@ template<typename TDevice> requires
 UInt64 initBuffers(SampleApp& app, TDevice& device, SharedPtr<IInputAssembler> inputAssembler)
 {
     // Get a command buffer
-    auto commandBuffer = device.bufferQueue().createCommandBuffer(true);
+    auto commandBuffer = device.defaultQueue(QueueType::Transfer).createCommandBuffer(true);
 
     // Create the staging buffer.
     // NOTE: The mapping works, because vertex and index buffers have an alignment of 0, so we can treat the whole buffer as a single element the size of the 
@@ -190,13 +188,13 @@ UInt64 initBuffers(SampleApp& app, TDevice& device, SharedPtr<IInputAssembler> i
     auto& transformBindingLayout = geometryPipeline.layout()->descriptorSet(DescriptorSets::PerFrame);
     auto transformBuffer = device.factory().createBuffer("Transform", transformBindingLayout, 0, BufferUsage::Dynamic, 3);
     auto transformBindings = transformBindingLayout.allocateMultiple(3, {
-        { {.binding = 0, .resource = *transformBuffer, .firstElement = 0, .elements = 1 } },
-        { {.binding = 0, .resource = *transformBuffer, .firstElement = 1, .elements = 1 } },
-        { {.binding = 0, .resource = *transformBuffer, .firstElement = 2, .elements = 1 } }
+        { { .binding = 0, .resource = *transformBuffer, .firstElement = 0, .elements = 1 } },
+        { { .binding = 0, .resource = *transformBuffer, .firstElement = 1, .elements = 1 } },
+        { { .binding = 0, .resource = *transformBuffer, .firstElement = 2, .elements = 1 } }
     });
 
     // End and submit the command buffer.
-    auto transferFence = device.bufferQueue().submit(commandBuffer);
+    auto transferFence = commandBuffer->submit();
 
     // Add everything to the state.
     device.state().add(std::move(vertexBuffer));
@@ -331,9 +329,9 @@ void SampleApp::onResize(const void* sender, ResizeEventArgs e)
 
     // Also update the camera.
     auto& cameraBuffer = m_device->state().buffer("Camera");
-    auto commandBuffer = m_device->bufferQueue().createCommandBuffer(true);
+    auto commandBuffer = m_device->defaultQueue(QueueType::Transfer).createCommandBuffer(true);
     this->updateCamera(*commandBuffer, cameraBuffer);
-    m_transferFence = m_device->bufferQueue().submit(commandBuffer);
+    m_transferFence = commandBuffer->submit();
 }
 
 void SampleApp::keyDown(int key, int scancode, int action, int mods)
@@ -429,9 +427,6 @@ void SampleApp::drawFrame()
     // Store the initial time this method has been called first.
     static auto start = std::chrono::high_resolution_clock::now();
 
-    // Wait for all transfers to finish.
-    m_device->bufferQueue().waitFor(m_transferFence);
-
     // Swap the back buffers for the next frame.
     auto backBuffer = m_device->swapChain().swapBackBuffer();
 
@@ -444,6 +439,9 @@ void SampleApp::drawFrame()
     auto& transformBindings = m_device->state().descriptorSet(fmt::format("Transform Bindings {0}", backBuffer));
     auto& vertexBuffer = m_device->state().vertexBuffer("Vertex Buffer");
     auto& indexBuffer = m_device->state().indexBuffer("Index Buffer");
+
+    // Wait for all transfers to finish.
+    renderPass.commandQueue().waitFor(m_device->defaultQueue(QueueType::Transfer), m_transferFence);
 
     // Begin rendering on the render pass and use the only pipeline we've created for it.
     renderPass.begin(backBuffer);

--- a/src/Samples/UniformArrays/src/sample.cpp
+++ b/src/Samples/UniformArrays/src/sample.cpp
@@ -129,7 +129,7 @@ void initRenderGraph(TRenderBackend* backend, SharedPtr<IInputAssembler>& inputA
 void SampleApp::initBuffers(IRenderBackend* backend)
 {
     // Get a command buffer
-    auto commandBuffer = m_device->bufferQueue().createCommandBuffer(true);
+    auto commandBuffer = m_device->defaultQueue(QueueType::Transfer).createCommandBuffer(true);
 
     // Create the staging buffer.
     // NOTE: The mapping works, because vertex and index buffers have an alignment of 0, so we can treat the whole buffer as a single element the size of the 
@@ -180,7 +180,7 @@ void SampleApp::initBuffers(IRenderBackend* backend)
     });
 
     // End and submit the command buffer.
-    m_transferFence = m_device->bufferQueue().submit(commandBuffer);
+    m_transferFence = commandBuffer->submit();
 
     // Add everything to the state.
     m_device->state().add(std::move(vertexBuffer));
@@ -322,9 +322,9 @@ void SampleApp::onResize(const void* sender, ResizeEventArgs e)
 
     // Also update the camera.
     auto& cameraBuffer = m_device->state().buffer("Camera");
-    auto commandBuffer = m_device->bufferQueue().createCommandBuffer(true);
+    auto commandBuffer = m_device->defaultQueue(QueueType::Transfer).createCommandBuffer(true);
     this->updateCamera(*commandBuffer, cameraBuffer);
-    m_transferFence = m_device->bufferQueue().submit(commandBuffer);
+    m_transferFence = commandBuffer->submit();
 }
 
 void SampleApp::keyDown(int key, int scancode, int action, int mods)
@@ -420,9 +420,6 @@ void SampleApp::drawFrame()
     // Store the initial time this method has been called first.
     static auto start = std::chrono::high_resolution_clock::now();
 
-    // Wait for all transfers to finish.
-    m_device->bufferQueue().waitFor(m_transferFence);
-
     // Swap the back buffers for the next frame.
     auto backBuffer = m_device->swapChain().swapBackBuffer();
 
@@ -434,6 +431,9 @@ void SampleApp::drawFrame()
     auto& transformBindings = m_device->state().descriptorSet(fmt::format("Transform Bindings {0}", backBuffer));
     auto& vertexBuffer = m_device->state().vertexBuffer("Vertex Buffer");
     auto& indexBuffer = m_device->state().indexBuffer("Index Buffer");
+
+    // Wait for all transfers to finish.
+    renderPass.commandQueue().waitFor(m_device->defaultQueue(QueueType::Transfer), m_transferFence);
 
     // Begin rendering on the render pass and use the only pipeline we've created for it.
     renderPass.begin(backBuffer);


### PR DESCRIPTION
**Describe the pull request**

The current implementation uses three integrated queues that it allocates when starting a backend. This is fine for applications that allocate commands in the order they need to be executed (after all Unity also uses only one queue), however it prevents more advanced GPU-side parallelism. For example, two queues could execute workloads in parallel until their results are required by a third queue. Additionally, it is now possible to use different dedicated transfer queues for host-device and device-host transfers. To support this, queues are now dynamically allocated and a new synchronization mechanism can be used to wait for fences on foreign queues.

The default queue interface has been removed and replaced with a newly unified method `defaultQueue`, that takes a `QueueType` and returns a pointer to a queue:

```cxx
auto transferQueue = m_device.defaultQueue(QueueType::Transfer); // was: m_device.bufferQueue();
auto graphicsQueue = m_device.defaultQueue(QueueType::Graphics); // was: m_device.graphicsQueue();
auto computeQueue = m_device.defaultQueue(QueueType::Compute); // was: m_device.computeQueue();
```

Internally the queues are managed in a way, that they are allocated, depending on device capabilities. If no dedicated queues are available, the pointers *could* all point to the same queue. This is most important for two queues of one type, where creating does not guarantee to return two distinct queues, if the device does not support it.

```cxx
auto graphicsQueue = m_device->createQueue(QueueType::Graphics); 
auto otherQueue = m_device->createDevice(QueueType::Graphics); // Can be the same as `graphicsQueue`, if device does not support multiple queues of type `Graphics`.
auto computeQueue = m_device->createQueue(QueueType::Compute); // Can be the same as `graphicsQueue`, if the device does not support dedicated `Compute` queues.
```

This is totally opaque to the caller, so use multiple queues, if you want to, but don't expect them to execute in parallel under all circumstances.

For synchronization, an additional overload for `waitFor` is available on a queue, that takes a reference to another queue and causes the queue to wait for a certain fence on the other one. This is a non-blocking call, meaning the program flow will immediately continue. However all submitted commands after the wait will be blocked, until the other queue has passed the provided fence.

```cxx
auto fence = computeQueue->submit(computeBuffer);
graphicsQueue->waitFor(computeQueue, fence); // Blocks `graphicsQueue` until `computeQueue` has passed `fence`.
```

Render passes can now also be initialized on a certain queue instance. This allows for parallel render-graph implementations.

```cxx
auto renderPass = makeUnique<RenderPass>(device, graphicsQueue);

// Alternatively:
UniquePtr<RenderPass> renderPass = device.buildRenderPass().executeOn(graphicsQueue);
```

With multiple queues flying around, it can be hard to track which command buffer needs to submit to which queue. To streamline this process, a command buffer now remembers the queue it has been created on and provides an `submit` method on its own:

```cxx
auto commandBuffer = device.defaultQueue(QueueType::Graphics).createCommandBuffer(true);
commandBuffer->submit();
```

**Related issues**

- Closes #58. Since dedicated queue allocation and inter-queue synchronization is now a thing, this can be implemented by clients.