### PR TITLE
Support vertical synchronization.

### DIFF
--- a/docs/release-logs/0.4.1.md
+++ b/docs/release-logs/0.4.1.md
@@ -39,6 +39,7 @@
 - Add optional support for ray-tracing and ray queries (enable `GraphicsDeviceFeatures::RayTracing` and/or `GraphicsDeviceFeatures::RayQueries` to turn it on). ([See PR #122](https://github.com/crud89/LiteFX/pull/122))
 - Render passes have been improved and simplified, now supporting automatic input attachment binding and event-based resize handlers. ([See PR #124](https://github.com/crud89/LiteFX/pull/124))
 - Frame buffers have been decoupled from render passes, allowing to share images between passes and binding resources of different sampling rates and resolutions to the same pass. ([See PR #125](https://github.com/crud89/LiteFX/pull/125))
+- Support for vertical synchronization has been added. ([See PR #127](https://github.com/crud89/LiteFX/pull/127))
 
 **🌋 Vulkan:**
 

--- a/src/Backends/DirectX12/include/litefx/backends/dx12.hpp
+++ b/src/Backends/DirectX12/include/litefx/backends/dx12.hpp
@@ -1713,8 +1713,9 @@ namespace LiteFX::Rendering::Backends {
         /// <param name="device">The device that owns the swap chain.</param>
         /// <param name="format">The initial surface format.</param>
         /// <param name="renderArea">The initial size of the render area.</param>
+        /// <param name="enableVsync">`true` if vertical synchronization should be used, otherwise `false`.</param>
         /// <param name="buffers">The initial number of buffers.</param>
-        explicit DirectX12SwapChain(const DirectX12Device& device, Format surfaceFormat = Format::B8G8R8A8_SRGB, const Size2d& renderArea = { 800, 600 }, UInt32 buffers = 3);
+        explicit DirectX12SwapChain(const DirectX12Device& device, Format surfaceFormat = Format::B8G8R8A8_SRGB, const Size2d& renderArea = { 800, 600 }, UInt32 buffers = 3, bool enableVsync = false);
         DirectX12SwapChain(const DirectX12SwapChain&) = delete;
         DirectX12SwapChain(DirectX12SwapChain&&) = delete;
         virtual ~DirectX12SwapChain() noexcept;
@@ -1757,6 +1758,9 @@ namespace LiteFX::Rendering::Backends {
         const Size2d& renderArea() const noexcept override;
 
         /// <inheritdoc />
+        bool verticalSynchronization() const noexcept override;
+
+        /// <inheritdoc />
         IDirectX12Image* image(UInt32 backBuffer) const override;
 
         /// <inheritdoc />
@@ -1776,7 +1780,7 @@ namespace LiteFX::Rendering::Backends {
         void addTimingEvent(SharedPtr<TimingEvent> timingEvent) override;
 
         /// <inheritdoc />
-        void reset(Format surfaceFormat, const Size2d& renderArea, UInt32 buffers) override;
+        void reset(Format surfaceFormat, const Size2d& renderArea, UInt32 buffers, bool enableVsync = false) override;
 
         /// <inheritdoc />
         [[nodiscard]] UInt32 swapBackBuffer() const override;
@@ -1881,12 +1885,13 @@ namespace LiteFX::Rendering::Backends {
         /// <param name="adapter">The adapter the device uses for drawing.</param>
         /// <param name="surface">The surface, the device should draw to.</param>
         /// <param name="format">The initial surface format, device uses for drawing.</param>
-        /// <param name="frameBufferSize">The initial size of the frame buffers.</param>
-        /// <param name="frameBuffers">The initial number of frame buffers.</param>
+        /// <param name="renderArea">The initial size of the render area.</param>
+        /// <param name="backBuffers">The initial number of back buffers.</param>
+        /// <param name="enableVsync">The initial setting for vertical synchronization.</param>
         /// <param name="features">The features that should be supported by this device.</param>
         /// <param name="globalBufferHeapSize">The size of the global heap for constant buffers, shader resources and images.</param>
         /// <param name="globalSamplerHeapSize">The size of the global heap for samplers.</param>
-        explicit DirectX12Device(const DirectX12Backend& backend, const DirectX12GraphicsAdapter& adapter, UniquePtr<DirectX12Surface>&& surface, Format format, const Size2d& frameBufferSize, UInt32 frameBuffers, GraphicsDeviceFeatures features = {}, UInt32 globalBufferHeapSize = 524287, UInt32 globalSamplerHeapSize = 2048);
+        explicit DirectX12Device(const DirectX12Backend& backend, const DirectX12GraphicsAdapter& adapter, UniquePtr<DirectX12Surface>&& surface, Format format, const Size2d& renderArea, UInt32 backBuffers, bool enableVsync = false, GraphicsDeviceFeatures features = {}, UInt32 globalBufferHeapSize = 524287, UInt32 globalSamplerHeapSize = 2048);
 
         DirectX12Device(const DirectX12Device&) = delete;
         DirectX12Device(DirectX12Device&&) = delete;

--- a/src/Backends/DirectX12/src/device.cpp
+++ b/src/Backends/DirectX12/src/device.cpp
@@ -181,9 +181,9 @@ public:
 		m_factory = makeUnique<DirectX12GraphicsFactory>(*m_parent);
 	}
 
-	void createSwapChain(Format format, const Size2d& frameBufferSize, UInt32 frameBuffers)
+	void createSwapChain(Format format, const Size2d& renderArea, UInt32 backBuffers, bool enableVsync)
 	{
-		m_swapChain = makeUnique<DirectX12SwapChain>(*m_parent, format, frameBufferSize, frameBuffers);
+		m_swapChain = makeUnique<DirectX12SwapChain>(*m_parent, format, renderArea, backBuffers, enableVsync);
 	}
 
 	void createQueues()
@@ -260,11 +260,11 @@ public:
 // ------------------------------------------------------------------------------------------------
 
 DirectX12Device::DirectX12Device(const DirectX12Backend& backend, const DirectX12GraphicsAdapter& adapter, UniquePtr<DirectX12Surface>&& surface, GraphicsDeviceFeatures features) :
-	DirectX12Device(backend, adapter, std::move(surface), Format::B8G8R8A8_SRGB, { 800, 600 }, 3, features)
+	DirectX12Device(backend, adapter, std::move(surface), Format::B8G8R8A8_SRGB, { 800, 600 }, 3, false, features)
 {
 }
 
-DirectX12Device::DirectX12Device(const DirectX12Backend& backend, const DirectX12GraphicsAdapter& adapter, UniquePtr<DirectX12Surface>&& surface, Format format, const Size2d& frameBufferSize, UInt32 frameBuffers, GraphicsDeviceFeatures features, UInt32 globalBufferHeapSize, UInt32 globalSamplerHeapSize) :
+DirectX12Device::DirectX12Device(const DirectX12Backend& backend, const DirectX12GraphicsAdapter& adapter, UniquePtr<DirectX12Surface>&& surface, Format format, const Size2d& renderArea, UInt32 backBuffers, bool enableVsync, GraphicsDeviceFeatures features, UInt32 globalBufferHeapSize, UInt32 globalSamplerHeapSize) :
 	ComResource<ID3D12Device10>(nullptr), m_impl(makePimpl<DirectX12DeviceImpl>(this, adapter, std::move(surface), backend, globalBufferHeapSize, globalSamplerHeapSize))
 {
 	LITEFX_DEBUG(DIRECTX12_LOG, "Creating DirectX 12 device {{ Surface: {0}, Adapter: {1} }}...", fmt::ptr(&surface), adapter.deviceId());
@@ -281,7 +281,7 @@ DirectX12Device::DirectX12Device(const DirectX12Backend& backend, const DirectX1
 	this->handle() = m_impl->initialize(features);
 	m_impl->createQueues();
 	m_impl->createFactory();
-	m_impl->createSwapChain(format, frameBufferSize, frameBuffers);
+	m_impl->createSwapChain(format, renderArea, backBuffers, enableVsync);
 	m_impl->createBlitPipeline();
 }
 

--- a/src/Backends/DirectX12/src/swapchain.cpp
+++ b/src/Backends/DirectX12/src/swapchain.cpp
@@ -19,6 +19,7 @@ private:
 	Array<UniquePtr<IDirectX12Image>> m_presentImages{ };
 	Array<UInt64> m_presentFences{ };
 	bool m_supportsVariableRefreshRates{ false };
+	bool m_vsync{ false };
 	const DirectX12Device& m_device;
 
 	Array<SharedPtr<TimingEvent>> m_timingEvents;
@@ -46,7 +47,7 @@ private:
 
 public:
 	[[nodiscard]]
-	ComPtr<IDXGISwapChain4> initialize(Format format, const Size2d& frameBufferSize, UInt32 frameBuffers)
+	ComPtr<IDXGISwapChain4> initialize(Format format, const Size2d& renderArea, UInt32 backBuffers, bool enableVsync)
 	{
 		if (!std::ranges::any_of(m_parent->getSurfaceFormats(), [&format](Format surfaceFormat) { return surfaceFormat == format; }))
 			throw InvalidArgumentException("format", "The provided surface format {0} it not a supported. Must be one of the following: {1}.", format, this->joinSupportedSurfaceFormats());
@@ -57,8 +58,8 @@ public:
 		const auto& backend = m_device.backend();
 
 		// Create the swap chain.
-		auto size = Size2d{ std::max<UInt32>(1, frameBufferSize.width()), std::max<UInt32>(1, frameBufferSize.height()) };
-		LITEFX_TRACE(DIRECTX12_LOG, "Creating swap chain for device {0} {{ Images: {1}, Extent: {2}x{3} Px }}...", fmt::ptr(m_device.handle().Get()), frameBuffers, size.width(), size.height());
+		auto size = Size2d{ std::max<UInt32>(1, renderArea.width()), std::max<UInt32>(1, renderArea.height()) };
+		LITEFX_TRACE(DIRECTX12_LOG, "Creating swap chain for device {0} {{ Images: {1}, Extent: {2}x{3} Px, Format: {4}, VSync: {5} }}...", fmt::ptr(m_device.handle().Get()), backBuffers, size.width(), size.height(), format, enableVsync);
 		
 		DXGI_SWAP_CHAIN_DESC1 swapChainDesc = {};
 		swapChainDesc.Width = static_cast<UInt32>(size.width());
@@ -66,7 +67,7 @@ public:
 		swapChainDesc.Format = DX12::getFormat(format);
 		swapChainDesc.Stereo = FALSE;
 		swapChainDesc.BufferUsage = DXGI_USAGE_RENDER_TARGET_OUTPUT; // NOTE: D3D12 does no longer allow UAV access to back buffers, so binding swap chain images to UAV in compute/ray-tracing shaders does not work.
-		swapChainDesc.BufferCount = std::max<UInt32>(2, frameBuffers);
+		swapChainDesc.BufferCount = std::max<UInt32>(2, backBuffers);
 		swapChainDesc.Scaling = DXGI_SCALING_STRETCH;
 		swapChainDesc.SwapEffect = DXGI_SWAP_EFFECT_FLIP_DISCARD;
 		swapChainDesc.AlphaMode = DXGI_ALPHA_MODE_UNSPECIFIED;
@@ -93,11 +94,12 @@ public:
 		m_format = format;
 		m_renderArea = size;
 		m_buffers = swapChainDesc.BufferCount;
+		m_vsync = enableVsync;
 
 		return swapChain;
 	}
 
-	void reset(Format format, const Size2d& frameBufferSize, UInt32 frameBuffers)
+	void reset(Format format, const Size2d& renderArea, UInt32 backBuffers, bool enableVsync)
 	{
 		if (!std::ranges::any_of(m_parent->getSurfaceFormats(), [&format](Format surfaceFormat) { return surfaceFormat == format; }))
 			throw InvalidArgumentException("format", "The provided surface format {0} it not a supported. Must be one of the following: {1}.", format, this->joinSupportedSurfaceFormats());
@@ -110,9 +112,10 @@ public:
 		const auto& backend = m_device.backend();
 
 		// Resize the buffers.
-		UInt32 buffers = std::max<UInt32>(2, frameBuffers);
-		auto size = Size2d{ std::max<UInt32>(1, frameBufferSize.width()), std::max<UInt32>(1, frameBufferSize.height()) };
+		UInt32 buffers = std::max<UInt32>(2, backBuffers);
+		auto size = Size2d{ std::max<UInt32>(1, renderArea.width()), std::max<UInt32>(1, renderArea.height()) };
 		raiseIfFailed(m_parent->handle()->ResizeBuffers(buffers, static_cast<UInt32>(size.width()), static_cast<UInt32>(size.height()), DX12::getFormat(format), m_supportsVariableRefreshRates ? DXGI_SWAP_CHAIN_FLAG_ALLOW_TEARING : 0), "Unable to resize swap chain back buffers.");
+		LITEFX_TRACE(DIRECTX12_LOG, "Resetting swap chain for device {0} {{ Images: {1}, Extent: {2}x{3} Px, Format: {4}, VSync: {5} }}...", fmt::ptr(m_device.handle().Get()), backBuffers, size.width(), size.height(), format, enableVsync);
 
 		// Acquire the swap chain images.
 		m_presentImages.resize(buffers);
@@ -127,6 +130,7 @@ public:
 		m_renderArea = size;
 		m_buffers = buffers;
 		m_currentImage = 0;
+		m_vsync = enableVsync;
 
 		// Initialize the query pools.
 		if (m_timingQueryHeaps.size() != buffers)
@@ -196,10 +200,10 @@ private:
 // Shared interface.
 // ------------------------------------------------------------------------------------------------
 
-DirectX12SwapChain::DirectX12SwapChain(const DirectX12Device& device, Format format, const Size2d& frameBufferSize, UInt32 frameBuffers) :
+DirectX12SwapChain::DirectX12SwapChain(const DirectX12Device& device, Format format, const Size2d& renderArea, UInt32 backBuffers, bool enableVsync) :
 	m_impl(makePimpl<DirectX12SwapChainImpl>(this, device)), ComResource<IDXGISwapChain4>(nullptr)
 {
-	this->handle() = m_impl->initialize(format, frameBufferSize, frameBuffers);
+	this->handle() = m_impl->initialize(format, renderArea, backBuffers, enableVsync);
 }
 
 DirectX12SwapChain::~DirectX12SwapChain() noexcept = default;
@@ -264,6 +268,11 @@ const Size2d& DirectX12SwapChain::renderArea() const noexcept
 	return m_impl->m_renderArea;
 }
 
+bool DirectX12SwapChain::verticalSynchronization() const noexcept
+{
+	return m_impl->m_vsync;
+}
+
 IDirectX12Image* DirectX12SwapChain::image(UInt32 backBuffer) const
 {
 	if (backBuffer >= m_impl->m_presentImages.size()) [[unlikely]]
@@ -287,7 +296,11 @@ void DirectX12SwapChain::present(UInt64 fence) const
 	// Store the last fence here that marks the end of the rendering to this frame buffer. Presenting is queued after rendering anyway, but when swapping the back buffers buffers,
 	// we need to wait for all commands to finish before being able to re-use the command buffers associated with queued commands.
 	m_impl->m_presentFences[m_impl->m_currentImage] = fence;
-	raiseIfFailed(this->handle()->Present(0, this->supportsVariableRefreshRate() ? DXGI_PRESENT_ALLOW_TEARING : 0), "Unable to present swap chain");
+
+	if (m_impl->m_vsync)
+		raiseIfFailed(this->handle()->Present(1, 0), "Unable to present swap chain");
+	else
+		raiseIfFailed(this->handle()->Present(0, this->supportsVariableRefreshRate() ? DXGI_PRESENT_ALLOW_TEARING : 0), "Unable to present swap chain");
 }
 
 Enumerable<Format> DirectX12SwapChain::getSurfaceFormats() const noexcept
@@ -315,10 +328,10 @@ void DirectX12SwapChain::addTimingEvent(SharedPtr<TimingEvent> timingEvent)
 	m_impl->resetQueryHeaps(events);
 }
 
-void DirectX12SwapChain::reset(Format surfaceFormat, const Size2d& renderArea, UInt32 buffers)
+void DirectX12SwapChain::reset(Format surfaceFormat, const Size2d& renderArea, UInt32 buffers, bool enableVsync)
 {
-	m_impl->reset(surfaceFormat, renderArea, buffers);
-	this->reseted(this, { surfaceFormat, renderArea, buffers });
+	m_impl->reset(surfaceFormat, renderArea, buffers, enableVsync);
+	this->reseted(this, { surfaceFormat, renderArea, buffers, enableVsync });
 }
 
 UInt32 DirectX12SwapChain::swapBackBuffer() const

--- a/src/Backends/Vulkan/include/litefx/backends/vulkan.hpp
+++ b/src/Backends/Vulkan/include/litefx/backends/vulkan.hpp
@@ -1723,7 +1723,8 @@ namespace LiteFX::Rendering::Backends {
         /// <param name="format">The initial surface format.</param>
         /// <param name="renderArea">The initial size of the render area.</param>
         /// <param name="buffers">The initial number of buffers.</param>
-        explicit VulkanSwapChain(const VulkanDevice& device, Format surfaceFormat = Format::B8G8R8A8_SRGB, const Size2d& renderArea = { 800, 600 }, UInt32 buffers = 3);
+        /// <param name="enableVsync">`true` if vertical synchronization should be used, otherwise `false`.</param>
+        explicit VulkanSwapChain(const VulkanDevice& device, Format surfaceFormat = Format::B8G8R8A8_SRGB, const Size2d& renderArea = { 800, 600 }, UInt32 buffers = 3, bool enableVsync = false);
         VulkanSwapChain(const VulkanSwapChain&) = delete;
         VulkanSwapChain(VulkanSwapChain&&) = delete;
         virtual ~VulkanSwapChain() noexcept;
@@ -1760,6 +1761,9 @@ namespace LiteFX::Rendering::Backends {
         const Size2d& renderArea() const noexcept override;
 
         /// <inheritdoc />
+        bool verticalSynchronization() const noexcept override;
+
+        /// <inheritdoc />
         IVulkanImage* image(UInt32 backBuffer) const override;
 
         /// <inheritdoc />
@@ -1779,7 +1783,7 @@ namespace LiteFX::Rendering::Backends {
         void addTimingEvent(SharedPtr<TimingEvent> timingEvent) override;
 
         /// <inheritdoc />
-        void reset(Format surfaceFormat, const Size2d& renderArea, UInt32 buffers) override;
+        void reset(Format surfaceFormat, const Size2d& renderArea, UInt32 buffers, bool enableVsync = false) override;
 
         /// <inheritdoc />
         [[nodiscard]] UInt32 swapBackBuffer() const override;
@@ -1882,11 +1886,12 @@ namespace LiteFX::Rendering::Backends {
         /// <param name="adapter">The adapter the device uses for drawing.</param>
         /// <param name="surface">The surface, the device should draw to.</param>
         /// <param name="format">The initial surface format, device uses for drawing.</param>
-        /// <param name="frameBufferSize">The initial size of the frame buffers.</param>
-        /// <param name="frameBuffers">The initial number of frame buffers.</param>
+        /// <param name="renderArea">The initial size of the render area.</param>
+        /// <param name="backBuffers">The initial number of back buffers.</param>
+        /// <param name="enableVsync">The initial setting for vertical synchronization.</param>
         /// <param name="features">The features that should be supported by this device.</param>
         /// <param name="extensions">The required extensions the device gets initialized with.</param>
-        explicit VulkanDevice(const VulkanBackend& backend, const VulkanGraphicsAdapter& adapter, UniquePtr<VulkanSurface>&& surface, Format format, const Size2d& frameBufferSize, UInt32 frameBuffers, GraphicsDeviceFeatures features = { }, Span<String> extensions = { });
+        explicit VulkanDevice(const VulkanBackend& backend, const VulkanGraphicsAdapter& adapter, UniquePtr<VulkanSurface>&& surface, Format format, const Size2d& renderArea, UInt32 backBuffers, bool enableVsync = false, GraphicsDeviceFeatures features = { }, Span<String> extensions = { });
 
         VulkanDevice(const VulkanDevice&) = delete;
         VulkanDevice(VulkanDevice&&) = delete;

--- a/src/Backends/Vulkan/src/device.cpp
+++ b/src/Backends/Vulkan/src/device.cpp
@@ -469,9 +469,9 @@ public:
         m_factory = makeUnique<VulkanGraphicsFactory>(*m_parent);
     }
 
-    void createSwapChain(Format format, const Size2d& frameBufferSize, UInt32 frameBuffers)
+    void createSwapChain(Format format, const Size2d& renderArea, UInt32 backBuffers, bool enableVsync)
     {
-        m_swapChain = makeUnique<VulkanSwapChain>(*m_parent, format, frameBufferSize, frameBuffers);
+        m_swapChain = makeUnique<VulkanSwapChain>(*m_parent, format, renderArea, backBuffers, enableVsync);
     }
 
 public:
@@ -503,11 +503,11 @@ public:
 // ------------------------------------------------------------------------------------------------
 
 VulkanDevice::VulkanDevice(const VulkanBackend& backend, const VulkanGraphicsAdapter& adapter, UniquePtr<VulkanSurface>&& surface, GraphicsDeviceFeatures features, Span<String> extensions) :
-    VulkanDevice(backend, adapter, std::move(surface), Format::B8G8R8A8_SRGB, { 800, 600 }, 3, features, extensions)
+    VulkanDevice(backend, adapter, std::move(surface), Format::B8G8R8A8_SRGB, { 800, 600 }, 3, false, features, extensions)
 {
 }
 
-VulkanDevice::VulkanDevice(const VulkanBackend& /*backend*/, const VulkanGraphicsAdapter& adapter, UniquePtr<VulkanSurface>&& surface, Format format, const Size2d& frameBufferSize, UInt32 frameBuffers, GraphicsDeviceFeatures features, Span<String> extensions) :
+VulkanDevice::VulkanDevice(const VulkanBackend& /*backend*/, const VulkanGraphicsAdapter& adapter, UniquePtr<VulkanSurface>&& surface, Format format, const Size2d& renderArea, UInt32 backBuffers, bool enableVsync, GraphicsDeviceFeatures features, Span<String> extensions) :
     Resource<VkDevice>(nullptr), m_impl(makePimpl<VulkanDeviceImpl>(this, adapter, std::move(surface), features, extensions))
 {
     LITEFX_DEBUG(VULKAN_LOG, "Creating Vulkan device {{ Surface: {0}, Adapter: {1}, Extensions: {2} }}...", fmt::ptr(reinterpret_cast<const void*>(m_impl->m_surface.get())), adapter.deviceId(), Join(this->enabledExtensions(), ", "));
@@ -527,7 +527,7 @@ VulkanDevice::VulkanDevice(const VulkanBackend& /*backend*/, const VulkanGraphic
     this->handle() = m_impl->initialize(features);
     m_impl->initializeDefaultQueues();
     m_impl->createFactory();
-    m_impl->createSwapChain(format, frameBufferSize, frameBuffers);
+    m_impl->createSwapChain(format, renderArea, backBuffers, enableVsync);
 }
 
 VulkanDevice::~VulkanDevice() noexcept

--- a/src/Backends/Vulkan/src/swapchain.cpp
+++ b/src/Backends/Vulkan/src/swapchain.cpp
@@ -29,6 +29,7 @@ private:
 	Array<VkQueryPool> m_timingQueryPools;
 	VkQueryPool m_currentQueryPool;
 	bool m_supportsTiming = false;
+	bool m_vsync = false;
 
 public:
 	VulkanSwapChainImpl(VulkanSwapChain* parent, const VulkanDevice& device) :
@@ -51,7 +52,7 @@ public:
 	}
 
 public:
-	void initialize(Format format, const Size2d& renderArea, UInt32 buffers)
+	void initialize(Format format, const Size2d& renderArea, UInt32 buffers, bool vsync)
 	{
 		if (format == Format::Other || format == Format::None) [[unlikely]]
 			throw InvalidArgumentException("format", "The provided surface format it not a valid value.");
@@ -93,9 +94,10 @@ public:
 		createInfo.imageExtent.width = std::max<UInt32>(1u, std::clamp(static_cast<UInt32>(renderArea.width()), deviceCaps.minImageExtent.width, deviceCaps.maxImageExtent.width));
 
 		// Set the present mode to VK_PRESENT_MODE_MAILBOX_KHR, since it offers best performance without tearing. For VSync use VK_PRESENT_MODE_FIFO_KHR, which is also the only one guaranteed to be available.
-		createInfo.presentMode = VK_PRESENT_MODE_MAILBOX_KHR;
+		createInfo.presentMode = vsync ? VK_PRESENT_MODE_FIFO_KHR : VK_PRESENT_MODE_MAILBOX_KHR;
+		m_vsync = vsync;
 
-		LITEFX_TRACE(VULKAN_LOG, "Creating swap chain for device {0} {{ Images: {1}, Extent: {2}x{3} Px, Format: {4} }}...", fmt::ptr(&m_device), images, createInfo.imageExtent.width, createInfo.imageExtent.height, selectedFormat);
+		LITEFX_TRACE(VULKAN_LOG, "Creating swap chain for device {0} {{ Images: {1}, Extent: {2}x{3} Px, Format: {4}, VSync: {5} }}...", fmt::ptr(&m_device), images, createInfo.imageExtent.width, createInfo.imageExtent.height, selectedFormat, vsync);
 
 		// Log if something needed to be changed.
 		[[unlikely]] if (selectedFormat != format)
@@ -176,11 +178,11 @@ public:
 		m_timestamps.resize(timingEvents.size());
 	}
 
-	void reset(Format format, const Size2d& renderArea, UInt32 buffers)
+	void reset(Format format, Size2d renderArea, UInt32 buffers, bool vsync)
 	{
 		// Cleanup and re-initialize.
 		this->cleanup();
-		this->initialize(format, renderArea, buffers);
+		this->initialize(format, renderArea, buffers, vsync);
 	}
 
 	void cleanup()
@@ -372,6 +374,7 @@ private:
 	Array<ComPtr<ID3D12GraphicsCommandList7>> m_presentCommandLists;
 	
 	bool m_supportsTearing = false;
+	bool m_vsync = false;
 	HANDLE m_fenceHandle;
 
 	Array<SharedPtr<TimingEvent>> m_timingEvents;
@@ -406,7 +409,7 @@ public:
 	}
 
 public:
-	void initialize(Format format, const Size2d& renderArea, UInt32 buffers)
+	void initialize(Format format, const Size2d& renderArea, UInt32 buffers, bool vsync)
 	{
 		if (format == Format::Other || format == Format::None) [[unlikely]]
 			throw InvalidArgumentException("format", "The provided surface format it not a valid value.");
@@ -445,6 +448,7 @@ public:
 		// Create a D3D12 factory.
 		ComPtr<IDXGIFactory7> factory;
 		UInt32 tearingSupport = 0;
+		m_vsync = vsync;
 #ifndef NDEBUG
 		D3D::raiseIfFailed(::CreateDXGIFactory2(DXGI_CREATE_FACTORY_DEBUG, IID_PPV_ARGS(&factory)), "Unable to crate D3D12 factory for interop.");
 #else
@@ -499,7 +503,7 @@ public:
 		D3D::raiseIfFailed(m_d3dDevice->CreateCommandQueue(&presentQueueDesc, IID_PPV_ARGS(&m_presentQueue)), "Unable to create present queue.");
 
 		// Create the swap chain instance.
-		LITEFX_TRACE(VULKAN_LOG, "Creating swap chain for device {0} {{ Images: {1}, Extent: {2}x{3} Px, Format: {4} }}...", fmt::ptr(&m_device), images, extent.width(), extent.height(), selectedFormat);
+		LITEFX_TRACE(VULKAN_LOG, "Creating swap chain for device {0} {{ Images: {1}, Extent: {2}x{3} Px, Format: {4}, VSync: {5} }}...", fmt::ptr(&m_device), images, extent.width(), extent.height(), selectedFormat, vsync);
 
 		DXGI_SWAP_CHAIN_DESC1 swapChainDesc {
 			.Width = static_cast<UInt32>(extent.width()),
@@ -558,7 +562,7 @@ public:
 		}
 	}
 
-	void reset(Format format, const Size2d& renderArea, UInt32 buffers)
+	void reset(Format format, const Size2d& renderArea, UInt32 buffers, bool vsync)
 	{
 		// Release the image memory of the previously allocated images.
 		std::ranges::for_each(m_presentImages, [this](const auto& image) { ::vkDestroyImage(m_device.handle(), std::as_const(*image).handle(), nullptr); });
@@ -592,7 +596,7 @@ public:
 			LITEFX_INFO(VULKAN_LOG, "The render area has been adjusted to {0}x{1} Px (was {2}x{3} Px).", extent.height(), extent.width(), static_cast<UInt32>(renderArea.height()), static_cast<UInt32>(renderArea.width()));
 
 		// Reset the swap chain instance.
-		LITEFX_TRACE(VULKAN_LOG, "Resetting swap chain for device {0} {{ Images: {1}, Extent: {2}x{3} Px, Format: {4} }}...", fmt::ptr(&m_device), images, extent.width(), extent.height(), selectedFormat);
+		LITEFX_TRACE(VULKAN_LOG, "Resetting swap chain for device {0} {{ Images: {1}, Extent: {2}x{3} Px, Format: {4}, VSync: {5} }}...", fmt::ptr(&m_device), images, extent.width(), extent.height(), selectedFormat, vsync);
 
 		// Wait for both devices to be idle.
 		this->waitForInteropDevice();
@@ -621,6 +625,9 @@ public:
 			D3D::raiseIfFailed(m_d3dDevice->CreateCommandAllocator(D3D12_COMMAND_LIST_TYPE_DIRECT, IID_PPV_ARGS(&m_presentCommandAllocators[i])), "Unable to create command allocator for present queue commands.");
 			D3D::raiseIfFailed(m_d3dDevice->CreateCommandList1(0, D3D12_COMMAND_LIST_TYPE_DIRECT, D3D12_COMMAND_LIST_FLAG_NONE, IID_PPV_ARGS(&m_presentCommandLists[i])), "Unable to create command list for present queue commands.");
 		}
+
+		// Store vsync flag.
+		m_vsync = vsync;
 	}
 
 	void createImages(Format format, const Size2d& renderArea, UInt32 buffers)
@@ -776,11 +783,10 @@ public:
 		// Release the image memory of the previously allocated images.
 		std::ranges::for_each(m_presentImages, [this](const auto& image) { ::vkDestroyImage(m_device.handle(), std::as_const(*image).handle(), nullptr); });
 
+		// Destroy the swap chain and interop device and resources.
+		this->waitForInteropDevice();
 		m_imageResources.clear();
 		m_presentImages.clear();
-
-		// Destroy the swap chain and interop device.
-		this->waitForInteropDevice();
 		m_swapChain.Reset();
 		m_d3dDevice.Reset();
 
@@ -887,7 +893,11 @@ public:
 		m_presentQueue->ExecuteCommandLists(commandBuffers.size(), commandBuffers.data());
 
 		// Do the presentation.
-		D3D::raiseIfFailed(m_swapChain->Present(0, m_supportsTearing ? DXGI_PRESENT_ALLOW_TEARING : 0), "Unable to queue present event on swap chain.");
+		if (m_vsync)
+			D3D::raiseIfFailed(m_swapChain->Present(1, 0), "Unable to queue present event on swap chain.");
+		else
+			D3D::raiseIfFailed(m_swapChain->Present(0, m_supportsTearing ? DXGI_PRESENT_ALLOW_TEARING : 0), "Unable to queue present event on swap chain.");
+
 		D3D::raiseIfFailed(m_presentQueue->Signal(m_presentationFence.Get(), m_presentFences[m_currentImage]), "Unable to signal presentation fence.");
 	}
 	
@@ -961,10 +971,10 @@ private:
 // Shared interface.
 // ------------------------------------------------------------------------------------------------
 
-VulkanSwapChain::VulkanSwapChain(const VulkanDevice& device, Format surfaceFormat, const Size2d& renderArea, UInt32 buffers) :
+VulkanSwapChain::VulkanSwapChain(const VulkanDevice& device, Format surfaceFormat, const Size2d& renderArea, UInt32 buffers, bool enableVsync) :
 	m_impl(makePimpl<VulkanSwapChainImpl>(this, device))
 {
-	m_impl->initialize(surfaceFormat, renderArea, buffers);
+	m_impl->initialize(surfaceFormat, renderArea, buffers, enableVsync);
 }
 
 VulkanSwapChain::~VulkanSwapChain() noexcept = default;
@@ -1030,6 +1040,11 @@ const Size2d& VulkanSwapChain::renderArea() const noexcept
 	return m_impl->m_renderArea;
 }
 
+bool VulkanSwapChain::verticalSynchronization() const noexcept
+{
+	return m_impl->m_vsync;
+}
+
 IVulkanImage* VulkanSwapChain::image(UInt32 backBuffer) const
 {
 	if (backBuffer >= m_impl->m_presentImages.size()) [[unlikely]]
@@ -1073,10 +1088,10 @@ void VulkanSwapChain::addTimingEvent(SharedPtr<TimingEvent> timingEvent)
 	m_impl->resetQueryPools(events);
 }
 
-void VulkanSwapChain::reset(Format surfaceFormat, const Size2d& renderArea, UInt32 buffers)
+void VulkanSwapChain::reset(Format surfaceFormat, const Size2d& renderArea, UInt32 buffers, bool enableVsync)
 {
-	m_impl->reset(surfaceFormat, renderArea, buffers);
-	this->reseted(this, { surfaceFormat, renderArea, buffers });
+	m_impl->reset(surfaceFormat, renderArea, buffers, enableVsync);
+	this->reseted(this, { surfaceFormat, renderArea, buffers, enableVsync });
 }
 
 UInt32 VulkanSwapChain::swapBackBuffer() const

--- a/src/Backends/Vulkan/src/swapchain.cpp
+++ b/src/Backends/Vulkan/src/swapchain.cpp
@@ -94,7 +94,7 @@ public:
 		createInfo.imageExtent.width = std::max<UInt32>(1u, std::clamp(static_cast<UInt32>(renderArea.width()), deviceCaps.minImageExtent.width, deviceCaps.maxImageExtent.width));
 
 		// Set the present mode to VK_PRESENT_MODE_MAILBOX_KHR, since it offers best performance without tearing. For VSync use VK_PRESENT_MODE_FIFO_KHR, which is also the only one guaranteed to be available.
-		createInfo.presentMode = vsync ? VK_PRESENT_MODE_FIFO_KHR : VK_PRESENT_MODE_MAILBOX_KHR;
+		createInfo.presentMode = vsync ? VK_PRESENT_MODE_FIFO_KHR : VK_PRESENT_MODE_IMMEDIATE_KHR;/* VK_PRESENT_MODE_MAILBOX_KHR;*/
 		m_vsync = vsync;
 
 		LITEFX_TRACE(VULKAN_LOG, "Creating swap chain for device {0} {{ Images: {1}, Extent: {2}x{3} Px, Format: {4}, VSync: {5} }}...", fmt::ptr(&m_device), images, createInfo.imageExtent.width, createInfo.imageExtent.height, selectedFormat, vsync);

--- a/src/Rendering/include/litefx/rendering_api.hpp
+++ b/src/Rendering/include/litefx/rendering_api.hpp
@@ -7357,10 +7357,11 @@ namespace LiteFX::Rendering {
             Format m_surfaceFormat;
             const Size2d& m_renderArea;
             UInt32 m_buffers;
+            bool m_vsync;
 
         public:
-            ResetEventArgs(Format surfaceFormat, const Size2d& renderArea, UInt32 buffers) :
-                EventArgs(), m_surfaceFormat(surfaceFormat), m_renderArea(renderArea), m_buffers(buffers) { }
+            ResetEventArgs(Format surfaceFormat, const Size2d& renderArea, UInt32 buffers, bool enableVsync) :
+                EventArgs(), m_surfaceFormat(surfaceFormat), m_renderArea(renderArea), m_buffers(buffers), m_vsync(enableVsync) { }
             ResetEventArgs(const ResetEventArgs&) = default;
             ResetEventArgs(ResetEventArgs&&) = default;
             virtual ~ResetEventArgs() noexcept = default;
@@ -7392,6 +7393,14 @@ namespace LiteFX::Rendering {
             /// <returns>The number of back-buffers in the swap chain.</returns>
             inline UInt32 buffers() const noexcept {
                 return m_buffers;
+            }
+
+            /// <summary>
+            /// Returns `true` if vertical synchronization is enabled or `false` otherwise.
+            /// </summary>
+            /// <returns>`true` if vertical synchronization is enabled or `false` otherwise.</returns>
+            inline bool enableVsync() const noexcept {
+                return m_vsync;
             }
         };
 
@@ -7467,6 +7476,12 @@ namespace LiteFX::Rendering {
         virtual const Size2d& renderArea() const noexcept = 0;
 
         /// <summary>
+        /// Returns `true`, if vertical synchronization should be used, otherwise `false`.
+        /// </summary>
+        /// <returns>`true`, if vertical synchronization should be used, otherwise `false`.</returns>
+        virtual bool verticalSynchronization() const noexcept = 0;
+
+        /// <summary>
         /// Returns the swap chain present image for <paramref name="backBuffer" />.
         /// </summary>
         /// <param name="backBuffer">The index of the back buffer for which to return the swap chain present image.</param>
@@ -7533,8 +7548,9 @@ namespace LiteFX::Rendering {
         /// <param name="surfaceFormat">The swap chain image format.</param>
         /// <param name="renderArea">The dimensions of the frame buffers.</param>
         /// <param name="buffers">The number of buffers in the swap chain.</param>
+        /// <param name="enableVsync">`true`, if vertical synchronization should be used, otherwise `false`.</param>
         /// <seealso cref="multiSamplingLevel" />
-        virtual void reset(Format surfaceFormat, const Size2d& renderArea, UInt32 buffers) = 0;
+        virtual void reset(Format surfaceFormat, const Size2d& renderArea, UInt32 buffers, bool enableVsync = false) = 0;
 
         /// <summary>
         /// Swaps the front buffer with the next back buffer in order.

--- a/src/Samples/BasicRendering/src/sample.cpp
+++ b/src/Samples/BasicRendering/src/sample.cpp
@@ -209,7 +209,7 @@ void SampleApp::onInit()
         auto surface = backend->createSurface(::glfwGetWin32Window(window));
 
         // Create the device.
-        m_device = backend->createDevice("Default", *adapter, std::move(surface), Format::B8G8R8A8_UNORM, m_viewport->getRectangle().extent(), 3);
+        m_device = backend->createDevice("Default", *adapter, std::move(surface), Format::B8G8R8A8_UNORM, m_viewport->getRectangle().extent(), 3, false);
 
         // Initialize resources.
         ::initRenderGraph(backend, m_inputAssembler);
@@ -246,7 +246,8 @@ void SampleApp::onResize(const void* sender, ResizeEventArgs e)
     // Resize the frame buffer and recreate the swap chain.
     auto surfaceFormat = m_device->swapChain().surfaceFormat();
     auto renderArea = Size2d(e.width(), e.height());
-    m_device->swapChain().reset(surfaceFormat, renderArea, 3);
+    auto vsync = m_device->swapChain().verticalSynchronization();
+    m_device->swapChain().reset(surfaceFormat, renderArea, 3, vsync);
 
     // Resize the frame buffers. Note that we could also use an event handler on the swap chain `reseted` event to do this automatically instead.
     m_device->state().frameBuffer("Frame Buffer 0").resize(renderArea);
@@ -326,6 +327,16 @@ void SampleApp::keyDown(int key, int scancode, int action, int mods)
             // NOTE: If we were to launch in fullscreen mode, we should use something like `max(windowRect.width(), defaultWidth)`.
             ::glfwSetWindowMonitor(m_window.get(), nullptr, windowRect.x(), windowRect.y(), windowRect.width(), windowRect.height(), 0);
         }
+    }
+
+    if (key == GLFW_KEY_F7 && action == GLFW_PRESS)
+    {
+        // Wait for the device.
+        m_device->wait();
+
+        // Toggle VSync on the swap chain.
+        auto& swapChain = m_device->swapChain();
+        swapChain.reset(swapChain.surfaceFormat(), swapChain.renderArea(), swapChain.buffers(), !swapChain.verticalSynchronization());
     }
 
     if (key == GLFW_KEY_ESCAPE && action == GLFW_PRESS)

--- a/src/Samples/Bindless/src/sample.cpp
+++ b/src/Samples/Bindless/src/sample.cpp
@@ -257,7 +257,7 @@ void SampleApp::onInit()
         auto surface = backend->createSurface(::glfwGetWin32Window(window));
 
         // Create the device.
-        m_device = backend->createDevice("Default", *adapter, std::move(surface), Format::B8G8R8A8_UNORM, m_viewport->getRectangle().extent(), 3);
+        m_device = backend->createDevice("Default", *adapter, std::move(surface), Format::B8G8R8A8_UNORM, m_viewport->getRectangle().extent(), 3, false);
 
         // Initialize resources.
         ::initRenderGraph(backend, m_inputAssembler);
@@ -294,7 +294,8 @@ void SampleApp::onResize(const void* sender, ResizeEventArgs e)
     // Resize the frame buffer and recreate the swap chain.
     auto surfaceFormat = m_device->swapChain().surfaceFormat();
     auto renderArea = Size2d(e.width(), e.height());
-    m_device->swapChain().reset(surfaceFormat, renderArea, 3);
+    bool vsync = m_device->swapChain().verticalSynchronization();
+    m_device->swapChain().reset(surfaceFormat, renderArea, 3, vsync);
 
     // Resize the frame buffers. Note that we could also use an event handler on the swap chain `reseted` event to do this automatically instead.
     m_device->state().frameBuffer("Frame Buffer 0").resize(renderArea);
@@ -374,6 +375,16 @@ void SampleApp::keyDown(int key, int scancode, int action, int mods)
             // NOTE: If we were to launch in fullscreen mode, we should use something like `max(windowRect.width(), defaultWidth)`.
             ::glfwSetWindowMonitor(m_window.get(), nullptr, windowRect.x(), windowRect.y(), windowRect.width(), windowRect.height(), 0);
         }
+    }
+
+    if (key == GLFW_KEY_F7 && action == GLFW_PRESS)
+    {
+        // Wait for the device.
+        m_device->wait();
+
+        // Toggle VSync on the swap chain.
+        auto& swapChain = m_device->swapChain();
+        swapChain.reset(swapChain.surfaceFormat(), swapChain.renderArea(), swapChain.buffers(), !swapChain.verticalSynchronization());
     }
 
     if (key == GLFW_KEY_ESCAPE && action == GLFW_PRESS)

--- a/src/Samples/Compute/src/sample.cpp
+++ b/src/Samples/Compute/src/sample.cpp
@@ -232,7 +232,7 @@ void SampleApp::onInit()
         auto surface = backend->createSurface(::glfwGetWin32Window(window));
 
         // Create the device.
-        m_device = backend->createDevice("Default", *adapter, std::move(surface), Format::B8G8R8A8_UNORM, m_viewport->getRectangle().extent(), 3);
+        m_device = backend->createDevice("Default", *adapter, std::move(surface), Format::B8G8R8A8_UNORM, m_viewport->getRectangle().extent(), 3, false);
 
         // Initialize resources.
         ::initRenderGraph(backend, m_inputAssembler);
@@ -269,7 +269,8 @@ void SampleApp::onResize(const void* sender, ResizeEventArgs e)
     // Resize the frame buffer and recreate the swap chain.
     auto surfaceFormat = m_device->swapChain().surfaceFormat();
     auto renderArea = Size2d(e.width(), e.height());
-    m_device->swapChain().reset(surfaceFormat, renderArea, 3);
+    bool vsync = m_device->swapChain().verticalSynchronization();
+    m_device->swapChain().reset(surfaceFormat, renderArea, 3, vsync);
 
     // Resize the frame buffers. Note that we could also use an event handler on the swap chain `reseted` event to do this automatically instead.
     for (int i = 0; i < 3; ++i)
@@ -354,6 +355,16 @@ void SampleApp::keyDown(int key, int scancode, int action, int mods)
             // NOTE: If we were to launch in fullscreen mode, we should use something like `max(windowRect.width(), defaultWidth)`.
             ::glfwSetWindowMonitor(m_window.get(), nullptr, windowRect.x(), windowRect.y(), windowRect.width(), windowRect.height(), 0);
         }
+    }
+
+    if (key == GLFW_KEY_F7 && action == GLFW_PRESS)
+    {
+        // Wait for the device.
+        m_device->wait();
+
+        // Toggle VSync on the swap chain.
+        auto& swapChain = m_device->swapChain();
+        swapChain.reset(swapChain.surfaceFormat(), swapChain.renderArea(), swapChain.buffers(), !swapChain.verticalSynchronization());
     }
 
     if (key == GLFW_KEY_ESCAPE && action == GLFW_PRESS)

--- a/src/Samples/MeshShader/src/sample.cpp
+++ b/src/Samples/MeshShader/src/sample.cpp
@@ -183,7 +183,7 @@ void SampleApp::onInit()
         auto surface = backend->createSurface(::glfwGetWin32Window(window));
 
         // Create the device.
-        m_device = backend->createDevice("Default", *adapter, std::move(surface), Format::B8G8R8A8_UNORM, m_viewport->getRectangle().extent(), 3, GraphicsDeviceFeatures { .MeshShaders = true });
+        m_device = backend->createDevice("Default", *adapter, std::move(surface), Format::B8G8R8A8_UNORM, m_viewport->getRectangle().extent(), 3, false, GraphicsDeviceFeatures { .MeshShaders = true });
 
         // Initialize resources.
         ::initRenderGraph(backend);
@@ -220,7 +220,8 @@ void SampleApp::onResize(const void* sender, ResizeEventArgs e)
     // Resize the frame buffer and recreate the swap chain.
     auto surfaceFormat = m_device->swapChain().surfaceFormat();
     auto renderArea = Size2d(e.width(), e.height());
-    m_device->swapChain().reset(surfaceFormat, renderArea, 3);
+    bool vsync = m_device->swapChain().verticalSynchronization();
+    m_device->swapChain().reset(surfaceFormat, renderArea, 3, vsync);
 
     // Resize the frame buffers. Note that we could also use an event handler on the swap chain `reseted` event to do this automatically instead.
     m_device->state().frameBuffer("Frame Buffer 0").resize(renderArea);
@@ -300,6 +301,16 @@ void SampleApp::keyDown(int key, int scancode, int action, int mods)
             // NOTE: If we were to launch in fullscreen mode, we should use something like `max(windowRect.width(), defaultWidth)`.
             ::glfwSetWindowMonitor(m_window.get(), nullptr, windowRect.x(), windowRect.y(), windowRect.width(), windowRect.height(), 0);
         }
+    }
+
+    if (key == GLFW_KEY_F7 && action == GLFW_PRESS)
+    {
+        // Wait for the device.
+        m_device->wait();
+
+        // Toggle VSync on the swap chain.
+        auto& swapChain = m_device->swapChain();
+        swapChain.reset(swapChain.surfaceFormat(), swapChain.renderArea(), swapChain.buffers(), !swapChain.verticalSynchronization());
     }
 
     if (key == GLFW_KEY_ESCAPE && action == GLFW_PRESS)

--- a/src/Samples/Multisampling/src/sample.cpp
+++ b/src/Samples/Multisampling/src/sample.cpp
@@ -211,7 +211,7 @@ void SampleApp::onInit()
         auto surface = backend->createSurface(::glfwGetWin32Window(window));
 
         // Create the device.
-        m_device = backend->createDevice("Default", *adapter, std::move(surface), Format::B8G8R8A8_UNORM, m_viewport->getRectangle().extent(), 3);
+        m_device = backend->createDevice("Default", *adapter, std::move(surface), Format::B8G8R8A8_UNORM, m_viewport->getRectangle().extent(), 3, false);
 
         // Initialize resources.
         ::initRenderGraph(backend, m_inputAssembler);
@@ -248,7 +248,8 @@ void SampleApp::onResize(const void* sender, ResizeEventArgs e)
     // Resize the frame buffer and recreate the swap chain.
     auto surfaceFormat = m_device->swapChain().surfaceFormat();
     auto renderArea = Size2d(e.width(), e.height());
-    m_device->swapChain().reset(surfaceFormat, renderArea, 3);
+    bool vsync = m_device->swapChain().verticalSynchronization();
+    m_device->swapChain().reset(surfaceFormat, renderArea, 3, vsync);
 
     // Resize the frame buffers. Note that we could also use an event handler on the swap chain `reseted` event to do this automatically instead.
     m_device->state().frameBuffer("Frame Buffer 0").resize(renderArea);
@@ -328,6 +329,16 @@ void SampleApp::keyDown(int key, int scancode, int action, int mods)
             // NOTE: If we were to launch in fullscreen mode, we should use something like `max(windowRect.width(), defaultWidth)`.
             ::glfwSetWindowMonitor(m_window.get(), nullptr, windowRect.x(), windowRect.y(), windowRect.width(), windowRect.height(), 0);
         }
+    }
+
+    if (key == GLFW_KEY_F7 && action == GLFW_PRESS)
+    {
+        // Wait for the device.
+        m_device->wait();
+
+        // Toggle VSync on the swap chain.
+        auto& swapChain = m_device->swapChain();
+        swapChain.reset(swapChain.surfaceFormat(), swapChain.renderArea(), swapChain.buffers(), !swapChain.verticalSynchronization());
     }
 
     if (key == GLFW_KEY_ESCAPE && action == GLFW_PRESS)

--- a/src/Samples/Multithreading/src/sample.cpp
+++ b/src/Samples/Multithreading/src/sample.cpp
@@ -224,7 +224,7 @@ void SampleApp::onInit()
         auto surface = backend->createSurface(::glfwGetWin32Window(window));
 
         // Create the device.
-        m_device = backend->createDevice("Default", *adapter, std::move(surface), Format::B8G8R8A8_UNORM, m_viewport->getRectangle().extent(), 3);
+        m_device = backend->createDevice("Default", *adapter, std::move(surface), Format::B8G8R8A8_UNORM, m_viewport->getRectangle().extent(), 3, false);
 
         // Initialize resources.
         ::initRenderGraph(backend, m_inputAssembler);
@@ -261,7 +261,8 @@ void SampleApp::onResize(const void* sender, ResizeEventArgs e)
     // Resize the frame buffer and recreate the swap chain.
     auto surfaceFormat = m_device->swapChain().surfaceFormat();
     auto renderArea = Size2d(e.width(), e.height());
-    m_device->swapChain().reset(surfaceFormat, renderArea, 3);
+    bool vsync = m_device->swapChain().verticalSynchronization();
+    m_device->swapChain().reset(surfaceFormat, renderArea, 3, vsync);
 
     // Resize the frame buffers. Note that we could also use an event handler on the swap chain `reseted` event to do this automatically instead.
     m_device->state().frameBuffer("Frame Buffer 0").resize(renderArea);
@@ -341,6 +342,16 @@ void SampleApp::keyDown(int key, int scancode, int action, int mods)
             // NOTE: If we were to launch in fullscreen mode, we should use something like `max(windowRect.width(), defaultWidth)`.
             ::glfwSetWindowMonitor(m_window.get(), nullptr, windowRect.x(), windowRect.y(), windowRect.width(), windowRect.height(), 0);
         }
+    }
+
+    if (key == GLFW_KEY_F7 && action == GLFW_PRESS)
+    {
+        // Wait for the device.
+        m_device->wait();
+
+        // Toggle VSync on the swap chain.
+        auto& swapChain = m_device->swapChain();
+        swapChain.reset(swapChain.surfaceFormat(), swapChain.renderArea(), swapChain.buffers(), !swapChain.verticalSynchronization());
     }
 
     if (key == GLFW_KEY_ESCAPE && action == GLFW_PRESS)

--- a/src/Samples/PushConstants/src/sample.cpp
+++ b/src/Samples/PushConstants/src/sample.cpp
@@ -225,7 +225,7 @@ void SampleApp::onInit()
         auto surface = backend->createSurface(::glfwGetWin32Window(window));
 
         // Create the device.
-        m_device = backend->createDevice("Default", *adapter, std::move(surface), Format::B8G8R8A8_UNORM, m_viewport->getRectangle().extent(), 3);
+        m_device = backend->createDevice("Default", *adapter, std::move(surface), Format::B8G8R8A8_UNORM, m_viewport->getRectangle().extent(), 3, false);
 
         // Initialize resources.
         ::initRenderGraph(backend, m_inputAssembler);
@@ -259,7 +259,8 @@ void SampleApp::onResize(const void* sender, ResizeEventArgs e)
     // Resize the frame buffer and recreate the swap chain.
     auto surfaceFormat = m_device->swapChain().surfaceFormat();
     auto renderArea = Size2d(e.width(), e.height());
-    m_device->swapChain().reset(surfaceFormat, renderArea, 3);
+    auto vsync = m_device->swapChain().verticalSynchronization();
+    m_device->swapChain().reset(surfaceFormat, renderArea, 3, vsync);
 
     // Resize the frame buffers. Note that we could also use an event handler on the swap chain `reseted` event to do this automatically instead.
     m_device->state().frameBuffer("Frame Buffer 0").resize(renderArea);
@@ -339,6 +340,16 @@ void SampleApp::keyDown(int key, int scancode, int action, int mods)
             // NOTE: If we were to launch in fullscreen mode, we should use something like `max(windowRect.width(), defaultWidth)`.
             ::glfwSetWindowMonitor(m_window.get(), nullptr, windowRect.x(), windowRect.y(), windowRect.width(), windowRect.height(), 0);
         }
