### PR TITLE
Rename `rtti` namespace to more appropriate `meta`.

### DIFF
--- a/docs/release-logs/0.4.1.md
+++ b/docs/release-logs/0.4.1.md
@@ -8,6 +8,7 @@
   - Builders are now `constexpr` where possible and are implemented using `deducing this` in place of CRTP, which makes them more lightweight.
   - New exceptions with support for `stacktrace` and `source_location`.
 - Updated vcpkg to version 2023.11.20. ([See PR #104](https://github.com/crud89/LiteFX/pull/104))
+- The namespace `rtti` has been renamed to `meta`. ([See PR #121](https://github.com/crud89/LiteFX/pull/121))
 - Improvements to C++ core guideline conformance. ([See PR #103](https://github.com/crud89/LiteFX/pull/103))
 - New event infrastructure. ([See PR #81](https://github.com/crud89/LiteFX/pull/81))
 - Add support for user-defined debug markers. ([See PR #82](https://github.com/crud89/LiteFX/pull/82))

--- a/src/AppModel/include/litefx/app.hpp
+++ b/src/AppModel/include/litefx/app.hpp
@@ -416,7 +416,7 @@ namespace LiteFX {
 		/// <typeparam name="TBackend">The type, the type index is derived from.</typeparam>
 		/// <returns>The registered backend instance for a type index, or <c>nullptr</c>, if the app has no backend of the provided type.</returns>
 		template <typename TBackend> requires
-			rtti::implements<TBackend, IBackend>
+			meta::implements<TBackend, IBackend>
 		TBackend* findBackend() {
 			return dynamic_cast<TBackend*>(this->getBackend(typeid(TBackend)));
 		}
@@ -508,7 +508,7 @@ namespace LiteFX {
 		/// <seealso cref="onBackendStop" />
 		/// <seealso cref="backendStarted" />
 		template <typename TBackend> requires
-			rtti::implements<TBackend, IBackend>
+			meta::implements<TBackend, IBackend>
 		void onBackendStart(const std::function<bool(TBackend*)>& callback) {
 			this->registerStartCallback(typeid(TBackend), [this, callback]() {
 				auto backend = this->findBackend<TBackend>();
@@ -535,7 +535,7 @@ namespace LiteFX {
 		/// <seealso cref="onBackendStart" />
 		/// <seealso cref="backendStopped" />
 		template <typename TBackend> requires
-			rtti::implements<TBackend, IBackend>
+			meta::implements<TBackend, IBackend>
 		void onBackendStop(const std::function<void(TBackend*)>& callback) {
 			this->registerStopCallback(typeid(TBackend), [this, callback]() {
 				auto backend = this->findBackend<TBackend>();
@@ -555,7 +555,7 @@ namespace LiteFX {
 		/// <typeparam name="TBackend">The type, the type index is derived from.</typeparam>
 		/// <returns>The registered backend instance for a type index, or <c>nullptr</c>, if the app has no backend of the provided type.</returns>
 		template <typename TBackend> requires
-			rtti::implements<TBackend, IBackend>
+			meta::implements<TBackend, IBackend>
 		const TBackend* findBackend() const {
 			return dynamic_cast<const TBackend*>(this->getBackend(typeid(TBackend)));
 		}
@@ -566,7 +566,7 @@ namespace LiteFX {
 		/// <typeparam name="TBackend">The type of the backend to start.</typeparam>
 		/// <exception cref="InvalidArgumentException">Thrown, if no backend of type <typeparamref name="TBackend" /> is registered.</exception>
 		template <typename TBackend> requires
-			rtti::implements<TBackend, IBackend>
+			meta::implements<TBackend, IBackend>
 		void startBackend() {
 			this->startBackend(typeid(TBackend));
 		}
@@ -577,7 +577,7 @@ namespace LiteFX {
 		/// <typeparam name="TBackend">The type of the backend to stop.</typeparam>
 		/// <exception cref="InvalidArgumentException">Thrown, if no backend of type <typeparamref name="TBackend" /> is registered.</exception>
 		template <typename TBackend> requires
-			rtti::implements<TBackend, IBackend>
+			meta::implements<TBackend, IBackend>
 		void stopBackend() {
 			this->stopBackend(typeid(TBackend));
 		}
@@ -659,7 +659,7 @@ namespace LiteFX {
 		/// Registers a new backend.
 		/// </summary>
 		template <typename TBackend, typename ...TArgs> requires
-			rtti::implements<TBackend, IBackend>
+			meta::implements<TBackend, IBackend>
 			constexpr inline AppBuilder& useBackend(TArgs&&... args) {
 			this->use(makeUnique<TBackend>(*this->instance(), std::forward<TArgs>(args)...));
 			return *this;

--- a/src/Core/include/litefx/containers.hpp
+++ b/src/Core/include/litefx/containers.hpp
@@ -248,7 +248,7 @@ namespace LiteFX {
 		/// </summary>
 		/// <typeparam name="...TArgs">The types of the arguments.</typeparam>
 		/// <param name="...args">The arguments.</param>
-		template <typename... TArgs> requires rtti::are_same<T, TArgs...>
+		template <typename... TArgs> requires meta::are_same<T, TArgs...>
 		constexpr explicit inline Enumerable(TArgs&&... args) noexcept
 		{
 			auto input = std::to_array({ std::forward<TArgs>(args)... });

--- a/src/Core/include/litefx/traits.hpp
+++ b/src/Core/include/litefx/traits.hpp
@@ -4,7 +4,10 @@
 #include <typeindex>
 #include <concepts>
 
-namespace LiteFX::rtti {
+/// <summary>
+/// Contains type traits and meta-programming features for compile-time evaluation.
+/// </summary>
+namespace LiteFX::meta {
 
     /// <summary>
     /// Trait that is evaluated, if a class does not have an builder member type defined.
@@ -23,80 +26,94 @@ namespace LiteFX::rtti {
     /// </summary>
     /// <example>
     /// <code>
-    /// template <typename T, std::enable_if_t<rtti::has_builder_v<T>, int> = 0, typename TBuilder = T::builder>
+    /// template <typename T, std::enable_if_t<meta::has_builder_v<T>, int> = 0, typename TBuilder = T::builder>
     /// TBuilder makeBuilder() { return TBuilder(); }
     ///
-    /// template <typename T, typename TBuilder, std::enable_if_t<!rtti::has_builder_v<T>, int> = 0, typename TBuilder = Builder<T, TBuilder>>
+    /// template <typename T, typename TBuilder, std::enable_if_t<!meta::has_builder_v<T>, int> = 0, typename TBuilder = Builder<T, TBuilder>>
     /// TBuilder makeBuilder() { return TBuilder(); }
     /// </code>
     /// </example>
     /// <typeparam name="T">The type to check for an builder.</typeparam>
+    /// <seealso cref="Builder" />
     template <class T>
     constexpr bool has_builder_v = has_builder_t<T>::value;
 
     /// <summary>
-    /// 
+    /// Checks if a type contains a builder.
     /// </summary>
+    /// <typeparam name="T">The type to check for an builder.</typeparam>
+    /// <seealso cref="Builder" />
     template <class T>
     concept has_builder = has_builder_v<T>;
 
     /// <summary>
-    /// 
+    /// Evaluates to either `true` or `false`, if <typeparamref name="T" /> can be constructed using the provided arguments, whilst not being able to be converted from <typeparamref name="TArg" />.
     /// </summary>
-    /// <typeparam name="T"></typeparam>
-    /// <typeparam name="TArg"></typeparam>
-    /// <typeparam name="...TArgs"></typeparam>
+    /// <typeparam name="T">The type to check.</typeparam>
+    /// <typeparam name="TArg">The parameter to check for conversion support.</typeparam>
+    /// <typeparam name="...TArgs">The remaining constructor parameters.</typeparam>
     template <typename T, typename TArg, typename ...TArgs>
     struct is_explicitly_constructible_t : std::bool_constant<std::is_constructible_v<T, TArg, TArgs...> && !std::is_convertible_v<TArg, T>> { };
 
     /// <summary>
     /// Evalues to `true` or `false`, depending if <typeparamref name="T" /> contains an explicit constructor that takes <typeparamref name="TArg" /> and <typeparamref name="TArgs" /> as arguments.
     /// </summary>
-    /// <typeparam name="T"></typeparam>
-    /// <typeparam name="TArg"></typeparam>
-    /// <typeparam name="...TArgs"></typeparam>
+    /// <typeparam name="T">The type to check.</typeparam>
+    /// <typeparam name="TArg">The parameter to check for conversion support.</typeparam>
+    /// <typeparam name="...TArgs">The remaining constructor parameters.</typeparam>
     template <typename T, typename TArg, typename ...TArgs>
     constexpr bool is_explicitly_constructible_v = is_explicitly_constructible_t<T, TArg, TArgs...>::value;
 
     /// <summary>
-    /// 
+    /// Checks if a type can be constructed using the provided arguments, whilst not being able to be converted from <typeparamref name="TArg" />.
     /// </summary>
+    /// <typeparam name="T">The type to check.</typeparam>
+    /// <typeparam name="TArg">The parameter to check for conversion support.</typeparam>
+    /// <typeparam name="...TArgs">The remaining constructor parameters.</typeparam>
     template <typename T, typename TArg, typename ...TArgs>
     concept is_explicitly_constructible = is_explicitly_constructible_v<T, TArg, TArgs...>;
 
     /// <summary>
-    /// 
+    /// Evaluates to either `true` or `false`, if <typeparamref name="T" /> can be constructed using the provided arguments and at the same time can also be converted from <typeparamref name="TArg" />.
     /// </summary>
-    /// <typeparam name="T"></typeparam>
-    /// <typeparam name="TArg"></typeparam>
-    /// <typeparam name="...TArgs"></typeparam>
+    /// <typeparam name="T">The type to check.</typeparam>
+    /// <typeparam name="TArg">The parameter to check for conversion support.</typeparam>
+    /// <typeparam name="...TArgs">The remaining constructor parameters.</typeparam>
     template <typename T, typename TArg, typename ...TArgs>
     struct is_implicitly_constructible_t : std::bool_constant<std::is_constructible_v<T, TArg, TArgs...> && std::is_convertible_v<TArg, T>> { };
 
     /// <summary>
     /// Evalues to `true` or `false`, depending if <typeparamref name="T" /> contains an implicit constructor that takes <typeparamref name="TArg" /> and <typeparamref name="TArgs" /> as arguments.
     /// </summary>
-    /// <typeparam name="T"></typeparam>
-    /// <typeparam name="TArg"></typeparam>
-    /// <typeparam name="...TArgs"></typeparam>
+    /// <typeparam name="T">The type to check.</typeparam>
+    /// <typeparam name="TArg">The parameter to check for conversion support.</typeparam>
+    /// <typeparam name="...TArgs">The remaining constructor parameters.</typeparam>
     template <typename T, typename TArg, typename ...TArgs>
     constexpr bool is_implicitly_constructible_v = is_explicitly_constructible_t<T, TArg, TArgs...>::value;
 
     /// <summary>
-    /// 
+    /// Checks if a type can be constructed using the provided arguments and at the same time can also be converted from <typeparamref name="TArg" />.
     /// </summary>
+    /// <typeparam name="T">The type to check.</typeparam>
+    /// <typeparam name="TArg">The parameter to check for conversion support.</typeparam>
+    /// <typeparam name="...TArgs">The remaining constructor parameters.</typeparam>
     template <typename T, typename TArg, typename ...TArgs>
     concept is_implicitly_constructible = is_explicitly_constructible_v<T, TArg, TArgs...>;
 
     /// <summary>
-    /// 
+    /// Checks if a type <typeparamref name="TDerived" /> is derived from another type <typeparamref name="TBase" /> and is non-abstract.
     /// </summary>
+    /// <typeparam name="TDerived">The type to check.</typeparam>
+    /// <typeparam name="TBase">The base type to check against.</typeparam>
     template <typename TDerived, typename TBase>
     concept implements = !std::is_abstract_v<TDerived> && std::derived_from<TDerived, TBase>;
 
     /// <summary>
-    /// 
+    /// Checks if a set of types are all equal to the type <typeparamref name="T" />.
     /// </summary>
+    /// <typeparam name="T">The type to check against.</typeparam>
+    /// <typeparam name="Ts">The types to check.</typeparam>
     template <typename T, typename... Ts>
     concept are_same = std::conjunction_v<std::is_same<T, Ts>...>;
+
 }

--- a/src/Rendering/include/litefx/rendering.hpp
+++ b/src/Rendering/include/litefx/rendering.hpp
@@ -194,8 +194,8 @@ namespace LiteFX::Rendering {
     /// <seealso cref="IDescriptorLayout" />
     /// <seealso cref="DescriptorSet" />
     template <typename TDescriptorLayout, typename TDescriptorSet> requires
-        rtti::implements<TDescriptorLayout, IDescriptorLayout> &&
-        rtti::implements<TDescriptorSet, DescriptorSet<typename TDescriptorSet::buffer_type, typename TDescriptorSet::image_type, typename TDescriptorSet::sampler_type>>
+        meta::implements<TDescriptorLayout, IDescriptorLayout> &&
+        meta::implements<TDescriptorSet, DescriptorSet<typename TDescriptorSet::buffer_type, typename TDescriptorSet::image_type, typename TDescriptorSet::sampler_type>>
     class DescriptorSetLayout : public IDescriptorSetLayout {
     public:
         using IDescriptorSetLayout::free;
@@ -280,7 +280,7 @@ namespace LiteFX::Rendering {
     /// <seealso cref="IPushConstantsRange" />
     /// <seealso cref="DescriptorSetLayout" />
     template <typename TPushConstantsRange> requires
-        rtti::implements<TPushConstantsRange, IPushConstantsRange>
+        meta::implements<TPushConstantsRange, IPushConstantsRange>
     class PushConstantsLayout : public IPushConstantsLayout {
     public:
         using push_constants_range_type = TPushConstantsRange;
@@ -304,7 +304,7 @@ namespace LiteFX::Rendering {
     /// <typeparam name="TShaderModule">The type of the shader module. Must implement <see cref="IShaderModule"/>.</typeparam>
     /// <seealso href="https://github.com/crud89/LiteFX/wiki/Shader-Development" />
     template <typename TShaderModule> requires
-        rtti::implements<TShaderModule, IShaderModule>
+        meta::implements<TShaderModule, IShaderModule>
     class ShaderProgram : public IShaderProgram {
     public:
         using shader_module_type = TShaderModule;
@@ -328,8 +328,8 @@ namespace LiteFX::Rendering {
     /// <typeparam name="TDescriptorSetLayout">The type of the descriptor set layout. Must implement <see cref="DescriptorSetLayout"/>.</typeparam>
     /// <typeparam name="TPushConstantsLayout">The type of the push constants layout. Must implement <see cref="PushConstantsLayout"/>.</typeparam>
     template <typename TDescriptorSetLayout, typename TPushConstantsLayout> requires
-        rtti::implements<TDescriptorSetLayout, DescriptorSetLayout<typename TDescriptorSetLayout::descriptor_layout_type, typename TDescriptorSetLayout::descriptor_set_type>> &&
-        rtti::implements<TPushConstantsLayout, PushConstantsLayout<typename TPushConstantsLayout::push_constants_range_type>>
+        meta::implements<TDescriptorSetLayout, DescriptorSetLayout<typename TDescriptorSetLayout::descriptor_layout_type, typename TDescriptorSetLayout::descriptor_set_type>> &&
+        meta::implements<TPushConstantsLayout, PushConstantsLayout<typename TPushConstantsLayout::push_constants_range_type>>
     class PipelineLayout : public IPipelineLayout {
     public:
         using descriptor_set_layout_type = TDescriptorSetLayout;
@@ -359,7 +359,7 @@ namespace LiteFX::Rendering {
     /// </summary>
     /// <typeparam name="TVertexBufferLayout">The type of the vertex buffer layout. Must implement <see cref="IVertexBufferLayout"/>.</typeparam>
     template <typename TVertexBufferLayout> requires
-        rtti::implements<TVertexBufferLayout, IVertexBufferLayout>
+        meta::implements<TVertexBufferLayout, IVertexBufferLayout>
     class VertexBuffer : public virtual IVertexBuffer {
     public:
         using vertex_buffer_layout_type = TVertexBufferLayout;
@@ -377,7 +377,7 @@ namespace LiteFX::Rendering {
     /// </summary>
     /// <typeparam name="TIndexBufferLayout">The type of the index buffer layout. Must implement <see cref="IIndexBufferLayout"/>.</typeparam>
     template <typename TIndexBufferLayout> requires
-        rtti::implements<TIndexBufferLayout, IIndexBufferLayout>
+        meta::implements<TIndexBufferLayout, IIndexBufferLayout>
     class IndexBuffer : public virtual IIndexBuffer {
     public:
         using index_buffer_layout_type = TIndexBufferLayout;
@@ -396,8 +396,8 @@ namespace LiteFX::Rendering {
     /// <typeparam name="TVertexBufferLayout">The type of the vertex buffer layout. Must implement <see cref="IVertexBufferLayout"/>.</typeparam>
     /// <typeparam name="TIndexBufferLayout">The type of the index buffer layout. Must implement <see cref="IIndexBufferLayout"/>.</typeparam>
     template <typename TVertexBufferLayout, typename TIndexBufferLayout> requires
-        rtti::implements<TVertexBufferLayout, IVertexBufferLayout> &&
-        rtti::implements<TIndexBufferLayout, IIndexBufferLayout>
+        meta::implements<TVertexBufferLayout, IVertexBufferLayout> &&
+        meta::implements<TIndexBufferLayout, IIndexBufferLayout>
     class InputAssembler : public IInputAssembler {
     public:
         using vertex_buffer_layout_type = TVertexBufferLayout;
@@ -430,8 +430,8 @@ namespace LiteFX::Rendering {
     /// <seealso cref="RenderPipeline" />
     /// <seealso cref="ComputePipeline" />
     template <typename TPipelineLayout, typename TShaderProgram> requires
-        rtti::implements<TPipelineLayout, PipelineLayout<typename TPipelineLayout::descriptor_set_layout_type, typename TPipelineLayout::push_constants_layout_type>> &&
-        rtti::implements<TShaderProgram, ShaderProgram<typename TShaderProgram::shader_module_type>>
+        meta::implements<TPipelineLayout, PipelineLayout<typename TPipelineLayout::descriptor_set_layout_type, typename TPipelineLayout::push_constants_layout_type>> &&
+        meta::implements<TShaderProgram, ShaderProgram<typename TShaderProgram::shader_module_type>>
     class Pipeline : public virtual IPipeline, public virtual StateResource {
     public:
         using shader_program_type = TShaderProgram;
@@ -468,7 +468,7 @@ namespace LiteFX::Rendering {
     /// <typeparam name="TBarrier">The barrier type. Must implement <see cref="Barrier"/>.</typeparam>
     /// <typeparam name="TPipeline">The common pipeline interface type. Must be derived from <see cref="Pipeline"/>.</typeparam>
     template <typename TCommandBuffer, typename TBuffer, typename TVertexBuffer, typename TIndexBuffer, typename TImage, typename TBarrier, typename TPipeline> requires
-        rtti::implements<TBarrier, Barrier<TBuffer, TImage>> &&
+        meta::implements<TBarrier, Barrier<TBuffer, TImage>> &&
         //std::derived_from<TCommandBuffer, ICommandBuffer> &&
         std::derived_from<TPipeline, Pipeline<typename TPipeline::pipeline_layout_type, typename TPipeline::shader_program_type>>
     class CommandBuffer : public ICommandBuffer {
@@ -671,8 +671,8 @@ namespace LiteFX::Rendering {
     /// <typeparam name="TRasterizer">The type of the rasterizer state. Must implement <see cref="Rasterizer"/>.</typeparam>
     /// <seealso cref="RenderPipelineBuilder" />
     template <typename TPipelineLayout, typename TShaderProgram, typename TInputAssembler, typename TRasterizer> requires
-        rtti::implements<TInputAssembler, InputAssembler<typename TInputAssembler::vertex_buffer_layout_type, typename TInputAssembler::index_buffer_layout_type>> &&
-        rtti::implements<TRasterizer, Rasterizer>
+        meta::implements<TInputAssembler, InputAssembler<typename TInputAssembler::vertex_buffer_layout_type, typename TInputAssembler::index_buffer_layout_type>> &&
+        meta::implements<TRasterizer, Rasterizer>
     class RenderPipeline : public IRenderPipeline, public Pipeline<TPipelineLayout, TShaderProgram> {
     public:
         using input_assembler_type = TInputAssembler;
@@ -716,7 +716,7 @@ namespace LiteFX::Rendering {
     /// <typeparam name="TCommandBuffer">The type of the command buffer. Must implement <see cref="CommandBuffer"/>.</typeparam>
     /// <seealso cref="RenderTarget" />
     template <typename TCommandBuffer> requires
-        rtti::implements<TCommandBuffer, CommandBuffer<typename TCommandBuffer::command_buffer_type, typename TCommandBuffer::buffer_type, typename TCommandBuffer::vertex_buffer_type, typename TCommandBuffer::index_buffer_type, typename TCommandBuffer::image_type, typename TCommandBuffer::barrier_type, typename TCommandBuffer::pipeline_type>>
+        meta::implements<TCommandBuffer, CommandBuffer<typename TCommandBuffer::command_buffer_type, typename TCommandBuffer::buffer_type, typename TCommandBuffer::vertex_buffer_type, typename TCommandBuffer::index_buffer_type, typename TCommandBuffer::image_type, typename TCommandBuffer::barrier_type, typename TCommandBuffer::pipeline_type>>
     class FrameBuffer : public IFrameBuffer {
     public:
         using command_buffer_type = TCommandBuffer;
@@ -757,7 +757,7 @@ namespace LiteFX::Rendering {
     /// </summary>
     /// <typeparam name="TFrameBuffer">The type of the frame buffer. Must implement <see cref="FrameBuffer" />.</typeparam>
     template <typename TFrameBuffer> requires
-        rtti::implements<TFrameBuffer, FrameBuffer<typename TFrameBuffer::command_buffer_type>>
+        meta::implements<TFrameBuffer, FrameBuffer<typename TFrameBuffer::command_buffer_type>>
     class InputAttachmentMappingSource : public IInputAttachmentMappingSource {
     public:
         using frame_buffer_type = TFrameBuffer;
@@ -775,7 +775,7 @@ namespace LiteFX::Rendering {
     /// </summary>
     /// <typeparam name="TInputAttachmentMappingSource">The type of the input attachment mapping source. Must implement <see cref="InputAttachmentMappingSource" />.</typeparam>
     template <typename TInputAttachmentMappingSource> requires
-        rtti::implements<TInputAttachmentMappingSource, InputAttachmentMappingSource<typename TInputAttachmentMappingSource::frame_buffer_type>>
+        meta::implements<TInputAttachmentMappingSource, InputAttachmentMappingSource<typename TInputAttachmentMappingSource::frame_buffer_type>>
     class IInputAttachmentMapping {
     public:
         using input_attachment_mapping_source_type = TInputAttachmentMappingSource;
@@ -819,10 +819,10 @@ namespace LiteFX::Rendering {
     /// <typeparam name="TFrameBuffer">The type of the frame buffer. Must implement <see cref="FrameBuffer" />.</typeparam>
     /// <typeparam name="TInputAttachmentMapping">The type of the input attachment mapping. Must implement <see cref="IInputAttachmentMapping" />.</typeparam>
     template <typename TRenderPipeline, typename TCommandQueue, typename TFrameBuffer, typename TInputAttachmentMapping> requires
-        rtti::implements<TFrameBuffer, FrameBuffer<typename TFrameBuffer::command_buffer_type>> &&
-        /*rtti::implements<TCommandQueue, CommandQueue<typename TFrameBuffer::command_buffer_type>> &&*/
-        rtti::implements<TRenderPipeline, RenderPipeline<typename TRenderPipeline::pipeline_layout_type, typename TRenderPipeline::shader_program_type, typename TRenderPipeline::input_assembler_type, typename TRenderPipeline::rasterizer_type>> /*&&
-        rtti::implements<TInputAttachmentMapping, IInputAttachmentMapping<TDerived>>*/
+        meta::implements<TFrameBuffer, FrameBuffer<typename TFrameBuffer::command_buffer_type>> &&
+        /*meta::implements<TCommandQueue, CommandQueue<typename TFrameBuffer::command_buffer_type>> &&*/
+        meta::implements<TRenderPipeline, RenderPipeline<typename TRenderPipeline::pipeline_layout_type, typename TRenderPipeline::shader_program_type, typename TRenderPipeline::input_assembler_type, typename TRenderPipeline::rasterizer_type>> /*&&
+        meta::implements<TInputAttachmentMapping, IInputAttachmentMapping<TDerived>>*/
     class RenderPass : public virtual StateResource, public IRenderPass, public InputAttachmentMappingSource<TFrameBuffer> {
     public:
         using IRenderPass::updateAttachments;
@@ -880,7 +880,7 @@ namespace LiteFX::Rendering {
     /// </summary>
     /// <typeparam name="TImageInterface">The type of the image interface. Must inherit from <see cref="IImage"/>.</typeparam>
     template <typename TImageInterface, typename TFrameBuffer> requires
-        rtti::implements<TFrameBuffer, FrameBuffer<typename TFrameBuffer::command_buffer_type>> &&
+        meta::implements<TFrameBuffer, FrameBuffer<typename TFrameBuffer::command_buffer_type>> &&
         std::derived_from<TImageInterface, IImage>
     class SwapChain : public ISwapChain {
     public:
@@ -916,7 +916,7 @@ namespace LiteFX::Rendering {
     /// </summary>
     /// <typeparam name="TCommandBuffer">The type of the command buffer for this queue. Must implement <see cref="CommandBuffer"/>.</typeparam>
     template <typename TCommandBuffer> requires
-        rtti::implements<TCommandBuffer, CommandBuffer<typename TCommandBuffer::command_buffer_type, typename TCommandBuffer::buffer_type, typename TCommandBuffer::vertex_buffer_type, typename TCommandBuffer::index_buffer_type, typename TCommandBuffer::image_type, typename TCommandBuffer::barrier_type, typename TCommandBuffer::pipeline_type>>
+        meta::implements<TCommandBuffer, CommandBuffer<typename TCommandBuffer::command_buffer_type, typename TCommandBuffer::buffer_type, typename TCommandBuffer::vertex_buffer_type, typename TCommandBuffer::index_buffer_type, typename TCommandBuffer::image_type, typename TCommandBuffer::barrier_type, typename TCommandBuffer::pipeline_type>>
     class CommandQueue : public ICommandQueue {
     public:
         using ICommandQueue::submit;
@@ -970,7 +970,7 @@ namespace LiteFX::Rendering {
     /// <typeparam name="TBuffer">The type of the buffer. Must inherit from <see cref="IBuffer"/>.</typeparam>
     /// <typeparam name="TSampler">The type of the sampler. Must inherit from <see cref="ISampler"/>.</typeparam>
     template <typename TDescriptorLayout, typename TBuffer, typename TVertexBuffer, typename TIndexBuffer, typename TImage, typename TSampler> requires
-        rtti::implements<TDescriptorLayout, IDescriptorLayout> &&
+        meta::implements<TDescriptorLayout, IDescriptorLayout> &&
         std::derived_from<TVertexBuffer, VertexBuffer<typename TVertexBuffer::vertex_buffer_layout_type>> &&
         std::derived_from<TIndexBuffer, IndexBuffer<typename TIndexBuffer::index_buffer_layout_type>> &&
         std::derived_from<TImage, IImage> &&
@@ -1117,14 +1117,14 @@ namespace LiteFX::Rendering {
     /// <typeparam name="TComputePipeline">The type of the compute pipeline. Must implement <see cref="ComputePipeline" />.</typeparam>
     /// <typeparam name="TBarrier">The type of the memory barrier. Must implement <see cref="Barrier" />.</typeparam>
     template <typename TFactory, typename TSurface, typename TGraphicsAdapter, typename TSwapChain, typename TCommandQueue, typename TRenderPass, typename TComputePipeline, typename TBarrier> requires
-        rtti::implements<TSurface, ISurface> &&
-        rtti::implements<TGraphicsAdapter, IGraphicsAdapter> &&
-        rtti::implements<TSwapChain, SwapChain<typename TFactory::image_type, typename TRenderPass::frame_buffer_type>> &&
-        rtti::implements<TCommandQueue, CommandQueue<typename TCommandQueue::command_buffer_type>> &&
-        rtti::implements<TFactory, GraphicsFactory<typename TFactory::descriptor_layout_type, typename TFactory::buffer_type, typename TFactory::vertex_buffer_type, typename TFactory::index_buffer_type, typename TFactory::image_type, typename TFactory::sampler_type>> &&
-        rtti::implements<TRenderPass, RenderPass<typename TRenderPass::render_pipeline_type, TCommandQueue, typename TRenderPass::frame_buffer_type, typename TRenderPass::input_attachment_mapping_type>> &&
-        rtti::implements<TComputePipeline, ComputePipeline<typename TComputePipeline::pipeline_layout_type, typename TComputePipeline::shader_program_type>> &&
-        rtti::implements<TBarrier, Barrier<typename TFactory::buffer_type, typename TFactory::image_type>>
+        meta::implements<TSurface, ISurface> &&
+        meta::implements<TGraphicsAdapter, IGraphicsAdapter> &&
+        meta::implements<TSwapChain, SwapChain<typename TFactory::image_type, typename TRenderPass::frame_buffer_type>> &&
+        meta::implements<TCommandQueue, CommandQueue<typename TCommandQueue::command_buffer_type>> &&
+        meta::implements<TFactory, GraphicsFactory<typename TFactory::descriptor_layout_type, typename TFactory::buffer_type, typename TFactory::vertex_buffer_type, typename TFactory::index_buffer_type, typename TFactory::image_type, typename TFactory::sampler_type>> &&
+        meta::implements<TRenderPass, RenderPass<typename TRenderPass::render_pipeline_type, TCommandQueue, typename TRenderPass::frame_buffer_type, typename TRenderPass::input_attachment_mapping_type>> &&
+        meta::implements<TComputePipeline, ComputePipeline<typename TComputePipeline::pipeline_layout_type, typename TComputePipeline::shader_program_type>> &&
+        meta::implements<TBarrier, Barrier<typename TFactory::buffer_type, typename TFactory::image_type>>
     class GraphicsDevice : public IGraphicsDevice {
     public:
         using surface_type = TSurface;
@@ -1278,7 +1278,7 @@ namespace LiteFX::Rendering {
     /// </summary>
     /// <typeparam name="TGraphicsDevice">The type of the graphics device. Must implement <see cref="GraphicsDevice" />.</typeparam>
     template <typename TGraphicsDevice> requires
-        rtti::implements<TGraphicsDevice, GraphicsDevice<typename TGraphicsDevice::factory_type, typename TGraphicsDevice::surface_type, typename TGraphicsDevice::adapter_type, typename TGraphicsDevice::swap_chain_type, typename TGraphicsDevice::command_queue_type, typename TGraphicsDevice::render_pass_type, typename TGraphicsDevice::compute_pipeline_type, typename TGraphicsDevice::barrier_type>>
+        meta::implements<TGraphicsDevice, GraphicsDevice<typename TGraphicsDevice::factory_type, typename TGraphicsDevice::surface_type, typename TGraphicsDevice::adapter_type, typename TGraphicsDevice::swap_chain_type, typename TGraphicsDevice::command_queue_type, typename TGraphicsDevice::render_pass_type, typename TGraphicsDevice::compute_pipeline_type, typename TGraphicsDevice::barrier_type>>
     class RenderBackend : public IRenderBackend {
     public:
         using device_type = TGraphicsDevice;

--- a/src/Rendering/include/litefx/rendering_builders.hpp
+++ b/src/Rendering/include/litefx/rendering_builders.hpp
@@ -13,11 +13,11 @@ namespace LiteFX::Rendering {
     /// <seealso cref="Barrier" />
     /// <seealso cref="IBarrier" />
     template <typename TBarrier> requires
-        rtti::implements<TBarrier, Barrier<typename TBarrier::buffer_type, typename TBarrier::image_type>>
+        meta::implements<TBarrier, Barrier<typename TBarrier::buffer_type, typename TBarrier::image_type>>
     class BarrierBuilder : public Builder<TBarrier> {
     public:
         template <typename TParent> requires
-            rtti::implements<TParent, BarrierBuilder<TBarrier>>
+            meta::implements<TParent, BarrierBuilder<TBarrier>>
         struct [[nodiscard]] ImageBarrierBuilder;
 
         /// <summary>
@@ -25,7 +25,7 @@ namespace LiteFX::Rendering {
         /// </summary>
         /// <typeparam name="TParent">The type of the parent barrier builder.</typeparam>
         template <typename TParent> requires
-            rtti::implements<TParent, BarrierBuilder<TBarrier>>
+            meta::implements<TParent, BarrierBuilder<TBarrier>>
         struct [[nodiscard]] SecondStageBuilder {
         private:
             PipelineStage m_from;
@@ -58,7 +58,7 @@ namespace LiteFX::Rendering {
         /// </summary>
         /// <typeparam name="TParent">The type of the parent barrier builder.</typeparam>
         template <typename TParent> requires
-            rtti::implements<TParent, BarrierBuilder<TBarrier>>
+            meta::implements<TParent, BarrierBuilder<TBarrier>>
         struct [[nodiscard]] GlobalBarrierBuilder {
         private:
             ResourceAccess m_access;
@@ -90,7 +90,7 @@ namespace LiteFX::Rendering {
         /// </summary>
         /// <typeparam name="TParent">The type of the parent barrier builder.</typeparam>
         template <typename TParent> requires
-            rtti::implements<TParent, BarrierBuilder<TBarrier>>
+            meta::implements<TParent, BarrierBuilder<TBarrier>>
         struct [[nodiscard]] BufferBarrierBuilder {
         private:
             ResourceAccess m_access;
@@ -124,7 +124,7 @@ namespace LiteFX::Rendering {
         /// </summary>
         /// <typeparam name="TParent">The type of the parent barrier builder.</typeparam>
         template <typename TParent> requires
-            rtti::implements<TParent, BarrierBuilder<TBarrier>>
+            meta::implements<TParent, BarrierBuilder<TBarrier>>
         struct [[nodiscard]] ImageLayoutBarrierBuilder {
         private:
             ResourceAccess m_access;
@@ -167,7 +167,7 @@ namespace LiteFX::Rendering {
         /// </summary> 
         /// <typeparam name="TParent">The type of the parent barrier builder.</typeparam>
         template <typename TParent> requires
-            rtti::implements<TParent, BarrierBuilder<TBarrier>>
+            meta::implements<TParent, BarrierBuilder<TBarrier>>
         struct [[nodiscard]] ImageBarrierBuilder {
         private:
             ResourceAccess m_access;
@@ -357,7 +357,7 @@ namespace LiteFX::Rendering {
     /// <typeparam name="TShaderProgram">The type of the shader program. Must implement <see cref="ShaderProgram" />.</typeparam>
     /// <seealso cref="ShaderProgram" />
     template <typename TShaderProgram> requires
-        rtti::implements<TShaderProgram, ShaderProgram<typename TShaderProgram::shader_module_type>>
+        meta::implements<TShaderProgram, ShaderProgram<typename TShaderProgram::shader_module_type>>
     class ShaderProgramBuilder : public Builder<TShaderProgram, std::nullptr_t, SharedPtr<TShaderProgram>> {
     public:
         using Builder<TShaderProgram, std::nullptr_t, SharedPtr<TShaderProgram>>::Builder;
@@ -595,7 +595,7 @@ namespace LiteFX::Rendering {
     /// <typeparam name="TRasterizer">The type of the rasterizer. Must implement <see cref="IRasterizer" />.</typeparam>
     /// <seealso cref="IRasterizer" />
     template <typename TRasterizer> requires
-        rtti::implements<TRasterizer, IRasterizer>
+        meta::implements<TRasterizer, IRasterizer>
     class RasterizerBuilder : public Builder<TRasterizer, std::nullptr_t, SharedPtr<TRasterizer>> {
     public:
         using Builder<TRasterizer, std::nullptr_t, SharedPtr<TRasterizer>>::Builder;
@@ -720,7 +720,7 @@ namespace LiteFX::Rendering {
     /// <typeparam name="TVertexBufferLayout">The type of the vertex buffer layout. Must implement <see cref="IVertexBufferLayout" />.</typeparam>
     /// <seealso cref="IVertexBufferLayout" />
     template <typename TVertexBufferLayout, typename TParent> requires
-        rtti::implements<TVertexBufferLayout, IVertexBufferLayout>
+        meta::implements<TVertexBufferLayout, IVertexBufferLayout>
     class VertexBufferLayoutBuilder : public Builder<TVertexBufferLayout, TParent> {
     public:
         using Builder<TVertexBufferLayout, TParent>::Builder;
@@ -786,7 +786,7 @@ namespace LiteFX::Rendering {
     /// <seealso cref="DescriptorSetLayout" />
     /// <seealso cref="PipelineLayout" />
     template <typename TDescriptorSetLayout, typename TParent> requires
-        rtti::implements<TDescriptorSetLayout, DescriptorSetLayout<typename TDescriptorSetLayout::descriptor_layout_type, typename TDescriptorSetLayout::descriptor_set_type>>
+        meta::implements<TDescriptorSetLayout, DescriptorSetLayout<typename TDescriptorSetLayout::descriptor_layout_type, typename TDescriptorSetLayout::descriptor_set_type>>
     class DescriptorSetLayoutBuilder : public Builder<TDescriptorSetLayout, TParent> {
     public:
         using Builder<TDescriptorSetLayout, TParent>::Builder;
@@ -1014,7 +1014,7 @@ namespace LiteFX::Rendering {
     /// <typeparam name="TPushConstantsLayout">The type of the push constants layout. Must implement <see cref="PushConstantsLayout" />.</typeparam>
     /// <seealso cref="PushConstantsLayout" />
     template <typename TPushConstantsLayout, typename TParent> requires
-        rtti::implements<TPushConstantsLayout, PushConstantsLayout<typename TPushConstantsLayout::push_constants_range_type>>
+        meta::implements<TPushConstantsLayout, PushConstantsLayout<typename TPushConstantsLayout::push_constants_range_type>>
     class PushConstantsLayoutBuilder : public Builder<TPushConstantsLayout, TParent> {
     public:
         using Builder<TPushConstantsLayout, TParent>::Builder;
@@ -1065,7 +1065,7 @@ namespace LiteFX::Rendering {
     /// <typeparam name="TPipelineLayout">The type of the pipeline layout. Must implement <see cref="PipelineLayout" />.</typeparam>
     /// <seealso cref="PipelineLayout" />
     template <typename TPipelineLayout> requires
-        rtti::implements<TPipelineLayout, PipelineLayout<typename TPipelineLayout::descriptor_set_layout_type, typename TPipelineLayout::push_constants_layout_type>>
+        meta::implements<TPipelineLayout, PipelineLayout<typename TPipelineLayout::descriptor_set_layout_type, typename TPipelineLayout::push_constants_layout_type>>
     class PipelineLayoutBuilder : public Builder<TPipelineLayout, std::nullptr_t, SharedPtr<TPipelineLayout>> {
     public:
         using Builder<TPipelineLayout, std::nullptr_t, SharedPtr<TPipelineLayout>>::Builder;
@@ -1119,7 +1119,7 @@ namespace LiteFX::Rendering {
     /// <typeparam name="TInputAssembler">The type of the input assembler state. Must implement <see cref="InputAssembler" />.</typeparam>
     /// <seealso cref="InputAssembler" />
     template <typename TInputAssembler> requires
-        rtti::implements<TInputAssembler, InputAssembler<typename TInputAssembler::vertex_buffer_layout_type, typename TInputAssembler::index_buffer_layout_type>>
+        meta::implements<TInputAssembler, InputAssembler<typename TInputAssembler::vertex_buffer_layout_type, typename TInputAssembler::index_buffer_layout_type>>
     class InputAssemblerBuilder : public Builder<TInputAssembler, std::nullptr_t, SharedPtr<TInputAssembler>> {
     public:
         using Builder<TInputAssembler, std::nullptr_t, SharedPtr<TInputAssembler>>::Builder;
@@ -1187,7 +1187,7 @@ namespace LiteFX::Rendering {
     /// <typeparam name="TRenderPipeline">The type of the render pipeline. Must implement <see cref="RenderPipeline" />.</typeparam>
     /// <seealso cref="RenderPipeline" />
     template <typename TRenderPipeline> requires
-        rtti::implements<TRenderPipeline, RenderPipeline<typename TRenderPipeline::pipeline_layout_type, typename TRenderPipeline::shader_program_type, typename TRenderPipeline::input_assembler_type, typename TRenderPipeline::rasterizer_type>>
+        meta::implements<TRenderPipeline, RenderPipeline<typename TRenderPipeline::pipeline_layout_type, typename TRenderPipeline::shader_program_type, typename TRenderPipeline::input_assembler_type, typename TRenderPipeline::rasterizer_type>>
     class RenderPipelineBuilder : public Builder<TRenderPipeline> {
     public:
         using Builder<TRenderPipeline>::Builder;
@@ -1293,7 +1293,7 @@ namespace LiteFX::Rendering {
     /// <typeparam name="TComputePipeline">The type of the compute pipeline. Must implement <see cref="ComputePipeline" />.</typeparam>
     /// <seealso cref="ComputePipeline" />
     template <typename TComputePipeline> requires
-        rtti::implements<TComputePipeline, ComputePipeline<typename TComputePipeline::pipeline_layout_type, typename TComputePipeline::shader_program_type>>
+        meta::implements<TComputePipeline, ComputePipeline<typename TComputePipeline::pipeline_layout_type, typename TComputePipeline::shader_program_type>>
     class ComputePipelineBuilder : public Builder<TComputePipeline> {
     public:
         using Builder<TComputePipeline>::Builder;
@@ -1350,7 +1350,7 @@ namespace LiteFX::Rendering {
     /// <typeparam name="TRenderPass">The type of the render pass. Must implement <see cref="RenderPass" />.</typeparam>
     /// <seealso cref="RenderPass" />
     template <typename TRenderPass> requires
-        rtti::implements<TRenderPass, RenderPass<typename TRenderPass::render_pipeline_type, typename TRenderPass::command_queue_type, typename TRenderPass::frame_buffer_type, typename TRenderPass::input_attachment_mapping_type>>
+        meta::implements<TRenderPass, RenderPass<typename TRenderPass::render_pipeline_type, typename TRenderPass::command_queue_type, typename TRenderPass::frame_buffer_type, typename TRenderPass::input_attachment_mapping_type>>
     class RenderPassBuilder : public Builder<TRenderPass> {
     public:
         using Builder<TRenderPass>::Builder;

--- a/src/Samples/BasicRendering/src/sample.cpp
+++ b/src/Samples/BasicRendering/src/sample.cpp
@@ -26,7 +26,7 @@ struct TransformBuffer {
 } transform;
 
 template<typename TRenderBackend> requires
-    rtti::implements<TRenderBackend, IRenderBackend>
+    meta::implements<TRenderBackend, IRenderBackend>
 struct FileExtensions {
     static const String SHADER;
 };
@@ -39,7 +39,7 @@ const String FileExtensions<DirectX12Backend>::SHADER = "dxi";
 #endif // LITEFX_BUILD_DIRECTX_12_BACKEND
 
 template<typename TRenderBackend> requires
-    rtti::implements<TRenderBackend, IRenderBackend>
+    meta::implements<TRenderBackend, IRenderBackend>
 void initRenderGraph(TRenderBackend* backend, SharedPtr<IInputAssembler>& inputAssemblerState)
 {
     using RenderPass = TRenderBackend::render_pass_type;

--- a/src/Samples/Bindless/src/sample.cpp
+++ b/src/Samples/Bindless/src/sample.cpp
@@ -37,7 +37,7 @@ struct InstanceBuffer {
 } instanceData[NUM_INSTANCES];
 
 template<typename TRenderBackend> requires
-    rtti::implements<TRenderBackend, IRenderBackend>
+    meta::implements<TRenderBackend, IRenderBackend>
 struct FileExtensions {
     static const String SHADER;
 };
@@ -70,7 +70,7 @@ static void initInstanceData()
 }
 
 template<typename TRenderBackend> requires
-    rtti::implements<TRenderBackend, IRenderBackend>
+    meta::implements<TRenderBackend, IRenderBackend>
 void initRenderGraph(TRenderBackend* backend, SharedPtr<IInputAssembler>& inputAssemblerState)
 {
     using RenderPass = TRenderBackend::render_pass_type;

--- a/src/Samples/Compute/src/sample.cpp
+++ b/src/Samples/Compute/src/sample.cpp
@@ -26,7 +26,7 @@ struct TransformBuffer {
 } transform;
 
 template<typename TRenderBackend> requires
-    rtti::implements<TRenderBackend, IRenderBackend>
+    meta::implements<TRenderBackend, IRenderBackend>
 struct FileExtensions {
     static const String SHADER;
 };
@@ -39,7 +39,7 @@ const String FileExtensions<DirectX12Backend>::SHADER = "dxi";
 #endif // LITEFX_BUILD_DIRECTX_12_BACKEND
 
 template<typename TRenderBackend> requires
-    rtti::implements<TRenderBackend, IRenderBackend>
+    meta::implements<TRenderBackend, IRenderBackend>
 void initRenderGraph(TRenderBackend* backend, SharedPtr<IInputAssembler>& inputAssemblerState)
 {
     using RenderPass = TRenderBackend::render_pass_type;

--- a/src/Samples/MeshShader/src/sample.cpp
+++ b/src/Samples/MeshShader/src/sample.cpp
@@ -16,7 +16,7 @@ struct TransformBuffer {
 } transform;
 
 template<typename TRenderBackend> requires
-    rtti::implements<TRenderBackend, IRenderBackend>
+    meta::implements<TRenderBackend, IRenderBackend>
 struct FileExtensions {
     static const String SHADER;
 };
@@ -29,7 +29,7 @@ const String FileExtensions<DirectX12Backend>::SHADER = "dxi";
 #endif // LITEFX_BUILD_DIRECTX_12_BACKEND
 
 template<typename TRenderBackend> requires
-    rtti::implements<TRenderBackend, IRenderBackend>
+    meta::implements<TRenderBackend, IRenderBackend>
 void initRenderGraph(TRenderBackend* backend)
 {
     using RenderPass = TRenderBackend::render_pass_type;

--- a/src/Samples/Multisampling/src/sample.cpp
+++ b/src/Samples/Multisampling/src/sample.cpp
@@ -26,7 +26,7 @@ struct TransformBuffer {
 } transform;
 
 template<typename TRenderBackend> requires
-    rtti::implements<TRenderBackend, IRenderBackend>
+    meta::implements<TRenderBackend, IRenderBackend>
 struct FileExtensions {
     static const String SHADER;
 };
@@ -39,7 +39,7 @@ const String FileExtensions<DirectX12Backend>::SHADER = "dxi";
 #endif // LITEFX_BUILD_DIRECTX_12_BACKEND
 
 template<typename TRenderBackend> requires
-    rtti::implements<TRenderBackend, IRenderBackend>
+    meta::implements<TRenderBackend, IRenderBackend>
 void initRenderGraph(TRenderBackend* backend, SharedPtr<IInputAssembler>& inputAssemblerState)
 {
     using RenderPass = TRenderBackend::render_pass_type;

--- a/src/Samples/Multithreading/src/sample.cpp
+++ b/src/Samples/Multithreading/src/sample.cpp
@@ -39,7 +39,7 @@ const Array<glm::vec3> translations =
 };
 
 template<typename TRenderBackend> requires
-    rtti::implements<TRenderBackend, IRenderBackend>
+    meta::implements<TRenderBackend, IRenderBackend>
 struct FileExtensions {
     static const String SHADER;
 };
@@ -52,7 +52,7 @@ const String FileExtensions<DirectX12Backend>::SHADER = "dxi";
 #endif // LITEFX_BUILD_DIRECTX_12_BACKEND
 
 template<typename TRenderBackend> requires
-    rtti::implements<TRenderBackend, IRenderBackend>
+    meta::implements<TRenderBackend, IRenderBackend>
 void initRenderGraph(TRenderBackend* backend, SharedPtr<IInputAssembler>& inputAssemblerState)
 {
     using RenderPass = TRenderBackend::render_pass_type;

--- a/src/Samples/PushConstants/src/sample.cpp
+++ b/src/Samples/PushConstants/src/sample.cpp
@@ -53,7 +53,7 @@ const Array<glm::vec4> colors =
 };
 
 template<typename TRenderBackend> requires
-    rtti::implements<TRenderBackend, IRenderBackend>
+    meta::implements<TRenderBackend, IRenderBackend>
 struct FileExtensions {
     static const String SHADER;
 };
@@ -66,7 +66,7 @@ const String FileExtensions<DirectX12Backend>::SHADER = "dxi";
 #endif // LITEFX_BUILD_DIRECTX_12_BACKEND
 
 template<typename TRenderBackend> requires
-    rtti::implements<TRenderBackend, IRenderBackend>
+    meta::implements<TRenderBackend, IRenderBackend>
 void initRenderGraph(TRenderBackend* backend, SharedPtr<IInputAssembler>& inputAssemblerState)
 {
     using RenderPass = TRenderBackend::render_pass_type;

--- a/src/Samples/RenderPasses/src/sample.cpp
+++ b/src/Samples/RenderPasses/src/sample.cpp
@@ -36,7 +36,7 @@ struct TransformBuffer {
 } transform;
 
 template<typename TRenderBackend> requires
-    rtti::implements<TRenderBackend, IRenderBackend>
+    meta::implements<TRenderBackend, IRenderBackend>
 struct FileExtensions {
     static const String SHADER;
 };
@@ -49,7 +49,7 @@ const String FileExtensions<DirectX12Backend>::SHADER = "dxi";
 #endif // LITEFX_BUILD_DIRECTX_12_BACKEND
 
 template<typename TRenderBackend> requires
-    rtti::implements<TRenderBackend, IRenderBackend>
+    meta::implements<TRenderBackend, IRenderBackend>
 void initRenderGraph(TRenderBackend* backend, SharedPtr<IInputAssembler>& inputAssemblerState)
 {
     using RenderPass = TRenderBackend::render_pass_type;

--- a/src/Samples/Textures/src/sample.cpp
+++ b/src/Samples/Textures/src/sample.cpp
@@ -30,7 +30,7 @@ struct TransformBuffer {
 } transform;
 
 template<typename TRenderBackend> requires
-rtti::implements<TRenderBackend, IRenderBackend>
+meta::implements<TRenderBackend, IRenderBackend>
 struct FileExtensions {
     static const String SHADER;
 };
@@ -43,7 +43,7 @@ const String FileExtensions<DirectX12Backend>::SHADER = "dxi";
 #endif // LITEFX_BUILD_DIRECTX_12_BACKEND
 
 template<typename TRenderBackend> requires
-    rtti::implements<TRenderBackend, IRenderBackend>
+    meta::implements<TRenderBackend, IRenderBackend>
 void initRenderGraph(TRenderBackend* backend, SharedPtr<IInputAssembler>& inputAssemblerState)
 {
     using RenderPass = TRenderBackend::render_pass_type;
@@ -95,7 +95,7 @@ void initRenderGraph(TRenderBackend* backend, SharedPtr<IInputAssembler>& inputA
 }
 
 template<typename TDevice> requires
-    rtti::implements<TDevice, IGraphicsDevice>
+    meta::implements<TDevice, IGraphicsDevice>
 void loadTexture(TDevice& device, UniquePtr<IImage>& texture, UniquePtr<ISampler>& sampler)
 {
     using TBarrier = typename TDevice::barrier_type;
@@ -146,7 +146,7 @@ void loadTexture(TDevice& device, UniquePtr<IImage>& texture, UniquePtr<ISampler
 }
 
 template<typename TDevice> requires
-    rtti::implements<TDevice, IGraphicsDevice>
+    meta::implements<TDevice, IGraphicsDevice>
 UInt64 initBuffers(SampleApp& app, TDevice& device, SharedPtr<IInputAssembler> inputAssembler)
 {
     // Get a command buffer

--- a/src/Samples/UniformArrays/src/sample.cpp
+++ b/src/Samples/UniformArrays/src/sample.cpp
@@ -62,7 +62,7 @@ struct LightBuffer {
 } lights[LIGHT_SOURCES];
 
 template<typename TRenderBackend> requires
-    rtti::implements<TRenderBackend, IRenderBackend>
+    meta::implements<TRenderBackend, IRenderBackend>
 struct FileExtensions {
     static const String SHADER;
 };
@@ -75,7 +75,7 @@ const String FileExtensions<DirectX12Backend>::SHADER = "dxi";
 #endif // LITEFX_BUILD_DIRECTX_12_BACKEND
 
 template<typename TRenderBackend> requires
-    rtti::implements<TRenderBackend, IRenderBackend>
+    meta::implements<TRenderBackend, IRenderBackend>
 void initRenderGraph(TRenderBackend* backend, SharedPtr<IInputAssembler>& inputAssemblerState)
 {
     using RenderPass = TRenderBackend::render_pass_type;


### PR DESCRIPTION
**Describe the pull request**

This PR renames the unintuitively names `rtti` namespace into `meta`, which is more appropriate. It also adds missing documentation for concepts and type traits.
