### PR TITLE
Use `std::format` for formatting.

### DIFF
--- a/NOTICE
+++ b/NOTICE
@@ -11,7 +11,6 @@ contact us by opening an issue:
 The following third party material may be included and re-distributed within 
 LiteFX releases:
 
-- {fmt}: Copyright (c) 2012 - present, Victor Zverovich (1)
 - spdlog: Copyright (c) 2016 Gabi Melman (1)
 - Vulkan Memory Allocator: (c) 2017-2019 Advanced Micro Devices, Inc. All 
   rights reserved. (1)

--- a/README.md
+++ b/README.md
@@ -181,12 +181,11 @@ If you are having problems building the project, you may find answers [in the wi
 
 ### Dependencies
 
-All dependencies are automatically installed using *vcpkg*, when performing a manual build. The engine only has two hard dependencies:
+All dependencies are automatically installed using *vcpkg*, when performing a manual build. The engine core by itself only has one hard dependency:
 
 - [spdlog](https://github.com/gabime/spdlog): Lightweight logging library.
-- [{fmt}](https://github.com/fmtlib/fmt): String formatting library and implicit dependency of *spdlog*.
 
-Depending on which rendering backends are build, the following dependencies are required:
+Depending on which rendering backends are build, the following dependencies are additionally linked against:
 
 - [Vulkan SDK](https://www.lunarg.com/vulkan-sdk/): Required by the Vulkan backend.
 - [Vulkan Memory Allocator](https://gpuopen.com/vulkan-memory-allocator/): Required by the Vulkan backend. Handles memory allocations.

--- a/docs/release-logs/0.4.1.md
+++ b/docs/release-logs/0.4.1.md
@@ -1,12 +1,13 @@
 # LiteFX 0.4.1 - Alpha 04
 
-- Adapt C++23 where applicable. ([See PR #98](https://github.com/crud89/LiteFX/pull/98), [PR #102](https://github.com/crud89/LiteFX/pull/102) and [PC #113](https://github.com/crud89/LiteFX/pull/113)) This includes:
+- Adapt C++23 where applicable. ([See PR #98](https://github.com/crud89/LiteFX/pull/98), [PR #102](https://github.com/crud89/LiteFX/pull/102) and [PR #113](https://github.com/crud89/LiteFX/pull/113)) This includes:
   - Many of the range adaptors could be simplified.
   - The adaptor `ranges::to` has been replaced with the STL counterpart.
   - A novel `Enumerable` container is introduced to pass around immutable collections.
   - Some places that previously used `std::ranges::generate` or `std::generate` now use `std::generator`.
   - Builders are now `constexpr` where possible and are implemented using `deducing this` in place of CRTP, which makes them more lightweight.
   - New exceptions with support for `stacktrace` and `source_location`.
+  - Replace `fmt` with `std::format`. ([See PR #128](https://github.com/crud89/LiteFX/pull/128))
 - Updated vcpkg to version 2023.11.20. ([See PR #104](https://github.com/crud89/LiteFX/pull/104))
 - The namespace `rtti` has been renamed to `meta`. ([See PR #121](https://github.com/crud89/LiteFX/pull/121))
 - Improvements to C++ core guideline conformance. ([See PR #103](https://github.com/crud89/LiteFX/pull/103))

--- a/src/AppModel/include/litefx/app_formatters.hpp
+++ b/src/AppModel/include/litefx/app_formatters.hpp
@@ -3,9 +3,8 @@
 #include <litefx/app_api.hpp>
 
 template <>
-struct LITEFX_APPMODEL_API fmt::formatter<LiteFX::Platform> : formatter<string_view> {
-	template <typename FormatContext>
-	auto format(LiteFX::Platform t, FormatContext& ctx) const {
+struct LITEFX_APPMODEL_API std::formatter<LiteFX::Platform> : std::formatter<std::string_view> {
+	auto format(LiteFX::Platform t, std::format_context& ctx) const {
 		string_view name = "Invalid";
 		switch (t) {
 		case LiteFX::Platform::Win32: name = "Win32"; break;
@@ -17,9 +16,8 @@ struct LITEFX_APPMODEL_API fmt::formatter<LiteFX::Platform> : formatter<string_v
 };
 
 template <>
-struct LITEFX_APPMODEL_API fmt::formatter<LiteFX::BackendType> : formatter<string_view> {
-	template <typename FormatContext>
-	auto format(LiteFX::BackendType t, FormatContext& ctx) const {
+struct LITEFX_APPMODEL_API std::formatter<LiteFX::BackendType> : std::formatter<std::string_view> {
+	auto format(LiteFX::BackendType t, std::format_context& ctx) const {
 		string_view name = "Invalid";
 		switch (t) {
 		case LiteFX::BackendType::Rendering: name = "Rendering"; break;
@@ -31,7 +29,7 @@ struct LITEFX_APPMODEL_API fmt::formatter<LiteFX::BackendType> : formatter<strin
 };
 
 template <>
-struct fmt::formatter<LiteFX::AppVersion> {
+struct std::formatter<LiteFX::AppVersion> {
 	bool engineVersion = false;
 
 	constexpr auto parse(format_parse_context& ctx) {
@@ -49,10 +47,9 @@ struct fmt::formatter<LiteFX::AppVersion> {
 		return it;
 	}
 
-	template <typename FormatContext>
-	auto format(const LiteFX::AppVersion& app, FormatContext& ctx) {
+	auto format(const LiteFX::AppVersion& app, std::format_context& ctx) const {
 		return engineVersion ?
-			fmt::format_to(ctx.out(), "{} Version {}", app.engineIdentifier(), app.engineVersion()) :
-			fmt::format_to(ctx.out(), "{}.{}.{}.{}", app.major(), app.minor(), app.patch(), app.revision());
+			std::format_to(ctx.out(), "{} Version {}", app.engineIdentifier(), app.engineVersion()) :
+			std::format_to(ctx.out(), "{}.{}.{}.{}", app.major(), app.minor(), app.patch(), app.revision());
 	}
 };

--- a/src/Backends/DirectX12/include/litefx/backends/dx12_api.hpp
+++ b/src/Backends/DirectX12/include/litefx/backends/dx12_api.hpp
@@ -36,6 +36,8 @@ using namespace Microsoft::WRL;
 #include <litefx/config.h>
 #include <litefx/rendering.hpp>
 
+#include "dx12_formatters.hpp"
+
 namespace LiteFX::Rendering::Backends {
     using namespace LiteFX::Math;
     using namespace LiteFX::Rendering;
@@ -311,7 +313,7 @@ namespace LiteFX::Rendering::Backends {
         /// <param name="args">The arguments passed to the error message format string.</param>
         template <typename ...TArgs>
         explicit DX12PlatformException(HRESULT result, StringView format, TArgs&&... args) noexcept :
-            DX12PlatformException(result, fmt::vformat(format, fmt::make_format_args(args...))) { }
+            DX12PlatformException(result, std::vformat(format, std::make_format_args(args...))) { }
 
         DX12PlatformException(const DX12PlatformException&) = default;
         DX12PlatformException(DX12PlatformException&&) = default;

--- a/src/Backends/DirectX12/include/litefx/backends/dx12_formatters.hpp
+++ b/src/Backends/DirectX12/include/litefx/backends/dx12_formatters.hpp
@@ -3,9 +3,8 @@
 #include "dx12_api.hpp"
 
 template <>
-struct LITEFX_DIRECTX12_API fmt::formatter<D3D12_MESSAGE_ID> : formatter<string_view> {
-    template <typename FormatContext>
-    auto format(D3D12_MESSAGE_ID t, FormatContext& ctx) {
+struct LITEFX_DIRECTX12_API std::formatter<D3D12_MESSAGE_ID> : std::formatter<std::string_view> {
+    auto format(D3D12_MESSAGE_ID t, std::format_context& ctx) const {
         string_view name;
 
         switch (t)
@@ -859,9 +858,8 @@ struct LITEFX_DIRECTX12_API fmt::formatter<D3D12_MESSAGE_ID> : formatter<string_
 };
 
 template <>
-struct LITEFX_DIRECTX12_API fmt::formatter<D3D12_ROOT_PARAMETER_TYPE> : formatter<string_view> {
-    template <typename FormatContext>
-    auto format(D3D12_ROOT_PARAMETER_TYPE t, FormatContext& ctx) {
+struct LITEFX_DIRECTX12_API std::formatter<D3D12_ROOT_PARAMETER_TYPE> : std::formatter<std::string_view> {
+    auto format(D3D12_ROOT_PARAMETER_TYPE t, std::format_context& ctx) const {
         std::string_view name;
 
         switch (t)
@@ -879,9 +877,8 @@ struct LITEFX_DIRECTX12_API fmt::formatter<D3D12_ROOT_PARAMETER_TYPE> : formatte
 };
 
 template <>
-struct LITEFX_DIRECTX12_API fmt::formatter<D3D_SHADER_INPUT_TYPE> : formatter<string_view> {
-    template <typename FormatContext>
-    auto format(D3D_SHADER_INPUT_TYPE t, FormatContext& ctx) {
+struct LITEFX_DIRECTX12_API std::formatter<D3D_SHADER_INPUT_TYPE> : std::formatter<std::string_view> {
+    auto format(D3D_SHADER_INPUT_TYPE t, std::format_context& ctx) const {
         std::string_view name;
 
         switch (t)

--- a/src/Backends/DirectX12/src/buffer.cpp
+++ b/src/Backends/DirectX12/src/buffer.cpp
@@ -164,7 +164,7 @@ UniquePtr<IDirectX12Buffer> DirectX12Buffer::allocate(const String& name, Alloca
 	ComPtr<ID3D12Resource> resource;
 	D3D12MA::Allocation* allocation;
 	raiseIfFailed(allocator->CreateResource3(&allocationDesc, &resourceDesc, D3D12_BARRIER_LAYOUT_UNDEFINED, nullptr, 0, nullptr, &allocation, IID_PPV_ARGS(&resource)), "Unable to allocate buffer.");
-	LITEFX_DEBUG(DIRECTX12_LOG, "Allocated buffer {0} with {4} bytes {{ Type: {1}, Elements: {2}, Element Size: {3}, Usage: {5} }}", name.empty() ? fmt::to_string(fmt::ptr(resource.Get())) : name, type, elements, elementSize, elements * elementSize, usage);
+	LITEFX_DEBUG(DIRECTX12_LOG, "Allocated buffer {0} with {4} bytes {{ Type: {1}, Elements: {2}, Element Size: {3}, Usage: {5} }}", name.empty() ? std::format("{0}", reinterpret_cast<void*>(resource.Get())) : name, type, elements, elementSize, elements * elementSize, usage);
 
 	return makeUnique<DirectX12Buffer>(std::move(resource), type, elements, elementSize, alignment, usage, allocator, AllocationPtr(allocation), name);
 }
@@ -234,7 +234,7 @@ UniquePtr<IDirectX12VertexBuffer> DirectX12VertexBuffer::allocate(const String& 
 	ComPtr<ID3D12Resource> resource;
 	D3D12MA::Allocation* allocation;
 	raiseIfFailed(allocator->CreateResource3(&allocationDesc, &resourceDesc, D3D12_BARRIER_LAYOUT_UNDEFINED, nullptr, 0, nullptr, &allocation, IID_PPV_ARGS(&resource)), "Unable to allocate vertex buffer.");
-	LITEFX_DEBUG(DIRECTX12_LOG, "Allocated buffer {0} with {4} bytes {{ Type: {1}, Elements: {2}, Element Size: {3}, Usage: {5} }}", name.empty() ? fmt::to_string(fmt::ptr(resource.Get())) : name, BufferType::Vertex, elements, layout.elementSize(), layout.elementSize() * elements, usage);
+	LITEFX_DEBUG(DIRECTX12_LOG, "Allocated buffer {0} with {4} bytes {{ Type: {1}, Elements: {2}, Element Size: {3}, Usage: {5} }}", name.empty() ? std::format("{0}", reinterpret_cast<void*>(resource.Get())) : name, BufferType::Vertex, elements, layout.elementSize(), layout.elementSize() * elements, usage);
 
 	return makeUnique<DirectX12VertexBuffer>(std::move(resource), layout, elements, usage, allocator, AllocationPtr(allocation), name);
 }
@@ -304,7 +304,7 @@ UniquePtr<IDirectX12IndexBuffer> DirectX12IndexBuffer::allocate(const String& na
 	ComPtr<ID3D12Resource> resource;
 	D3D12MA::Allocation* allocation;
 	raiseIfFailed(allocator->CreateResource3(&allocationDesc, &resourceDesc, D3D12_BARRIER_LAYOUT_UNDEFINED, nullptr, 0, nullptr, &allocation, IID_PPV_ARGS(&resource)), "Unable to allocate vertex buffer.");
-	LITEFX_DEBUG(DIRECTX12_LOG, "Allocated buffer {0} with {4} bytes {{ Type: {1}, Elements: {2}, Element Size: {3}, Usage: {5} }}", name.empty() ? fmt::to_string(fmt::ptr(resource.Get())) : name, BufferType::Index, elements, layout.elementSize(), layout.elementSize() * elements, usage);
+	LITEFX_DEBUG(DIRECTX12_LOG, "Allocated buffer {0} with {4} bytes {{ Type: {1}, Elements: {2}, Element Size: {3}, Usage: {5} }}", name.empty() ? std::format("{0}", reinterpret_cast<void*>(resource.Get())) : name, BufferType::Index, elements, layout.elementSize(), layout.elementSize() * elements, usage);
 
 	return makeUnique<DirectX12IndexBuffer>(std::move(resource), layout, elements, usage, allocator, AllocationPtr(allocation), name);
 }

--- a/src/Backends/DirectX12/src/compute_pipeline.cpp
+++ b/src/Backends/DirectX12/src/compute_pipeline.cpp
@@ -36,7 +36,7 @@ public:
 
 		// Setup shader stages.
 		auto modules = m_program->modules();
-		LITEFX_TRACE(DIRECTX12_LOG, "Using shader program {0} with {1} modules...", fmt::ptr(m_program.get()), modules.size());
+		LITEFX_TRACE(DIRECTX12_LOG, "Using shader program {0} with {1} modules...", reinterpret_cast<void*>(m_program.get()), modules.size());
 
 		std::ranges::for_each(modules, [&, i = 0](const DirectX12ShaderModule* shaderModule) mutable {
 			LITEFX_TRACE(DIRECTX12_LOG, "\tModule {0}/{1} (\"{2}\") state: {{ Type: {3}, EntryPoint: {4} }}", ++i, modules.size(), shaderModule->fileName(), shaderModule->type(), shaderModule->entryPoint());

--- a/src/Backends/DirectX12/src/device.cpp
+++ b/src/Backends/DirectX12/src/device.cpp
@@ -267,7 +267,7 @@ DirectX12Device::DirectX12Device(const DirectX12Backend& backend, const DirectX1
 DirectX12Device::DirectX12Device(const DirectX12Backend& backend, const DirectX12GraphicsAdapter& adapter, UniquePtr<DirectX12Surface>&& surface, Format format, const Size2d& renderArea, UInt32 backBuffers, bool enableVsync, GraphicsDeviceFeatures features, UInt32 globalBufferHeapSize, UInt32 globalSamplerHeapSize) :
 	ComResource<ID3D12Device10>(nullptr), m_impl(makePimpl<DirectX12DeviceImpl>(this, adapter, std::move(surface), backend, globalBufferHeapSize, globalSamplerHeapSize))
 {
-	LITEFX_DEBUG(DIRECTX12_LOG, "Creating DirectX 12 device {{ Surface: {0}, Adapter: {1} }}...", fmt::ptr(&surface), adapter.deviceId());
+	LITEFX_DEBUG(DIRECTX12_LOG, "Creating DirectX 12 device {{ Surface: {0}, Adapter: {1} }}...", reinterpret_cast<void*>(&surface), adapter.deviceId());
 	LITEFX_DEBUG(DIRECTX12_LOG, "--------------------------------------------------------------------------");
 	LITEFX_DEBUG(DIRECTX12_LOG, "Vendor: {0:#0x} (\"{1}\")", adapter.vendorId(), DX12::getVendorName(adapter.vendorId()).c_str());
 	LITEFX_DEBUG(DIRECTX12_LOG, "Driver Version: {0:#0x}", adapter.driverVersion());

--- a/src/Backends/DirectX12/src/image.cpp
+++ b/src/Backends/DirectX12/src/image.cpp
@@ -191,7 +191,7 @@ UniquePtr<DirectX12Image> DirectX12Image::allocate(const String& name, const Dir
 	ComPtr<ID3D12Resource> resource;
 	D3D12MA::Allocation* allocation;
 	raiseIfFailed(allocator->CreateResource3(&allocationDesc, &resourceDesc, isDepthStencil ? D3D12_BARRIER_LAYOUT_DEPTH_STENCIL_READ : D3D12_BARRIER_LAYOUT_COMMON, nullptr, 0, nullptr, &allocation, IID_PPV_ARGS(&resource)), "Unable to create image resource.");
-	LITEFX_DEBUG(DIRECTX12_LOG, "Allocated image {0} with {1} bytes {{ Extent: {2}x{3} Px, Format: {4}, Levels: {5}, Layers: {6}, Samples: {8}, Usage: {7} }}", name.empty() ? fmt::to_string(fmt::ptr(resource.Get())) : name, ::getSize(format) * extent.width() * extent.height(), extent.width(), extent.height(), format, levels, layers, usage, samples);
+	LITEFX_DEBUG(DIRECTX12_LOG, "Allocated image {0} with {1} bytes {{ Extent: {2}x{3} Px, Format: {4}, Levels: {5}, Layers: {6}, Samples: {8}, Usage: {7} }}", name.empty() ? std::format("{0}", reinterpret_cast<void*>(resource.Get())) : name, ::getSize(format) * extent.width() * extent.height(), extent.width(), extent.height(), format, levels, layers, usage, samples);
 	
 	return makeUnique<DirectX12Image>(device, std::move(resource), extent, format, dimension, levels, layers, samples, usage, allocator, AllocationPtr(allocation), name);
 }

--- a/src/Backends/DirectX12/src/pipeline_layout.cpp
+++ b/src/Backends/DirectX12/src/pipeline_layout.cpp
@@ -79,7 +79,7 @@ public:
         bool hasInputAttachmentSampler = false;
         UInt32 rootParameterIndex{ 0 };
 
-        LITEFX_TRACE(DIRECTX12_LOG, "Creating render pipeline layout {0} {{ Descriptor Sets: {1}, Push Constant Ranges: {2} }}...", fmt::ptr(m_parent), m_descriptorSetLayouts.size(), m_pushConstantsLayout == nullptr ? 0 : m_pushConstantsLayout->ranges().size());
+        LITEFX_TRACE(DIRECTX12_LOG, "Creating render pipeline layout {0} {{ Descriptor Sets: {1}, Push Constant Ranges: {2} }}...", reinterpret_cast<void*>(m_parent), m_descriptorSetLayouts.size(), m_pushConstantsLayout == nullptr ? 0 : m_pushConstantsLayout->ranges().size());
 
         if (m_pushConstantsLayout != nullptr)
         {

--- a/src/Backends/DirectX12/src/ray_tracing_pipeline.cpp
+++ b/src/Backends/DirectX12/src/ray_tracing_pipeline.cpp
@@ -71,7 +71,7 @@ public:
 		if (m_program != m_shaderRecordCollection.program()) [[unlikely]]
 			throw InvalidArgumentException("shaderRecords", "The ray tracing pipeline shader program must be the same as used to build the shader record collection.");
 
-		LITEFX_TRACE(DIRECTX12_LOG, "Creating ray-tracing pipeline (\"{1}\") for layout {0} (records: {2})...", fmt::ptr(reinterpret_cast<void*>(m_layout.get())), m_parent->name(), m_shaderRecordCollection.shaderRecords().size());
+		LITEFX_TRACE(DIRECTX12_LOG, "Creating ray-tracing pipeline (\"{1}\") for layout {0} (records: {2})...", reinterpret_cast<void*>(m_layout.get()), m_parent->name(), m_shaderRecordCollection.shaderRecords().size());
 		
 		// Validate shader stage usage.
 		auto modules = m_program->modules();
@@ -87,7 +87,7 @@ public:
 		else if (hasMeshShaders) [[unlikely]]
 			throw InvalidArgumentException("shaderProgram", "The shader program contains a mesh shader, which is not supported in a ray-tracing pipeline");
 		
-		LITEFX_TRACE(DIRECTX12_LOG, "Using shader program {0} with {1} modules...", fmt::ptr(m_program.get()), modules.size());
+		LITEFX_TRACE(DIRECTX12_LOG, "Using shader program {0} with {1} modules...", reinterpret_cast<const void*>(m_program.get()), modules.size());
 
 		// Start by describing the shader modules individually.
 		struct ShaderModuleSubobjectData {

--- a/src/Backends/DirectX12/src/render_pass.cpp
+++ b/src/Backends/DirectX12/src/render_pass.cpp
@@ -94,7 +94,7 @@ public:
             {
                 auto commandBuffer = m_queue->createCommandBuffer(false);
 #ifndef NDEBUG
-                std::as_const(*commandBuffer).handle()->SetName(Widen(fmt::format("{0} Begin Commands {1}", m_parent->name(), m_beginCommandBuffers.size())).c_str());
+                std::as_const(*commandBuffer).handle()->SetName(Widen(std::format("{0} Begin Commands {1}", m_parent->name(), m_beginCommandBuffers.size())).c_str());
 #endif
                 m_beginCommandBuffers[interfacePointer] = commandBuffer;
             }
@@ -103,7 +103,7 @@ public:
             {
                 auto commandBuffer = m_queue->createCommandBuffer(false);
 #ifndef NDEBUG
-                std::as_const(*commandBuffer).handle()->SetName(Widen(fmt::format("{0} End Commands {1}", m_parent->name(), m_endCommandBuffers.size())).c_str());
+                std::as_const(*commandBuffer).handle()->SetName(Widen(std::format("{0} End Commands {1}", m_parent->name(), m_endCommandBuffers.size())).c_str());
 #endif
                 m_endCommandBuffers[interfacePointer] = commandBuffer;
             }
@@ -113,7 +113,7 @@ public:
                 std::views::transform([this](UInt32 i) {
                     auto commandBuffer = m_queue->createCommandBuffer(false);
 #ifndef NDEBUG
-                    std::as_const(*commandBuffer).handle()->SetName(Widen(fmt::format("{0} Secondary Commands {1}", m_parent->name(), i)).c_str());
+                    std::as_const(*commandBuffer).handle()->SetName(Widen(std::format("{0} Secondary Commands {1}", m_parent->name(), i)).c_str());
 #endif
                     return commandBuffer;
                 }) | std::ranges::to<Array<SharedPtr<DirectX12CommandBuffer>>>();
@@ -364,7 +364,7 @@ void DirectX12RenderPass::begin(const DirectX12FrameBuffer& frameBuffer) const
     beginCommandBuffer->barrier(inputAttachmentBarrier);
 
     if (!this->name().empty())
-        m_impl->m_queue->beginDebugRegion(fmt::format("{0} Render Pass", this->name()));
+        m_impl->m_queue->beginDebugRegion(std::format("{0} Render Pass", this->name()));
 
     // Begin a suspending render pass for the transition and a suspend-the-resume render pass on each command buffer of the frame buffer.
     std::as_const(*beginCommandBuffer).handle()->BeginRenderPass(std::get<0>(context).size(), std::get<0>(context).data(), std::get<1>(context).has_value() ? &std::get<1>(context).value() : nullptr, D3D12_RENDER_PASS_FLAG_SUSPENDING_PASS);

--- a/src/Backends/DirectX12/src/render_pipeline.cpp
+++ b/src/Backends/DirectX12/src/render_pipeline.cpp
@@ -55,7 +55,7 @@ public:
 public:
 	ComPtr<ID3D12PipelineState> initialize(MultiSamplingLevel samples)
 	{
-		LITEFX_TRACE(DIRECTX12_LOG, "Creating render pipeline \"{1}\" for layout {0}...", fmt::ptr(reinterpret_cast<void*>(m_layout.get())), m_parent->name());
+		LITEFX_TRACE(DIRECTX12_LOG, "Creating render pipeline \"{1}\" for layout {0}...", reinterpret_cast<void*>(m_layout.get()), m_parent->name());
 		m_samples = samples;
 
 		// Check if there are mesh shaders in the program.
@@ -215,7 +215,7 @@ public:
 
 		// Setup shader stages.
 		auto modules = m_program->modules();
-		LITEFX_TRACE(DIRECTX12_LOG, "Using shader program {0} with {1} modules...", fmt::ptr(m_program.get()), modules.size());
+		LITEFX_TRACE(DIRECTX12_LOG, "Using shader program {0} with {1} modules...", reinterpret_cast<void*>(m_program.get()), modules.size());
 
 		std::ranges::for_each(modules, [&, i = 0](const DirectX12ShaderModule* shaderModule) mutable {
 			LITEFX_TRACE(DIRECTX12_LOG, "\tModule {0}/{1} (\"{2}\") state: {{ Type: {3}, EntryPoint: {4} }}", ++i, modules.size(), shaderModule->fileName(), shaderModule->type(), shaderModule->entryPoint());
@@ -276,7 +276,7 @@ public:
 		
 		// Setup shader stages.
 		auto modules = m_program->modules();
-		LITEFX_TRACE(DIRECTX12_LOG, "Using shader program {0} with {1} modules...", fmt::ptr(m_program.get()), modules.size());
+		LITEFX_TRACE(DIRECTX12_LOG, "Using shader program {0} with {1} modules...", reinterpret_cast<void*>(m_program.get()), modules.size());
 
 		std::ranges::for_each(modules, [&, i = 0](const DirectX12ShaderModule* shaderModule) mutable {
 			LITEFX_TRACE(DIRECTX12_LOG, "\tModule {0}/{1} (\"{2}\") state: {{ Type: {3}, EntryPoint: {4} }}", ++i, modules.size(), shaderModule->fileName(), shaderModule->type(), shaderModule->entryPoint());

--- a/src/Backends/DirectX12/src/swapchain.cpp
+++ b/src/Backends/DirectX12/src/swapchain.cpp
@@ -59,7 +59,7 @@ public:
 
 		// Create the swap chain.
 		auto size = Size2d{ std::max<UInt32>(1, renderArea.width()), std::max<UInt32>(1, renderArea.height()) };
-		LITEFX_TRACE(DIRECTX12_LOG, "Creating swap chain for device {0} {{ Images: {1}, Extent: {2}x{3} Px, Format: {4}, VSync: {5} }}...", fmt::ptr(m_device.handle().Get()), backBuffers, size.width(), size.height(), format, enableVsync);
+		LITEFX_TRACE(DIRECTX12_LOG, "Creating swap chain for device {0} {{ Images: {1}, Extent: {2}x{3} Px, Format: {4}, VSync: {5} }}...", reinterpret_cast<void*>(m_device.handle().Get()), backBuffers, size.width(), size.height(), format, enableVsync);
 		
 		DXGI_SWAP_CHAIN_DESC1 swapChainDesc = {};
 		swapChainDesc.Width = static_cast<UInt32>(size.width());
@@ -115,7 +115,7 @@ public:
 		UInt32 buffers = std::max<UInt32>(2, backBuffers);
 		auto size = Size2d{ std::max<UInt32>(1, renderArea.width()), std::max<UInt32>(1, renderArea.height()) };
 		raiseIfFailed(m_parent->handle()->ResizeBuffers(buffers, static_cast<UInt32>(size.width()), static_cast<UInt32>(size.height()), DX12::getFormat(format), m_supportsVariableRefreshRates ? DXGI_SWAP_CHAIN_FLAG_ALLOW_TEARING : 0), "Unable to resize swap chain back buffers.");
-		LITEFX_TRACE(DIRECTX12_LOG, "Resetting swap chain for device {0} {{ Images: {1}, Extent: {2}x{3} Px, Format: {4}, VSync: {5} }}...", fmt::ptr(m_device.handle().Get()), backBuffers, size.width(), size.height(), format, enableVsync);
+		LITEFX_TRACE(DIRECTX12_LOG, "Resetting swap chain for device {0} {{ Images: {1}, Extent: {2}x{3} Px, Format: {4}, VSync: {5} }}...", reinterpret_cast<void*>(m_device.handle().Get()), backBuffers, size.width(), size.height(), format, enableVsync);
 
 		// Acquire the swap chain images.
 		m_presentImages.resize(buffers);
@@ -191,7 +191,7 @@ private:
 		auto formats = m_parent->getSurfaceFormats();
 
 		return Join(formats |
-			std::views::transform([](Format format) { return fmt::to_string(format); }) |
+			std::views::transform([](Format format) { return std::format("{0}", format); }) |
 			std::ranges::to<Array<String>>(), ", ");
 	}
 };

--- a/src/Backends/Vulkan/include/litefx/backends/vulkan_api.hpp
+++ b/src/Backends/Vulkan/include/litefx/backends/vulkan_api.hpp
@@ -23,6 +23,7 @@
 #include <litefx/config.h>
 #include <litefx/rendering.hpp>
 #include <vulkan/vulkan.h>
+#include "vulkan_formatters.hpp"
 
 namespace LiteFX::Rendering::Backends {
     using namespace LiteFX::Math;
@@ -356,7 +357,7 @@ namespace LiteFX::Rendering::Backends {
         /// <param name="args">The arguments passed to the error message format string.</param>
         template <typename ...TArgs>
         explicit VulkanPlatformException(VkResult result, StringView format, TArgs&&... args) noexcept :
-            VulkanPlatformException(fmt::vformat(format, fmt::make_format_args(args...)), result) { }
+            VulkanPlatformException(std::vformat(format, std::make_format_args(args...)), result) { }
 
         VulkanPlatformException(const VulkanPlatformException&) = default;
         VulkanPlatformException(VulkanPlatformException&&) = default;

--- a/src/Backends/Vulkan/include/litefx/backends/vulkan_formatters.hpp
+++ b/src/Backends/Vulkan/include/litefx/backends/vulkan_formatters.hpp
@@ -3,9 +3,8 @@
 #include "vulkan_api.hpp"
 
 template <>
-struct LITEFX_VULKAN_API fmt::formatter<VkResult> : formatter<string_view> {
-    template <typename FormatContext>
-    auto format(VkResult t, FormatContext& ctx) {
+struct LITEFX_VULKAN_API std::formatter<VkResult> : std::formatter<std::string_view> {
+    auto format(VkResult t, std::format_context& ctx) const {
         string_view name;
 
         switch (t)

--- a/src/Backends/Vulkan/src/buffer.cpp
+++ b/src/Backends/Vulkan/src/buffer.cpp
@@ -40,7 +40,7 @@ VulkanBuffer::VulkanBuffer(VkBuffer buffer, BufferType type, UInt32 elements, si
 VulkanBuffer::~VulkanBuffer() noexcept
 {
 	::vmaDestroyBuffer(m_impl->m_allocator, this->handle(), m_impl->m_allocation);
-	LITEFX_TRACE(VULKAN_LOG, "Destroyed buffer {0}", fmt::ptr(reinterpret_cast<void*>(this->handle())));
+	LITEFX_TRACE(VULKAN_LOG, "Destroyed buffer {0}", reinterpret_cast<void*>(this->handle()));
 }
 
 BufferType VulkanBuffer::type() const noexcept
@@ -153,7 +153,7 @@ UniquePtr<IVulkanBuffer> VulkanBuffer::allocate(const String& name, BufferType t
 	VmaAllocation allocation;
 
 	raiseIfFailed(::vmaCreateBuffer(allocator, &createInfo, &allocationInfo, &buffer, &allocation, allocationResult), "Unable to allocate buffer.");
-	LITEFX_DEBUG(VULKAN_LOG, "Allocated buffer {0} with {4} bytes {{ Type: {1}, Elements: {2}, Element Size: {3}, Usage: {5} }}", name.empty() ? fmt::to_string(fmt::ptr(reinterpret_cast<void*>(buffer))) : name, type, elements, elementSize, elements * elementSize, usage);
+	LITEFX_DEBUG(VULKAN_LOG, "Allocated buffer {0} with {4} bytes {{ Type: {1}, Elements: {2}, Element Size: {3}, Usage: {5} }}", name.empty() ? std::format("{0}", reinterpret_cast<void*>(buffer)) : name, type, elements, elementSize, elements * elementSize, usage);
 
 	return makeUnique<VulkanBuffer>(buffer, type, elements, elementSize, alignment, usage, device, allocator, allocation, name);
 }
@@ -203,7 +203,7 @@ UniquePtr<IVulkanVertexBuffer> VulkanVertexBuffer::allocate(const String& name, 
 	VmaAllocation allocation;
 
 	raiseIfFailed(::vmaCreateBuffer(allocator, &createInfo, &allocationInfo, &buffer, &allocation, allocationResult), "Unable to allocate vertex buffer.");
-	LITEFX_DEBUG(VULKAN_LOG, "Allocated buffer {0} with {4} bytes {{ Type: {1}, Elements: {2}, Element Size: {3}, Usage: {5} }}", name.empty() ? fmt::to_string(fmt::ptr(reinterpret_cast<void*>(buffer))) : name, BufferType::Vertex, elements, layout.elementSize(), layout.elementSize() * elements, usage);
+	LITEFX_DEBUG(VULKAN_LOG, "Allocated buffer {0} with {4} bytes {{ Type: {1}, Elements: {2}, Element Size: {3}, Usage: {5} }}", name.empty() ? std::format("{0}", reinterpret_cast<void*>(buffer)) : name, BufferType::Vertex, elements, layout.elementSize(), layout.elementSize() * elements, usage);
 
 	return makeUnique<VulkanVertexBuffer>(buffer, layout, elements, usage, device, allocator, allocation, name);
 }
@@ -253,7 +253,7 @@ UniquePtr<IVulkanIndexBuffer> VulkanIndexBuffer::allocate(const String& name, co
 	VmaAllocation allocation;
 
 	raiseIfFailed(::vmaCreateBuffer(allocator, &createInfo, &allocationInfo, &buffer, &allocation, allocationResult), "Unable to allocate index buffer.");
-	LITEFX_DEBUG(VULKAN_LOG, "Allocated buffer {0} with {4} bytes {{ Type: {1}, Elements: {2}, Element Size: {3}, Usage: {5} }}", name.empty() ? fmt::to_string(fmt::ptr(reinterpret_cast<void*>(buffer))) : name, BufferType::Index, elements, layout.elementSize(), layout.elementSize() * elements, usage);
+	LITEFX_DEBUG(VULKAN_LOG, "Allocated buffer {0} with {4} bytes {{ Type: {1}, Elements: {2}, Element Size: {3}, Usage: {5} }}", name.empty() ? std::format("{0}", reinterpret_cast<void*>(buffer)) : name, BufferType::Index, elements, layout.elementSize(), layout.elementSize() * elements, usage);
 
 	return makeUnique<VulkanIndexBuffer>(buffer, layout, elements, usage, device, allocator, allocation, name);
 }

--- a/src/Backends/Vulkan/src/compute_pipeline.cpp
+++ b/src/Backends/Vulkan/src/compute_pipeline.cpp
@@ -31,11 +31,11 @@ public:
 public:
 	VkPipeline initialize()
 	{
-		LITEFX_TRACE(VULKAN_LOG, "Creating compute pipeline (\"{1}\") for layout {0}...", fmt::ptr(reinterpret_cast<void*>(m_layout.get())), m_parent->name());
+		LITEFX_TRACE(VULKAN_LOG, "Creating compute pipeline (\"{1}\") for layout {0}...", reinterpret_cast<void*>(m_layout.get()), m_parent->name());
 	
 		// Setup shader stages.
 		auto modules = m_program->modules();
-		LITEFX_TRACE(VULKAN_LOG, "Using shader program {0} with {1} modules...", fmt::ptr(reinterpret_cast<const void*>(m_program.get())), modules.size());
+		LITEFX_TRACE(VULKAN_LOG, "Using shader program {0} with {1} modules...", reinterpret_cast<void*>(m_program.get()), modules.size());
 
 		if (modules.size() > 1)
 			throw RuntimeException("Only one shader module must be bound to a compute pipeline.");

--- a/src/Backends/Vulkan/src/device.cpp
+++ b/src/Backends/Vulkan/src/device.cpp
@@ -327,7 +327,7 @@ public:
             .maintenance4 = true
         };
 
-        // Enable various descriptor related features, as well as timelime semaphores and other little QoL improvements.
+        // Enable various descriptor related features, as well as timeline semaphores and other little QoL improvements.
         VkPhysicalDeviceVulkan12Features deviceFeatures12 = {
             .sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_VULKAN_1_2_FEATURES,
             .pNext = &deviceFeatures13,
@@ -342,7 +342,7 @@ public:
             .shaderInputAttachmentArrayNonUniformIndexing = true,
             .shaderUniformTexelBufferArrayNonUniformIndexing = true,
             .shaderStorageTexelBufferArrayNonUniformIndexing = true,
-            .descriptorBindingUniformBufferUpdateAfterBind = true,
+            .descriptorBindingUniformBufferUpdateAfterBind = true, // On NVidia cards this requires Turing or later.
             .descriptorBindingSampledImageUpdateAfterBind = true,
             .descriptorBindingStorageImageUpdateAfterBind = true,
             .descriptorBindingStorageBufferUpdateAfterBind = true,
@@ -510,7 +510,7 @@ VulkanDevice::VulkanDevice(const VulkanBackend& backend, const VulkanGraphicsAda
 VulkanDevice::VulkanDevice(const VulkanBackend& /*backend*/, const VulkanGraphicsAdapter& adapter, UniquePtr<VulkanSurface>&& surface, Format format, const Size2d& renderArea, UInt32 backBuffers, bool enableVsync, GraphicsDeviceFeatures features, Span<String> extensions) :
     Resource<VkDevice>(nullptr), m_impl(makePimpl<VulkanDeviceImpl>(this, adapter, std::move(surface), features, extensions))
 {
-    LITEFX_DEBUG(VULKAN_LOG, "Creating Vulkan device {{ Surface: {0}, Adapter: {1}, Extensions: {2} }}...", fmt::ptr(reinterpret_cast<const void*>(m_impl->m_surface.get())), adapter.deviceId(), Join(this->enabledExtensions(), ", "));
+    LITEFX_DEBUG(VULKAN_LOG, "Creating Vulkan device {{ Surface: {0}, Adapter: {1}, Extensions: {2} }}...", reinterpret_cast<void*>(m_impl->m_surface.get()), adapter.deviceId(), Join(this->enabledExtensions(), ", "));
     LITEFX_DEBUG(VULKAN_LOG, "--------------------------------------------------------------------------");
     LITEFX_DEBUG(VULKAN_LOG, "Vendor: {0:#0x}", adapter.vendorId());
     LITEFX_DEBUG(VULKAN_LOG, "Driver Version: {0:#0x}", adapter.driverVersion());
@@ -557,7 +557,7 @@ void VulkanDevice::setDebugName(UInt64 handle, VkDebugReportObjectTypeEXT type, 
         };
         
         if (m_impl->debugMarkerSetObjectName(this->handle(), &nameInfo) != VK_SUCCESS)
-            LITEFX_WARNING(VULKAN_LOG, "Unable to set object name for object handle {0}.", fmt::ptr(reinterpret_cast<void*>(handle)));
+            LITEFX_WARNING(VULKAN_LOG, "Unable to set object name for object handle {0}.", reinterpret_cast<void*>(handle));
     }
 #endif
 }

--- a/src/Backends/Vulkan/src/image.cpp
+++ b/src/Backends/Vulkan/src/image.cpp
@@ -54,7 +54,7 @@ VulkanImage::~VulkanImage() noexcept
 	if (m_impl->m_allocator != nullptr && m_impl->m_allocationInfo != nullptr)
 	{
 		::vmaDestroyImage(m_impl->m_allocator, this->handle(), m_impl->m_allocationInfo);
-		LITEFX_TRACE(VULKAN_LOG, "Destroyed image {0}", fmt::ptr(reinterpret_cast<void*>(this->handle())));
+		LITEFX_TRACE(VULKAN_LOG, "Destroyed image {0}", reinterpret_cast<void*>(this->handle()));
 	}
 }
 
@@ -274,7 +274,7 @@ UniquePtr<VulkanImage> VulkanImage::allocate(const String& name, const VulkanDev
 	VmaAllocation allocation;
 
 	raiseIfFailed(::vmaCreateImage(allocator, &createInfo, &allocationInfo, &image, &allocation, allocationResult), "Unable to allocate texture.");
-	LITEFX_DEBUG(VULKAN_LOG, "Allocated image {0} with {1} bytes {{ Extent: {2}x{3} Px, Format: {4}, Levels: {5}, Layers: {6}, Samples: {8}, Usage: {7} }}", name.empty() ? fmt::to_string(fmt::ptr(reinterpret_cast<void*>(image))) : name, ::getSize(format) * extent.width() * extent.height(), extent.width(), extent.height(), format, levels, layers, usage, samples);
+	LITEFX_DEBUG(VULKAN_LOG, "Allocated image {0} with {1} bytes {{ Extent: {2}x{3} Px, Format: {4}, Levels: {5}, Layers: {6}, Samples: {8}, Usage: {7} }}", name.empty() ? std::format("{0}", reinterpret_cast<void*>(image)) : name, ::getSize(format) * extent.width() * extent.height(), extent.width(), extent.height(), format, levels, layers, usage, samples);
 
 	return makeUnique<VulkanImage>(device, image, extent, format, dimensions, levels, layers, samples, usage, allocator, allocation, name);
 }

--- a/src/Backends/Vulkan/src/pipeline_layout.cpp
+++ b/src/Backends/Vulkan/src/pipeline_layout.cpp
@@ -78,7 +78,7 @@ public:
             std::ranges::to<Array<VkPushConstantRange>>();
 
         // Create the pipeline layout.
-        LITEFX_TRACE(VULKAN_LOG, "Creating pipeline layout {0} {{ Descriptor Sets: {1}, Push Constant Ranges: {2} }}...", fmt::ptr(m_parent), descriptorSetLayouts.size(), rangeHandles.size());
+        LITEFX_TRACE(VULKAN_LOG, "Creating pipeline layout {0} {{ Descriptor Sets: {1}, Push Constant Ranges: {2} }}...", reinterpret_cast<void*>(m_parent), descriptorSetLayouts.size(), rangeHandles.size());
 
         VkPipelineLayoutCreateInfo pipelineLayoutInfo = {};
         pipelineLayoutInfo.sType = VK_STRUCTURE_TYPE_PIPELINE_LAYOUT_CREATE_INFO;

--- a/src/Backends/Vulkan/src/ray_tracing_pipeline.cpp
+++ b/src/Backends/Vulkan/src/ray_tracing_pipeline.cpp
@@ -44,7 +44,7 @@ public:
 		if (m_program != m_shaderRecordCollection.program()) [[unlikely]]
 			throw InvalidArgumentException("shaderRecords", "The ray tracing pipeline shader program must be the same as used to build the shader record collection.");
 
-		LITEFX_TRACE(VULKAN_LOG, "Creating ray-tracing pipeline (\"{1}\") for layout {0} (records: {2})...", fmt::ptr(reinterpret_cast<void*>(m_layout.get())), m_parent->name(), m_shaderRecordCollection.shaderRecords().size());
+		LITEFX_TRACE(VULKAN_LOG, "Creating ray-tracing pipeline (\"{1}\") for layout {0} (records: {2})...", reinterpret_cast<void*>(m_layout.get()), m_parent->name(), m_shaderRecordCollection.shaderRecords().size());
 	
 		// Validate shader stage usage.
 		auto modules = m_program->modules() | std::ranges::to<std::vector>();
@@ -60,7 +60,7 @@ public:
 		else if (hasMeshShaders) [[unlikely]]
 			throw InvalidArgumentException("shaderProgram", "The shader program contains a mesh shader, which is not supported in a ray-tracing pipeline");
 
-		LITEFX_TRACE(VULKAN_LOG, "Using shader program {0} with {1} modules...", fmt::ptr(reinterpret_cast<const void*>(m_program.get())), modules.size());
+		LITEFX_TRACE(VULKAN_LOG, "Using shader program {0} with {1} modules...", reinterpret_cast<const void*>(m_program.get()), modules.size());
 
 		Array<VkPipelineShaderStageCreateInfo> shaderStages = modules |
 			std::views::transform([](const VulkanShaderModule* shaderModule) { return shaderModule->shaderStageDefinition(); }) |

--- a/src/Backends/Vulkan/src/render_pass.cpp
+++ b/src/Backends/Vulkan/src/render_pass.cpp
@@ -106,7 +106,7 @@ public:
                 auto commandBuffer = m_queue->createCommandBuffer(false);
 #ifndef NDEBUG
                 m_device.setDebugName(*reinterpret_cast<const UInt64*>(&std::as_const(*commandBuffer).handle()), VK_DEBUG_REPORT_OBJECT_TYPE_COMMAND_BUFFER_EXT, 
-                    fmt::format("{0} Primary Commands {1}", m_parent->name(), m_primaryCommandBuffers.size()).c_str());
+                    std::format("{0} Primary Commands {1}", m_parent->name(), m_primaryCommandBuffers.size()).c_str());
 #endif
                 m_primaryCommandBuffers[interfacePointer] = commandBuffer;
             }
@@ -117,7 +117,7 @@ public:
                     auto commandBuffer = m_queue->createCommandBuffer(false, true);
 #ifndef NDEBUG
                     m_device.setDebugName(*reinterpret_cast<const UInt64*>(&std::as_const(*commandBuffer).handle()), VK_DEBUG_REPORT_OBJECT_TYPE_COMMAND_BUFFER_EXT, 
-                        fmt::format("{0} Secondary Commands {1}", m_parent->name(), i).c_str());
+                        std::format("{0} Secondary Commands {1}", m_parent->name(), i).c_str());
 #endif
                     return commandBuffer;
                 }) | std::ranges::to<Array<SharedPtr<VulkanCommandBuffer>>>();
@@ -425,7 +425,7 @@ void VulkanRenderPass::begin(const VulkanFrameBuffer& frameBuffer) const
     primaryCommandBuffer->barrier(depthStencilBarrier);
     
     if (!this->name().empty())
-        m_impl->m_queue->beginDebugRegion(fmt::format("{0} Render Pass", this->name()));
+        m_impl->m_queue->beginDebugRegion(std::format("{0} Render Pass", this->name()));
 
     // Begin the render pass on the primary command buffer.
     ::vkCmdBeginRendering(std::as_const(*primaryCommandBuffer).handle(), &renderingInfo);

--- a/src/Backends/Vulkan/src/render_pipeline.cpp
+++ b/src/Backends/Vulkan/src/render_pipeline.cpp
@@ -72,7 +72,7 @@ public:
 		dynamicState.dynamicStateCount = static_cast<UInt32>(dynamicStates.size());
 
 		// Setup shader stages.
-		LITEFX_TRACE(VULKAN_LOG, "Using shader program {0} with {1} modules...", fmt::ptr(reinterpret_cast<const void*>(m_program.get())), modules.size());
+		LITEFX_TRACE(VULKAN_LOG, "Using shader program {0} with {1} modules...", reinterpret_cast<void*>(m_program.get()), modules.size());
 
 		Array<VkPipelineShaderStageCreateInfo> shaderStages = modules |
 			std::views::transform([](const VulkanShaderModule* shaderModule) { return shaderModule->shaderStageDefinition(); }) |
@@ -93,7 +93,7 @@ public:
 
 	VkPipeline initializeGraphicsPipeline(const VkPipelineDynamicStateCreateInfo& dynamicState, const LiteFX::Array<VkPipelineShaderStageCreateInfo>& shaderStages)
 	{
-		LITEFX_TRACE(VULKAN_LOG, "Creating render pipeline \"{1}\" for layout {0}...", fmt::ptr(reinterpret_cast<void*>(m_layout.get())), m_parent->name());
+		LITEFX_TRACE(VULKAN_LOG, "Creating render pipeline \"{1}\" for layout {0}...", reinterpret_cast<void*>(m_layout.get()), m_parent->name());
 
 		// Get the device.
 		const auto& device = m_renderPass.device();

--- a/src/Backends/Vulkan/src/shader_module.cpp
+++ b/src/Backends/Vulkan/src/shader_module.cpp
@@ -63,7 +63,7 @@ public:
 			throw std::runtime_error("Unable to compile shader file.");
 
 #ifndef NDEBUG
-		m_device.setDebugName(*reinterpret_cast<const UInt64*>(&module), VK_DEBUG_REPORT_OBJECT_TYPE_SHADER_MODULE_EXT, fmt::format("{0}: {1}", m_fileName, m_entryPoint));
+		m_device.setDebugName(*reinterpret_cast<const UInt64*>(&module), VK_DEBUG_REPORT_OBJECT_TYPE_SHADER_MODULE_EXT, std::format("{0}: {1}", m_fileName, m_entryPoint));
 #endif
 
 		m_bytecode = fileContents;

--- a/src/Backends/Vulkan/src/shader_program.cpp
+++ b/src/Backends/Vulkan/src/shader_program.cpp
@@ -11,9 +11,8 @@ using namespace LiteFX::Rendering::Backends;
 // ------------------------------------------------------------------------------------------------
 
 template <>
-struct LITEFX_VULKAN_API fmt::formatter<SpvReflectResult> : formatter<string_view> {
-    template <typename FormatContext>
-    auto format(SpvReflectResult t, FormatContext& ctx) {
+struct LITEFX_VULKAN_API std::formatter<SpvReflectResult> : std::formatter<std::string_view> {
+    auto format(SpvReflectResult t, std::format_context& ctx) {
         string_view name;
 
         switch (t)
@@ -209,26 +208,26 @@ public:
             auto result = reflection.GetResult();
 
             if (result != SPV_REFLECT_RESULT_SUCCESS) [[unlikely]]
-                throw RuntimeException("Unable to reflect shader module (Error {0}).", reflection.GetResult());
+                throw RuntimeException("Unable to reflect shader module (Error {0:x}).", static_cast<UInt32>(reflection.GetResult()));
 
             // Get the number of descriptor sets and push constants.
             UInt32 descriptorSetCount, pushConstantCount;
 
             if ((result = reflection.EnumerateDescriptorSets(&descriptorSetCount, nullptr)) != SPV_REFLECT_RESULT_SUCCESS) [[unlikely]]
-                throw RuntimeException("Unable to get descriptor set count (Error {0}).", result);
+                throw RuntimeException("Unable to get descriptor set count (Error {0:x}).", static_cast<UInt32>(result));
 
             if ((result = reflection.EnumeratePushConstants(&pushConstantCount, nullptr)) != SPV_REFLECT_RESULT_SUCCESS) [[unlikely]]
-                throw RuntimeException("Unable to get push constants count (Error {0}).", result);
+                throw RuntimeException("Unable to get push constants count (Error {0:x}).", static_cast<UInt32>(result));
 
             // Acquire the descriptor sets and push constants.
             Array<SpvReflectDescriptorSet*> descriptorSets(descriptorSetCount);
             Array<SpvReflectBlockVariable*> pushConstants(pushConstantCount);
 
             if ((result = reflection.EnumerateDescriptorSets(&descriptorSetCount, descriptorSets.data())) != SPV_REFLECT_RESULT_SUCCESS) [[unlikely]]
-                throw RuntimeException("Unable to enumerate descriptor sets (Error {0}).", result);
+                throw RuntimeException("Unable to enumerate descriptor sets (Error {0:x}).", static_cast<UInt32>(result));
 
             if ((result = reflection.EnumeratePushConstants(&pushConstantCount, pushConstants.data())) != SPV_REFLECT_RESULT_SUCCESS) [[unlikely]]
-                throw RuntimeException("Unable to enumerate push constants (Error {0}).", result);
+                throw RuntimeException("Unable to enumerate push constants (Error {0:x}).", static_cast<UInt32>(result));
 
             // Parse the descriptor sets.
             std::ranges::for_each(descriptorSets, [this, &shaderModule, &reflection, &descriptorSetLayouts](const SpvReflectDescriptorSet* descriptorSet) {
@@ -319,7 +318,7 @@ public:
                         if (auto match = std::ranges::find_if(layout.descriptors, [&descriptor](const DescriptorInfo& element) { return element.location == descriptor.location; }); match == layout.descriptors.end())
                             layout.descriptors.push_back(descriptor);
                         else if (!descriptor.equals(*match))
-                            LITEFX_WARNING(VULKAN_LOG, "Mismatching descriptors detected: the descriptor at location {0} ({3} elements with size of {4} bytes) of the descriptor set {1} in shader stage {2} conflicts with a descriptor from at least one other shader stage and will be dropped (conflicts with descriptor of type {9} in stage/s {6} with {7} elements of {8} bytes).",
+                            LITEFX_WARNING(VULKAN_LOG, "Mismatching descriptors detected: the descriptor at location {0} ({3} elements with size of {4} bytes) of the descriptor set {1} in shader stage {2} conflicts with a descriptor from at least one other shader stage and will be dropped (conflicts with descriptor of type {8} in stage/s {5} with {6} elements of {7} bytes).",
                                 descriptor.location, descriptorSet->set, shaderModule->type(), descriptor.elements, descriptor.elementSize, layout.stage, match->elements, match->elementSize, match->type);
                     }
 

--- a/src/Backends/Vulkan/src/swapchain.cpp
+++ b/src/Backends/Vulkan/src/swapchain.cpp
@@ -97,7 +97,7 @@ public:
 		createInfo.presentMode = vsync ? VK_PRESENT_MODE_FIFO_KHR : VK_PRESENT_MODE_IMMEDIATE_KHR;/* VK_PRESENT_MODE_MAILBOX_KHR;*/
 		m_vsync = vsync;
 
-		LITEFX_TRACE(VULKAN_LOG, "Creating swap chain for device {0} {{ Images: {1}, Extent: {2}x{3} Px, Format: {4}, VSync: {5} }}...", fmt::ptr(&m_device), images, createInfo.imageExtent.width, createInfo.imageExtent.height, selectedFormat, vsync);
+		LITEFX_TRACE(VULKAN_LOG, "Creating swap chain for device {0} {{ Images: {1}, Extent: {2}x{3} Px, Format: {4}, VSync: {5} }}...", reinterpret_cast<void*>(&m_device), images, createInfo.imageExtent.width, createInfo.imageExtent.height, selectedFormat, vsync);
 
 		// Log if something needed to be changed.
 		[[unlikely]] if (selectedFormat != format)
@@ -503,7 +503,7 @@ public:
 		D3D::raiseIfFailed(m_d3dDevice->CreateCommandQueue(&presentQueueDesc, IID_PPV_ARGS(&m_presentQueue)), "Unable to create present queue.");
 
 		// Create the swap chain instance.
-		LITEFX_TRACE(VULKAN_LOG, "Creating swap chain for device {0} {{ Images: {1}, Extent: {2}x{3} Px, Format: {4}, VSync: {5} }}...", fmt::ptr(&m_device), images, extent.width(), extent.height(), selectedFormat, vsync);
+		LITEFX_TRACE(VULKAN_LOG, "Creating swap chain for device {0} {{ Images: {1}, Extent: {2}x{3} Px, Format: {4}, VSync: {5} }}...", reinterpret_cast<const void*>(&m_device), images, extent.width(), extent.height(), selectedFormat, vsync);
 
 		DXGI_SWAP_CHAIN_DESC1 swapChainDesc {
 			.Width = static_cast<UInt32>(extent.width()),
@@ -596,7 +596,7 @@ public:
 			LITEFX_INFO(VULKAN_LOG, "The render area has been adjusted to {0}x{1} Px (was {2}x{3} Px).", extent.height(), extent.width(), static_cast<UInt32>(renderArea.height()), static_cast<UInt32>(renderArea.width()));
 
 		// Reset the swap chain instance.
-		LITEFX_TRACE(VULKAN_LOG, "Resetting swap chain for device {0} {{ Images: {1}, Extent: {2}x{3} Px, Format: {4}, VSync: {5} }}...", fmt::ptr(&m_device), images, extent.width(), extent.height(), selectedFormat, vsync);
+		LITEFX_TRACE(VULKAN_LOG, "Resetting swap chain for device {0} {{ Images: {1}, Extent: {2}x{3} Px, Format: {4}, VSync: {5} }}...", reinterpret_cast<const void*>(&m_device), images, extent.width(), extent.height(), selectedFormat, vsync);
 
 		// Wait for both devices to be idle.
 		this->waitForInteropDevice();

--- a/src/Core/CMakeLists.txt
+++ b/src/Core/CMakeLists.txt
@@ -7,9 +7,6 @@
 PROJECT(LiteFX.Core VERSION ${LITEFX_VERSION} LANGUAGES CXX)
 MESSAGE(STATUS "Initializing: ${PROJECT_NAME}...")
 
-# Resolve package dependencies.
-FIND_PACKAGE(fmt CONFIG REQUIRED)
-
 CONFIGURE_FILE("config.tmpl" "${CMAKE_CURRENT_BINARY_DIR}/include/litefx/config.h")
 CONFIGURE_FILE("version.tmpl" "${CMAKE_CURRENT_BINARY_DIR}/include/litefx/version.h")
 CONFIGURE_FILE("core.tmpl" "${CMAKE_CURRENT_BINARY_DIR}/include/litefx/core.h")
@@ -63,9 +60,6 @@ TARGET_INCLUDE_DIRECTORIES(${PROJECT_NAME}
         $<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}/include>
         $<INSTALL_INTERFACE:$<INSTALL_PREFIX>/include>
 )
-
-# Link project dependencies.
-TARGET_LINK_LIBRARIES(${PROJECT_NAME} PUBLIC fmt::fmt)
 
 # Pre-compile core header.
 IF(LITEFX_BUILD_PRECOMPILED_HEADERS)

--- a/src/Core/include/litefx/exceptions.hpp
+++ b/src/Core/include/litefx/exceptions.hpp
@@ -6,9 +6,7 @@
 #include <stacktrace>
 #include <string>
 #include <type_traits>
-
-//#include <format>
-#include <fmt/format.h>
+#include <format>
 
 namespace LiteFX {
 
@@ -69,7 +67,7 @@ namespace LiteFX {
 		/// </summary>
 		/// <param name="argument">The name of the argument that was invalid.</param>
 		explicit InvalidArgumentException(std::string_view argument) noexcept :
-			Exception(fmt::format("Invalid argument provided: {}.", argument), std::source_location::current(), std::stacktrace::current()), m_argument(argument) { }
+			Exception(std::format("Invalid argument provided: {}.", argument), std::source_location::current(), std::stacktrace::current()), m_argument(argument) { }
 
 		/// <summary>
 		/// Initializes a new exception.
@@ -77,7 +75,7 @@ namespace LiteFX {
 		/// <param name="argument">The name of the argument that was invalid.</param>
 		/// <param name="message">The error message.</param>
 		explicit InvalidArgumentException(std::string_view argument, std::string_view message) noexcept :
-			Exception(fmt::format("Invalid argument provided: {}. {}", argument, message), std::source_location::current(), std::stacktrace::current()), m_argument(argument) { }
+			Exception(std::format("Invalid argument provided: {}. {}", argument, message), std::source_location::current(), std::stacktrace::current()), m_argument(argument) { }
 
 		/// <summary>
 		/// Initializes a new exception.
@@ -87,7 +85,7 @@ namespace LiteFX {
 		/// <param name="args">The arguments passed to the error message format string.</param>
 		template <typename ...TArgs>
 		explicit InvalidArgumentException(std::string_view argument, std::string_view format, TArgs&&... args) noexcept :
-			Exception(fmt::format("Invalid argument provided: {}. {}", argument, fmt::vformat(format, fmt::make_format_args(args...))), std::source_location::current(), std::stacktrace::current()), m_argument(argument) { }
+			Exception(std::format("Invalid argument provided: {}. {}", argument, std::vformat(format, std::make_format_args(args...))), std::source_location::current(), std::stacktrace::current()), m_argument(argument) { }
 
 		InvalidArgumentException(const InvalidArgumentException&) = default;
 		InvalidArgumentException(InvalidArgumentException&&) = default;
@@ -119,7 +117,7 @@ namespace LiteFX {
 		/// </summary>
 		/// <param name="argument">The name of the argument that was out of range.</param>
 		explicit ArgumentOutOfRangeException(std::string_view argument) noexcept :
-			Exception(fmt::format("Argument was out of range: {}.", argument), std::source_location::current(), std::stacktrace::current()), m_argument(argument) { }
+			Exception(std::format("Argument was out of range: {}.", argument), std::source_location::current(), std::stacktrace::current()), m_argument(argument) { }
 
 		/// <summary>
 		/// Initializes a new exception.
@@ -127,7 +125,7 @@ namespace LiteFX {
 		/// <param name="argument">The name of the argument that was out of range.</param>
 		/// <param name="message">The error message.</param>
 		explicit ArgumentOutOfRangeException(std::string_view argument, std::string_view message) noexcept :
-			Exception(fmt::format("Argument was out of range: {}. {}", argument, message), std::source_location::current(), std::stacktrace::current()), m_argument(argument) { }
+			Exception(std::format("Argument was out of range: {}. {}", argument, message), std::source_location::current(), std::stacktrace::current()), m_argument(argument) { }
 
 		/// <summary>
 		/// Initializes a new exception.
@@ -140,7 +138,7 @@ namespace LiteFX {
 		/// <param name="message">The error message.</param>
 		template <typename T>
 		explicit ArgumentOutOfRangeException(std::string_view argument, T fromIncluse, T toExclusive, T value, std::string_view message) noexcept :
-			Exception(fmt::format("Argument was out of range: {} (valid range is [{}, {}) but actual value was {}). {}", argument, fromIncluse, toExclusive, value, message), std::source_location::current(), std::stacktrace::current()), m_argument(argument) { }
+			Exception(std::format("Argument was out of range: {} (valid range is [{}, {}) but actual value was {}). {}", argument, fromIncluse, toExclusive, value, message), std::source_location::current(), std::stacktrace::current()), m_argument(argument) { }
 
 		/// <summary>
 		/// Initializes a new exception.
@@ -150,7 +148,7 @@ namespace LiteFX {
 		/// <param name="args">The arguments passed to the error message format string.</param>
 		template <typename ...TArgs>
 		explicit ArgumentOutOfRangeException(std::string_view argument, std::string_view format, TArgs&&... args) noexcept :
-			Exception(fmt::format("Argument was out of range: {}. {}", argument, fmt::vformat(format, fmt::make_format_args(args...))), std::source_location::current(), std::stacktrace::current()), m_argument(argument) { }
+			Exception(std::format("Argument was out of range: {}. {}", argument, std::vformat(format, std::make_format_args(args...))), std::source_location::current(), std::stacktrace::current()), m_argument(argument) { }
 
 		/// <summary>
 		/// Initializes a new exception.
@@ -164,7 +162,7 @@ namespace LiteFX {
 		/// <param name="args">The arguments passed to the error message format string.</param>
 		template <typename T, typename ...TArgs>
 		explicit ArgumentOutOfRangeException(std::string_view argument, T fromIncluse, T toExclusive, T value, std::string_view format, TArgs&&... args) noexcept :
-			Exception(fmt::format("Argument was out of range: {} (valid range is [{}, {}) but actual value was {}). {}", argument, fromIncluse, toExclusive, value, fmt::vformat(format, fmt::make_format_args(args...))), std::source_location::current(), std::stacktrace::current()), m_argument(argument) { }
+			Exception(std::format("Argument was out of range: {} (valid range is [{}, {}) but actual value was {}). {}", argument, fromIncluse, toExclusive, value, std::vformat(format, std::make_format_args(args...))), std::source_location::current(), std::stacktrace::current()), m_argument(argument) { }
 
 		ArgumentOutOfRangeException(const ArgumentOutOfRangeException&) = default;
 		ArgumentOutOfRangeException(ArgumentOutOfRangeException&&) = default;
@@ -196,7 +194,7 @@ namespace LiteFX {
 		/// </summary>
 		/// <param name="argument">The name of the argument that was not initialized.</param>
 		explicit ArgumentNotInitializedException(std::string_view argument) noexcept :
-			Exception(fmt::format("Argument was not initialized: {}.", argument), std::source_location::current(), std::stacktrace::current()), m_argument(argument) { }
+			Exception(std::format("Argument was not initialized: {}.", argument), std::source_location::current(), std::stacktrace::current()), m_argument(argument) { }
 
 		/// <summary>
 		/// Initializes a new exception.
@@ -204,7 +202,7 @@ namespace LiteFX {
 		/// <param name="argument">The name of the argument that was not initialized.</param>
 		/// <param name="message">The error message.</param>
 		explicit ArgumentNotInitializedException(std::string_view argument, std::string_view message) noexcept :
-			Exception(fmt::format("Argument was not initialized: {}. {}", argument, message), std::source_location::current(), std::stacktrace::current()), m_argument(argument) { }
+			Exception(std::format("Argument was not initialized: {}. {}", argument, message), std::source_location::current(), std::stacktrace::current()), m_argument(argument) { }
 
 		/// <summary>
 		/// Initializes a new exception.
@@ -214,7 +212,7 @@ namespace LiteFX {
 		/// <param name="args">The arguments passed to the error message format string.</param>
 		template <typename ...TArgs>
 		explicit ArgumentNotInitializedException(std::string_view argument, std::string_view format, TArgs&&... args) noexcept :
-			Exception(fmt::format("Argument was not initialized: {}. {}", argument, fmt::vformat(format, fmt::make_format_args(args...))), std::source_location::current(), std::stacktrace::current()), m_argument(argument) { }
+			Exception(std::format("Argument was not initialized: {}. {}", argument, std::vformat(format, std::make_format_args(args...))), std::source_location::current(), std::stacktrace::current()), m_argument(argument) { }
 
 		ArgumentNotInitializedException(const ArgumentNotInitializedException&) = default;
 		ArgumentNotInitializedException(ArgumentNotInitializedException&&) = default;
@@ -249,7 +247,7 @@ namespace LiteFX {
 		/// </summary>
 		/// <param name="message">The error message.</param>
 		explicit RuntimeException(std::string_view message) noexcept :
-			Exception(fmt::format("The operation could not be executed: {}", message), std::source_location::current(), std::stacktrace::current()) { }
+			Exception(std::format("The operation could not be executed: {}", message), std::source_location::current(), std::stacktrace::current()) { }
 
 		/// <summary>
 		/// Initializes a new exception.
@@ -258,7 +256,7 @@ namespace LiteFX {
 		/// <param name="args">The arguments passed to the error message format string.</param>
 		template <typename ...TArgs>
 		explicit RuntimeException(std::string_view format, TArgs&&... args) noexcept :
-			Exception(fmt::format("The operation could not be executed: {}", fmt::vformat(format, fmt::make_format_args(args...))), std::source_location::current(), std::stacktrace::current()) { }
+			Exception(std::format("The operation could not be executed: {}", std::vformat(format, std::make_format_args(args...))), std::source_location::current(), std::stacktrace::current()) { }
 
 		RuntimeException(const RuntimeException&) = default;
 		RuntimeException(RuntimeException&&) = default;

--- a/src/Graphics/include/litefx/graphics_formatters.hpp
+++ b/src/Graphics/include/litefx/graphics_formatters.hpp
@@ -1,14 +1,13 @@
 #pragma once
 
+#include <format>
 #include "graphics_api.hpp"
-#include <fmt/format.h>
 
 using namespace LiteFX::Graphics;
 
 template <>
-struct LITEFX_GRAPHICS_API fmt::formatter<LiteFX::Graphics::PrimitiveTopology> : formatter<string_view> {
-	template <typename FormatContext>
-	auto format(LiteFX::Graphics::PrimitiveTopology t, FormatContext& ctx) {
+struct LITEFX_GRAPHICS_API std::formatter<LiteFX::Graphics::PrimitiveTopology> : std::formatter<std::string_view> {
+	auto format(LiteFX::Graphics::PrimitiveTopology t, std::format_context& ctx) const {
 		string_view name = "Invalid";
 		switch (t) {
 		using enum PrimitiveTopology;

--- a/src/Logging/CMakeLists.txt
+++ b/src/Logging/CMakeLists.txt
@@ -53,7 +53,6 @@ TARGET_INCLUDE_DIRECTORIES(${PROJECT_NAME}
 # Link project dependencies.
 TARGET_LINK_LIBRARIES(${PROJECT_NAME}
     PUBLIC LiteFX.Core spdlog::spdlog
-    PRIVATE spdlog::spdlog_header_only
 )
 
 # Re-use pre-compiled core header.

--- a/src/Logging/include/litefx/logging.hpp
+++ b/src/Logging/include/litefx/logging.hpp
@@ -15,7 +15,6 @@
 #endif
 
 #include <litefx/core.h>
-#include <fmt/core.h>
 #include <spdlog/spdlog.h>
 #include <spdlog/sinks/sink.h>
 
@@ -127,41 +126,41 @@ namespace LiteFX::Logging {
 
     public:
         template<typename ...TArgs>
-        inline void log(LogLevel level, StringView format, TArgs&&... args) {
-            this->log(level, fmt::format(fmt::runtime(format), std::forward<TArgs>(args)...));
+        inline void log(LogLevel level, std::format_string<TArgs...> format, TArgs&&... args) {
+            this->log(level, std::format(format, std::forward<TArgs>(args)...));
         }
 
         template<typename ...TArgs>
-        inline void trace(StringView format, TArgs&&... args) {
+        inline void trace(std::format_string<TArgs...> format, TArgs&&... args) {
 #ifndef NDEBUG
             this->log(LogLevel::Trace, format, std::forward<TArgs>(args)...);
 #endif
         }
 
         template<typename ...TArgs>
-        inline void debug(StringView format, TArgs&&... args) {
+        inline void debug(std::format_string<TArgs...> format, TArgs&&... args) {
 #ifndef NDEBUG
             this->log(LogLevel::Debug, format, std::forward<TArgs>(args)...);
 #endif
         }
 
         template<typename ...TArgs>
-        inline void info(StringView format, TArgs&&... args) {
+        inline void info(std::format_string<TArgs...> format, TArgs&&... args) {
             this->log(LogLevel::Info, format, std::forward<TArgs>(args)...);
         }
 
         template<typename ...TArgs>
-        inline void warning(StringView format, TArgs&&... args) {
+        inline void warning(std::format_string<TArgs...> format, TArgs&&... args) {
             this->log(LogLevel::Warning, format, std::forward<TArgs>(args)...);
         }
 
         template<typename ...TArgs>
-        inline void error(StringView format, TArgs&&... args) {
+        inline void error(std::format_string<TArgs...> format, TArgs&&... args) {
             this->log(LogLevel::Error, format, std::forward<TArgs>(args)...);
         }
 
         template<typename ...TArgs>
-        inline void fatal(StringView format, TArgs&&... args) {
+        inline void fatal(std::format_string<TArgs...> format, TArgs&&... args) {
             this->log(LogLevel::Fatal, format, std::forward<TArgs>(args)...);
         }
     };

--- a/src/Modules/overlay-ports/spdlog/portfile.cmake
+++ b/src/Modules/overlay-ports/spdlog/portfile.cmake
@@ -1,0 +1,62 @@
+vcpkg_from_github(
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO gabime/spdlog
+    REF "v${VERSION}"
+    SHA512 db9a4f13b6c39ffde759db99bcdfe5e2dbe4231e73b29eb906a3fa78d6b8ec66920b8bd4371df17ae21b7b562472a236bc4435678f3af92b6496be090074181d
+    HEAD_REF v1.x
+)
+
+vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS
+    FEATURES
+        benchmark SPDLOG_BUILD_BENCH
+        wchar     SPDLOG_WCHAR_SUPPORT
+)
+
+# SPDLOG_WCHAR_FILENAMES can only be configured in triplet file since it is an alternative (not additive)
+if(NOT DEFINED SPDLOG_WCHAR_FILENAMES)
+    set(SPDLOG_WCHAR_FILENAMES OFF)
+endif()
+if(NOT VCPKG_TARGET_IS_WINDOWS AND SPDLOG_WCHAR_FILENAMES)
+    message(FATAL_ERROR "Build option 'SPDLOG_WCHAR_FILENAMES' is for Windows.")
+endif()
+
+string(COMPARE EQUAL "${VCPKG_LIBRARY_LINKAGE}" "dynamic" SPDLOG_BUILD_SHARED)
+
+vcpkg_cmake_configure(
+    SOURCE_PATH "${SOURCE_PATH}"
+    OPTIONS
+        ${FEATURE_OPTIONS}
+        -DSPDLOG_FMT_EXTERNAL=OFF
+        -DSPDLOG_USE_STD_FORMAT=ON
+        -DSPDLOG_INSTALL=ON
+        -DSPDLOG_BUILD_SHARED=${SPDLOG_BUILD_SHARED}
+        -DSPDLOG_WCHAR_FILENAMES=${SPDLOG_WCHAR_FILENAMES}
+        -DSPDLOG_BUILD_EXAMPLE=OFF
+)
+
+vcpkg_cmake_install()
+vcpkg_cmake_config_fixup(CONFIG_PATH lib/cmake/spdlog)
+vcpkg_fixup_pkgconfig()
+vcpkg_copy_pdbs()
+
+# add support for integration other than cmake
+if(SPDLOG_WCHAR_SUPPORT)
+    vcpkg_replace_string(${CURRENT_PACKAGES_DIR}/include/spdlog/tweakme.h
+        "// #define SPDLOG_WCHAR_TO_UTF8_SUPPORT"
+        "#ifndef SPDLOG_WCHAR_TO_UTF8_SUPPORT\n#define SPDLOG_WCHAR_TO_UTF8_SUPPORT\n#endif"
+    )
+endif()
+if(SPDLOG_WCHAR_FILENAMES)
+    vcpkg_replace_string(${CURRENT_PACKAGES_DIR}/include/spdlog/tweakme.h
+        "// #define SPDLOG_WCHAR_FILENAMES"
+        "#ifndef SPDLOG_WCHAR_FILENAMES\n#define SPDLOG_WCHAR_FILENAMES\n#endif"
+    )
+endif()
+
+file(REMOVE_RECURSE
+    "${CURRENT_PACKAGES_DIR}/debug/include"
+    "${CURRENT_PACKAGES_DIR}/debug/share"
+)
+
+file(INSTALL "${CMAKE_CURRENT_LIST_DIR}/usage" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}")
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE")

--- a/src/Modules/overlay-ports/spdlog/usage
+++ b/src/Modules/overlay-ports/spdlog/usage
@@ -1,0 +1,8 @@
+The package spdlog provides CMake targets:
+
+    find_package(spdlog CONFIG REQUIRED)
+    target_link_libraries(main PRIVATE spdlog::spdlog)
+
+    # Or use the header-only version
+    find_package(spdlog CONFIG REQUIRED)
+    target_link_libraries(main PRIVATE spdlog::spdlog_header_only)

--- a/src/Modules/overlay-ports/spdlog/vcpkg.json
+++ b/src/Modules/overlay-ports/spdlog/vcpkg.json
@@ -1,0 +1,29 @@
+{
+  "name": "spdlog",
+  "version-semver": "1.12.0",
+  "description": "Very fast, header only, C++ logging library",
+  "homepage": "https://github.com/gabime/spdlog",
+  "license": "MIT",
+  "dependencies": [
+    {
+      "name": "vcpkg-cmake",
+      "host": true
+    },
+    {
+      "name": "vcpkg-cmake-config",
+      "host": true
+    }
+  ],
+  "features": {
+    "benchmark": {
+      "description": "Use google benchmark",
+      "dependencies": [
+        "benchmark"
+      ]
+    },
+    "wchar": {
+      "description": "Build with wchar_t (Windows only)",
+      "supports": "windows"
+    }
+  }
+}

--- a/src/Rendering/include/litefx/rendering_formatters.hpp
+++ b/src/Rendering/include/litefx/rendering_formatters.hpp
@@ -5,9 +5,8 @@
 using namespace LiteFX::Rendering;
 
 template <>
-struct LITEFX_RENDERING_API fmt::formatter<GraphicsAdapterType> : formatter<string_view> {
-	template <typename FormatContext>
-	auto format(GraphicsAdapterType t, FormatContext& ctx) {
+struct LITEFX_RENDERING_API std::formatter<GraphicsAdapterType> : std::formatter<std::string_view> {
+	auto format(GraphicsAdapterType t, std::format_context& ctx) const {
 		string_view name = "Invalid";
 		switch (t) {
 		using enum GraphicsAdapterType;
@@ -21,9 +20,8 @@ struct LITEFX_RENDERING_API fmt::formatter<GraphicsAdapterType> : formatter<stri
 };
 
 template <>
-struct LITEFX_RENDERING_API fmt::formatter<QueueType> : formatter<string_view> {
-	template <typename FormatContext>
-	auto format(QueueType t, FormatContext& ctx) {
+struct LITEFX_RENDERING_API std::formatter<QueueType> : std::formatter<std::string_view> {
+	auto format(QueueType t, std::format_context& ctx) const {
 		Array<String> names;
 
 		if (t == QueueType::None)
@@ -46,9 +44,8 @@ struct LITEFX_RENDERING_API fmt::formatter<QueueType> : formatter<string_view> {
 };
 
 template <>
-struct LITEFX_RENDERING_API fmt::formatter<QueuePriority> : formatter<string_view> {
-	template <typename FormatContext>
-	auto format(QueuePriority t, FormatContext& ctx) {
+struct LITEFX_RENDERING_API std::formatter<QueuePriority> : std::formatter<std::string_view> {
+	auto format(QueuePriority t, std::format_context& ctx) const {
 		String name;
 
 		switch (t) {
@@ -64,9 +61,8 @@ struct LITEFX_RENDERING_API fmt::formatter<QueuePriority> : formatter<string_vie
 };
 
 template <>
-struct LITEFX_RENDERING_API fmt::formatter<Format> : formatter<string_view> {
-	template <typename FormatContext>
-	auto format(Format t, FormatContext& ctx) {
+struct LITEFX_RENDERING_API std::formatter<Format> : std::formatter<std::string_view> {
+	auto format(Format t, std::format_context& ctx) const {
 		string_view name = "Invalid";
 		switch (t) {
 		using enum Format;
@@ -224,9 +220,8 @@ struct LITEFX_RENDERING_API fmt::formatter<Format> : formatter<string_view> {
 };
 
 template <>
-struct LITEFX_RENDERING_API fmt::formatter<DescriptorType> : formatter<string_view> {
-	template <typename FormatContext>
-	auto format(DescriptorType t, FormatContext& ctx) {
+struct LITEFX_RENDERING_API std::formatter<DescriptorType> : std::formatter<std::string_view> {
+	auto format(DescriptorType t, std::format_context& ctx) const {
 		string_view name = "Invalid";
 		switch (t) {
 		using enum DescriptorType;
@@ -248,9 +243,8 @@ struct LITEFX_RENDERING_API fmt::formatter<DescriptorType> : formatter<string_vi
 };
 
 template <>
-struct LITEFX_RENDERING_API fmt::formatter<BufferType> : formatter<string_view> {
-	template <typename FormatContext>
-	auto format(BufferType t, FormatContext& ctx) {
+struct LITEFX_RENDERING_API std::formatter<BufferType> : std::formatter<std::string_view> {
+	auto format(BufferType t, std::format_context& ctx) const {
 		string_view name = "Invalid";
 		switch (t) {
 		using enum BufferType;
@@ -268,9 +262,8 @@ struct LITEFX_RENDERING_API fmt::formatter<BufferType> : formatter<string_view> 
 };
 
 template <>
-struct LITEFX_RENDERING_API fmt::formatter<ResourceUsage> : formatter<string_view> {
-	template <typename FormatContext>
-	auto format(ResourceUsage t, FormatContext& ctx) {
+struct LITEFX_RENDERING_API std::formatter<ResourceUsage> : std::formatter<std::string_view> {
+	auto format(ResourceUsage t, std::format_context& ctx) const {
 		Array<String> names;
 
 		if (t == ResourceUsage::None)
@@ -295,9 +288,8 @@ struct LITEFX_RENDERING_API fmt::formatter<ResourceUsage> : formatter<string_vie
 };
 
 template <>
-struct LITEFX_RENDERING_API fmt::formatter<ResourceHeap> : formatter<string_view> {
-	template <typename FormatContext>
-	auto format(ResourceHeap t, FormatContext& ctx) {
+struct LITEFX_RENDERING_API std::formatter<ResourceHeap> : std::formatter<std::string_view> {
+	auto format(ResourceHeap t, std::format_context& ctx) const {
 		string_view name = "Invalid";
 		switch (t) {
 		using enum ResourceHeap;
@@ -311,9 +303,8 @@ struct LITEFX_RENDERING_API fmt::formatter<ResourceHeap> : formatter<string_view
 };
 
 template <>
-struct LITEFX_RENDERING_API fmt::formatter<IndexType> : formatter<string_view> {
-	template <typename FormatContext>
-	auto format(IndexType t, FormatContext& ctx) {
+struct LITEFX_RENDERING_API std::formatter<IndexType> : std::formatter<std::string_view> {
+	auto format(IndexType t, std::format_context& ctx) const {
 		string_view name = "Invalid";
 		switch (t) {
 		using enum IndexType;
@@ -325,9 +316,8 @@ struct LITEFX_RENDERING_API fmt::formatter<IndexType> : formatter<string_view> {
 };
 
 template <>
-struct LITEFX_RENDERING_API fmt::formatter<ShaderStage> : formatter<string_view> {
-	template <typename FormatContext>
-	auto format(ShaderStage t, FormatContext& ctx) {
+struct LITEFX_RENDERING_API std::formatter<ShaderStage> : std::formatter<std::string_view> {
+	auto format(ShaderStage t, std::format_context& ctx) const {
 		Array<String> names;
 
 		if (t == ShaderStage::Other)
@@ -374,9 +364,8 @@ struct LITEFX_RENDERING_API fmt::formatter<ShaderStage> : formatter<string_view>
 };
 
 template <>
-struct LITEFX_RENDERING_API fmt::formatter<BufferFormat> : formatter<string_view> {
-	template <typename FormatContext>
-	auto format(BufferFormat t, FormatContext& ctx) {
+struct LITEFX_RENDERING_API std::formatter<BufferFormat> : std::formatter<std::string_view> {
+	auto format(BufferFormat t, std::format_context& ctx) const {
 		Array<String> names;
 
 		switch (::getBufferFormatChannels(t))
@@ -436,9 +425,8 @@ struct LITEFX_RENDERING_API fmt::formatter<BufferFormat> : formatter<string_view
 };
 
 template <>
-struct LITEFX_RENDERING_API fmt::formatter<PolygonMode> : formatter<string_view> {
-	template <typename FormatContext>
-	auto format(PolygonMode t, FormatContext& ctx) {
+struct LITEFX_RENDERING_API std::formatter<PolygonMode> : std::formatter<std::string_view> {
+	auto format(PolygonMode t, std::format_context& ctx) const {
 		string_view name;
 
 		switch (t) {
@@ -454,9 +442,8 @@ struct LITEFX_RENDERING_API fmt::formatter<PolygonMode> : formatter<string_view>
 };
 
 template <>
-struct LITEFX_RENDERING_API fmt::formatter<CullMode> : formatter<string_view> {
-	template <typename FormatContext>
-	auto format(CullMode t, FormatContext& ctx) {
+struct LITEFX_RENDERING_API std::formatter<CullMode> : std::formatter<std::string_view> {
+	auto format(CullMode t, std::format_context& ctx) const {
 		string_view name;
 
 		switch (t) {
@@ -473,9 +460,8 @@ struct LITEFX_RENDERING_API fmt::formatter<CullMode> : formatter<string_view> {
 };
 
 template <>
-struct LITEFX_RENDERING_API fmt::formatter<CullOrder> : formatter<string_view> {
-	template <typename FormatContext>
-	auto format(CullOrder t, FormatContext& ctx) {
+struct LITEFX_RENDERING_API std::formatter<CullOrder> : std::formatter<std::string_view> {
+	auto format(CullOrder t, std::format_context& ctx) const {
 		string_view name;
 
 		switch (t) {
@@ -490,9 +476,8 @@ struct LITEFX_RENDERING_API fmt::formatter<CullOrder> : formatter<string_view> {
 };
 
 template <>
-struct LITEFX_RENDERING_API fmt::formatter<RenderTargetType> : formatter<string_view> {
-	template <typename FormatContext>
-	auto format(RenderTargetType t, FormatContext& ctx) {
+struct LITEFX_RENDERING_API std::formatter<RenderTargetType> : std::formatter<std::string_view> {
+	auto format(RenderTargetType t, std::format_context& ctx) const {
 		string_view name;
 
 		switch (t) {
@@ -508,9 +493,8 @@ struct LITEFX_RENDERING_API fmt::formatter<RenderTargetType> : formatter<string_
 };
 
 template <>
-struct LITEFX_RENDERING_API fmt::formatter<MultiSamplingLevel> : formatter<string_view> {
-	template <typename FormatContext>
-	auto format(MultiSamplingLevel t, FormatContext& ctx) {
+struct LITEFX_RENDERING_API std::formatter<MultiSamplingLevel> : std::formatter<std::string_view> {
+	auto format(MultiSamplingLevel t, std::format_context& ctx) const {
 		string_view name;
 
 		switch (t) {
@@ -530,9 +514,8 @@ struct LITEFX_RENDERING_API fmt::formatter<MultiSamplingLevel> : formatter<strin
 };
 
 template <>
-struct LITEFX_RENDERING_API fmt::formatter<FilterMode> : formatter<string_view> {
-	template <typename FormatContext>
-	auto format(FilterMode t, FormatContext& ctx) {
+struct LITEFX_RENDERING_API std::formatter<FilterMode> : std::formatter<std::string_view> {
+	auto format(FilterMode t, std::format_context& ctx) const {
 		string_view name;
 
 		switch (t) {
@@ -547,9 +530,8 @@ struct LITEFX_RENDERING_API fmt::formatter<FilterMode> : formatter<string_view> 
 };
 
 template <>
-struct LITEFX_RENDERING_API fmt::formatter<MipMapMode> : formatter<string_view> {
-	template <typename FormatContext>
-	auto format(MipMapMode t, FormatContext& ctx) {
+struct LITEFX_RENDERING_API std::formatter<MipMapMode> : std::formatter<std::string_view> {
+	auto format(MipMapMode t, std::format_context& ctx) const {
 		string_view name;
 
 		switch (t) {
@@ -564,9 +546,8 @@ struct LITEFX_RENDERING_API fmt::formatter<MipMapMode> : formatter<string_view> 
 };
 
 template <>
-struct LITEFX_RENDERING_API fmt::formatter<BorderMode> : formatter<string_view> {
-	template <typename FormatContext>
-	auto format(BorderMode t, FormatContext& ctx) {
+struct LITEFX_RENDERING_API std::formatter<BorderMode> : std::formatter<std::string_view> {
+	auto format(BorderMode t, std::format_context& ctx) const {
 		string_view name;
 
 		switch (t) {
@@ -584,9 +565,8 @@ struct LITEFX_RENDERING_API fmt::formatter<BorderMode> : formatter<string_view> 
 };
 
 template <>
-struct LITEFX_RENDERING_API fmt::formatter<AttributeSemantic> : formatter<string_view> {
-	template <typename FormatContext>
-	auto format(AttributeSemantic t, FormatContext& ctx) {
+struct LITEFX_RENDERING_API std::formatter<AttributeSemantic> : std::formatter<std::string_view> {
+	auto format(AttributeSemantic t, std::format_context& ctx) const {
 		string_view name;
 
 		switch (t) {
@@ -609,9 +589,8 @@ struct LITEFX_RENDERING_API fmt::formatter<AttributeSemantic> : formatter<string
 };
 
 template <>
-struct LITEFX_RENDERING_API fmt::formatter<GeometryFlags> : formatter<string_view> {
-	template <typename FormatContext>
-	auto format(GeometryFlags t, FormatContext& ctx) {
+struct LITEFX_RENDERING_API std::formatter<GeometryFlags> : std::formatter<std::string_view> {
+	auto format(GeometryFlags t, std::format_context& ctx) const {
 		Array<String> names;
 
 		if (t == GeometryFlags::None)
@@ -630,9 +609,8 @@ struct LITEFX_RENDERING_API fmt::formatter<GeometryFlags> : formatter<string_vie
 };
 
 template <>
-struct LITEFX_RENDERING_API fmt::formatter<AccelerationStructureFlags> : formatter<string_view> {
-	template <typename FormatContext>
-	auto format(AccelerationStructureFlags t, FormatContext& ctx) {
+struct LITEFX_RENDERING_API std::formatter<AccelerationStructureFlags> : std::formatter<std::string_view> {
+	auto format(AccelerationStructureFlags t, std::format_context& ctx) const {
 		Array<String> names;
 
 		if (t == AccelerationStructureFlags::None)
@@ -657,9 +635,8 @@ struct LITEFX_RENDERING_API fmt::formatter<AccelerationStructureFlags> : formatt
 };
 
 template <>
-struct LITEFX_RENDERING_API fmt::formatter<InstanceFlags> : formatter<string_view> {
-	template <typename FormatContext>
-	auto format(InstanceFlags t, FormatContext& ctx) {
+struct LITEFX_RENDERING_API std::formatter<InstanceFlags> : std::formatter<std::string_view> {
+	auto format(InstanceFlags t, std::format_context& ctx) const {
 		Array<String> names;
 
 		if (t == InstanceFlags::None)

--- a/src/Rendering/src/state_resource.cpp
+++ b/src/Rendering/src/state_resource.cpp
@@ -25,7 +25,7 @@ public:
 // ------------------------------------------------------------------------------------------------
 
 StateResource::StateResource() noexcept :
-    StateResource(fmt::format("{0}", fmt::ptr(this)))
+    StateResource(std::format("{0}", reinterpret_cast<void*>(this)))
 {
 }
 

--- a/src/Samples/BasicRendering/src/sample.cpp
+++ b/src/Samples/BasicRendering/src/sample.cpp
@@ -55,7 +55,7 @@ void initRenderGraph(TRenderBackend* backend, SharedPtr<IInputAssembler>& inputA
 
     // Create the frame buffers for all back buffers.
     auto frameBuffers = std::views::iota(0u, device->swapChain().buffers()) |
-        std::views::transform([&](UInt32 index) { return device->makeFrameBuffer(fmt::format("Frame Buffer {0}", index), device->swapChain().renderArea()); }) |
+        std::views::transform([&](UInt32 index) { return device->makeFrameBuffer(std::format("Frame Buffer {0}", index), device->swapChain().renderArea()); }) |
         std::ranges::to<Array<UniquePtr<FrameBuffer>>>();
 
     // Create input assembler state.
@@ -141,7 +141,7 @@ void SampleApp::initBuffers(IRenderBackend* backend)
     m_device->state().add(std::move(cameraBuffer));
     m_device->state().add(std::move(transformBuffer));
     m_device->state().add("Camera Bindings", std::move(cameraBindings));
-    std::ranges::for_each(transformBindings, [this, i = 0](auto& binding) mutable { m_device->state().add(fmt::format("Transform Bindings {0}", i++), std::move(binding)); });
+    std::ranges::for_each(transformBindings, [this, i = 0](auto& binding) mutable { m_device->state().add(std::format("Transform Bindings {0}", i++), std::move(binding)); });
 }
 
 void SampleApp::updateCamera(const ICommandBuffer& commandBuffer, IBuffer& buffer) const
@@ -372,12 +372,12 @@ void SampleApp::drawFrame()
     auto backBuffer = m_device->swapChain().swapBackBuffer();
 
     // Query state. For performance reasons, those state variables should be cached for more complex applications, instead of looking them up every frame.
-    auto& frameBuffer = m_device->state().frameBuffer(fmt::format("Frame Buffer {0}", backBuffer));
+    auto& frameBuffer = m_device->state().frameBuffer(std::format("Frame Buffer {0}", backBuffer));
     auto& renderPass = m_device->state().renderPass("Opaque");
     auto& geometryPipeline = m_device->state().pipeline("Geometry");
     auto& transformBuffer = m_device->state().buffer("Transform");
     auto& cameraBindings = m_device->state().descriptorSet("Camera Bindings");
-    auto& transformBindings = m_device->state().descriptorSet(fmt::format("Transform Bindings {0}", backBuffer));
+    auto& transformBindings = m_device->state().descriptorSet(std::format("Transform Bindings {0}", backBuffer));
     auto& vertexBuffer = m_device->state().vertexBuffer("Vertex Buffer");
     auto& indexBuffer = m_device->state().indexBuffer("Index Buffer");
 

--- a/src/Samples/Bindless/src/sample.cpp
+++ b/src/Samples/Bindless/src/sample.cpp
@@ -86,7 +86,7 @@ void initRenderGraph(TRenderBackend* backend, SharedPtr<IInputAssembler>& inputA
 
     // Create the frame buffers for all back buffers.
     auto frameBuffers = std::views::iota(0u, device->swapChain().buffers()) |
-        std::views::transform([&](UInt32 index) { return device->makeFrameBuffer(fmt::format("Frame Buffer {0}", index), device->swapChain().renderArea()); }) |
+        std::views::transform([&](UInt32 index) { return device->makeFrameBuffer(std::format("Frame Buffer {0}", index), device->swapChain().renderArea()); }) |
         std::ranges::to<Array<UniquePtr<FrameBuffer>>>();
 
     // Create input assembler state.
@@ -185,7 +185,7 @@ void SampleApp::initBuffers(IRenderBackend* backend)
     m_device->state().add(std::move(drawDataBuffer));
     m_device->state().add(std::move(instanceBuffer));
     m_device->state().add("Camera Bindings", std::move(cameraBindings));
-    std::ranges::for_each(drawDataBindings, [this, i = 0](auto& binding) mutable { m_device->state().add(fmt::format("Draw Data Bindings {0}", i++), std::move(binding)); });
+    std::ranges::for_each(drawDataBindings, [this, i = 0](auto& binding) mutable { m_device->state().add(std::format("Draw Data Bindings {0}", i++), std::move(binding)); });
     m_device->state().add("Instance Bindings", std::move(instanceBinding));
 }
 
@@ -420,11 +420,11 @@ void SampleApp::drawFrame()
     auto backBuffer = m_device->swapChain().swapBackBuffer();
 
     // Query state. For performance reasons, those state variables should be cached for more complex applications, instead of looking them up every frame.
-    auto& frameBuffer = m_device->state().frameBuffer(fmt::format("Frame Buffer {0}", backBuffer));
+    auto& frameBuffer = m_device->state().frameBuffer(std::format("Frame Buffer {0}", backBuffer));
     auto& renderPass = m_device->state().renderPass("Opaque");
     auto& geometryPipeline = m_device->state().pipeline("Geometry");
     auto& drawDataBuffer = m_device->state().buffer("Draw Data");
-    auto& drawDataBindings = m_device->state().descriptorSet(fmt::format("Draw Data Bindings {0}", backBuffer));
+    auto& drawDataBindings = m_device->state().descriptorSet(std::format("Draw Data Bindings {0}", backBuffer));
     auto& cameraBindings = m_device->state().descriptorSet("Camera Bindings");
     auto& instanceBindings = m_device->state().descriptorSet("Instance Bindings");
     auto& vertexBuffer = m_device->state().vertexBuffer("Vertex Buffer");

--- a/src/Samples/Compute/src/sample.cpp
+++ b/src/Samples/Compute/src/sample.cpp
@@ -56,7 +56,7 @@ void initRenderGraph(TRenderBackend* backend, SharedPtr<IInputAssembler>& inputA
 
     // Create the frame buffers for all back buffers.
     auto frameBuffers = std::views::iota(0u, device->swapChain().buffers()) |
-        std::views::transform([&](UInt32 index) { return device->makeFrameBuffer(fmt::format("Frame Buffer {0}", index), device->swapChain().renderArea()); }) |
+        std::views::transform([&](UInt32 index) { return device->makeFrameBuffer(std::format("Frame Buffer {0}", index), device->swapChain().renderArea()); }) |
         std::ranges::to<Array<UniquePtr<FrameBuffer>>>();
 
     // Create input assembler state.
@@ -163,8 +163,8 @@ void SampleApp::initBuffers(IRenderBackend* backend)
     m_device->state().add(std::move(cameraBuffer));
     m_device->state().add(std::move(transformBuffer));
     m_device->state().add("Camera Bindings", std::move(cameraBindings));
-    std::ranges::for_each(postBindings, [this, i = 0](auto& binding) mutable { m_device->state().add(fmt::format("Post Bindings {0}", i++), std::move(binding)); });
-    std::ranges::for_each(transformBindings, [this, i = 0](auto& binding) mutable { m_device->state().add(fmt::format("Transform Bindings {0}", i++), std::move(binding)); });
+    std::ranges::for_each(postBindings, [this, i = 0](auto& binding) mutable { m_device->state().add(std::format("Post Bindings {0}", i++), std::move(binding)); });
+    std::ranges::for_each(transformBindings, [this, i = 0](auto& binding) mutable { m_device->state().add(std::format("Transform Bindings {0}", i++), std::move(binding)); });
 }
 
 void SampleApp::updateCamera(const ICommandBuffer& commandBuffer, IBuffer& buffer) const
@@ -275,11 +275,11 @@ void SampleApp::onResize(const void* sender, ResizeEventArgs e)
     // Resize the frame buffers. Note that we could also use an event handler on the swap chain `reseted` event to do this automatically instead.
     for (int i = 0; i < 3; ++i)
     {
-        auto& frameBuffer = m_device->state().frameBuffer(fmt::format("Frame Buffer {0}", i));
+        auto& frameBuffer = m_device->state().frameBuffer(std::format("Frame Buffer {0}", i));
         frameBuffer.resize(renderArea);
 
         // Update the post-processing bindings that reference the "opaque" frame buffer.
-        m_device->state().descriptorSet(fmt::format("Post Bindings {0}", i)).update(0, frameBuffer["Color Target"]);
+        m_device->state().descriptorSet(std::format("Post Bindings {0}", i)).update(0, frameBuffer["Color Target"]);
     }
 
     // Also resize viewport and scissor.
@@ -400,14 +400,14 @@ void SampleApp::drawFrame()
     auto backBuffer = m_device->swapChain().swapBackBuffer();
 
     // Query state. For performance reasons, those state variables should be cached for more complex applications, instead of looking them up every frame.
-    auto& frameBuffer = m_device->state().frameBuffer(fmt::format("Frame Buffer {0}", backBuffer));
+    auto& frameBuffer = m_device->state().frameBuffer(std::format("Frame Buffer {0}", backBuffer));
     auto& renderPass = m_device->state().renderPass("Opaque");
     auto& postPipeline = m_device->state().pipeline("Post");
     auto& geometryPipeline = m_device->state().pipeline("Geometry");
     auto& transformBuffer = m_device->state().buffer("Transform");
     auto& cameraBindings = m_device->state().descriptorSet("Camera Bindings");
-    auto& postBindings = m_device->state().descriptorSet(fmt::format("Post Bindings {0}", backBuffer));
-    auto& transformBindings = m_device->state().descriptorSet(fmt::format("Transform Bindings {0}", backBuffer));
+    auto& postBindings = m_device->state().descriptorSet(std::format("Post Bindings {0}", backBuffer));
+    auto& transformBindings = m_device->state().descriptorSet(std::format("Transform Bindings {0}", backBuffer));
     auto& vertexBuffer = m_device->state().vertexBuffer("Vertex Buffer");
     auto& indexBuffer = m_device->state().indexBuffer("Index Buffer");
 

--- a/src/Samples/MeshShader/src/sample.cpp
+++ b/src/Samples/MeshShader/src/sample.cpp
@@ -45,7 +45,7 @@ void initRenderGraph(TRenderBackend* backend)
 
     // Create the frame buffers for all back buffers.
     auto frameBuffers = std::views::iota(0u, device->swapChain().buffers()) |
-        std::views::transform([&](UInt32 index) { return device->makeFrameBuffer(fmt::format("Frame Buffer {0}", index), device->swapChain().renderArea()); }) |
+        std::views::transform([&](UInt32 index) { return device->makeFrameBuffer(std::format("Frame Buffer {0}", index), device->swapChain().renderArea()); }) |
         std::ranges::to<Array<UniquePtr<FrameBuffer>>>();
 
     // Create input assembler state.
@@ -115,7 +115,7 @@ void SampleApp::initBuffers(IRenderBackend* backend)
     m_device->state().add(std::move(cameraBuffer));
     m_device->state().add(std::move(transformBuffer));
     m_device->state().add("Camera Bindings", std::move(cameraBindings));
-    std::ranges::for_each(transformBindings, [this, i = 0](auto& binding) mutable { m_device->state().add(fmt::format("Transform Bindings {0}", i++), std::move(binding)); });
+    std::ranges::for_each(transformBindings, [this, i = 0](auto& binding) mutable { m_device->state().add(std::format("Transform Bindings {0}", i++), std::move(binding)); });
 }
 
 void SampleApp::updateCamera(const ICommandBuffer& commandBuffer, IBuffer& buffer) const
@@ -346,12 +346,12 @@ void SampleApp::drawFrame()
     auto backBuffer = m_device->swapChain().swapBackBuffer();
 
     // Query state. For performance reasons, those state variables should be cached for more complex applications, instead of looking them up every frame.
-    auto& frameBuffer = m_device->state().frameBuffer(fmt::format("Frame Buffer {0}", backBuffer));
+    auto& frameBuffer = m_device->state().frameBuffer(std::format("Frame Buffer {0}", backBuffer));
     auto& renderPass = m_device->state().renderPass("Opaque");
     auto& geometryPipeline = m_device->state().pipeline("Geometry");
     auto& transformBuffer = m_device->state().buffer("Transform");
     auto& cameraBindings = m_device->state().descriptorSet("Camera Bindings");
-    auto& transformBindings = m_device->state().descriptorSet(fmt::format("Transform Bindings {0}", backBuffer));
+    auto& transformBindings = m_device->state().descriptorSet(std::format("Transform Bindings {0}", backBuffer));
 
     // Wait for all transfers to finish.
     renderPass.commandQueue().waitFor(m_device->defaultQueue(QueueType::Transfer), m_transferFence);

--- a/src/Samples/Multisampling/src/sample.cpp
+++ b/src/Samples/Multisampling/src/sample.cpp
@@ -56,7 +56,7 @@ void initRenderGraph(TRenderBackend* backend, SharedPtr<IInputAssembler>& inputA
 
     // Create the frame buffers for all back buffers.
     auto frameBuffers = std::views::iota(0u, device->swapChain().buffers()) |
-        std::views::transform([&](UInt32 index) { return device->makeFrameBuffer(fmt::format("Frame Buffer {0}", index), device->swapChain().renderArea()); }) |
+        std::views::transform([&](UInt32 index) { return device->makeFrameBuffer(std::format("Frame Buffer {0}", index), device->swapChain().renderArea()); }) |
         std::ranges::to<Array<UniquePtr<FrameBuffer>>>();
 
     // Create input assembler state.
@@ -143,7 +143,7 @@ void SampleApp::initBuffers(IRenderBackend* backend)
     m_device->state().add(std::move(cameraBuffer));
     m_device->state().add(std::move(transformBuffer));
     m_device->state().add("Camera Bindings", std::move(cameraBindings));
-    std::ranges::for_each(transformBindings, [this, i = 0](auto& binding) mutable { m_device->state().add(fmt::format("Transform Bindings {0}", i++), std::move(binding)); });
+    std::ranges::for_each(transformBindings, [this, i = 0](auto& binding) mutable { m_device->state().add(std::format("Transform Bindings {0}", i++), std::move(binding)); });
 }
 
 void SampleApp::updateCamera(const ICommandBuffer& commandBuffer, IBuffer& buffer) const
@@ -374,12 +374,12 @@ void SampleApp::drawFrame()
     auto backBuffer = m_device->swapChain().swapBackBuffer();
 
     // Query state. For performance reasons, those state variables should be cached for more complex applications, instead of looking them up every frame.
-    auto& frameBuffer = m_device->state().frameBuffer(fmt::format("Frame Buffer {0}", backBuffer));
+    auto& frameBuffer = m_device->state().frameBuffer(std::format("Frame Buffer {0}", backBuffer));
     auto& renderPass = m_device->state().renderPass("Opaque");
     auto& geometryPipeline = m_device->state().pipeline("Geometry");
     auto& transformBuffer = m_device->state().buffer("Transform");
     auto& cameraBindings = m_device->state().descriptorSet("Camera Bindings");
-    auto& transformBindings = m_device->state().descriptorSet(fmt::format("Transform Bindings {0}", backBuffer));
+    auto& transformBindings = m_device->state().descriptorSet(std::format("Transform Bindings {0}", backBuffer));
     auto& vertexBuffer = m_device->state().vertexBuffer("Vertex Buffer");
     auto& indexBuffer = m_device->state().indexBuffer("Index Buffer");
 

--- a/src/Samples/Multithreading/src/sample.cpp
+++ b/src/Samples/Multithreading/src/sample.cpp
@@ -68,7 +68,7 @@ void initRenderGraph(TRenderBackend* backend, SharedPtr<IInputAssembler>& inputA
 
     // Create the frame buffers for all back buffers.
     auto frameBuffers = std::views::iota(0u, device->swapChain().buffers()) |
-        std::views::transform([&](UInt32 index) { return device->makeFrameBuffer(fmt::format("Frame Buffer {0}", index), device->swapChain().renderArea()); }) |
+        std::views::transform([&](UInt32 index) { return device->makeFrameBuffer(std::format("Frame Buffer {0}", index), device->swapChain().renderArea()); }) |
         std::ranges::to<Array<UniquePtr<FrameBuffer>>>();
 
     // Create input assembler state.
@@ -142,7 +142,7 @@ void SampleApp::initBuffers(IRenderBackend* backend)
     
     // Create a transform buffer array for each worker and bind it to one of the descriptor sets.
     Array<UniquePtr<IBuffer>> transformBuffers(NUM_WORKERS);
-    std::ranges::generate(transformBuffers, [&, i = 0]() mutable { return m_device->factory().createBuffer(fmt::format("Transform {0}", i++), transformBindingLayout, 0, ResourceHeap::Dynamic, 3); });
+    std::ranges::generate(transformBuffers, [&, i = 0]() mutable { return m_device->factory().createBuffer(std::format("Transform {0}", i++), transformBindingLayout, 0, ResourceHeap::Dynamic, 3); });
     auto transformBindings = transformBindingLayout.allocateMultiple(3 * NUM_WORKERS, [&transformBuffers](UInt32 set) -> Enumerable<DescriptorBinding> { 
         return { { .binding = 0, .resource = *transformBuffers[set % NUM_WORKERS], .firstElement = set / NUM_WORKERS, .elements = 1 } }; 
     });
@@ -156,7 +156,7 @@ void SampleApp::initBuffers(IRenderBackend* backend)
     m_device->state().add(std::move(cameraBuffer));
     m_device->state().add("Camera Bindings", std::move(cameraBindings));
     std::ranges::for_each(transformBuffers, [this](auto& buffer) { m_device->state().add(std::move(buffer)); });
-    std::ranges::for_each(transformBindings, [this, i = 0](auto& binding) mutable { m_device->state().add(fmt::format("Transform Bindings {0}", i++), std::move(binding)); });
+    std::ranges::for_each(transformBindings, [this, i = 0](auto& binding) mutable { m_device->state().add(std::format("Transform Bindings {0}", i++), std::move(binding)); });
 }
 
 void SampleApp::updateCamera(const ICommandBuffer& commandBuffer, IBuffer& buffer) const
@@ -382,9 +382,9 @@ void SampleApp::drawObject(const IRenderPass* renderPass, int index, int backBuf
 {
     // Query state. Be careful here, not to alter the state somewhere else!
     auto& geometryPipeline = m_device->state().pipeline("Geometry");
-    auto& transformBuffer = m_device->state().buffer(fmt::format("Transform {0}", index));
+    auto& transformBuffer = m_device->state().buffer(std::format("Transform {0}", index));
     auto& cameraBindings = m_device->state().descriptorSet("Camera Bindings");
-    auto& transformBindings = m_device->state().descriptorSet(fmt::format("Transform Bindings {0}", backBuffer * NUM_WORKERS + index));
+    auto& transformBindings = m_device->state().descriptorSet(std::format("Transform Bindings {0}", backBuffer * NUM_WORKERS + index));
     auto& vertexBuffer = m_device->state().vertexBuffer("Vertex Buffer");
     auto& indexBuffer = m_device->state().indexBuffer("Index Buffer");
 
@@ -420,7 +420,7 @@ void SampleApp::drawFrame()
     auto backBuffer = m_device->swapChain().swapBackBuffer();
 
     // Query state. For performance reasons, those state variables should be cached for more complex applications, instead of looking them up every frame.
-    auto& frameBuffer = m_device->state().frameBuffer(fmt::format("Frame Buffer {0}", backBuffer));
+    auto& frameBuffer = m_device->state().frameBuffer(std::format("Frame Buffer {0}", backBuffer));
     auto& renderPass = m_device->state().renderPass("Opaque");
 
     // Wait for all transfers to finish.

--- a/src/Samples/PushConstants/src/sample.cpp
+++ b/src/Samples/PushConstants/src/sample.cpp
@@ -82,7 +82,7 @@ void initRenderGraph(TRenderBackend* backend, SharedPtr<IInputAssembler>& inputA
 
     // Create the frame buffers for all back buffers.
     auto frameBuffers = std::views::iota(0u, device->swapChain().buffers()) |
-        std::views::transform([&](UInt32 index) { return device->makeFrameBuffer(fmt::format("Frame Buffer {0}", index), device->swapChain().renderArea()); }) |
+        std::views::transform([&](UInt32 index) { return device->makeFrameBuffer(std::format("Frame Buffer {0}", index), device->swapChain().renderArea()); }) |
         std::ranges::to<Array<UniquePtr<FrameBuffer>>>();
 
     // Create input assembler state.
@@ -385,7 +385,7 @@ void SampleApp::drawFrame()
     auto backBuffer = m_device->swapChain().swapBackBuffer();
 
     // Query state. For performance reasons, those state variables should be cached for more complex applications, instead of looking them up every frame.
-    auto& frameBuffer = m_device->state().frameBuffer(fmt::format("Frame Buffer {0}", backBuffer));
+    auto& frameBuffer = m_device->state().frameBuffer(std::format("Frame Buffer {0}", backBuffer));
     auto& renderPass = m_device->state().renderPass("Opaque");
     auto& geometryPipeline = m_device->state().pipeline("Geometry");
     auto& cameraBindings = m_device->state().descriptorSet("Camera Bindings");

--- a/src/Samples/RayQueries/src/sample.cpp
+++ b/src/Samples/RayQueries/src/sample.cpp
@@ -95,7 +95,7 @@ void initRenderGraph(TRenderBackend* backend, SharedPtr<IInputAssembler>& inputA
 
     // Create the frame buffers for all back buffers.
     auto frameBuffers = std::views::iota(0u, device->swapChain().buffers()) |
-        std::views::transform([&](UInt32 index) { return device->makeFrameBuffer(fmt::format("Frame Buffer {0}", index), device->swapChain().renderArea()); }) |
+        std::views::transform([&](UInt32 index) { return device->makeFrameBuffer(std::format("Frame Buffer {0}", index), device->swapChain().renderArea()); }) |
         std::ranges::to<Array<UniquePtr<FrameBuffer>>>();
 
     // Create input assembler state for the geometry.
@@ -545,7 +545,7 @@ void SampleApp::drawFrame()
     auto backBuffer = m_device->swapChain().swapBackBuffer();
 
     // Query state. For performance reasons, those state variables should be cached for more complex applications, instead of looking them up every frame.
-    auto& frameBuffer = m_device->state().frameBuffer(fmt::format("Frame Buffer {0}", backBuffer));
+    auto& frameBuffer = m_device->state().frameBuffer(std::format("Frame Buffer {0}", backBuffer));
     auto& renderPass = m_device->state().renderPass("Deferred");
     auto& geometryPipeline = m_device->state().pipeline("Geometry");
     auto& staticDataBindings = m_device->state().descriptorSet("Static Data Bindings");

--- a/src/Samples/RayTracing/src/sample.cpp
+++ b/src/Samples/RayTracing/src/sample.cpp
@@ -317,7 +317,7 @@ void SampleApp::initBuffers(IRenderBackend* backend)
     m_device->state().add(std::move(shaderBindingTable));
     m_device->state().add(std::move(backBuffers));
     m_device->state().add("Sampler Bindings", std::move(samplerBindings));
-    std::ranges::for_each(outputBindings, [this, i = 0](auto& binding) mutable { m_device->state().add(fmt::format("Output Bindings {0}", i++), std::move(binding)); });
+    std::ranges::for_each(outputBindings, [this, i = 0](auto& binding) mutable { m_device->state().add(std::format("Output Bindings {0}", i++), std::move(binding)); });
     m_device->state().add("Material Bindings", std::move(materialBindings));
 }
 
@@ -438,7 +438,7 @@ void SampleApp::onResize(const void* sender, ResizeEventArgs e)
     
     for (int i = 0; i < m_device->swapChain().buffers(); ++i)
     {
-        auto& outputBindings = m_device->state().descriptorSet(fmt::format("Output Bindings {0}", i));
+        auto& outputBindings = m_device->state().descriptorSet(std::format("Output Bindings {0}", i));
         outputBindings.update(0, *backBuffers, 0, 0, 1, i, 1);
     }
 
@@ -558,7 +558,7 @@ void SampleApp::drawFrame()
     auto& staticDataBindings = m_device->state().descriptorSet("Static Data Bindings");
     auto& materialBindings = m_device->state().descriptorSet("Material Bindings");
     auto& samplerBindings = m_device->state().descriptorSet("Sampler Bindings");
-    auto& outputBindings = m_device->state().descriptorSet(fmt::format("Output Bindings {0}", backBuffer));
+    auto& outputBindings = m_device->state().descriptorSet(std::format("Output Bindings {0}", backBuffer));
     auto& shaderBindingTable = m_device->state().buffer("Shader Binding Table");
     auto& backBuffers = m_device->state().image("Back Buffers");
     auto& cameraBuffer = m_device->state().buffer("Camera");

--- a/src/Samples/RenderPasses/src/sample.cpp
+++ b/src/Samples/RenderPasses/src/sample.cpp
@@ -66,7 +66,7 @@ void initRenderGraph(TRenderBackend* backend, SharedPtr<IInputAssembler>& inputA
     // Create the frame buffers for all back buffers.
     auto frameBuffers = std::views::iota(0u, device->swapChain().buffers()) |
         std::views::transform([&](UInt32 index) { 
-            auto frameBuffer = device->makeFrameBuffer(fmt::format("Frame Buffer {0}", index), device->swapChain().renderArea());
+            auto frameBuffer = device->makeFrameBuffer(std::format("Frame Buffer {0}", index), device->swapChain().renderArea());
 
             // NOTE: In this example we manually add the images to the frame buffers and map them later. This demonstrates how to share the same image 
             //       on multiple render targets. Note that the formats must match. If you intend to use multi-sampling you also have to keep the sample
@@ -217,7 +217,7 @@ void SampleApp::initBuffers(IRenderBackend* backend)
     m_device->state().add(std::move(cameraBuffer));
     m_device->state().add(std::move(transformBuffer));
     m_device->state().add("Camera Bindings", std::move(cameraBindings));
-    std::ranges::for_each(transformBindings, [this, i = 0](auto& binding) mutable { m_device->state().add(fmt::format("Transform Bindings {0}", i++), std::move(binding)); });
+    std::ranges::for_each(transformBindings, [this, i = 0](auto& binding) mutable { m_device->state().add(std::format("Transform Bindings {0}", i++), std::move(binding)); });
 }
 
 void SampleApp::updateCamera(const ICommandBuffer& commandBuffer, IBuffer& buffer) const
@@ -443,7 +443,7 @@ void SampleApp::drawFrame()
 
     // Swap the back buffers for the next frame.
     auto backBuffer = m_device->swapChain().swapBackBuffer();
-    auto& frameBuffer = m_device->state().frameBuffer(fmt::format("Frame Buffer {0}", backBuffer));
+    auto& frameBuffer = m_device->state().frameBuffer(std::format("Frame Buffer {0}", backBuffer));
     UInt64 fence = 0;
 
     {
@@ -452,7 +452,7 @@ void SampleApp::drawFrame()
         auto& pipeline = m_device->state().pipeline("First Pass Pipeline");
         auto& transformBuffer = m_device->state().buffer("Transform");
         auto& cameraBindings = m_device->state().descriptorSet("Camera Bindings");
-        auto& transformBindings = m_device->state().descriptorSet(fmt::format("Transform Bindings {0}", backBuffer));
+        auto& transformBindings = m_device->state().descriptorSet(std::format("Transform Bindings {0}", backBuffer));
         auto& vertexBuffer = m_device->state().vertexBuffer("Vertex Buffer");
         auto& indexBuffer = m_device->state().indexBuffer("Index Buffer");
 
@@ -516,7 +516,7 @@ void SampleApp::drawFrame()
         auto& pipeline = m_device->state().pipeline("Third Pass Pipeline");
         auto& transformBuffer = m_device->state().buffer("Transform");
         auto& cameraBindings = m_device->state().descriptorSet("Camera Bindings");
-        auto& transformBindings = m_device->state().descriptorSet(fmt::format("Transform Bindings {0}", backBuffer));
+        auto& transformBindings = m_device->state().descriptorSet(std::format("Transform Bindings {0}", backBuffer));
         auto& vertexBuffer = m_device->state().vertexBuffer("Vertex Buffer");
         auto& indexBuffer = m_device->state().indexBuffer("Index Buffer");
 

--- a/src/Samples/Textures/src/sample.cpp
+++ b/src/Samples/Textures/src/sample.cpp
@@ -59,7 +59,7 @@ void initRenderGraph(TRenderBackend* backend, SharedPtr<IInputAssembler>& inputA
 
     // Create the frame buffers for all back buffers.
     auto frameBuffers = std::views::iota(0u, device->swapChain().buffers()) |
-        std::views::transform([&](UInt32 index) { return device->makeFrameBuffer(fmt::format("Frame Buffer {0}", index), device->swapChain().renderArea()); }) |
+        std::views::transform([&](UInt32 index) { return device->makeFrameBuffer(std::format("Frame Buffer {0}", index), device->swapChain().renderArea()); }) |
         std::ranges::to<Array<UniquePtr<FrameBuffer>>>();
 
     // Create input assembler state.
@@ -206,7 +206,7 @@ UInt64 initBuffers(SampleApp& app, TDevice& device, SharedPtr<IInputAssembler> i
     device.state().add(std::move(sampler));
     device.state().add("Static Bindings", std::move(staticBindings));
     device.state().add("Sampler Bindings", std::move(samplerBindings));
-    std::ranges::for_each(transformBindings, [&, i = 0](auto& binding) mutable { device.state().add(fmt::format("Transform Bindings {0}", i++), std::move(binding)); });
+    std::ranges::for_each(transformBindings, [&, i = 0](auto& binding) mutable { device.state().add(std::format("Transform Bindings {0}", i++), std::move(binding)); });
 
     // Return the fence.
     return transferFence;
@@ -449,13 +449,13 @@ void SampleApp::drawFrame()
     auto backBuffer = m_device->swapChain().swapBackBuffer();
 
     // Query state. For performance reasons, those state variables should be cached for more complex applications, instead of looking them up every frame.
-    auto& frameBuffer = m_device->state().frameBuffer(fmt::format("Frame Buffer {0}", backBuffer));
+    auto& frameBuffer = m_device->state().frameBuffer(std::format("Frame Buffer {0}", backBuffer));
     auto& renderPass = m_device->state().renderPass("Opaque");
     auto& geometryPipeline = m_device->state().pipeline("Geometry");
     auto& transformBuffer = m_device->state().buffer("Transform");
     auto& staticBindings = m_device->state().descriptorSet("Static Bindings");
     auto& samplerBindings = m_device->state().descriptorSet("Sampler Bindings");
-    auto& transformBindings = m_device->state().descriptorSet(fmt::format("Transform Bindings {0}", backBuffer));
+    auto& transformBindings = m_device->state().descriptorSet(std::format("Transform Bindings {0}", backBuffer));
     auto& vertexBuffer = m_device->state().vertexBuffer("Vertex Buffer");
     auto& indexBuffer = m_device->state().indexBuffer("Index Buffer");
 

--- a/src/Samples/UniformArrays/src/sample.cpp
+++ b/src/Samples/UniformArrays/src/sample.cpp
@@ -91,7 +91,7 @@ void initRenderGraph(TRenderBackend* backend, SharedPtr<IInputAssembler>& inputA
 
     // Create the frame buffers for all back buffers.
     auto frameBuffers = std::views::iota(0u, device->swapChain().buffers()) |
-        std::views::transform([&](UInt32 index) { return device->makeFrameBuffer(fmt::format("Frame Buffer {0}", index), device->swapChain().renderArea()); }) |
+        std::views::transform([&](UInt32 index) { return device->makeFrameBuffer(std::format("Frame Buffer {0}", index), device->swapChain().renderArea()); }) |
         std::ranges::to<Array<UniquePtr<FrameBuffer>>>();
 
     // Create input assembler state.
@@ -186,7 +186,7 @@ void SampleApp::initBuffers(IRenderBackend* backend)
     m_device->state().add(std::move(lightsBuffer));
     m_device->state().add(std::move(transformBuffer));
     m_device->state().add("Static Bindings", std::move(staticBindings));
-    std::ranges::for_each(transformBindings, [this, i = 0](auto& binding) mutable { m_device->state().add(fmt::format("Transform Bindings {0}", i++), std::move(binding)); });
+    std::ranges::for_each(transformBindings, [this, i = 0](auto& binding) mutable { m_device->state().add(std::format("Transform Bindings {0}", i++), std::move(binding)); });
 }
 
 void SampleApp::initLights()
@@ -430,12 +430,12 @@ void SampleApp::drawFrame()
     auto backBuffer = m_device->swapChain().swapBackBuffer();
 
     // Query state. For performance reasons, those state variables should be cached for more complex applications, instead of looking them up every frame.
-    auto& frameBuffer = m_device->state().frameBuffer(fmt::format("Frame Buffer {0}", backBuffer));
+    auto& frameBuffer = m_device->state().frameBuffer(std::format("Frame Buffer {0}", backBuffer));
     auto& renderPass = m_device->state().renderPass("Opaque");
     auto& geometryPipeline = m_device->state().pipeline("Geometry");
     auto& transformBuffer = m_device->state().buffer("Transform");
     auto& staticBindings = m_device->state().descriptorSet("Static Bindings");
-    auto& transformBindings = m_device->state().descriptorSet(fmt::format("Transform Bindings {0}", backBuffer));
+    auto& transformBindings = m_device->state().descriptorSet(std::format("Transform Bindings {0}", backBuffer));
     auto& vertexBuffer = m_device->state().vertexBuffer("Vertex Buffer");
     auto& indexBuffer = m_device->state().indexBuffer("Index Buffer");
 

--- a/src/cmake/LiteFXConfig.cmake
+++ b/src/cmake/LiteFXConfig.cmake
@@ -14,7 +14,7 @@ SET(LITEFX_HAS_DIRECTX_MATH @LITEFX_BUILD_WITH_DIRECTX_MATH@)
 SET(LITEFX_HAS_GLM @LITEFX_BUILD_WITH_GLM@)
 
 # Keep track of the imported libraries for convenience.
-SET(LITEFX_DEPENDENCIES fmt::fmt spdlog::spdlog LiteFX.Core LiteFX.Logging LiteFX.AppModel LiteFX.Math LiteFX.Graphics LiteFX.Rendering)
+SET(LITEFX_DEPENDENCIES LiteFX.Core LiteFX.Logging LiteFX.AppModel LiteFX.Math LiteFX.Graphics LiteFX.Rendering)
 
 # Lookup package dependencies.
 INCLUDE(CMakeFindDependencyMacro)
@@ -43,9 +43,6 @@ ENDIF(LITEFX_HAS_DIRECTX_MATH)
 IF(LITEFX_HAS_GLM)
   FIND_DEPENDENCY(glm CONFIG)
 ENDIF(LITEFX_HAS_GLM)
-
-FIND_DEPENDENCY(fmt CONFIG)
-FIND_DEPENDENCY(spdlog CONFIG)
 
 FIND_PROGRAM(LITEFX_BUILD_GLSLC_COMPILER glslc HINTS ENV VULKAN_SDK PATH_SUFFIXES bin DOC "The full path to the `glslc.exe` shader compiler binary.")
 FIND_PROGRAM(LITEFX_BUILD_DXC_COMPILER dxc HINTS ENV VULKAN_SDK PATH_SUFFIXES bin DOC "The full path to the `dxc.exe` shader compiler binary.")

--- a/src/cmake/Modules.cmake
+++ b/src/cmake/Modules.cmake
@@ -10,4 +10,4 @@ IF("${CMAKE_MODULE_PATH}" STREQUAL "")
 ENDIF("${CMAKE_MODULE_PATH}" STREQUAL "")
 
 # Define overlay ports (separated by `;`).
-SET(VCPKG_OVERLAY_PORTS "${CMAKE_SOURCE_DIR}/modules/overlay-ports/winpixeventruntime/;${CMAKE_SOURCE_DIR}/modules/overlay-ports/dx-agility-sdk/;${CMAKE_SOURCE_DIR}/modules/overlay-ports/d3d12-memory-allocator/")
+SET(VCPKG_OVERLAY_PORTS "${CMAKE_SOURCE_DIR}/modules/overlay-ports/winpixeventruntime/;${CMAKE_SOURCE_DIR}/modules/overlay-ports/dx-agility-sdk/;${CMAKE_SOURCE_DIR}/modules/overlay-ports/d3d12-memory-allocator/;${CMAKE_SOURCE_DIR}/modules/overlay-ports/spdlog/")


### PR DESCRIPTION
**Describe the pull request**

This PR replaces the spdlog port shipped with vcpkg with a custom one that does not introduce a dependency on fmt. It also replaces all formatting primitives with `std::format` accordingly.