+    }
+
+    if (key == GLFW_KEY_F7 && action == GLFW_PRESS)
+    {
+        // Wait for the device.
+        m_device->wait();
+
+        // Toggle VSync on the swap chain.
+        auto& swapChain = m_device->swapChain();
+        swapChain.reset(swapChain.surfaceFormat(), swapChain.renderArea(), swapChain.buffers(), !swapChain.verticalSynchronization());
     }
 
     if (key == GLFW_KEY_ESCAPE && action == GLFW_PRESS)

--- a/src/Samples/RenderPasses/src/sample.cpp
+++ b/src/Samples/RenderPasses/src/sample.cpp
@@ -444,6 +444,7 @@ void SampleApp::drawFrame()
     // Swap the back buffers for the next frame.
     auto backBuffer = m_device->swapChain().swapBackBuffer();
     auto& frameBuffer = m_device->state().frameBuffer(fmt::format("Frame Buffer {0}", backBuffer));
+    UInt64 fence = 0;
 
     {
         // Query state.
@@ -482,7 +483,7 @@ void SampleApp::drawFrame()
 
         // Draw the object and end the render pass.
         commandBuffer->drawIndexed(indexBuffer.elements());
-        renderPass.end();
+        fence = renderPass.end();
     }
 
     {
@@ -493,6 +494,7 @@ void SampleApp::drawFrame()
         auto& viewPlaneIndexBuffer = m_device->state().indexBuffer("View Plane Indices");
 
         // Start the lighting pass.
+        renderPass.commandQueue().waitFor(fence);
         renderPass.begin(frameBuffer);
         auto commandBuffer = renderPass.commandBuffer(0);
         commandBuffer->use(pipeline);
@@ -505,7 +507,7 @@ void SampleApp::drawFrame()
         commandBuffer->drawIndexed(viewPlaneIndexBuffer.elements());
 
         // End the lighting pass.
-        renderPass.end();
+        fence = renderPass.end();
     }
 
     {
@@ -519,6 +521,7 @@ void SampleApp::drawFrame()
         auto& indexBuffer = m_device->state().indexBuffer("Index Buffer");
 
         // Begin rendering on the render pass and use the only pipeline we've created for it.
+        renderPass.commandQueue().waitFor(fence);
         renderPass.begin(frameBuffer);
         auto commandBuffer = renderPass.commandBuffer(0);
         commandBuffer->use(pipeline);

--- a/src/Samples/RenderPasses/src/sample.cpp
+++ b/src/Samples/RenderPasses/src/sample.cpp
@@ -285,7 +285,7 @@ void SampleApp::onInit()
         auto surface = backend->createSurface(::glfwGetWin32Window(window));
 
         // Create the device.
-        m_device = backend->createDevice("Default", *adapter, std::move(surface), Format::B8G8R8A8_UNORM, m_viewport->getRectangle().extent(), 3);
+        m_device = backend->createDevice("Default", *adapter, std::move(surface), Format::B8G8R8A8_UNORM, m_viewport->getRectangle().extent(), 3, false);
 
         // Initialize resources.
         ::initRenderGraph(backend, m_inputAssembler);
@@ -319,7 +319,8 @@ void SampleApp::onResize(const void* sender, ResizeEventArgs e)
     // Resize the frame buffer and recreate the swap chain.
     auto surfaceFormat = m_device->swapChain().surfaceFormat();
     auto renderArea = Size2d(e.width(), e.height());
-    m_device->swapChain().reset(surfaceFormat, renderArea, 3);
+    auto vsync = m_device->swapChain().verticalSynchronization();
+    m_device->swapChain().reset(surfaceFormat, renderArea, 3, vsync);
 
     // Resize the frame buffers. Note that we could also use an event handler on the swap chain `reseted` event to do this automatically instead.
     m_device->state().frameBuffer("Frame Buffer 0").resize(renderArea);
@@ -399,6 +400,16 @@ void SampleApp::keyDown(int key, int scancode, int action, int mods)
             // NOTE: If we were to launch in fullscreen mode, we should use something like `max(windowRect.width(), defaultWidth)`.
             ::glfwSetWindowMonitor(m_window.get(), nullptr, windowRect.x(), windowRect.y(), windowRect.width(), windowRect.height(), 0);
         }
