### PR TITLE
Allocate descriptor set pools on demand.

### DIFF
--- a/src/Backends/DirectX12/include/litefx/backends/dx12_builders.hpp
+++ b/src/Backends/DirectX12/include/litefx/backends/dx12_builders.hpp
@@ -158,9 +158,8 @@ namespace LiteFX::Rendering::Backends {
 		/// <param name="parent">The parent pipeline layout builder.</param>
 		/// <param name="space">The space the descriptor set is bound to.</param>
 		/// <param name="stages">The shader stages, the descriptor set is accessible from.</param>
-		/// <param name="poolSize">Ignored for DirectX 12, but required for compatibility.</param>
 		/// <param name="maxUnboundedArraySize">Ignored for DirectX 12, but required for compatibility.</param>
-		constexpr inline explicit DirectX12DescriptorSetLayoutBuilder(DirectX12PipelineLayoutBuilder& parent, UInt32 space = 0, ShaderStage stages = ShaderStage::Fragment | ShaderStage::Geometry | ShaderStage::TessellationControl | ShaderStage::TessellationEvaluation | ShaderStage::Vertex, UInt32 poolSize = 0, UInt32 maxUnboundedArraySize = 0);
+		constexpr inline explicit DirectX12DescriptorSetLayoutBuilder(DirectX12PipelineLayoutBuilder& parent, UInt32 space = 0, ShaderStage stages = ShaderStage::Fragment | ShaderStage::Geometry | ShaderStage::TessellationControl | ShaderStage::TessellationEvaluation | ShaderStage::Vertex, UInt32 maxUnboundedArraySize = 0);
 		DirectX12DescriptorSetLayoutBuilder(const DirectX12DescriptorSetLayoutBuilder&) = delete;
 		DirectX12DescriptorSetLayoutBuilder(DirectX12DescriptorSetLayoutBuilder&&) = delete;
 		constexpr inline virtual ~DirectX12DescriptorSetLayoutBuilder() noexcept;
@@ -237,9 +236,8 @@ namespace LiteFX::Rendering::Backends {
 		/// </summary>
 		/// <param name="space">The space, the descriptor set is bound to.</param>
 		/// <param name="stages">The stages, the descriptor set will be accessible from.</param>
-		/// <param name="poolSize">Unused for this backend.</param>
 		/// <param name="maxUnboundedArraySize">Unused for this backend.</param>
-		constexpr inline DirectX12DescriptorSetLayoutBuilder descriptorSet(UInt32 space = 0, ShaderStage stages = ShaderStage::Compute | ShaderStage::Fragment | ShaderStage::Geometry | ShaderStage::TessellationControl | ShaderStage::TessellationEvaluation | ShaderStage::Vertex, UInt32 poolSize = 0, UInt32 maxUnboundedArraySize = 0);
+		constexpr inline DirectX12DescriptorSetLayoutBuilder descriptorSet(UInt32 space = 0, ShaderStage stages = ShaderStage::Compute | ShaderStage::Fragment | ShaderStage::Geometry | ShaderStage::TessellationControl | ShaderStage::TessellationEvaluation | ShaderStage::Vertex, UInt32 maxUnboundedArraySize = 0);
 
 		/// <summary>
 		/// Builds a new push constants layout for the pipeline layout.

--- a/src/Backends/DirectX12/src/descriptor_set_layout.cpp
+++ b/src/Backends/DirectX12/src/descriptor_set_layout.cpp
@@ -302,13 +302,11 @@ void DirectX12DescriptorSetLayout::free(const DirectX12DescriptorSet& descriptor
 // Descriptor set layout builder shared interface.
 // ------------------------------------------------------------------------------------------------
 
-constexpr DirectX12DescriptorSetLayoutBuilder::DirectX12DescriptorSetLayoutBuilder(DirectX12PipelineLayoutBuilder& parent, UInt32 space, ShaderStage stages, UInt32 poolSize, UInt32 maxUnboundedArraySize) :
+constexpr DirectX12DescriptorSetLayoutBuilder::DirectX12DescriptorSetLayoutBuilder(DirectX12PipelineLayoutBuilder& parent, UInt32 space, ShaderStage stages, UInt32 maxUnboundedArraySize) :
     DescriptorSetLayoutBuilder(parent, UniquePtr<DirectX12DescriptorSetLayout>(new DirectX12DescriptorSetLayout(parent.device())))
 {
-    m_state.poolSize = poolSize;
     m_state.maxUnboundedArraySize = maxUnboundedArraySize;
 }
-
 constexpr DirectX12DescriptorSetLayoutBuilder::~DirectX12DescriptorSetLayoutBuilder() noexcept = default;
 
 void DirectX12DescriptorSetLayoutBuilder::build()

--- a/src/Backends/DirectX12/src/pipeline_layout.cpp
+++ b/src/Backends/DirectX12/src/pipeline_layout.cpp
@@ -293,7 +293,7 @@ void DirectX12PipelineLayoutBuilder::build()
     instance->handle() = instance->m_impl->initialize();
 }
 
-constexpr DirectX12DescriptorSetLayoutBuilder DirectX12PipelineLayoutBuilder::descriptorSet(UInt32 space, ShaderStage stages, UInt32 /*poolSize*/, UInt32 /*maxUnboundedArraySize*/)
+constexpr DirectX12DescriptorSetLayoutBuilder DirectX12PipelineLayoutBuilder::descriptorSet(UInt32 space, ShaderStage stages, UInt32 /*maxUnboundedArraySize*/)
 {
     return DirectX12DescriptorSetLayoutBuilder(*this, space, stages);
 }

--- a/src/Backends/Vulkan/include/litefx/backends/vulkan.hpp
+++ b/src/Backends/Vulkan/include/litefx/backends/vulkan.hpp
@@ -460,9 +460,8 @@ namespace LiteFX::Rendering::Backends {
         /// <param name="descriptorLayouts">The descriptor layouts of the descriptors within the descriptor set.</param>
         /// <param name="space">The space or set id of the descriptor set.</param>
         /// <param name="stages">The shader stages, the descriptor sets are bound to.</param>
-        /// <param name="poolSize">The size of a descriptor pool.</param>
         /// <param name="maxUnboundedArraySize">The maximum number of descriptors in an unbounded array.</param>
-        explicit VulkanDescriptorSetLayout(const VulkanDevice& device, Enumerable<UniquePtr<VulkanDescriptorLayout>>&& descriptorLayouts, UInt32 space, ShaderStage stages, UInt32 poolSize = 1024, UInt32 maxUnboundedArraySize = 104857);
+        explicit VulkanDescriptorSetLayout(const VulkanDevice& device, Enumerable<UniquePtr<VulkanDescriptorLayout>>&& descriptorLayouts, UInt32 space, ShaderStage stages, UInt32 maxUnboundedArraySize = 104857);
         VulkanDescriptorSetLayout(VulkanDescriptorSetLayout&&) = delete;
         VulkanDescriptorSetLayout(const VulkanDescriptorSetLayout&) = delete;
         virtual ~VulkanDescriptorSetLayout() noexcept;
@@ -539,32 +538,11 @@ namespace LiteFX::Rendering::Backends {
 
     public:
         /// <summary>
-        /// The size of each descriptor pool.
-        /// </summary>
-        /// <remarks>
-        /// Descriptors are allocated from descriptor pools in Vulkan. Each descriptor pool has a number of descriptor sets it can hand out. Before allocating a new descriptor set
-        /// the layout tries to find an unused descriptor set, that it can hand out. If there are no free descriptor sets, the layout tries to allocate a new one. This is only possible
-        /// if the descriptor pool is not yet full, in which case a new pool needs to be created. All created pools are cached and destroyed, if the layout itself gets destroyed, 
-        /// causing all descriptor sets allocated from the layout to be invalidated. 
-        /// 
-        /// In general, if the number of required descriptor sets can be pre-calculated, it should be used as a pool size. Otherwise there is a trade-off to be made, based on the 
-        /// frequency of which new descriptor sets are required. A small pool size is more memory efficient, but can have a significant runtime cost, as long as new allocations happen
-        /// and no descriptor sets can be reused. A large pool size on the other hand is faster, whilst it may leave a large chunk of descriptor sets unallocated. Keep in mind, that the 
-        /// layout might not be the only active layout, hence a large portion of descriptor sets might end up not being used.
-        /// </remarks>
-        /// <returns>The size of one descriptor pool.</returns>
-        /// <seealso cref="allocate" />
-        /// <seealso cref="free" />
-        /// <seealso cref="pools" />
-        virtual UInt32 poolSize() const noexcept;
-
-        /// <summary>
         /// Returns the number of active descriptor pools.
         /// </summary>
         /// <returns>The number of active descriptor pools.</returns>
         /// <seealso cref="allocate" />
         /// <seealso cref="free" />
-        /// <seealso cref="poolSize" />
         virtual size_t pools() const noexcept;
     };
 

--- a/src/Backends/Vulkan/include/litefx/backends/vulkan_builders.hpp
+++ b/src/Backends/Vulkan/include/litefx/backends/vulkan_builders.hpp
@@ -158,9 +158,8 @@ namespace LiteFX::Rendering::Backends {
 		/// <param name="parent">The parent pipeline layout builder.</param>
 		/// <param name="space">The space the descriptor set is bound to.</param>
 		/// <param name="stages">The shader stages, the descriptor set is accessible from.</param>
-		/// <param name="poolSize">The size of the descriptor pools used for descriptor set allocation.</param>
 		/// <param name="maxUnboundedArraySize">The maximum array size of unbounded descriptor arrays in this descriptor set.</param>
-		constexpr inline explicit VulkanDescriptorSetLayoutBuilder(VulkanPipelineLayoutBuilder& parent, UInt32 space = 0, ShaderStage stages = ShaderStage::Fragment | ShaderStage::Geometry | ShaderStage::TessellationControl | ShaderStage::TessellationEvaluation | ShaderStage::Vertex, UInt32 poolSize = 1024, UInt32 maxUnboundedArraySize = 0);
+		constexpr inline explicit VulkanDescriptorSetLayoutBuilder(VulkanPipelineLayoutBuilder& parent, UInt32 space = 0, ShaderStage stages = ShaderStage::Fragment | ShaderStage::Geometry | ShaderStage::TessellationControl | ShaderStage::TessellationEvaluation | ShaderStage::Vertex, UInt32 maxUnboundedArraySize = 0);
 		VulkanDescriptorSetLayoutBuilder(const VulkanDescriptorSetLayoutBuilder&) = delete;
 		VulkanDescriptorSetLayoutBuilder(VulkanDescriptorSetLayoutBuilder&&) = delete;
 		constexpr inline virtual ~VulkanDescriptorSetLayoutBuilder() noexcept;
@@ -237,9 +236,8 @@ namespace LiteFX::Rendering::Backends {
 		/// </summary>
 		/// <param name="space">The space, the descriptor set is bound to.</param>
 		/// <param name="stages">The stages, the descriptor set will be accessible from.</param>
-		/// <param name="poolSize">The size of the descriptor pools used for descriptor set allocation.</param>
 		/// <param name="maxUnboundedArraySize">The maximum array size of unbounded descriptor arrays in this descriptor set.</param>
-		constexpr inline VulkanDescriptorSetLayoutBuilder descriptorSet(UInt32 space = 0, ShaderStage stages = ShaderStage::Compute | ShaderStage::Fragment | ShaderStage::Geometry | ShaderStage::TessellationControl | ShaderStage::TessellationEvaluation | ShaderStage::Vertex, UInt32 poolSize = 1024, UInt32 maxUnboundedArraySize = 0);
+		constexpr inline VulkanDescriptorSetLayoutBuilder descriptorSet(UInt32 space = 0, ShaderStage stages = ShaderStage::Compute | ShaderStage::Fragment | ShaderStage::Geometry | ShaderStage::TessellationControl | ShaderStage::TessellationEvaluation | ShaderStage::Vertex, UInt32 maxUnboundedArraySize = 0);
 
 		/// <summary>
 		/// Builds a new push constants layout for the pipeline layout.

--- a/src/Backends/Vulkan/src/pipeline_layout.cpp
+++ b/src/Backends/Vulkan/src/pipeline_layout.cpp
@@ -55,7 +55,7 @@ public:
         if (!emptySets.empty())
         {
             for (auto s : emptySets)
-                m_descriptorSetLayouts.push_back(UniquePtr<VulkanDescriptorSetLayout>{ new VulkanDescriptorSetLayout(m_device, { }, s, ShaderStage::Vertex | ShaderStage::Fragment, 0, 0) }); // No descriptor can ever be allocated from an empty descriptor set.
+                m_descriptorSetLayouts.push_back(UniquePtr<VulkanDescriptorSetLayout>{ new VulkanDescriptorSetLayout(m_device, { }, s, ShaderStage::Vertex | ShaderStage::Fragment, 0) }); // No descriptor can ever be allocated from an empty descriptor set.
 
             // Re-order them.
             std::ranges::sort(m_descriptorSetLayouts, [](const UniquePtr<VulkanDescriptorSetLayout>& a, const UniquePtr<VulkanDescriptorSetLayout>& b) { return a->space() < b->space(); });
@@ -174,9 +174,9 @@ void VulkanPipelineLayoutBuilder::build()
     instance->handle() = instance->m_impl->initialize();
 }
 
-constexpr VulkanDescriptorSetLayoutBuilder VulkanPipelineLayoutBuilder::descriptorSet(UInt32 space, ShaderStage stages, UInt32 poolSize, UInt32 maxUnboundedArraySize)
+constexpr VulkanDescriptorSetLayoutBuilder VulkanPipelineLayoutBuilder::descriptorSet(UInt32 space, ShaderStage stages, UInt32 maxUnboundedArraySize)
 {
-    return VulkanDescriptorSetLayoutBuilder(*this, space, stages, poolSize, maxUnboundedArraySize);
+    return VulkanDescriptorSetLayoutBuilder(*this, space, stages, maxUnboundedArraySize);
 }
 
 constexpr VulkanPushConstantsLayoutBuilder VulkanPipelineLayoutBuilder::pushConstants(UInt32 size)

--- a/src/Rendering/include/litefx/rendering_builders.hpp
+++ b/src/Rendering/include/litefx/rendering_builders.hpp
@@ -761,14 +761,6 @@ namespace LiteFX::Rendering {
             /// The space of the descriptor set.
             /// </summary>
             UInt32 space;
-
-            /// <summary>
-            /// The pool size (if supported), of the descriptor pool that allocates the descriptors in the descriptor set.
-            /// </summary>
-            /// <remarks>
-            /// Descriptor pools are only supported in Vulkan. For DirectX 12, this setting is ignored.
-            /// </remarks>
-            UInt32 poolSize;
             
             /// <summary>
             /// The maximum size of unbounded (i.e., bindless) descriptor arrays.
@@ -958,16 +950,6 @@ namespace LiteFX::Rendering {
         template <typename TSelf>
         constexpr inline auto shaderStages(this TSelf&& self, ShaderStage stages) noexcept -> TSelf& {
             self.m_state.stages = stages;
-            return self;
-        }
-
-        /// <summary>
-        /// Sets the size of the descriptor pools used for descriptor set allocations. Ignored for DirectX 12, but required for interface compatibility.
-        /// </summary>
-        /// <param name="poolSize">The size of the descriptor pools used for descriptor set allocations.</param>
-        template <typename TSelf>
-        constexpr inline auto poolSize(this TSelf&& self, UInt32 poolSize) noexcept -> TSelf& {
-            self.m_state.poolSize = poolSize;
             return self;
         }
 


### PR DESCRIPTION
**Describe the pull request**

In the Vulkan backend, descriptor sets are allocated from fixed-size descriptor pools. If descriptor sets are allocated from descriptor pools, they eventually run out of memory. This causes new pools to be allocated. To prevent unnecessary allocations, the pool size could be configured by clients. The default pool size is pretty conservatively assumed at `1024` descriptor sets per pool. Most descriptor sets are, however, only allocated sparingly, so a lot of space is wasted.

With this PR, pool sizes are determined by the amount of descriptor sets to be allocated. If a descriptor set layout needs to allocate large quantities of descriptor sets, it is now up to the client to allocate them in larger chunks. The favoured way would be to allocate a large set of descriptor sets (using `allocateMultiple`) and discard them immediately. This will cause the descriptor sets to be cached until they are requested later on, when they will be handed out again.

However, most descriptor sets are only created infrequently (ideally once) in small quantities, as this is the preferred way of using them. In this case, the new approach will no longer cause excessive pool sizes.

The `poolSize` parameters have been removed from the descriptor set layout and its builder interface.

**Related issues**

- Closes #108. 
