### PR TITLE
Fix build with for MSVC 17.10.

### DIFF
--- a/src/Backends/Vulkan/CMakeLists.txt
+++ b/src/Backends/Vulkan/CMakeLists.txt
@@ -87,7 +87,7 @@ TARGET_INCLUDE_DIRECTORIES(${PROJECT_NAME}
 # Link project dependencies.
 TARGET_LINK_LIBRARIES(${PROJECT_NAME}
     PUBLIC LiteFX.Core LiteFX.Math LiteFX.Rendering LiteFX.AppModel Vulkan::Vulkan
-    PRIVATE GPUOpen::VulkanMemoryAllocator unofficial::spirv-reflect::spirv-reflect
+    PRIVATE GPUOpen::VulkanMemoryAllocator unofficial::spirv-reflect
 )
 
 # Link against D3D12 to enable flip-model swap chains.

--- a/src/Samples/RayQueries/src/sample.cpp
+++ b/src/Samples/RayQueries/src/sample.cpp
@@ -1,4 +1,6 @@
 #include "sample.h"
+
+#define GLM_ENABLE_EXPERIMENTAL
 #include <glm/gtc/matrix_transform.hpp>
 #include <glm/gtx/euler_angles.hpp>
 

--- a/src/Samples/RayTracing/src/sample.cpp
+++ b/src/Samples/RayTracing/src/sample.cpp
@@ -1,4 +1,6 @@
 #include "sample.h"
+
+#define GLM_ENABLE_EXPERIMENTAL
 #include <glm/gtc/matrix_transform.hpp>
 #include <glm/gtx/euler_angles.hpp>
 


### PR DESCRIPTION
**Describe the pull request**

MSVC 17.10 broke builds with earlier releases of vcpkg. This PR fixes those issues and thus implicitly raises some dependency versions. Most notably, glm has been pushed to version 1.0, which broke some samples. An appropriate fix is included in the release.

**Related issues**

As MSVC 17.10 contains a compiler fix required for #120, this PR is a prerequisite to finally merge it. Additionally, the latest version of vcpkg contains a port for DXC, which allows us to not depend on external DXC distributions (most notably we do no longer require future Windows packages to provide DXIL.dll). An additional branch for this change has been created and will be merged in a separate PR. This allows us to then merge #118. 