+    }
+
+    if (key == GLFW_KEY_F7 && action == GLFW_PRESS)
+    {
+        // Wait for the device.
+        m_device->wait();
+
+        // Toggle VSync on the swap chain.
+        auto& swapChain = m_device->swapChain();
+        swapChain.reset(swapChain.surfaceFormat(), swapChain.renderArea(), swapChain.buffers(), !swapChain.verticalSynchronization());
     }
 
     if (key == GLFW_KEY_ESCAPE && action == GLFW_PRESS)

--- a/src/Samples/Textures/src/sample.cpp
+++ b/src/Samples/Textures/src/sample.cpp
@@ -277,7 +277,7 @@ void SampleApp::onInit()
         auto surface = backend->createSurface(::glfwGetWin32Window(window));
 
         // Create the device.
-        auto device = backend->createDevice("Default", *adapter, std::move(surface), Format::B8G8R8A8_UNORM, m_viewport->getRectangle().extent(), 3);
+        auto device = backend->createDevice("Default", *adapter, std::move(surface), Format::B8G8R8A8_UNORM, m_viewport->getRectangle().extent(), 3, false);
         m_device = device;
 
         // Initialize resources.
@@ -315,7 +315,8 @@ void SampleApp::onResize(const void* sender, ResizeEventArgs e)
     // Resize the frame buffer and recreate the swap chain.
     auto surfaceFormat = m_device->swapChain().surfaceFormat();
     auto renderArea = Size2d(e.width(), e.height());
