### PR TITLE
Allow unbound descriptors in descriptor sets.

### DIFF
--- a/docs/release-logs/0.4.1.md
+++ b/docs/release-logs/0.4.1.md
@@ -12,11 +12,12 @@
 - Improvements to C++ core guideline conformance. ([See PR #103](https://github.com/crud89/LiteFX/pull/103))
 - New event infrastructure. ([See PR #81](https://github.com/crud89/LiteFX/pull/81))
 - Add support for user-defined debug markers. ([See PR #82](https://github.com/crud89/LiteFX/pull/82))
-- Improved resource allocation and binding: ([See PR #83](https://github.com/crud89/LiteFX/pull/83), [PR #110](https://github.com/crud89/LiteFX/pull/110), [PR #111](https://github.com/crud89/LiteFX/pull/111) and [PR #123](https://github.com/crud89/LiteFX/pull/123))
+- Improved resource allocation and binding: ([See PR #83](https://github.com/crud89/LiteFX/pull/83), [PR #110](https://github.com/crud89/LiteFX/pull/110), [PR #111](https://github.com/crud89/LiteFX/pull/111), [PR #123](https://github.com/crud89/LiteFX/pull/123) and [PR #126](https://github.com/crud89/LiteFX/pull/126))
   - Resources can now be created without querying the descriptor set layout or descriptor layout in advance.
   - When allocating descriptor sets, default bindings can be provided to make bind-once scenarios more straightforward.
   - Descriptor sets can also be allocated without providing any binding index (in which case continuous counting is assumed) or resources (which enables late binding or resource updating).
   - Descriptor set binding has been simplified by caching last used pipeline on command buffers and providing the possibility to bind multiple descriptor sets at once.
+  - Binding to descriptors that are not part of the layout does no longer throw an exception.
 - Improved handling of temporary command buffers. ([See PR #89](https://github.com/crud89/LiteFX/pull/89) and [PR # 123](https://github.com/crud89/LiteFX/pull/123))
   - Command buffers can now be submitted with shared ownership to a command queue, which then stores them and releases the references, if the submit fence is passed (during `waitFor`).
   - Command buffer transfers can now receive resources with shared ownership. Resource references are released in a similar fashion.

--- a/src/Backends/Vulkan/src/descriptor_set.cpp
+++ b/src/Backends/Vulkan/src/descriptor_set.cpp
@@ -50,6 +50,18 @@ const VulkanDescriptorSetLayout& VulkanDescriptorSet::layout() const noexcept
 
 void VulkanDescriptorSet::update(UInt32 binding, const IVulkanBuffer& buffer, UInt32 bufferElement, UInt32 elements, UInt32 firstDescriptor) const
 {
+    // Find the descriptor.
+    auto descriptors = m_impl->m_layout.descriptors();
+    auto match = std::ranges::find_if(descriptors, [&binding](const VulkanDescriptorLayout* layout) { return layout->binding() == binding; });
+
+    if (match == descriptors.end()) [[unlikely]]
+    {
+        LITEFX_WARNING(VULKAN_LOG, "The descriptor set {0} does not contain a descriptor at binding {1}.", m_impl->m_layout.space(), binding);
+        return;
+    }
+    
+    const auto& descriptorLayout = *(*match);
+
     VkWriteDescriptorSet descriptorWrite{ };
     descriptorWrite.sType = VK_STRUCTURE_TYPE_WRITE_DESCRIPTOR_SET;
     descriptorWrite.dstSet = this->handle();
@@ -57,7 +69,6 @@ void VulkanDescriptorSet::update(UInt32 binding, const IVulkanBuffer& buffer, UI
     descriptorWrite.dstArrayElement = firstDescriptor;
     descriptorWrite.descriptorCount = 1;
 
-    auto& descriptorLayout = m_impl->m_layout.descriptor(binding);
     Array<VkDescriptorBufferInfo> bufferInfos;
     UInt32 elementCount = elements > 0 ? elements : buffer.elements() - bufferElement;
 
@@ -159,6 +170,18 @@ void VulkanDescriptorSet::update(UInt32 binding, const IVulkanBuffer& buffer, UI
 
 void VulkanDescriptorSet::update(UInt32 binding, const IVulkanImage& texture, UInt32 descriptor, UInt32 firstLevel, UInt32 levels, UInt32 firstLayer, UInt32 layers) const
 {
+    // Find the descriptor.
+    auto descriptors = m_impl->m_layout.descriptors();
+    auto match = std::ranges::find_if(descriptors, [&binding](const VulkanDescriptorLayout* layout) { return layout->binding() == binding; });
+
+    if (match == descriptors.end()) [[unlikely]]
+    {
+        LITEFX_WARNING(VULKAN_LOG, "The descriptor set {0} does not contain a descriptor at binding {1}.", m_impl->m_layout.space(), binding);
+        return;
+    }
+    
+    const auto& layout = *(*match);
+
     VkDescriptorImageInfo imageInfo{ };
     VkWriteDescriptorSet descriptorWrite{ };
     descriptorWrite.sType = VK_STRUCTURE_TYPE_WRITE_DESCRIPTOR_SET;
@@ -167,8 +190,6 @@ void VulkanDescriptorSet::update(UInt32 binding, const IVulkanImage& texture, UI
     descriptorWrite.dstArrayElement = descriptor;
     descriptorWrite.descriptorCount = 1;
     descriptorWrite.pImageInfo = &imageInfo;
-
-    const auto& layout = m_impl->m_layout.descriptor(binding);
 
     switch (layout.descriptorType())
     {
@@ -241,7 +262,17 @@ void VulkanDescriptorSet::update(UInt32 binding, const IVulkanImage& texture, UI
 
 void VulkanDescriptorSet::update(UInt32 binding, const IVulkanSampler& sampler, UInt32 descriptor) const
 {
-    const auto& layout = m_impl->m_layout.descriptor(binding);
+    // Find the descriptor.
+    auto descriptors = m_impl->m_layout.descriptors();
+    auto match = std::ranges::find_if(descriptors, [&binding](const VulkanDescriptorLayout* layout) { return layout->binding() == binding; });
+
+    if (match == descriptors.end()) [[unlikely]]
+    {
+        LITEFX_WARNING(VULKAN_LOG, "The descriptor set {0} does not contain a descriptor at binding {1}.", m_impl->m_layout.space(), binding);
+        return;
+    }
+    
+    const auto& layout = *(*match);
 
     if (layout.descriptorType() != DescriptorType::Sampler) [[unlikely]]
         throw InvalidArgumentException("binding", "Invalid descriptor type. The binding {0} does not point to a sampler descriptor.", binding);
@@ -263,7 +294,17 @@ void VulkanDescriptorSet::update(UInt32 binding, const IVulkanSampler& sampler, 
 
 void VulkanDescriptorSet::update(UInt32 binding, const IVulkanAccelerationStructure& accelerationStructure, UInt32 descriptor) const
 {
-    const auto& layout = m_impl->m_layout.descriptor(binding);
+    // Find the descriptor.
+    auto descriptors = m_impl->m_layout.descriptors();
+    auto match = std::ranges::find_if(descriptors, [&binding](const VulkanDescriptorLayout* layout) { return layout->binding() == binding; });
+
+    if (match == descriptors.end()) [[unlikely]]
+    {
+        LITEFX_WARNING(VULKAN_LOG, "The descriptor set {0} does not contain a descriptor at binding {1}.", m_impl->m_layout.space(), binding);
+        return;
+    }
+    
+    const auto& layout = *(*match);
 
     if (layout.descriptorType() != DescriptorType::AccelerationStructure) [[unlikely]]
         throw InvalidArgumentException("binding", "Invalid descriptor type. The binding {0} does not point to an acceleration structure descriptor.", binding);


### PR DESCRIPTION
**Describe the pull request**

Currently trying to update a descriptor in a descriptor set, that does not exist in the pipeline layout throws an exception. However, when authoring shaders, it is common that descriptors are not actually used and get removed from the shader. Shader reflection in this case does produce a pipeline layout without the descriptor, which then would cause an exception to be thrown. To simplify this process, this no longer throws with this PR, but rather issues a warning. This removes the need for changing the application itself frequently during shader development.