### PR TITLE
Command buffer improvements

### DIFF
--- a/docs/release-logs/0.4.1.md
+++ b/docs/release-logs/0.4.1.md
@@ -12,14 +12,15 @@
 - Improvements to C++ core guideline conformance. ([See PR #103](https://github.com/crud89/LiteFX/pull/103))
 - New event infrastructure. ([See PR #81](https://github.com/crud89/LiteFX/pull/81))
 - Add support for user-defined debug markers. ([See PR #82](https://github.com/crud89/LiteFX/pull/82))
-- Improved resource allocation and binding: ([See PR #83](https://github.com/crud89/LiteFX/pull/83), [PR #110](https://github.com/crud89/LiteFX/pull/110) and [PR #111](https://github.com/crud89/LiteFX/pull/111))
+- Improved resource allocation and binding: ([See PR #83](https://github.com/crud89/LiteFX/pull/83), [PR #110](https://github.com/crud89/LiteFX/pull/110), [PR #111](https://github.com/crud89/LiteFX/pull/111) and [PR #123](https://github.com/crud89/LiteFX/pull/123))
   - Resources can now be created without querying the descriptor set layout or descriptor layout in advance.
   - When allocating descriptor sets, default bindings can be provided to make bind-once scenarios more straightforward.
-  - Descriptor sets can also be allocated without providing any binding index (in which case continous counting is assumed) or resources (which enables late binding or resource updating).
-  - Descriptor set binding has been simplified by caching last used pipeline on command buffers.
-- Improved handling of temporary command buffers. ([See PR #89](https://github.com/crud89/LiteFX/pull/89))
+  - Descriptor sets can also be allocated without providing any binding index (in which case continuous counting is assumed) or resources (which enables late binding or resource updating).
+  - Descriptor set binding has been simplified by caching last used pipeline on command buffers and providing the possibility to bind multiple descriptor sets at once.
+- Improved handling of temporary command buffers. ([See PR #89](https://github.com/crud89/LiteFX/pull/89) and [PR # 123](https://github.com/crud89/LiteFX/pull/123))
   - Command buffers can now be submitted with shared ownership to a command queue, which then stores them and releases the references, if the submit fence is passed (during `waitFor`).
   - Command buffer transfers can now receive resources with shared ownership. Resource references are released in a similar fashion.
+  - It is no longer required to manually allocate staging buffers, as raw data can now be passed to transfers on command buffers directly.
   - To share ownership, the `asShared` function can be used.
 - Allow manual command queue allocation for advanced parallel workloads. ([See PR #112](https://github.com/crud89/LiteFX/pull/112) and [PR #114](https://github.com/crud89/LiteFX/pull/114))
   -  New "Compute" example demonstrates how to use and synchronize different graphics and compute queues.
@@ -27,7 +28,7 @@
 - Vector conversion to math types can now be done for constant vectors. ([See PR #87](https://github.com/crud89/LiteFX/pull/87))
 - Backend types now import contra-variant interface functions instead of hiding them. ([See PR #91](https://github.com/crud89/LiteFX/pull/91))
 - Add support for GPU time measurements (*Timing Events*). ([See PR #94](https://github.com/crud89/LiteFX/pull/94))
-- Add builder interface for barriers and extent barrier flexibility. ([See PR #97](https://github.com/crud89/LiteFX/pull/97))
+- Add builder interface for barriers and extent barrier flexibility. ([See PR #97](https://github.com/crud89/LiteFX/pull/97) and [PR #123](https://github.com/crud89/LiteFX/pull/123))
 - Add support for static secondary command buffers aka. bundles. ([See PR #100](https://github.com/crud89/LiteFX/pull/100))
 - Render targets are now created with a set of flags instead of individual boolean switches. ([See PR #114](https://github.com/crud89/LiteFX/pull/114))
   - This also enables for more use cases, like using render targets in read-write bindings or sharing between different queues.

--- a/src/Backends/DirectX12/include/litefx/backends/dx12.hpp
+++ b/src/Backends/DirectX12/include/litefx/backends/dx12.hpp
@@ -1081,6 +1081,9 @@ namespace LiteFX::Rendering::Backends {
         void generateMipMaps(IDirectX12Image& image) noexcept override;
 
         /// <inheritdoc />
+        UniquePtr<DirectX12Barrier> makeBarrier(PipelineStage syncBefore, PipelineStage syncAfter) const noexcept override;
+
+        /// <inheritdoc />
         void barrier(const DirectX12Barrier& barrier) const noexcept override;
 
         /// <inheritdoc />

--- a/src/Backends/DirectX12/include/litefx/backends/dx12.hpp
+++ b/src/Backends/DirectX12/include/litefx/backends/dx12.hpp
@@ -1125,8 +1125,14 @@ namespace LiteFX::Rendering::Backends {
 		/// <inheritdoc />
 		void bind(const DirectX12DescriptorSet& descriptorSet) const override;
 
+        /// <inheritdoc />
+        void bind(Span<const DirectX12DescriptorSet*> descriptorSets) const override;
+
+        /// <inheritdoc />
+        void bind(const DirectX12DescriptorSet& descriptorSet, const DirectX12PipelineState& pipeline) const noexcept override;
+
 		/// <inheritdoc />
-		void bind(const DirectX12DescriptorSet& descriptorSet, const DirectX12PipelineState& pipeline) const noexcept override;
+		void bind(Span<const DirectX12DescriptorSet*> descriptorSets, const DirectX12PipelineState& pipeline) const noexcept override;
 
         /// <inheritdoc />
         void bind(const IDirectX12VertexBuffer& buffer) const noexcept override;

--- a/src/Backends/DirectX12/include/litefx/backends/dx12.hpp
+++ b/src/Backends/DirectX12/include/litefx/backends/dx12.hpp
@@ -1087,7 +1087,19 @@ namespace LiteFX::Rendering::Backends {
         void transfer(IDirectX12Buffer& source, IDirectX12Buffer& target, UInt32 sourceElement = 0, UInt32 targetElement = 0, UInt32 elements = 1) const override;
 
         /// <inheritdoc />
+        void transfer(const void* const data, size_t size, IDirectX12Buffer& target, UInt32 targetElement = 0, UInt32 elements = 1) const override;
+
+        /// <inheritdoc />
+        void transfer(Span<const void* const> data, size_t elementSize, IDirectX12Buffer& target, UInt32 firstElement = 0) const override;
+
+        /// <inheritdoc />
         void transfer(IDirectX12Buffer& source, IDirectX12Image& target, UInt32 sourceElement = 0, UInt32 firstSubresource = 0, UInt32 elements = 1) const override;
+
+        /// <inheritdoc />
+        void transfer(const void* const data, size_t size, IDirectX12Image& target, UInt32 subresource = 0) const override;
+
+        /// <inheritdoc />
+        void transfer(Span<const void* const> data, size_t elementSize, IDirectX12Image& target, UInt32 firstSubresource = 0, UInt32 subresources = 1) const override;
 
         /// <inheritdoc />
         void transfer(IDirectX12Image& source, IDirectX12Image& target, UInt32 sourceSubresource = 0, UInt32 targetSubresource = 0, UInt32 subresources = 1) const override;

--- a/src/Backends/DirectX12/src/command_buffer.cpp
+++ b/src/Backends/DirectX12/src/command_buffer.cpp
@@ -329,6 +329,27 @@ void DirectX12CommandBuffer::transfer(IDirectX12Buffer& source, IDirectX12Buffer
 	this->handle()->CopyBufferRegion(std::as_const(target).handle().Get(), targetElement * target.alignedElementSize(), std::as_const(source).handle().Get(), sourceElement * source.alignedElementSize(), elements * source.alignedElementSize());
 }
 
+void DirectX12CommandBuffer::transfer(const void* const data, size_t size, IDirectX12Buffer& target, UInt32 targetElement, UInt32 elements) const
+{
+	auto alignment = target.elementAlignment();
+	auto elementSize = target.elementSize();
+	auto alignedSize = target.alignedElementSize();
+
+	auto stagingBuffer = asShared(std::move(m_impl->m_queue.device().factory().createBuffer(target.type(), ResourceHeap::Staging, target.elementSize(), elements)));
+	stagingBuffer->map(data, size, 0);
+
+	this->transfer(stagingBuffer, target, 0, targetElement, elements);
+}
+
+void DirectX12CommandBuffer::transfer(Span<const void* const> data, size_t elementSize, IDirectX12Buffer& target, UInt32 firstElement) const
+{
+	auto elements = static_cast<UInt32>(data.size());
+	auto stagingBuffer = asShared(std::move(m_impl->m_queue.device().factory().createBuffer(target.type(), ResourceHeap::Staging, target.elementSize(), elements)));
+	stagingBuffer->map(data, elementSize, 0);
+
+	this->transfer(stagingBuffer, target, 0, firstElement, elements);
+}
+
 void DirectX12CommandBuffer::transfer(IDirectX12Buffer& source, IDirectX12Image& target, UInt32 sourceElement, UInt32 firstSubresource, UInt32 elements) const
 {
 	if (source.elements() < sourceElement + elements) [[unlikely]]
@@ -346,6 +367,23 @@ void DirectX12CommandBuffer::transfer(IDirectX12Buffer& source, IDirectX12Image&
 		CD3DX12_TEXTURE_COPY_LOCATION sourceLocation(std::as_const(source).handle().Get(), footprint), targetLocation(std::as_const(target).handle().Get(), firstSubresource + sr);
 		this->handle()->CopyTextureRegion(&targetLocation, 0, 0, 0, &sourceLocation, nullptr);
 	}
+}
+
+void DirectX12CommandBuffer::transfer(const void* const data, size_t size, IDirectX12Image& target, UInt32 subresource) const
+{
+	auto stagingBuffer = asShared(std::move(m_impl->m_queue.device().factory().createBuffer(BufferType::Other, ResourceHeap::Staging, size)));
+	stagingBuffer->map(data, size, 0);
+
+	this->transfer(stagingBuffer, target, 0, subresource, 1);
+}
+
+void DirectX12CommandBuffer::transfer(Span<const void* const> data, size_t elementSize, IDirectX12Image& target, UInt32 firstSubresource, UInt32 subresources) const
+{
+	auto elements = static_cast<UInt32>(data.size());
+	auto stagingBuffer = asShared(std::move(m_impl->m_queue.device().factory().createBuffer(BufferType::Other, ResourceHeap::Staging, elementSize, elements)));
+	stagingBuffer->map(data, elementSize, 0);
+
+	this->transfer(stagingBuffer, target, 0, firstSubresource, subresources);
 }
 
 void DirectX12CommandBuffer::transfer(IDirectX12Image& source, IDirectX12Image& target, UInt32 sourceSubresource, UInt32 targetSubresource, UInt32 subresources) const

--- a/src/Backends/DirectX12/src/command_buffer.cpp
+++ b/src/Backends/DirectX12/src/command_buffer.cpp
@@ -313,6 +313,11 @@ void DirectX12CommandBuffer::generateMipMaps(IDirectX12Image& image) noexcept
 	}
 }
 
+UniquePtr<DirectX12Barrier> DirectX12CommandBuffer::makeBarrier(PipelineStage syncBefore, PipelineStage syncAfter) const noexcept
+{
+	return m_impl->m_queue.device().makeBarrier(syncBefore, syncAfter);
+}
+
 void DirectX12CommandBuffer::barrier(const DirectX12Barrier& barrier) const noexcept
 {
 	barrier.execute(*this);

--- a/src/Backends/DirectX12/src/command_buffer.cpp
+++ b/src/Backends/DirectX12/src/command_buffer.cpp
@@ -458,9 +458,22 @@ void DirectX12CommandBuffer::bind(const DirectX12DescriptorSet& descriptorSet) c
 		throw RuntimeException("No pipeline has been used on the command buffer before attempting to bind the descriptor set.");
 }
 
+void DirectX12CommandBuffer::bind(Span<const DirectX12DescriptorSet*> descriptorSets) const
+{
+	if (m_impl->m_lastPipeline) [[likely]]
+		std::ranges::for_each(descriptorSets | std::views::filter([](auto descriptorSet) { return descriptorSet != nullptr; }), [this](auto descriptorSet) { m_impl->m_queue.device().bindDescriptorSet(*this, *descriptorSet, *m_impl->m_lastPipeline); });
+	else
+		throw RuntimeException("No pipeline has been used on the command buffer before attempting to bind the descriptor set.");
+}
+
 void DirectX12CommandBuffer::bind(const DirectX12DescriptorSet& descriptorSet, const DirectX12PipelineState& pipeline) const noexcept
 {
 	m_impl->m_queue.device().bindDescriptorSet(*this, descriptorSet, pipeline);
+}
+
+void DirectX12CommandBuffer::bind(Span<const DirectX12DescriptorSet*> descriptorSets, const DirectX12PipelineState& pipeline) const noexcept
+{
+	std::ranges::for_each(descriptorSets | std::views::filter([](auto descriptorSet) { return descriptorSet != nullptr; }), [this](auto descriptorSet) { m_impl->m_queue.device().bindDescriptorSet(*this, *descriptorSet, *m_impl->m_lastPipeline); });
 }
 
 void DirectX12CommandBuffer::bind(const IDirectX12VertexBuffer& buffer) const noexcept 

--- a/src/Backends/DirectX12/src/factory.cpp
+++ b/src/Backends/DirectX12/src/factory.cpp
@@ -68,13 +68,20 @@ UniquePtr<IDirectX12Buffer> DirectX12GraphicsFactory::createBuffer(const String&
 	// Constant buffers are aligned to 256 byte chunks. All other buffers can be aligned to a multiple of 4 bytes (`sizeof(DWORD)`). The actual amount of memory allocated 
 	// is then defined as the smallest multiple of 64kb, that's greater or equal to `resourceDesc.Width` below. For more info, see:
 	// https://docs.microsoft.com/en-us/windows/win32/api/d3d12/nf-d3d12-id3d12device-getresourceallocationinfo#remarks.
-	size_t elementAlignment = type == BufferType::Uniform ? D3D12_CONSTANT_BUFFER_DATA_PLACEMENT_ALIGNMENT : sizeof(DWORD);
+	size_t elementAlignment = 0;
+
+	switch (type)
+	{
+	case BufferType::Uniform: elementAlignment = D3D12_CONSTANT_BUFFER_DATA_PLACEMENT_ALIGNMENT; break;
+	case BufferType::Vertex:
+	case BufferType::Index:   elementAlignment = 0; break;
+	default:                  elementAlignment = sizeof(DWORD); break;
+	}
 
 	D3D12_RESOURCE_DESC1 resourceDesc { };
 	resourceDesc.Dimension = D3D12_RESOURCE_DIMENSION_BUFFER;
 	resourceDesc.Alignment = 0;
-	//resourceDesc.Width = layout.elementSize() * elements;
-	resourceDesc.Width = elements * ((elementSize + elementAlignment - 1) & ~(elementAlignment - 1));	// Align elements to 256 bytes.
+	resourceDesc.Width = elements * (elementAlignment > 0 ? Math::align(elementSize, elementAlignment) : elementSize);
 	resourceDesc.Height = 1;
 	resourceDesc.DepthOrArraySize = 1;
 	resourceDesc.MipLevels = 1;

--- a/src/Backends/Vulkan/include/litefx/backends/vulkan.hpp
+++ b/src/Backends/Vulkan/include/litefx/backends/vulkan.hpp
@@ -960,8 +960,8 @@ namespace LiteFX::Rendering::Backends {
         /// Binds a descriptor set on a command buffer.
         /// </summary>
         /// <param name="commandBuffer">The command buffer to issue the bind command on.</param>
-        /// <param name="descriptorSet">The descriptor set to bind.</param>
-        virtual void bind(const VulkanCommandBuffer& commandBuffer, const VulkanDescriptorSet& descriptorSet) const noexcept = 0;
+        /// <param name="descriptorSets">The descriptor sets to bind.</param>
+        virtual void bind(const VulkanCommandBuffer& commandBuffer, Span<const VulkanDescriptorSet*> descriptorSets) const noexcept = 0;
     };
 
     /// <summary>
@@ -1104,8 +1104,14 @@ namespace LiteFX::Rendering::Backends {
 		/// <inheritdoc />
 		void bind(const VulkanDescriptorSet& descriptorSet) const override;
 
+        /// <inheritdoc />
+        void bind(Span<const VulkanDescriptorSet*> descriptorSets) const override;
+
 		/// <inheritdoc />
 		void bind(const VulkanDescriptorSet& descriptorSet, const VulkanPipelineState& pipeline) const noexcept override;
+
+        /// <inheritdoc />
+        void bind(Span<const VulkanDescriptorSet*> descriptorSets, const VulkanPipelineState& pipeline) const noexcept override;
 
         /// <inheritdoc />
         void bind(const IVulkanVertexBuffer& buffer) const noexcept override;
@@ -1220,7 +1226,7 @@ namespace LiteFX::Rendering::Backends {
         void use(const VulkanCommandBuffer& commandBuffer) const noexcept override;
 
         /// <inheritdoc />
-        void bind(const VulkanCommandBuffer& commandBuffer, const VulkanDescriptorSet& descriptorSet) const noexcept override;
+        void bind(const VulkanCommandBuffer& commandBuffer, Span<const VulkanDescriptorSet*> descriptorSets) const noexcept override;
     };
 
     /// <summary>
@@ -1266,7 +1272,7 @@ namespace LiteFX::Rendering::Backends {
         void use(const VulkanCommandBuffer& commandBuffer) const noexcept override;
 
         /// <inheritdoc />
-        void bind(const VulkanCommandBuffer& commandBuffer, const VulkanDescriptorSet& descriptorSet) const noexcept override;
+        void bind(const VulkanCommandBuffer& commandBuffer, Span<const VulkanDescriptorSet*> descriptorSets) const noexcept override;
     };
     
     /// <summary>
@@ -1334,7 +1340,7 @@ namespace LiteFX::Rendering::Backends {
         void use(const VulkanCommandBuffer& commandBuffer) const noexcept override;
 
         /// <inheritdoc />
-        void bind(const VulkanCommandBuffer& commandBuffer, const VulkanDescriptorSet& descriptorSet) const noexcept override;
+        void bind(const VulkanCommandBuffer& commandBuffer, Span<const VulkanDescriptorSet*> descriptorSets) const noexcept override;
     };
 
     /// <summary>

--- a/src/Backends/Vulkan/include/litefx/backends/vulkan.hpp
+++ b/src/Backends/Vulkan/include/litefx/backends/vulkan.hpp
@@ -1060,6 +1060,9 @@ namespace LiteFX::Rendering::Backends {
         void generateMipMaps(IVulkanImage& image) noexcept override;
 
         /// <inheritdoc />
+        UniquePtr<VulkanBarrier> makeBarrier(PipelineStage syncBefore, PipelineStage syncAfter) const noexcept override;
+
+        /// <inheritdoc />
         void barrier(const VulkanBarrier& barrier) const noexcept override;
 
         /// <inheritdoc />

--- a/src/Backends/Vulkan/include/litefx/backends/vulkan.hpp
+++ b/src/Backends/Vulkan/include/litefx/backends/vulkan.hpp
@@ -1066,7 +1066,19 @@ namespace LiteFX::Rendering::Backends {
         void transfer(IVulkanBuffer& source, IVulkanBuffer& target, UInt32 sourceElement = 0, UInt32 targetElement = 0, UInt32 elements = 1) const override;
 
         /// <inheritdoc />
-        void transfer(IVulkanBuffer& source, IVulkanImage& target, UInt32 sourceElement = 0, UInt32 firstSubresource = 0, UInt32 elements = 1) const override;
+        void transfer(const void* const data, size_t size, IVulkanBuffer& target, UInt32 targetElement = 0, UInt32 elements = 1) const override;
+
+        /// <inheritdoc />
+        void transfer(Span<const void* const> data, size_t elementSize, IVulkanBuffer& target, UInt32 firstElement = 0) const override;
+
+        /// <inheritdoc />
+        void transfer(IVulkanBuffer& source, IVulkanImage& target, UInt32 sourceElement = 0, UInt32 firstSubresource = 0, UInt32 subresources = 1) const override;
+
+        /// <inheritdoc />
+        void transfer(const void* const data, size_t size, IVulkanImage& target, UInt32 subresource = 0) const override;
+
+        /// <inheritdoc />
+        void transfer(Span<const void* const> data, size_t elementSize, IVulkanImage& target, UInt32 firstSubresource = 0, UInt32 subresources = 1) const override;
 
         /// <inheritdoc />
         void transfer(IVulkanImage& source, IVulkanImage& target, UInt32 sourceSubresource = 0, UInt32 targetSubresource = 0, UInt32 subresources = 1) const override;

--- a/src/Backends/Vulkan/src/command_buffer.cpp
+++ b/src/Backends/Vulkan/src/command_buffer.cpp
@@ -562,15 +562,31 @@ void VulkanCommandBuffer::use(const VulkanPipelineState& pipeline) const noexcep
 
 void VulkanCommandBuffer::bind(const VulkanDescriptorSet& descriptorSet) const
 {
+	auto set = &descriptorSet;
+
 	if (m_impl->m_lastPipeline) [[likely]]
-		m_impl->m_lastPipeline->bind(*this, descriptorSet);
+		m_impl->m_lastPipeline->bind(*this, { std::addressof(set), 1});
+	else
+		throw RuntimeException("No pipeline has been used on the command buffer before attempting to bind the descriptor set.");
+}
+
+void VulkanCommandBuffer::bind(Span<const VulkanDescriptorSet*> descriptorSets) const
+{
+	if (m_impl->m_lastPipeline) [[likely]]
+		m_impl->m_lastPipeline->bind(*this, descriptorSets);
 	else
 		throw RuntimeException("No pipeline has been used on the command buffer before attempting to bind the descriptor set.");
 }
 
 void VulkanCommandBuffer::bind(const VulkanDescriptorSet& descriptorSet, const VulkanPipelineState& pipeline) const noexcept
 {
-	pipeline.bind(*this, descriptorSet);
+	auto set = &descriptorSet;
+	pipeline.bind(*this, { std::addressof(set), 1 });
+}
+
+void VulkanCommandBuffer::bind(Span<const VulkanDescriptorSet*> descriptorSets, const VulkanPipelineState& pipeline) const noexcept
+{
+	pipeline.bind(*this, descriptorSets);
 }
 
 void VulkanCommandBuffer::bind(const IVulkanVertexBuffer& buffer) const noexcept

--- a/src/Backends/Vulkan/src/command_buffer.cpp
+++ b/src/Backends/Vulkan/src/command_buffer.cpp
@@ -373,6 +373,11 @@ void VulkanCommandBuffer::generateMipMaps(IVulkanImage& image) noexcept
 	this->barrier(endBarrier);
 }
 
+UniquePtr<VulkanBarrier> VulkanCommandBuffer::makeBarrier(PipelineStage syncBefore, PipelineStage syncAfter) const noexcept
+{
+	return m_impl->m_queue.device().makeBarrier(syncBefore, syncAfter);
+}
+
 void VulkanCommandBuffer::barrier(const VulkanBarrier& barrier) const noexcept
 {
 	barrier.execute(*this);

--- a/src/Backends/Vulkan/src/compute_pipeline.cpp
+++ b/src/Backends/Vulkan/src/compute_pipeline.cpp
@@ -99,10 +99,32 @@ void VulkanComputePipeline::use(const VulkanCommandBuffer& commandBuffer) const 
 	::vkCmdBindPipeline(commandBuffer.handle(), VK_PIPELINE_BIND_POINT_COMPUTE, this->handle());
 }
 
-void VulkanComputePipeline::bind(const VulkanCommandBuffer& commandBuffer, const VulkanDescriptorSet& descriptorSet) const noexcept
+void VulkanComputePipeline::bind(const VulkanCommandBuffer& commandBuffer, Span<const VulkanDescriptorSet*> descriptorSets) const noexcept
 {
-	// DescriptorSet -> DescriptorSetLayout
-	::vkCmdBindDescriptorSets(commandBuffer.handle(), VK_PIPELINE_BIND_POINT_COMPUTE, std::as_const(*m_impl->m_layout).handle(), descriptorSet.layout().space(), 1, &descriptorSet.handle(), 0, nullptr);
+	// Filter out uninitialized sets.
+	auto sets = descriptorSets | std::views::filter([](auto set) { return set != nullptr; }) | std::ranges::to<Array<const VulkanDescriptorSet*>>();
+
+	if (sets.empty()) [[unlikely]]
+		return; // Nothing to do on empty sets.
+	else if (sets.size() == 1)
+		::vkCmdBindDescriptorSets(commandBuffer.handle(), VK_PIPELINE_BIND_POINT_COMPUTE, std::as_const(*m_impl->m_layout).handle(), sets.front()->layout().space(), 1, &sets.front()->handle(), 0, nullptr);
+	else
+	{
+		// Sort the descriptor sets by space, as we might be able to pass the sets more efficiently if they are sorted and continuous.
+		std::ranges::sort(sets, [](auto lhs, auto rhs) { return lhs->layout().space() > rhs->layout().space(); });
+
+		// In a sorted range, last - (first - 1) equals the size of the range only if there are no duplicates and no gaps.
+		auto startSpace = sets.back()->layout().space();
+
+		if (startSpace - (sets.front()->layout().space() - 1) != static_cast<UInt32>(sets.size()))
+			std::ranges::for_each(sets, [&](auto set) { ::vkCmdBindDescriptorSets(commandBuffer.handle(), VK_PIPELINE_BIND_POINT_COMPUTE, std::as_const(*m_impl->m_layout).handle(), set->layout().space(), 1, &set->handle(), 0, nullptr); });
+		else
+		{
+			// Obtain the handles and bind the sets.
+			auto handles = sets | std::views::transform([](auto set) { return set->handle(); }) | std::ranges::to<Array<VkDescriptorSet>>();
+			::vkCmdBindDescriptorSets(commandBuffer.handle(), VK_PIPELINE_BIND_POINT_COMPUTE, std::as_const(*m_impl->m_layout).handle(), startSpace, static_cast<UInt32>(handles.size()), handles.data(), 0, nullptr);
+		}
+	}
 }
 
 #if defined(LITEFX_BUILD_DEFINE_BUILDERS)

--- a/src/Backends/Vulkan/src/ray_tracing_pipeline.cpp
+++ b/src/Backends/Vulkan/src/ray_tracing_pipeline.cpp
@@ -326,10 +326,32 @@ void VulkanRayTracingPipeline::use(const VulkanCommandBuffer& commandBuffer) con
 	::vkCmdBindPipeline(commandBuffer.handle(), VK_PIPELINE_BIND_POINT_RAY_TRACING_KHR, this->handle());
 }
 
-void VulkanRayTracingPipeline::bind(const VulkanCommandBuffer& commandBuffer, const VulkanDescriptorSet& descriptorSet) const noexcept
+void VulkanRayTracingPipeline::bind(const VulkanCommandBuffer& commandBuffer, Span<const VulkanDescriptorSet*> descriptorSets) const noexcept
 {
-	// DescriptorSet -> DescriptorSetLayout
-	::vkCmdBindDescriptorSets(commandBuffer.handle(), VK_PIPELINE_BIND_POINT_RAY_TRACING_KHR, std::as_const(*m_impl->m_layout).handle(), descriptorSet.layout().space(), 1, &descriptorSet.handle(), 0, nullptr);
+	// Filter out uninitialized sets.
+	auto sets = descriptorSets | std::views::filter([](auto set) { return set != nullptr; }) | std::ranges::to<Array<const VulkanDescriptorSet*>>();
+
+	if (sets.empty()) [[unlikely]]
+		return; // Nothing to do on empty sets.
+	else if (sets.size() == 1)
+		::vkCmdBindDescriptorSets(commandBuffer.handle(), VK_PIPELINE_BIND_POINT_RAY_TRACING_KHR, std::as_const(*m_impl->m_layout).handle(), sets.front()->layout().space(), 1, &sets.front()->handle(), 0, nullptr);
+	else
+	{
+		// Sort the descriptor sets by space, as we might be able to pass the sets more efficiently if they are sorted and continuous.
+		std::ranges::sort(sets, [](auto lhs, auto rhs) { return lhs->layout().space() > rhs->layout().space(); });
+
+		// In a sorted range, last - (first - 1) equals the size of the range only if there are no duplicates and no gaps.
+		auto startSpace = sets.back()->layout().space();
+
+		if (startSpace - (sets.front()->layout().space() - 1) != static_cast<UInt32>(sets.size()))
+			std::ranges::for_each(sets, [&](auto set) { ::vkCmdBindDescriptorSets(commandBuffer.handle(), VK_PIPELINE_BIND_POINT_RAY_TRACING_KHR, std::as_const(*m_impl->m_layout).handle(), set->layout().space(), 1, &set->handle(), 0, nullptr); });
+		else
+		{
+			// Obtain the handles and bind the sets.
+			auto handles = sets | std::views::transform([](auto set) { return set->handle(); }) | std::ranges::to<Array<VkDescriptorSet>>();
+			::vkCmdBindDescriptorSets(commandBuffer.handle(), VK_PIPELINE_BIND_POINT_RAY_TRACING_KHR, std::as_const(*m_impl->m_layout).handle(), startSpace, static_cast<UInt32>(handles.size()), handles.data(), 0, nullptr);
+		}
+	}
 }
 
 #if defined(LITEFX_BUILD_DEFINE_BUILDERS)

--- a/src/Rendering/include/litefx/rendering.hpp
+++ b/src/Rendering/include/litefx/rendering.hpp
@@ -530,6 +530,9 @@ namespace LiteFX::Rendering {
 
     public:
         /// <inheritdoc />
+        virtual UniquePtr<barrier_type> makeBarrier(PipelineStage syncBefore, PipelineStage syncAfter) const noexcept = 0;
+
+        /// <inheritdoc />
         virtual void barrier(const barrier_type& barrier) const noexcept = 0;
 
         /// <inheritdoc />
@@ -647,6 +650,10 @@ namespace LiteFX::Rendering {
         }
 
     private:
+        inline UniquePtr<IBarrier> getBarrier(PipelineStage syncBefore, PipelineStage syncAfter) const noexcept {
+            return this->makeBarrier(syncBefore, syncAfter);
+        }
+
         inline void cmdBarrier(const IBarrier& barrier) const noexcept override {
             this->barrier(dynamic_cast<const barrier_type&>(barrier));
         }

--- a/src/Rendering/include/litefx/rendering.hpp
+++ b/src/Rendering/include/litefx/rendering.hpp
@@ -539,7 +539,19 @@ namespace LiteFX::Rendering {
         virtual void transfer(buffer_type& source, buffer_type& target, UInt32 sourceElement = 0, UInt32 targetElement = 0, UInt32 elements = 1) const = 0;
 
         /// <inheritdoc />
+        virtual void transfer(const void* const data, size_t size, buffer_type& target, UInt32 targetElement = 0, UInt32 elements = 1) const = 0;
+
+        /// <inheritdoc />
+        virtual void transfer(Span<const void* const> data, size_t elementSize, buffer_type& target, UInt32 firstElement = 0) const = 0;
+
+        /// <inheritdoc />
         virtual void transfer(buffer_type& source, image_type& target, UInt32 sourceElement = 0, UInt32 firstSubresource = 0, UInt32 elements = 1) const = 0;
+
+        /// <inheritdoc />
+        virtual void transfer(const void* const data, size_t size, image_type& target, UInt32 subresource = 0) const = 0;
+
+        /// <inheritdoc />
+        virtual void transfer(Span<const void* const> data, size_t elementSize, image_type& target, UInt32 firstSubresource = 0, UInt32 subresources = 1) const = 0;
 
         /// <inheritdoc />
         virtual void transfer(image_type& source, image_type& target, UInt32 sourceSubresource = 0, UInt32 targetSubresource = 0, UInt32 subresources = 1) const = 0;
@@ -667,6 +679,22 @@ namespace LiteFX::Rendering {
         
         inline void cmdTransfer(SharedPtr<IImage> source, IBuffer& target, UInt32 firstSubresource, UInt32 targetElement, UInt32 subresources) const override {
             this->transfer(std::dynamic_pointer_cast<image_type>(source), dynamic_cast<buffer_type&>(target), firstSubresource, targetElement, subresources);
+        }
+
+        inline void cmdTransfer(const void* const data, size_t size, IBuffer& target, UInt32 targetElement, UInt32 elements) const override {
+            this->transfer(data, size, dynamic_cast<buffer_type&>(target), targetElement, elements);
+        }
+
+        inline void cmdTransfer(Span<const void* const> data, size_t elementSize, IBuffer& target, UInt32 targetElement) const override {
+            this->transfer(data, elementSize, dynamic_cast<buffer_type&>(target), targetElement);
+        }
+
+        inline void cmdTransfer(const void* const data, size_t size, IImage& target, UInt32 subresource) const override {
+            this->transfer(data, size, dynamic_cast<image_type&>(target), subresource);
+        }
+
+        inline void cmdTransfer(Span<const void* const> data, size_t elementSize, IImage& target, UInt32 firstSubresource, UInt32 elements) const override {
+            this->transfer(data, elementSize, dynamic_cast<image_type&>(target), firstSubresource, elements);
         }
 
         inline void cmdUse(const IPipeline& pipeline) const noexcept override {

--- a/src/Rendering/include/litefx/rendering.hpp
+++ b/src/Rendering/include/litefx/rendering.hpp
@@ -578,7 +578,13 @@ namespace LiteFX::Rendering {
         virtual void bind(const descriptor_set_type& descriptorSet) const = 0;
 
         /// <inheritdoc />
+        virtual void bind(Span<const descriptor_set_type*> descriptorSets) const = 0;
+
+        /// <inheritdoc />
         virtual void bind(const descriptor_set_type& descriptorSet, const pipeline_type& pipeline) const noexcept = 0;
+
+        /// <inheritdoc />
+        virtual void bind(Span<const descriptor_set_type*> descriptorSets, const pipeline_type& pipeline) const noexcept = 0;
 
         /// <inheritdoc />
         virtual void bind(const vertex_buffer_type& buffer) const noexcept = 0;
@@ -705,8 +711,18 @@ namespace LiteFX::Rendering {
             this->bind(dynamic_cast<const descriptor_set_type&>(descriptorSet));
         }
 
+        inline void cmdBind(Span<const IDescriptorSet*> descriptorSets) const override {
+            auto sets = descriptorSets | std::views::transform([](auto set) { return dynamic_cast<const descriptor_set_type*>(set); }) | std::ranges::to<Array<const descriptor_set_type*>>();
+            this->bind(Span<const descriptor_set_type*>(sets));
+        }
+
         inline void cmdBind(const IDescriptorSet& descriptorSet, const IPipeline& pipeline) const noexcept override {
             this->bind(dynamic_cast<const descriptor_set_type&>(descriptorSet), dynamic_cast<const pipeline_type&>(pipeline));
+        }
+
+        inline void cmdBind(Span<const IDescriptorSet*> descriptorSets, const IPipeline& pipeline) const noexcept override {
+            auto sets = descriptorSets | std::views::transform([](auto set) { return dynamic_cast<const descriptor_set_type*>(set); }) | std::ranges::to<Array<const descriptor_set_type*>>();
+            this->bind(Span<const descriptor_set_type*>(sets), dynamic_cast<const pipeline_type&>(pipeline));
         }
         
         inline void cmdBind(const IVertexBuffer& buffer) const noexcept override {

--- a/src/Rendering/include/litefx/rendering_api.hpp
+++ b/src/Rendering/include/litefx/rendering_api.hpp
@@ -5744,6 +5744,16 @@ namespace LiteFX::Rendering {
 
     public:
         /// <summary>
+        /// Creates a new barrier instance.
+        /// </summary>
+        /// <param name="syncBefore">The pipeline stage(s) all previous commands have to finish before the barrier is executed.</param>
+        /// <param name="syncAfter">The pipeline stage(s) all subsequent commands are blocked at until the barrier is executed.</param>
+        /// <returns>The instance of the barrier.</returns>
+        inline [[nodiscard]] UniquePtr<IBarrier> makeBarrier(PipelineStage syncBefore, PipelineStage syncAfter) const noexcept {
+            return this->getBarrier(syncBefore, syncAfter);
+        }
+
+        /// <summary>
         /// Executes the transitions that have been added to <paramref name="barrier" />.
         /// </summary>
         /// <remarks>
@@ -6557,6 +6567,7 @@ namespace LiteFX::Rendering {
         virtual void releaseSharedState() const = 0;
 
     private:
+        virtual UniquePtr<IBarrier> getBarrier(PipelineStage syncBefore, PipelineStage syncAfter) const noexcept = 0;
         virtual void cmdBarrier(const IBarrier& barrier) const noexcept = 0;
         virtual void cmdGenerateMipMaps(IImage& image) noexcept = 0;
         virtual void cmdTransfer(IBuffer& source, IBuffer& target, UInt32 sourceElement, UInt32 targetElement, UInt32 elements) const = 0;

--- a/src/Rendering/include/litefx/rendering_api.hpp
+++ b/src/Rendering/include/litefx/rendering_api.hpp
@@ -3397,7 +3397,7 @@ namespace LiteFX::Rendering {
         /// </summary>
         /// <param name="data">The data blocks to map.</param>
         /// <param name="size">The size of each data block within <paramref name="data" />.</param>
-        /// <param name="firsElement">The first element of the array to map.</param>
+        /// <param name="firstElement">The first element of the array to map.</param>
         virtual void map(Span<const void* const> data, size_t elementSize, UInt32 firstElement = 0) = 0;
 
         /// <summary>
@@ -3414,7 +3414,7 @@ namespace LiteFX::Rendering {
         /// </summary>
         /// <param name="data">The data blocks to map.</param>
         /// <param name="size">The size of each data block within <paramref name="data" />.</param>
-        /// <param name="firsElement">The first element of the array to map.</param>
+        /// <param name="firstElement">The first element of the array to map.</param>
         /// <param name="write">If `true`, <paramref name="data" /> is copied into the internal memory. If `false` the internal memory is copied into <paramref name="data" />.</param>
         virtual void map(Span<void*> data, size_t elementSize, UInt32 firstElement = 0, bool write = true) = 0;
     };
@@ -5816,6 +5816,39 @@ namespace LiteFX::Rendering {
         }
 
         /// <summary>
+        /// Performs a buffer-to-buffer transfer from a temporary buffer into <paramref name="target" />.
+        /// </summary>
+        /// <remarks>
+        /// This method creates a temporary buffer and maps <paramref name="data" /> into it, before transferring it into <paramref name="target" />. A reference of the temporary buffer is stored 
+        /// until the parent command queue finished using the command buffer. At this point, the command queue calls <see cref="releaseSharedState" /> to release all shared references. Note that this
+        /// is a relaxed constraint. It is only guaranteed, that the queue calls this method at some point after the command buffer has been executed. 
+        /// </remarks>
+        /// <param name="data">The address that marks the beginning of the data to map.</param>
+        /// <param name="size">The number of bytes to map.</param>
+        /// <param name="target">The target buffer to transfer data to.</param>
+        /// <param name="targetElement">The array element to map the data to.</param>
+        /// <param name="elements">The number of elements to copy.</param>
+        inline void transfer(const void* const data, size_t size, IBuffer& target, UInt32 targetElement = 0, UInt32 elements = 1) const {
+            this->cmdTransfer(data, size, target, targetElement, elements);
+        }
+
+        /// <summary>
+        /// Performs a buffer-to-buffer transfer from a temporary buffer into <paramref name="target" />.
+        /// </summary>
+        /// <remarks>
+        /// This method creates a temporary buffer and maps <paramref name="data" /> into it, before transferring it into <paramref name="target" />. A reference of the temporary buffer is stored 
+        /// until the parent command queue finished using the command buffer. At this point, the command queue calls <see cref="releaseSharedState" /> to release all shared references. Note that this
+        /// is a relaxed constraint. It is only guaranteed, that the queue calls this method at some point after the command buffer has been executed. 
+        /// </remarks>
+        /// <param name="data">The addresses that mark the beginning of the element data to map.</param>
+        /// <param name="elementSize">The number of bytes to map for each element.</param>
+        /// <param name="target">The target buffer to transfer data to.</param>
+        /// <param name="targetElement">The first array element to transfer the data to.</param>
+        inline void transfer(Span<const void* const> data, size_t elementSize, IBuffer& target, UInt32 targetElement = 0) const {
+            this->cmdTransfer(data, elementSize, target, targetElement);
+        }
+
+        /// <summary>
         /// Performs a buffer-to-image transfer from <paramref name="source" /> to <paramref name="target" />.
         /// </summary>
         /// <remarks>
@@ -5898,6 +5931,40 @@ namespace LiteFX::Rendering {
         /// <exception cref="ArgumentOutOfRangeException">Thrown, if the number of either the source buffer or the target buffer has not enough elements for the specified <paramref name="elements" /> parameter.</exception>
         inline void transfer(SharedPtr<IBuffer> source, IImage& target, UInt32 sourceElement = 0, UInt32 firstSubresource = 0, UInt32 elements = 1) const {
             this->cmdTransfer(source, target, sourceElement, firstSubresource, elements);
+        }
+
+        /// <summary>
+        /// Performs a buffer-to-buffer transfer from a temporary buffer into <paramref name="target" />.
+        /// </summary>
+        /// <remarks>
+        /// This method creates a temporary buffer and maps <paramref name="data" /> into it, before transferring it into <paramref name="target" />. A reference of the temporary buffer is stored 
+        /// until the parent command queue finished using the command buffer. At this point, the command queue calls <see cref="releaseSharedState" /> to release all shared references. Note that this
+        /// is a relaxed constraint. It is only guaranteed, that the queue calls this method at some point after the command buffer has been executed. 
+        /// </remarks>
+        /// <param name="data">The address that marks the beginning of the data to map.</param>
+        /// <param name="size">The number of bytes to map.</param>
+        /// <param name="target">The target buffer to transfer data to.</param>
+        /// <param name="firstSubresource">The index of the first sub-resource of the target image to receive data.</param>
+        /// <param name="elements">The number of elements to copy from the source buffer into the target image sub-resources.</param>
+        inline void transfer(const void* const data, size_t size, IImage& target, UInt32 subresource = 0) const {
+            this->cmdTransfer(data, size, target, subresource);
+        }
+
+        /// <summary>
+        /// Performs a buffer-to-buffer transfer from a temporary buffer into <paramref name="target" />.
+        /// </summary>
+        /// <remarks>
+        /// This method creates a temporary buffer and maps <paramref name="data" /> into it, before transferring it into <paramref name="target" />. A reference of the temporary buffer is stored 
+        /// until the parent command queue finished using the command buffer. At this point, the command queue calls <see cref="releaseSharedState" /> to release all shared references. Note that this
+        /// is a relaxed constraint. It is only guaranteed, that the queue calls this method at some point after the command buffer has been executed. 
+        /// </remarks>
+        /// <param name="data">The addresses that mark the beginning of the element data to map.</param>
+        /// <param name="elementSize">The number of bytes to map for each element.</param>
+        /// <param name="target">The target buffer to transfer data to.</param>
+        /// <param name="firstSubresource">The index of the first sub-resource of the target image to receive data.</param>
+        /// <param name="elements">The number of elements to copy from the source buffer into the target image sub-resources.</param>
+        inline void transfer(Span<const void* const> data, size_t elementSize, IImage& target, UInt32 firstSubresource = 0, UInt32 elements = 1) const {
+            this->cmdTransfer(data, elementSize, target, firstSubresource, elements);
         }
 
         /// <summary>
@@ -6401,6 +6468,10 @@ namespace LiteFX::Rendering {
         virtual void cmdTransfer(SharedPtr<IBuffer> source, IImage& target, UInt32 sourceElement, UInt32 firstSubresource, UInt32 elements) const = 0;
         virtual void cmdTransfer(SharedPtr<IImage> source, IImage& target, UInt32 sourceSubresource, UInt32 targetSubresource, UInt32 subresources) const = 0;
         virtual void cmdTransfer(SharedPtr<IImage> source, IBuffer& target, UInt32 firstSubresource, UInt32 targetElement, UInt32 subresources) const = 0;
+        virtual void cmdTransfer(const void* const data, size_t size, IBuffer& target, UInt32 targetElement, UInt32 elements) const = 0;
+        virtual void cmdTransfer(Span<const void* const> data, size_t elementSize, IBuffer& target, UInt32 targetElement) const = 0;
+        virtual void cmdTransfer(const void* const data, size_t size, IImage& target, UInt32 subresource) const = 0;
+        virtual void cmdTransfer(Span<const void* const> data, size_t elementSize, IImage& target, UInt32 firstSubresource, UInt32 elements) const = 0;
         virtual void cmdUse(const IPipeline& pipeline) const noexcept = 0;
         virtual void cmdBind(const IDescriptorSet& descriptorSet) const = 0;
         virtual void cmdBind(const IDescriptorSet& descriptorSet, const IPipeline& pipeline) const noexcept = 0;

--- a/src/Samples/BasicRendering/src/sample.cpp
+++ b/src/Samples/BasicRendering/src/sample.cpp
@@ -94,23 +94,13 @@ void SampleApp::initBuffers(IRenderBackend* backend)
     // Get a command buffer
     auto commandBuffer = m_device->defaultQueue(QueueType::Transfer).createCommandBuffer(true);
 
-    // Create the staging buffer.
-    // NOTE: The mapping works, because vertex and index buffers have an alignment of 0, so we can treat the whole buffer as a single element the size of the 
-    //       whole buffer.
-    auto stagedVertices = m_device->factory().createVertexBuffer(*m_inputAssembler->vertexBufferLayout(0), ResourceHeap::Staging, vertices.size());
-    stagedVertices->map(vertices.data(), vertices.size() * sizeof(::Vertex), 0);
-
-    // Create the actual vertex buffer and transfer the staging buffer into it.
+    // Create the vertex buffer and transfer the staging buffer into it.
     auto vertexBuffer = m_device->factory().createVertexBuffer("Vertex Buffer", *m_inputAssembler->vertexBufferLayout(0), ResourceHeap::Resource, vertices.size());
-    commandBuffer->transfer(asShared(std::move(stagedVertices)), *vertexBuffer, 0, 0, vertices.size());
+    commandBuffer->transfer(vertices.data(), vertices.size() * sizeof(::Vertex), *vertexBuffer, 0, vertices.size());
 
-    // Create the staging buffer for the indices. For infos about the mapping see the note about the vertex buffer mapping above.
-    auto stagedIndices = m_device->factory().createIndexBuffer(*m_inputAssembler->indexBufferLayout(), ResourceHeap::Staging, indices.size());
-    stagedIndices->map(indices.data(), indices.size() * m_inputAssembler->indexBufferLayout()->elementSize(), 0);
-
-    // Create the actual index buffer and transfer the staging buffer into it.
+    // Create the index buffer and transfer the staging buffer into it.
     auto indexBuffer = m_device->factory().createIndexBuffer("Index Buffer", *m_inputAssembler->indexBufferLayout(), ResourceHeap::Resource, indices.size());
-    commandBuffer->transfer(asShared(std::move(stagedIndices)), *indexBuffer, 0, 0, indices.size());
+    commandBuffer->transfer(indices.data(), indices.size() * m_inputAssembler->indexBufferLayout()->elementSize(), *indexBuffer, 0, indices.size());
 
     // Initialize the camera buffer. The camera buffer is constant, so we only need to create one buffer, that can be read from all frames. Since this is a 
     // write-once/read-multiple scenario, we also transfer the buffer to the more efficient memory heap on the GPU.
@@ -153,9 +143,7 @@ void SampleApp::updateCamera(const ICommandBuffer& commandBuffer, IBuffer& buffe
     camera.ViewProjection = projection * view;
 
     // Create a staging buffer and use to transfer the new uniform buffer to.
-    auto cameraStagingBuffer = m_device->factory().createBuffer(m_device->state().pipeline("Geometry"), DescriptorSets::Constant, 0, ResourceHeap::Staging);
-    cameraStagingBuffer->map(reinterpret_cast<const void*>(&camera), sizeof(camera));
-    commandBuffer.transfer(asShared(std::move(cameraStagingBuffer)), buffer);
+    commandBuffer.transfer(reinterpret_cast<const void*>(&camera), sizeof(camera), buffer);
 }
 
 void SampleApp::onStartup()

--- a/src/Samples/BasicRendering/src/sample.cpp
+++ b/src/Samples/BasicRendering/src/sample.cpp
@@ -378,8 +378,7 @@ void SampleApp::drawFrame()
     transformBuffer.map(reinterpret_cast<const void*>(&transform), sizeof(transform), backBuffer);
 
     // Bind both descriptor sets to the pipeline.
-    commandBuffer->bind(cameraBindings);
-    commandBuffer->bind(transformBindings);
+    commandBuffer->bind({ &cameraBindings, &transformBindings });
 
     // Bind the vertex and index buffers.
     commandBuffer->bind(vertexBuffer);

--- a/src/Samples/Bindless/src/sample.cpp
+++ b/src/Samples/Bindless/src/sample.cpp
@@ -428,9 +428,7 @@ void SampleApp::drawFrame()
     drawDataBuffer.map(reinterpret_cast<const void*>(&drawData), sizeof(drawData), backBuffer);
 
     // Bind all descriptor sets to the pipeline.
-    commandBuffer->bind(cameraBindings, geometryPipeline);
-    commandBuffer->bind(drawDataBindings, geometryPipeline);
-    commandBuffer->bind(instanceBindings, geometryPipeline);
+    commandBuffer->bind({ &cameraBindings, &drawDataBindings, &instanceBindings });
 
     // Bind the vertex and index buffers.
     commandBuffer->bind(vertexBuffer);

--- a/src/Samples/Bindless/src/sample.cpp
+++ b/src/Samples/Bindless/src/sample.cpp
@@ -125,23 +125,13 @@ void SampleApp::initBuffers(IRenderBackend* backend)
     // Get a command buffer.
     auto commandBuffer = m_device->defaultQueue(QueueType::Transfer).createCommandBuffer(true);
 
-    // Create the staging buffer.
-    // NOTE: The mapping works, because vertex and index buffers have an alignment of 0, so we can treat the whole buffer as a single element the size of the 
-    //       whole buffer.
-    auto stagedVertices = m_device->factory().createVertexBuffer(*m_inputAssembler->vertexBufferLayout(0), ResourceHeap::Staging, vertices.size());
-    stagedVertices->map(vertices.data(), vertices.size() * sizeof(::Vertex), 0);
-    
-    // Create the actual vertex buffer and transfer the staging buffer into it.
+    // Create the vertex buffer and transfer the staging buffer into it.
     auto vertexBuffer = m_device->factory().createVertexBuffer("Vertex Buffer", *m_inputAssembler->vertexBufferLayout(0), ResourceHeap::Resource, vertices.size());
-    commandBuffer->transfer(asShared(std::move(stagedVertices)), *vertexBuffer, 0, 0, vertices.size());
+    commandBuffer->transfer(vertices.data(), vertices.size() * sizeof(::Vertex), *vertexBuffer, 0, vertices.size());
 
-    // Create the staging buffer for the indices. For infos about the mapping see the note about the vertex buffer mapping above.
-    auto stagedIndices = m_device->factory().createIndexBuffer(*m_inputAssembler->indexBufferLayout(), ResourceHeap::Staging, indices.size());
-    stagedIndices->map(indices.data(), indices.size() * m_inputAssembler->indexBufferLayout()->elementSize(), 0);
-
-    // Create the actual index buffer and transfer the staging buffer into it.
+    // Create the index buffer and transfer the staging buffer into it.
     auto indexBuffer = m_device->factory().createIndexBuffer("Index Buffer", *m_inputAssembler->indexBufferLayout(), ResourceHeap::Resource, indices.size());
-    commandBuffer->transfer(asShared(std::move(stagedIndices)), *indexBuffer, 0, 0, indices.size());
+    commandBuffer->transfer(indices.data(), indices.size() * m_inputAssembler->indexBufferLayout()->elementSize(), *indexBuffer, 0, indices.size());
 
     // Initialize the camera buffer. The camera buffer is constant, so we only need to create one buffer, that can be read from all frames. Since this is a 
     // write-once/read-multiple scenario, we also transfer the buffer to the more efficient memory heap on the GPU.
@@ -171,11 +161,9 @@ void SampleApp::initBuffers(IRenderBackend* backend)
     auto& instanceBindingLayout = geometryPipeline.layout()->descriptorSet(DescriptorSets::InstanceData);
 
     // Since we are using an unstructured storage buffer, we need to specify the element size manually.
-    auto instanceStagingBuffer = m_device->factory().createBuffer(instanceBindingLayout, 0, ResourceHeap::Staging, sizeof(InstanceBuffer), NUM_INSTANCES);
     auto instanceBuffer = m_device->factory().createBuffer("Instance Buffer", instanceBindingLayout, 0, ResourceHeap::Resource, sizeof(InstanceBuffer), NUM_INSTANCES);
     auto instanceBinding = instanceBindingLayout.allocate(NUM_INSTANCES, { { 0, *instanceBuffer } });
-    instanceStagingBuffer->map(reinterpret_cast<const void*>(&instanceData), sizeof(instanceData));
-    commandBuffer->transfer(asShared(std::move(instanceStagingBuffer)), *instanceBuffer, 0, 0, NUM_INSTANCES);
+    commandBuffer->transfer(reinterpret_cast<const void*>(&instanceData), sizeof(instanceData), *instanceBuffer, 0, NUM_INSTANCES);
 
     // End and submit the command buffer.
     m_transferFence = commandBuffer->submit();
@@ -200,9 +188,7 @@ void SampleApp::updateCamera(const ICommandBuffer& commandBuffer, IBuffer& buffe
     camera.ViewProjection = projection * view;
 
     // Create a staging buffer and use to transfer the new uniform buffer to.
-    auto cameraStagingBuffer = m_device->factory().createBuffer(m_device->state().pipeline("Geometry"), DescriptorSets::CameraData, 0, ResourceHeap::Staging);
-    cameraStagingBuffer->map(reinterpret_cast<const void*>(&camera), sizeof(camera));
-    commandBuffer.transfer(asShared(std::move(cameraStagingBuffer)), buffer);
+    commandBuffer.transfer(reinterpret_cast<const void*>(&camera), sizeof(camera), buffer);
 }
 
 void SampleApp::onStartup() 

--- a/src/Samples/Compute/src/sample.cpp
+++ b/src/Samples/Compute/src/sample.cpp
@@ -105,23 +105,13 @@ void SampleApp::initBuffers(IRenderBackend* backend)
     // Get a command buffer
     auto commandBuffer = m_device->defaultQueue(QueueType::Transfer).createCommandBuffer(true);
 
-    // Create the staging buffer.
-    // NOTE: The mapping works, because vertex and index buffers have an alignment of 0, so we can treat the whole buffer as a single element the size of the 
-    //       whole buffer.
-    auto stagedVertices = m_device->factory().createVertexBuffer(*m_inputAssembler->vertexBufferLayout(0), ResourceHeap::Staging, vertices.size());
-    stagedVertices->map(vertices.data(), vertices.size() * sizeof(::Vertex), 0);
-
-    // Create the actual vertex buffer and transfer the staging buffer into it.
+    // Create the vertex buffer and transfer the staging buffer into it.
     auto vertexBuffer = m_device->factory().createVertexBuffer("Vertex Buffer", *m_inputAssembler->vertexBufferLayout(0), ResourceHeap::Resource, vertices.size());
-    commandBuffer->transfer(asShared(std::move(stagedVertices)), *vertexBuffer, 0, 0, vertices.size());
+    commandBuffer->transfer(vertices.data(), vertices.size() * sizeof(::Vertex), *vertexBuffer, 0, vertices.size());
 
-    // Create the staging buffer for the indices. For infos about the mapping see the note about the vertex buffer mapping above.
-    auto stagedIndices = m_device->factory().createIndexBuffer(*m_inputAssembler->indexBufferLayout(), ResourceHeap::Staging, indices.size());
-    stagedIndices->map(indices.data(), indices.size() * m_inputAssembler->indexBufferLayout()->elementSize(), 0);
-
-    // Create the actual index buffer and transfer the staging buffer into it.
+    // Create the index buffer and transfer the staging buffer into it.
     auto indexBuffer = m_device->factory().createIndexBuffer("Index Buffer", *m_inputAssembler->indexBufferLayout(), ResourceHeap::Resource, indices.size());
-    commandBuffer->transfer(asShared(std::move(stagedIndices)), *indexBuffer, 0, 0, indices.size());
+    commandBuffer->transfer(indices.data(), indices.size() * m_inputAssembler->indexBufferLayout()->elementSize(), *indexBuffer, 0, indices.size());
 
     // Initialize the camera buffer. The camera buffer is constant, so we only need to create one buffer, that can be read from all frames. Since this is a 
     // write-once/read-multiple scenario, we also transfer the buffer to the more efficient memory heap on the GPU.
@@ -173,9 +163,7 @@ void SampleApp::updateCamera(const ICommandBuffer& commandBuffer, IBuffer& buffe
     camera.ViewProjection = projection * view;
 
     // Create a staging buffer and use to transfer the new uniform buffer to.
-    auto cameraStagingBuffer = m_device->factory().createBuffer(m_device->state().pipeline("Geometry"), DescriptorSets::Constant, 0, ResourceHeap::Staging);
-    cameraStagingBuffer->map(reinterpret_cast<const void*>(&camera), sizeof(camera));
-    commandBuffer.transfer(asShared(std::move(cameraStagingBuffer)), buffer);
+    commandBuffer.transfer(reinterpret_cast<const void*>(&camera), sizeof(camera), buffer);
 }
 
 void SampleApp::onStartup()
@@ -461,7 +449,7 @@ void SampleApp::drawFrame()
 
         // After post-processing, transition the image back into a state where it can be copied from.
         barrier = m_device->makeBarrier(PipelineStage::Compute, PipelineStage::None);
-        barrier->transition(image, ResourceAccess::ShaderReadWrite, ResourceAccess::None, ImageLayout::CopySource);
+        barrier->transition(image, ResourceAccess::ShaderReadWrite, ResourceAccess::None, ImageLayout::ReadWrite, ImageLayout::CopySource);
         commandBuffer->barrier(*barrier);
 
         // Submit the command buffer.

--- a/src/Samples/Compute/src/sample.cpp
+++ b/src/Samples/Compute/src/sample.cpp
@@ -410,8 +410,7 @@ void SampleApp::drawFrame()
         transformBuffer.map(reinterpret_cast<const void*>(&transform), sizeof(transform), backBuffer);
 
         // Bind both descriptor sets to the pipeline.
-        commandBuffer->bind(cameraBindings);
-        commandBuffer->bind(transformBindings);
+        commandBuffer->bind({ &cameraBindings, &transformBindings });
 
         // Bind the vertex and index buffers.
         commandBuffer->bind(vertexBuffer);

--- a/src/Samples/MeshShader/src/sample.cpp
+++ b/src/Samples/MeshShader/src/sample.cpp
@@ -117,9 +117,7 @@ void SampleApp::updateCamera(const ICommandBuffer& commandBuffer, IBuffer& buffe
     camera.ViewProjection = projection * view;
 
     // Create a staging buffer and use to transfer the new uniform buffer to.
-    auto cameraStagingBuffer = m_device->factory().createBuffer(m_device->state().pipeline("Geometry"), DescriptorSets::Constant, 0, ResourceHeap::Staging);
-    cameraStagingBuffer->map(reinterpret_cast<const void*>(&camera), sizeof(camera));
-    commandBuffer.transfer(asShared(std::move(cameraStagingBuffer)), buffer);
+    commandBuffer.transfer(reinterpret_cast<const void*>(&camera), sizeof(camera), buffer);
 }
 
 void SampleApp::onStartup()

--- a/src/Samples/MeshShader/src/sample.cpp
+++ b/src/Samples/MeshShader/src/sample.cpp
@@ -350,8 +350,7 @@ void SampleApp::drawFrame()
     transformBuffer.map(reinterpret_cast<const void*>(&transform), sizeof(transform), backBuffer);
 
     // Bind both descriptor sets to the pipeline.
-    commandBuffer->bind(cameraBindings);
-    commandBuffer->bind(transformBindings);
+    commandBuffer->bind({ &cameraBindings, &transformBindings });
 
     // Draw the object and present the frame by ending the render pass.
     commandBuffer->dispatchMesh(4, 1, 1); // This will create 4 faces.

--- a/src/Samples/Multisampling/src/sample.cpp
+++ b/src/Samples/Multisampling/src/sample.cpp
@@ -94,23 +94,13 @@ void SampleApp::initBuffers(IRenderBackend* backend)
     // Get a command buffer
     auto commandBuffer = m_device->defaultQueue(QueueType::Transfer).createCommandBuffer(true);
 
-    // Create the staging buffer.
-    // NOTE: The mapping works, because vertex and index buffers have an alignment of 0, so we can treat the whole buffer as a single element the size of the 
-    //       whole buffer.
-    auto stagedVertices = m_device->factory().createVertexBuffer(*m_inputAssembler->vertexBufferLayout(0), ResourceHeap::Staging, vertices.size());
-    stagedVertices->map(vertices.data(), vertices.size() * sizeof(::Vertex), 0);
-    
-    // Create the actual vertex buffer and transfer the staging buffer into it.
+    // Create the vertex buffer and transfer the staging buffer into it.
     auto vertexBuffer = m_device->factory().createVertexBuffer("Vertex Buffer", *m_inputAssembler->vertexBufferLayout(0), ResourceHeap::Resource, vertices.size());
-    commandBuffer->transfer(asShared(std::move(stagedVertices)), *vertexBuffer, 0, 0, vertices.size());
+    commandBuffer->transfer(vertices.data(), vertices.size() * sizeof(::Vertex), *vertexBuffer, 0, vertices.size());
 
-    // Create the staging buffer for the indices. For infos about the mapping see the note about the vertex buffer mapping above.
-    auto stagedIndices = m_device->factory().createIndexBuffer(*m_inputAssembler->indexBufferLayout(), ResourceHeap::Staging, indices.size());
-    stagedIndices->map(indices.data(), indices.size() * m_inputAssembler->indexBufferLayout()->elementSize(), 0);
-
-    // Create the actual index buffer and transfer the staging buffer into it.
+    // Create the index buffer and transfer the staging buffer into it.
     auto indexBuffer = m_device->factory().createIndexBuffer("Index Buffer", *m_inputAssembler->indexBufferLayout(), ResourceHeap::Resource, indices.size());
-    commandBuffer->transfer(asShared(std::move(stagedIndices)), *indexBuffer, 0, 0, indices.size());
+    commandBuffer->transfer(indices.data(), indices.size() * m_inputAssembler->indexBufferLayout()->elementSize(), *indexBuffer, 0, indices.size());
 
     // Initialize the camera buffer. The camera buffer is constant, so we only need to create one buffer, that can be read from all frames. Since this is a 
     // write-once/read-multiple scenario, we also transfer the buffer to the more efficient memory heap on the GPU.
@@ -153,9 +143,7 @@ void SampleApp::updateCamera(const ICommandBuffer& commandBuffer, IBuffer& buffe
     camera.ViewProjection = projection * view;
 
     // Create a staging buffer and use to transfer the new uniform buffer to.
-    auto cameraStagingBuffer = m_device->factory().createBuffer(m_device->state().pipeline("Geometry"), DescriptorSets::Constant, 0, ResourceHeap::Staging);
-    cameraStagingBuffer->map(reinterpret_cast<const void*>(&camera), sizeof(camera));
-    commandBuffer.transfer(asShared(std::move(cameraStagingBuffer)), buffer);
+    commandBuffer.transfer(reinterpret_cast<const void*>(&camera), sizeof(camera), buffer);
 }
 
 void SampleApp::onStartup() 

--- a/src/Samples/Multisampling/src/sample.cpp
+++ b/src/Samples/Multisampling/src/sample.cpp
@@ -378,8 +378,7 @@ void SampleApp::drawFrame()
     transformBuffer.map(reinterpret_cast<const void*>(&transform), sizeof(transform), backBuffer);
 
     // Bind both descriptor sets to the pipeline.
-    commandBuffer->bind(cameraBindings, geometryPipeline);
-    commandBuffer->bind(transformBindings, geometryPipeline);
+    commandBuffer->bind({ &cameraBindings, &transformBindings });
 
     // Bind the vertex and index buffers.
     commandBuffer->bind(vertexBuffer);

--- a/src/Samples/Multithreading/src/sample.cpp
+++ b/src/Samples/Multithreading/src/sample.cpp
@@ -108,23 +108,13 @@ void SampleApp::initBuffers(IRenderBackend* backend)
     // Get a command buffer
     auto commandBuffer = m_device->defaultQueue(QueueType::Transfer).createCommandBuffer(true);
 
-    // Create the staging buffer.
-    // NOTE: The mapping works, because vertex and index buffers have an alignment of 0, so we can treat the whole buffer as a single element the size of the 
-    //       whole buffer.
-    auto stagedVertices = m_device->factory().createVertexBuffer(*m_inputAssembler->vertexBufferLayout(0), ResourceHeap::Staging, vertices.size());
-    stagedVertices->map(vertices.data(), vertices.size() * sizeof(::Vertex), 0);
-    
-    // Create the actual vertex buffer and transfer the staging buffer into it.
+    // Create the vertex buffer and transfer the staging buffer into it.
     auto vertexBuffer = m_device->factory().createVertexBuffer("Vertex Buffer", *m_inputAssembler->vertexBufferLayout(0), ResourceHeap::Resource, vertices.size());
-    commandBuffer->transfer(asShared(std::move(stagedVertices)), *vertexBuffer, 0, 0, vertices.size());
+    commandBuffer->transfer(vertices.data(), vertices.size() * sizeof(::Vertex), *vertexBuffer, 0, vertices.size());
 
-    // Create the staging buffer for the indices. For infos about the mapping see the note about the vertex buffer mapping above.
-    auto stagedIndices = m_device->factory().createIndexBuffer(*m_inputAssembler->indexBufferLayout(), ResourceHeap::Staging, indices.size());
-    stagedIndices->map(indices.data(), indices.size() * m_inputAssembler->indexBufferLayout()->elementSize(), 0);
-
-    // Create the actual index buffer and transfer the staging buffer into it.
+    // Create the index buffer and transfer the staging buffer into it.
     auto indexBuffer = m_device->factory().createIndexBuffer("Index Buffer", *m_inputAssembler->indexBufferLayout(), ResourceHeap::Resource, indices.size());
-    commandBuffer->transfer(asShared(std::move(stagedIndices)), *indexBuffer, 0, 0, indices.size());
+    commandBuffer->transfer(indices.data(), indices.size() * m_inputAssembler->indexBufferLayout()->elementSize(), *indexBuffer, 0, indices.size());
 
     // Initialize the camera buffer. The camera buffer is constant, so we only need to create one buffer, that can be read from all frames. Since this is a 
     // write-once/read-multiple scenario, we also transfer the buffer to the more efficient memory heap on the GPU.
@@ -168,9 +158,7 @@ void SampleApp::updateCamera(const ICommandBuffer& commandBuffer, IBuffer& buffe
     camera.ViewProjection = projection * view;
 
     // Create a staging buffer and use to transfer the new uniform buffer to.
-    auto cameraStagingBuffer = m_device->factory().createBuffer(m_device->state().pipeline("Geometry"), DescriptorSets::Constant, 0, ResourceHeap::Staging);
-    cameraStagingBuffer->map(reinterpret_cast<const void*>(&camera), sizeof(camera));
-    commandBuffer.transfer(asShared(std::move(cameraStagingBuffer)), buffer);
+    commandBuffer.transfer(reinterpret_cast<const void*>(&camera), sizeof(camera), buffer);
 }
 
 void SampleApp::onStartup() 

--- a/src/Samples/Multithreading/src/sample.cpp
+++ b/src/Samples/Multithreading/src/sample.cpp
@@ -380,8 +380,7 @@ void SampleApp::drawObject(const IRenderPass* renderPass, int index, int backBuf
     transformBuffer.map(reinterpret_cast<const void*>(&transform[index]), sizeof(TransformBuffer), backBuffer);
 
     // Bind both descriptor sets to the pipeline.
-    commandBuffer->bind(cameraBindings, geometryPipeline);
-    commandBuffer->bind(transformBindings, geometryPipeline);
+    commandBuffer->bind({ &cameraBindings, &transformBindings });
 
     // Bind the vertex and index buffers.
     commandBuffer->bind(vertexBuffer);

--- a/src/Samples/PushConstants/src/sample.cpp
+++ b/src/Samples/PushConstants/src/sample.cpp
@@ -122,23 +122,13 @@ void SampleApp::initBuffers(IRenderBackend* backend)
     // Get a command buffer
     auto commandBuffer = m_device->defaultQueue(QueueType::Transfer).createCommandBuffer(true);
 
-    // Create the staging buffer.
-    // NOTE: The mapping works, because vertex and index buffers have an alignment of 0, so we can treat the whole buffer as a single element the size of the 
-    //       whole buffer.
-    auto stagedVertices = m_device->factory().createVertexBuffer(*m_inputAssembler->vertexBufferLayout(0), ResourceHeap::Staging, vertices.size());
-    stagedVertices->map(vertices.data(), vertices.size() * sizeof(::Vertex), 0);
-    
-    // Create the actual vertex buffer and transfer the staging buffer into it.
+    // Create the vertex buffer and transfer the staging buffer into it.
     auto vertexBuffer = m_device->factory().createVertexBuffer("Vertex Buffer", *m_inputAssembler->vertexBufferLayout(0), ResourceHeap::Resource, vertices.size());
-    commandBuffer->transfer(asShared(std::move(stagedVertices)), *vertexBuffer, 0, 0, vertices.size());
+    commandBuffer->transfer(vertices.data(), vertices.size() * sizeof(::Vertex), *vertexBuffer, 0, vertices.size());
 
-    // Create the staging buffer for the indices. For infos about the mapping see the note about the vertex buffer mapping above.
-    auto stagedIndices = m_device->factory().createIndexBuffer(*m_inputAssembler->indexBufferLayout(), ResourceHeap::Staging, indices.size());
-    stagedIndices->map(indices.data(), indices.size() * m_inputAssembler->indexBufferLayout()->elementSize(), 0);
-
-    // Create the actual index buffer and transfer the staging buffer into it.
+    // Create the index buffer and transfer the staging buffer into it.
     auto indexBuffer = m_device->factory().createIndexBuffer("Index Buffer", *m_inputAssembler->indexBufferLayout(), ResourceHeap::Resource, indices.size());
-    commandBuffer->transfer(asShared(std::move(stagedIndices)), *indexBuffer, 0, 0, indices.size());
+    commandBuffer->transfer(indices.data(), indices.size() * m_inputAssembler->indexBufferLayout()->elementSize(), *indexBuffer, 0, indices.size());
 
     // Initialize the camera buffer. The camera buffer is constant, so we only need to create one buffer, that can be read from all frames. Since this is a 
     // write-once/read-multiple scenario, we also transfer the buffer to the more efficient memory heap on the GPU.
@@ -169,9 +159,7 @@ void SampleApp::updateCamera(const ICommandBuffer& commandBuffer, IBuffer& buffe
     camera.ViewProjection = projection * view;
 
     // Create a staging buffer and use to transfer the new uniform buffer to.
-    auto cameraStagingBuffer = m_device->factory().createBuffer(m_device->state().pipeline("Geometry"), DescriptorSets::Constant, 0, ResourceHeap::Staging);
-    cameraStagingBuffer->map(reinterpret_cast<const void*>(&camera), sizeof(camera));
-    commandBuffer.transfer(asShared(std::move(cameraStagingBuffer)), buffer);
+    commandBuffer.transfer(reinterpret_cast<const void*>(&camera), sizeof(camera), buffer);
 }
 
 void SampleApp::onStartup() 

--- a/src/Samples/PushConstants/src/sample.cpp
+++ b/src/Samples/PushConstants/src/sample.cpp
@@ -385,7 +385,7 @@ void SampleApp::drawFrame()
     auto time = std::chrono::duration<float, std::chrono::seconds::period>(now - start).count();
 
     // Bind both descriptor sets to the pipeline.
-    commandBuffer->bind(cameraBindings, geometryPipeline);
+    commandBuffer->bind(cameraBindings);
 
     // Bind the vertex and index buffers.
     commandBuffer->bind(vertexBuffer);

--- a/src/Samples/RayQueries/src/sample.cpp
+++ b/src/Samples/RayQueries/src/sample.cpp
@@ -542,9 +542,7 @@ void SampleApp::drawFrame()
     this->updateCamera(cameraBuffer);
 
     // Bind all descriptor sets to the pipeline.
-    commandBuffer->bind(staticDataBindings);
-    commandBuffer->bind(materialBindings);
-    commandBuffer->bind(samplerBindings);
+    commandBuffer->bind({ &staticDataBindings, &materialBindings, &samplerBindings });
 
     // Draw the screen quad and present the frame by ending the render pass. The screen quad is a single triangle that gets clipped.
     commandBuffer->draw(3);

--- a/src/Samples/RayQueries/src/sample.cpp
+++ b/src/Samples/RayQueries/src/sample.cpp
@@ -137,23 +137,13 @@ void SampleApp::initBuffers(IRenderBackend* backend)
     // Get a command buffer. Note that we use the graphics queue here, as it also supports transfers, but additionally allows us to build acceleration structures.
     auto commandBuffer = m_device->defaultQueue(QueueType::Graphics).createCommandBuffer(true);
 
-    // Create the staging buffer.
-    // NOTE: The mapping works, because vertex and index buffers have an alignment of 0, so we can treat the whole buffer as a single element the size of the 
-    //       whole buffer.
-    auto stagedVertices = m_device->factory().createVertexBuffer(*m_inputAssembler->vertexBufferLayout(0), ResourceHeap::Staging, vertices.size());
-    stagedVertices->map(vertices.data(), vertices.size() * sizeof(::Vertex), 0);
+    // Create the vertex buffer and transfer the staging buffer into it.
+    auto vertexBuffer = m_device->factory().createVertexBuffer("Vertex Buffer", *m_inputAssembler->vertexBufferLayout(0), ResourceHeap::Resource, vertices.size());
+    commandBuffer->transfer(vertices.data(), vertices.size() * sizeof(::Vertex), *vertexBuffer, 0, vertices.size());
 
-    // Create the actual vertex buffer and transfer the staging buffer into it.
-    auto vertexBuffer = m_device->factory().createVertexBuffer("Vertex Buffer", *m_inputAssembler->vertexBufferLayout(0), ResourceHeap::Resource, vertices.size(), ResourceUsage::TransferDestination | ResourceUsage::AccelerationStructureBuildInput);
-    commandBuffer->transfer(asShared(std::move(stagedVertices)), *vertexBuffer, 0, 0, vertices.size());
-
-    // Create the staging buffer for the indices. For infos about the mapping see the note about the vertex buffer mapping above.
-    auto stagedIndices = m_device->factory().createIndexBuffer(*m_inputAssembler->indexBufferLayout(), ResourceHeap::Staging, indices.size());
-    stagedIndices->map(indices.data(), indices.size() * m_inputAssembler->indexBufferLayout()->elementSize(), 0);
-
-    // Create the actual index buffer and transfer the staging buffer into it.
-    auto indexBuffer = m_device->factory().createIndexBuffer("Index Buffer", *m_inputAssembler->indexBufferLayout(), ResourceHeap::Resource, indices.size(), ResourceUsage::TransferDestination | ResourceUsage::AccelerationStructureBuildInput);
-    commandBuffer->transfer(asShared(std::move(stagedIndices)), *indexBuffer, 0, 0, indices.size());
+    // Create the index buffer and transfer the staging buffer into it.
+    auto indexBuffer = m_device->factory().createIndexBuffer("Index Buffer", *m_inputAssembler->indexBufferLayout(), ResourceHeap::Resource, indices.size());
+    commandBuffer->transfer(indices.data(), indices.size() * m_inputAssembler->indexBufferLayout()->elementSize(), *indexBuffer, 0, indices.size());
 
     // Before building the acceleration structures the GPU needs to wait for the transfer to finish.
     auto barrier = m_device->makeBarrier(PipelineStage::Transfer, PipelineStage::AccelerationStructureBuild);
@@ -229,11 +219,9 @@ void SampleApp::initBuffers(IRenderBackend* backend)
     barrier = m_device->makeBarrier(PipelineStage::None, PipelineStage::Transfer);
     barrier->transition(*texture, ResourceAccess::None, ResourceAccess::TransferWrite, ImageLayout::Undefined, ImageLayout::CopyDestination);
     commandBuffer->barrier(*barrier);
-    auto stagedTexture = m_device->factory().createBuffer(BufferType::Other, ResourceHeap::Staging, texture->size(0));
-    stagedTexture->map(imageData.get(), texture->size(0), 0);
 
     // Transfer the skybox texture.
-    commandBuffer->transfer(asShared(std::move(stagedTexture)), *texture);
+    commandBuffer->transfer(imageData.get(), texture->size(0), *texture);
     barrier = m_device->makeBarrier(PipelineStage::Transfer, PipelineStage::None);
     barrier->transition(*texture, ResourceAccess::TransferWrite, ResourceAccess::None, ImageLayout::CopyDestination, ImageLayout::ShaderResource);
     commandBuffer->barrier(*barrier);

--- a/src/Samples/RayTracing/src/sample.cpp
+++ b/src/Samples/RayTracing/src/sample.cpp
@@ -142,23 +142,13 @@ void SampleApp::initBuffers(IRenderBackend* backend)
     // Get a command buffer. Note that we use the graphics queue here, as it also supports transfers, but additionally allows us to build acceleration structures.
     auto commandBuffer = m_device->defaultQueue(QueueType::Graphics).createCommandBuffer(true);
 
-    // Create the staging buffer.
-    // NOTE: The mapping works, because vertex and index buffers have an alignment of 0, so we can treat the whole buffer as a single element the size of the 
-    //       whole buffer.
-    auto stagedVertices = m_device->factory().createVertexBuffer(*m_inputAssembler->vertexBufferLayout(0), ResourceHeap::Staging, vertices.size());
-    stagedVertices->map(vertices.data(), vertices.size() * sizeof(::Vertex), 0);
+    // Create the vertex buffer and transfer the staging buffer into it.
+    auto vertexBuffer = m_device->factory().createVertexBuffer("Vertex Buffer", *m_inputAssembler->vertexBufferLayout(0), ResourceHeap::Resource, vertices.size());
+    commandBuffer->transfer(vertices.data(), vertices.size() * sizeof(::Vertex), *vertexBuffer, 0, vertices.size());
 
-    // Create the actual vertex buffer and transfer the staging buffer into it.
-    auto vertexBuffer = m_device->factory().createVertexBuffer("Vertex Buffer", *m_inputAssembler->vertexBufferLayout(0), ResourceHeap::Resource, vertices.size(), ResourceUsage::TransferDestination | ResourceUsage::AccelerationStructureBuildInput);
-    commandBuffer->transfer(asShared(std::move(stagedVertices)), *vertexBuffer, 0, 0, vertices.size());
-
-    // Create the staging buffer for the indices. For infos about the mapping see the note about the vertex buffer mapping above.
-    auto stagedIndices = m_device->factory().createIndexBuffer(*m_inputAssembler->indexBufferLayout(), ResourceHeap::Staging, indices.size());
-    stagedIndices->map(indices.data(), indices.size() * m_inputAssembler->indexBufferLayout()->elementSize(), 0);
-
-    // Create the actual index buffer and transfer the staging buffer into it.
-    auto indexBuffer = m_device->factory().createIndexBuffer("Index Buffer", *m_inputAssembler->indexBufferLayout(), ResourceHeap::Resource, indices.size(), ResourceUsage::TransferDestination | ResourceUsage::AccelerationStructureBuildInput);
-    commandBuffer->transfer(asShared(std::move(stagedIndices)), *indexBuffer, 0, 0, indices.size());
+    // Create the index buffer and transfer the staging buffer into it.
+    auto indexBuffer = m_device->factory().createIndexBuffer("Index Buffer", *m_inputAssembler->indexBufferLayout(), ResourceHeap::Resource, indices.size());
+    commandBuffer->transfer(indices.data(), indices.size() * m_inputAssembler->indexBufferLayout()->elementSize(), *indexBuffer, 0, indices.size());
 
     // Before building the acceleration structures the GPU needs to wait for the transfer to finish.
     auto barrier = m_device->makeBarrier(PipelineStage::Transfer, PipelineStage::AccelerationStructureBuild);
@@ -240,11 +230,9 @@ void SampleApp::initBuffers(IRenderBackend* backend)
     barrier = m_device->makeBarrier(PipelineStage::None, PipelineStage::Transfer);
     barrier->transition(*texture, ResourceAccess::None, ResourceAccess::TransferWrite, ImageLayout::Undefined, ImageLayout::CopyDestination);
     commandBuffer->barrier(*barrier);
-    auto stagedTexture = m_device->factory().createBuffer(BufferType::Other, ResourceHeap::Staging, texture->size(0));
-    stagedTexture->map(imageData.get(), texture->size(0), 0);
 
     // Transfer the skybox texture.
-    commandBuffer->transfer(asShared(std::move(stagedTexture)), *texture);
+    commandBuffer->transfer(imageData.get(), texture->size(0), *texture);
     barrier = m_device->makeBarrier(PipelineStage::Transfer, PipelineStage::None);
     barrier->transition(*texture, ResourceAccess::TransferWrite, ResourceAccess::None, ImageLayout::CopyDestination, ImageLayout::ShaderResource);
     commandBuffer->barrier(*barrier);

--- a/src/Samples/RayTracing/src/sample.cpp
+++ b/src/Samples/RayTracing/src/sample.cpp
@@ -569,10 +569,7 @@ void SampleApp::drawFrame()
     commandBuffer->use(geometryPipeline);
 
     // Bind both descriptor sets to the pipeline.
-    commandBuffer->bind(staticDataBindings);
-    commandBuffer->bind(outputBindings);
-    commandBuffer->bind(materialBindings);
-    commandBuffer->bind(samplerBindings);
+    commandBuffer->bind({ &outputBindings, &staticDataBindings, &materialBindings, &samplerBindings });
 
     // Draw the object and present the frame by ending the render pass.
     commandBuffer->traceRays(m_device->swapChain().renderArea().width(), m_device->swapChain().renderArea().height(), 1, m_offsets, shaderBindingTable, &shaderBindingTable, &shaderBindingTable);

--- a/src/Samples/RenderPasses/src/sample.cpp
+++ b/src/Samples/RenderPasses/src/sample.cpp
@@ -425,8 +425,7 @@ void SampleApp::drawFrame()
         transformBuffer.map(reinterpret_cast<const void*>(&transform), sizeof(transform), backBuffer);
 
         // Bind both descriptor sets to the pipeline.
-        commandBuffer->bind(cameraBindings, geometryPipeline);
-        commandBuffer->bind(transformBindings, geometryPipeline);
+        commandBuffer->bind({ &cameraBindings, &transformBindings });
 
         // Bind the vertex and index buffers.
         commandBuffer->bind(vertexBuffer);

--- a/src/Samples/RenderPasses/src/sample.cpp
+++ b/src/Samples/RenderPasses/src/sample.cpp
@@ -129,23 +129,13 @@ void SampleApp::initBuffers(IRenderBackend* backend)
     // Get a command buffer
     auto commandBuffer = m_device->defaultQueue(QueueType::Transfer).createCommandBuffer(true);
 
-    // Create the staging buffer.
-    // NOTE: The mapping works, because vertex and index buffers have an alignment of 0, so we can treat the whole buffer as a single element the size of the 
-    //       whole buffer.
-    auto stagedVertices = m_device->factory().createVertexBuffer(*m_inputAssembler->vertexBufferLayout(0), ResourceHeap::Staging, vertices.size());
-    stagedVertices->map(vertices.data(), vertices.size() * sizeof(::Vertex), 0);
-    
-    // Create the actual vertex buffer and transfer the staging buffer into it.
+    // Create the vertex buffer and transfer the staging buffer into it.
     auto vertexBuffer = m_device->factory().createVertexBuffer("Vertex Buffer", *m_inputAssembler->vertexBufferLayout(0), ResourceHeap::Resource, vertices.size());
-    commandBuffer->transfer(asShared(std::move(stagedVertices)), *vertexBuffer, 0, 0, vertices.size());
+    commandBuffer->transfer(vertices.data(), vertices.size() * sizeof(::Vertex), *vertexBuffer, 0, vertices.size());
 
-    // Create the staging buffer for the indices. For infos about the mapping see the note about the vertex buffer mapping above.
-    auto stagedIndices = m_device->factory().createIndexBuffer(*m_inputAssembler->indexBufferLayout(), ResourceHeap::Staging, indices.size());
-    stagedIndices->map(indices.data(), indices.size() * m_inputAssembler->indexBufferLayout()->elementSize(), 0);
-
-    // Create the actual index buffer and transfer the staging buffer into it.
+    // Create the index buffer and transfer the staging buffer into it.
     auto indexBuffer = m_device->factory().createIndexBuffer("Index Buffer", *m_inputAssembler->indexBufferLayout(), ResourceHeap::Resource, indices.size());
-    commandBuffer->transfer(asShared(std::move(stagedIndices)), *indexBuffer, 0, 0, indices.size());
+    commandBuffer->transfer(indices.data(), indices.size() * m_inputAssembler->indexBufferLayout()->elementSize(), *indexBuffer, 0, indices.size());
 
     // Initialize the camera buffer. The camera buffer is constant, so we only need to create one buffer, that can be read from all frames. Since this is a 
     // write-once/read-multiple scenario, we also transfer the buffer to the more efficient memory heap on the GPU.
@@ -168,15 +158,10 @@ void SampleApp::initBuffers(IRenderBackend* backend)
     });
 
     // Create buffers for lighting pass, i.e. the view plane vertex and index buffers.
-    auto stagedViewPlaneVertices = m_device->factory().createVertexBuffer(*m_inputAssembler->vertexBufferLayout(0), ResourceHeap::Staging, viewPlaneVertices.size());
-    stagedViewPlaneVertices->map(viewPlaneVertices.data(), viewPlaneVertices.size() * sizeof(::Vertex), 0);
     auto viewPlaneVertexBuffer = m_device->factory().createVertexBuffer("View Plane Vertices", *m_inputAssembler->vertexBufferLayout(0), ResourceHeap::Resource, viewPlaneVertices.size());
-    commandBuffer->transfer(asShared(std::move(stagedViewPlaneVertices)), *viewPlaneVertexBuffer, 0, 0, viewPlaneVertices.size());
-
-    auto stagedViewPlaneIndices = m_device->factory().createIndexBuffer(*m_inputAssembler->indexBufferLayout(), ResourceHeap::Staging, viewPlaneIndices.size());
-    stagedViewPlaneIndices->map(viewPlaneIndices.data(), viewPlaneIndices.size() * m_inputAssembler->indexBufferLayout()->elementSize(), 0);
     auto viewPlaneIndexBuffer = m_device->factory().createIndexBuffer("View Plane Indices", *m_inputAssembler->indexBufferLayout(), ResourceHeap::Resource, viewPlaneIndices.size());
-    commandBuffer->transfer(asShared(std::move(stagedViewPlaneIndices)), *viewPlaneIndexBuffer, 0, 0, viewPlaneIndices.size());
+    commandBuffer->transfer(viewPlaneVertices.data(), viewPlaneVertices.size() * sizeof(::Vertex), *viewPlaneVertexBuffer, 0, viewPlaneVertices.size());
+    commandBuffer->transfer(viewPlaneIndices.data(), viewPlaneIndices.size() * m_inputAssembler->indexBufferLayout()->elementSize(), *viewPlaneIndexBuffer, 0, viewPlaneIndices.size());
 
     // Create the G-Buffer bindings.
     auto& lightingPipeline = m_device->state().pipeline("Lighting");
@@ -206,9 +191,7 @@ void SampleApp::updateCamera(const ICommandBuffer& commandBuffer, IBuffer& buffe
     camera.ViewProjection = projection * view;
 
     // Create a staging buffer and use to transfer the new uniform buffer to.
-    auto cameraStagingBuffer = m_device->factory().createBuffer(m_device->state().pipeline("Geometry"), DescriptorSets::Constant, 0, ResourceHeap::Staging);
-    cameraStagingBuffer->map(reinterpret_cast<const void*>(&camera), sizeof(camera));
-    commandBuffer.transfer(asShared(std::move(cameraStagingBuffer)), buffer);
+    commandBuffer.transfer(reinterpret_cast<const void*>(&camera), sizeof(camera), buffer);
 }
 
 void SampleApp::onStartup() 

--- a/src/Samples/Textures/src/sample.cpp
+++ b/src/Samples/Textures/src/sample.cpp
@@ -411,6 +411,14 @@ void SampleApp::handleEvents()
     ::glfwPollEvents();
 }
 
+inline auto test(std::ranges::input_range auto&& descriptorSets) requires
+    std::derived_from<std::remove_cv_t<std::remove_pointer_t<std::iter_value_t<std::ranges::iterator_t<std::remove_cv_t<std::remove_reference_t<decltype(descriptorSets)>>>>>>, IDescriptorSet>
+{
+    using descriptor_set_type = std::remove_cv_t<std::remove_pointer_t<std::iter_value_t<std::ranges::iterator_t<std::remove_cv_t<std::remove_reference_t<decltype(descriptorSets)>>>>>>;
+    auto sets = descriptorSets | std::ranges::to<Array<const descriptor_set_type*>>();
+    return sets;
+}
+
 void SampleApp::drawFrame()
 {
     // Store the initial time this method has been called first.
@@ -448,9 +456,7 @@ void SampleApp::drawFrame()
     transformBuffer.map(reinterpret_cast<const void*>(&transform), sizeof(transform), backBuffer);
 
     // Bind both descriptor sets to the pipeline.
-    commandBuffer->bind(staticBindings, geometryPipeline);
-    commandBuffer->bind(samplerBindings, geometryPipeline);
-    commandBuffer->bind(transformBindings, geometryPipeline);
+    commandBuffer->bind({ &staticBindings, &samplerBindings, &transformBindings });
 
     // Bind the vertex and index buffers.
     commandBuffer->bind(vertexBuffer);

--- a/src/Samples/Textures/src/sample.cpp
+++ b/src/Samples/Textures/src/sample.cpp
@@ -114,10 +114,6 @@ void loadTexture(TDevice& device, UniquePtr<IImage>& texture, UniquePtr<ISampler
     //       in the backend using a compute shader, that needs to write back to the texture.
     texture = device.factory().createTexture("Texture", Format::R8G8B8A8_UNORM, Size2d(width, height), ImageDimensions::DIM_2, 6, 1, MultiSamplingLevel::x1, ResourceUsage::AllowWrite | ResourceUsage::TransferDestination | ResourceUsage::TransferSource);
 
-    // Create a staging buffer for the first mip-map of the texture.
-    auto stagedTexture = device.factory().createBuffer(BufferType::Other, ResourceHeap::Staging, texture->size(0));
-    stagedTexture->map(imageData.get(), texture->size(0), 0);
-
     // Transfer the texture using the graphics queue (since we want to be able to generate mip maps, which is done on the graphics queue in Vulkan and a compute-capable queue in D3D12).
     auto commandBuffer = device.defaultQueue(QueueType::Graphics).createCommandBuffer(true);
     UniquePtr<TBarrier> barrier = device.buildBarrier()
@@ -125,7 +121,7 @@ void loadTexture(TDevice& device, UniquePtr<IImage>& texture, UniquePtr<ISampler
         .blockAccessTo(*texture, ResourceAccess::TransferWrite).transitionLayout(ImageLayout::CopyDestination).whenFinishedWith(ResourceAccess::None);
 
     commandBuffer->barrier(*barrier);
-    commandBuffer->transfer(asShared(std::move(stagedTexture)), *texture);
+    commandBuffer->transfer(imageData.get(), texture->size(0), *texture);
 
     // Generate the rest of the mip maps.
     commandBuffer->generateMipMaps(*texture);
@@ -152,23 +148,13 @@ UInt64 initBuffers(SampleApp& app, TDevice& device, SharedPtr<IInputAssembler> i
     // Get a command buffer
     auto commandBuffer = device.defaultQueue(QueueType::Transfer).createCommandBuffer(true);
 
-    // Create the staging buffer.
-    // NOTE: The mapping works, because vertex and index buffers have an alignment of 0, so we can treat the whole buffer as a single element the size of the 
-    //       whole buffer.
-    auto stagedVertices = device.factory().createVertexBuffer(*inputAssembler->vertexBufferLayout(0), ResourceHeap::Staging, vertices.size());
-    stagedVertices->map(vertices.data(), vertices.size() * sizeof(::Vertex), 0);
-
-    // Create the actual vertex buffer and transfer the staging buffer into it.
+    // Create the vertex buffer and transfer the staging buffer into it.
     auto vertexBuffer = device.factory().createVertexBuffer("Vertex Buffer", *inputAssembler->vertexBufferLayout(0), ResourceHeap::Resource, vertices.size());
-    commandBuffer->transfer(asShared(std::move(stagedVertices)), *vertexBuffer, 0, 0, vertices.size());
+    commandBuffer->transfer(vertices.data(), vertices.size() * sizeof(::Vertex), *vertexBuffer, 0, vertices.size());
 
-    // Create the staging buffer for the indices. For infos about the mapping see the note about the vertex buffer mapping above.
-    auto stagedIndices = device.factory().createIndexBuffer(*inputAssembler->indexBufferLayout(), ResourceHeap::Staging, indices.size());
-    stagedIndices->map(indices.data(), indices.size() * inputAssembler->indexBufferLayout()->elementSize(), 0);
-
-    // Create the actual index buffer and transfer the staging buffer into it.
+    // Create the index buffer and transfer the staging buffer into it.
     auto indexBuffer = device.factory().createIndexBuffer("Index Buffer", *inputAssembler->indexBufferLayout(), ResourceHeap::Resource, indices.size());
-    commandBuffer->transfer(asShared(std::move(stagedIndices)), *indexBuffer, 0, 0, indices.size());
+    commandBuffer->transfer(indices.data(), indices.size() * inputAssembler->indexBufferLayout()->elementSize(), *indexBuffer, 0, indices.size());
     
     // Initialize the camera buffer. The camera buffer is constant, so we only need to create one buffer, that can be read from all frames. Since this is a 
     // write-once/read-multiple scenario, we also transfer the buffer to the more efficient memory heap on the GPU.
@@ -225,9 +211,7 @@ void SampleApp::updateCamera(const ICommandBuffer& commandBuffer, IBuffer& buffe
     camera.ViewProjection = projection * view;
 
     // Create a staging buffer and use to transfer the new uniform buffer to.
-    auto cameraStagingBuffer = m_device->factory().createBuffer(m_device->state().pipeline("Geometry"), DescriptorSets::Constant, 0, ResourceHeap::Staging);
-    cameraStagingBuffer->map(reinterpret_cast<const void*>(&camera), sizeof(camera));
-    commandBuffer.transfer(asShared(std::move(cameraStagingBuffer)), buffer);
+    commandBuffer.transfer(reinterpret_cast<const void*>(&camera), sizeof(camera), buffer);
 }
 
 void SampleApp::onStartup()

--- a/src/Samples/UniformArrays/src/sample.cpp
+++ b/src/Samples/UniformArrays/src/sample.cpp
@@ -131,23 +131,13 @@ void SampleApp::initBuffers(IRenderBackend* backend)
     // Get a command buffer
     auto commandBuffer = m_device->defaultQueue(QueueType::Transfer).createCommandBuffer(true);
 
-    // Create the staging buffer.
-    // NOTE: The mapping works, because vertex and index buffers have an alignment of 0, so we can treat the whole buffer as a single element the size of the 
-    //       whole buffer.
-    auto stagedVertices = m_device->factory().createVertexBuffer(*m_inputAssembler->vertexBufferLayout(0), ResourceHeap::Staging, vertices.size());
-    stagedVertices->map(vertices.data(), vertices.size() * sizeof(::Vertex), 0);
-    
-    // Create the actual vertex buffer and transfer the staging buffer into it.
+    // Create the vertex buffer and transfer the staging buffer into it.
     auto vertexBuffer = m_device->factory().createVertexBuffer("Vertex Buffer", *m_inputAssembler->vertexBufferLayout(0), ResourceHeap::Resource, vertices.size());
-    commandBuffer->transfer(asShared(std::move(stagedVertices)), *vertexBuffer, 0, 0, vertices.size());
+    commandBuffer->transfer(vertices.data(), vertices.size() * sizeof(::Vertex), *vertexBuffer, 0, vertices.size());
 
-    // Create the staging buffer for the indices. For infos about the mapping see the note about the vertex buffer mapping above.
-    auto stagedIndices = m_device->factory().createIndexBuffer(*m_inputAssembler->indexBufferLayout(), ResourceHeap::Staging, indices.size());
-    stagedIndices->map(indices.data(), indices.size() * m_inputAssembler->indexBufferLayout()->elementSize(), 0);
-
-    // Create the actual index buffer and transfer the staging buffer into it.
+    // Create the index buffer and transfer the staging buffer into it.
     auto indexBuffer = m_device->factory().createIndexBuffer("Index Buffer", *m_inputAssembler->indexBufferLayout(), ResourceHeap::Resource, indices.size());
-    commandBuffer->transfer(asShared(std::move(stagedIndices)), *indexBuffer, 0, 0, indices.size());
+    commandBuffer->transfer(indices.data(), indices.size() * m_inputAssembler->indexBufferLayout()->elementSize(), *indexBuffer, 0, indices.size());
 
     // Initialize the camera buffer. The camera buffer is constant, so we only need to create one buffer, that can be read from all frames. Since this is a 
     // write-once/read-multiple scenario, we also transfer the buffer to the more efficient memory heap on the GPU.
@@ -160,11 +150,8 @@ void SampleApp::initBuffers(IRenderBackend* backend)
 
     // Allocate the lights buffer and the lights staging buffer.
     this->initLights();
-    auto lightsStagingBuffer = m_device->factory().createBuffer("Lights Staging", staticBindingLayout, 1, ResourceHeap::Staging, LIGHT_SOURCES);
     auto lightsBuffer = m_device->factory().createBuffer("Lights", staticBindingLayout, 1, ResourceHeap::Resource, LIGHT_SOURCES);
-    auto lightsData = lights | std::views::transform([](const LightBuffer& light) { return reinterpret_cast<const void*>(&light); }) | std::ranges::to<Array<const void*>>();
-    lightsStagingBuffer->map(lightsData, sizeof(LightBuffer));
-    commandBuffer->transfer(asShared(std::move(lightsStagingBuffer)), *lightsBuffer, 0, 0, LIGHT_SOURCES);
+    commandBuffer->transfer(lights | std::views::transform([](const LightBuffer& light) { return reinterpret_cast<const void*>(&light); }) | std::ranges::to<Array<const void*>>(), sizeof(LightBuffer), *lightsBuffer, 0);
 
     // Allocate the static bindings.
     auto staticBindings = staticBindingLayout.allocate({ { 0, *cameraBuffer }, { 1, *lightsBuffer } });
@@ -214,9 +201,7 @@ void SampleApp::updateCamera(const ICommandBuffer& commandBuffer, IBuffer& buffe
     camera.ViewProjection = projection * view;
 
     // Create a staging buffer and use to transfer the new uniform buffer to.
-    auto cameraStagingBuffer = m_device->factory().createBuffer(m_device->state().pipeline("Geometry"), DescriptorSets::Constant, 0, ResourceHeap::Staging);
-    cameraStagingBuffer->map(reinterpret_cast<const void*>(&camera), sizeof(camera));
-    commandBuffer.transfer(asShared(std::move(cameraStagingBuffer)), buffer);
+    commandBuffer.transfer(reinterpret_cast<const void*>(&camera), sizeof(camera), buffer);
 }
 
 void SampleApp::onStartup() 

--- a/src/Samples/UniformArrays/src/sample.cpp
+++ b/src/Samples/UniformArrays/src/sample.cpp
@@ -436,8 +436,7 @@ void SampleApp::drawFrame()
     transformBuffer.map(reinterpret_cast<const void*>(&transform), sizeof(transform), backBuffer);
 
     // Bind both descriptor sets to the pipeline.
-    commandBuffer->bind(staticBindings, geometryPipeline);
-    commandBuffer->bind(transformBindings, geometryPipeline);
+    commandBuffer->bind({ &staticBindings, &transformBindings });
 
     // Bind the vertex and index buffers.
     commandBuffer->bind(vertexBuffer);


### PR DESCRIPTION
**Describe the pull request**

This PR improves command buffers to allow for some boilerplate code to be removed from application implementations:

- Staging buffers can now be avoided by directly mapping memory through an extended `ICommandBuffer::transfer` overload.
- It is now possible to bind multiple descriptor sets at once using a new `ICommandBuffer::bind` overload. This can even be advantageous for Vulkan descriptor sets, if they are in a contiguous range, as this allows the engine to bind them through a single command (although the effect is probably minimal).
- Barriers can now be created from command buffers.