-    m_device->swapChain().reset(surfaceFormat, renderArea, 3);
+    auto vsync = m_device->swapChain().verticalSynchronization();
+    m_device->swapChain().reset(surfaceFormat, renderArea, 3, vsync);
 
     // Resize the frame buffers. Note that we could also use an event handler on the swap chain `reseted` event to do this automatically instead.
     m_device->state().frameBuffer("Frame Buffer 0").resize(renderArea);
@@ -395,6 +396,16 @@ void SampleApp::keyDown(int key, int scancode, int action, int mods)
             // NOTE: If we were to launch in fullscreen mode, we should use something like `max(windowRect.width(), defaultWidth)`.
             ::glfwSetWindowMonitor(m_window.get(), nullptr, windowRect.x(), windowRect.y(), windowRect.width(), windowRect.height(), 0);
         }
+    }
+
+    if (key == GLFW_KEY_F7 && action == GLFW_PRESS)
+    {
+        // Wait for the device.
+        m_device->wait();
+
+        // Toggle VSync on the swap chain.
+        auto& swapChain = m_device->swapChain();
+        swapChain.reset(swapChain.surfaceFormat(), swapChain.renderArea(), swapChain.buffers(), !swapChain.verticalSynchronization());
     }
 
     if (key == GLFW_KEY_ESCAPE && action == GLFW_PRESS)

--- a/src/Samples/UniformArrays/src/sample.cpp
+++ b/src/Samples/UniformArrays/src/sample.cpp
@@ -267,7 +267,7 @@ void SampleApp::onInit()
         auto surface = backend->createSurface(::glfwGetWin32Window(window));
 
         // Create the device.
-        m_device = backend->createDevice("Default", *adapter, std::move(surface), Format::B8G8R8A8_UNORM, m_viewport->getRectangle().extent(), 3);
+        m_device = backend->createDevice("Default", *adapter, std::move(surface), Format::B8G8R8A8_UNORM, m_viewport->getRectangle().extent(), 3, false);
 
         // Initialize resources.
         ::initRenderGraph(backend, m_inputAssembler);
@@ -304,7 +304,8 @@ void SampleApp::onResize(const void* sender, ResizeEventArgs e)
     // Resize the frame buffer and recreate the swap chain.
     auto surfaceFormat = m_device->swapChain().surfaceFormat();
     auto renderArea = Size2d(e.width(), e.height());
-    m_device->swapChain().reset(surfaceFormat, renderArea, 3);
+    auto vsync = m_device->swapChain().verticalSynchronization();
+    m_device->swapChain().reset(surfaceFormat, renderArea, 3, vsync);
 
     // Resize the frame buffers. Note that we could also use an event handler on the swap chain `reseted` event to do this automatically instead.
     m_device->state().frameBuffer("Frame Buffer 0").resize(renderArea);
@@ -384,6 +385,16 @@ void SampleApp::keyDown(int key, int scancode, int action, int mods)
             // NOTE: If we were to launch in fullscreen mode, we should use something like `max(windowRect.width(), defaultWidth)`.
             ::glfwSetWindowMonitor(m_window.get(), nullptr, windowRect.x(), windowRect.y(), windowRect.width(), windowRect.height(), 0);
         }
+    }
+
+    if (key == GLFW_KEY_F7 && action == GLFW_PRESS)
+    {
+        // Wait for the device.
+        m_device->wait();
+
+        // Toggle VSync on the swap chain.
+        auto& swapChain = m_device->swapChain();
+        swapChain.reset(swapChain.surfaceFormat(), swapChain.renderArea(), swapChain.buffers(), !swapChain.verticalSynchronization());
     }
 
     if (key == GLFW_KEY_ESCAPE && action == GLFW_PRESS)


### PR DESCRIPTION
**Describe the pull request**

This PR adds support for vertical synchronization. V-Sync can be toggled on or off on a swap chain. All samples have been updated to toggle V-Sync when pressing F7. Additionally it is possible to specify the initial setting for V-Sync during device or swap chain creation.

Changing the V-Sync mode on a swap chain will raise it's reset event, which will also include the new setting.