### PR TITLE
Fix x86 build in weekly CI.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -244,7 +244,9 @@ jobs:
 
       - name: Update LLVM
         if: ${{ matrix.compiler }} == 'clang'
-        run: choco upgrade llvm 
+        uses: KyleMayes/install-llvm-action@v2
+        with:
+            version: ${{ llvmVersion }}
 
       - name: Setup build and test environment
         id: setup-environment
@@ -427,7 +429,9 @@ jobs:
           
       - name: Update LLVM
         if: ${{ matrix.compiler }} == 'clang'
-        run: choco upgrade llvm 
+        uses: KyleMayes/install-llvm-action@v2
+        with:
+            version: ${{ llvmVersion }}
         
       - name: Setup build and test environment
         id: setup-environment

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -79,7 +79,7 @@ jobs:
           buildPreset: '${{ matrix.profile }}-debug'
           
       - name: Upload build artifacts (Debug)
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         if: failure()
         with:
           name: LiteFX-${{ matrix.triplet }}-build-dbg
@@ -99,7 +99,7 @@ jobs:
           buildPreset: '${{ matrix.profile }}-release'
 
       - name: Upload build artifacts (Release)
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         if: failure()
         with:
           name: LiteFX-${{ matrix.triplet }}-build-rel
@@ -119,7 +119,7 @@ jobs:
           recursive: true
 
       - name: Upload install artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: LiteFX-${{ matrix.triplet }}-install
           path: '${{ github.workspace }}/out/install/${{ matrix.profile }}-release'

--- a/.github/workflows/weekly.yml
+++ b/.github/workflows/weekly.yml
@@ -72,7 +72,7 @@ jobs:
           
       - name: Upload build artifacts
         if: ${{ github.event.inputs.uploadBuildArtifacts == 'true' }}
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: LiteFX-${{ matrix.triplet }}-build
           path: '${{ github.workspace }}/out/build/${{ matrix.configuration }}'
@@ -83,7 +83,7 @@ jobs:
           cmake --install .
 
       - name: Upload install artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: LiteFX-${{ matrix.triplet }}-install
           path: '${{ github.workspace }}/out/install/${{ matrix.configuration }}'

--- a/docs/release-logs/0.4.1.md
+++ b/docs/release-logs/0.4.1.md
@@ -8,7 +8,7 @@
   - Builders are now `constexpr` where possible and are implemented using `deducing this` in place of CRTP, which makes them more lightweight.
   - New exceptions with support for `stacktrace` and `source_location`.
   - Replace `fmt` with `std::format`. ([See PR #128](https://github.com/crud89/LiteFX/pull/128))
-- Add support for compilation using clang. ([See PR #138](https://github.com/crud89/LiteFX/pull/138))
+- Add support for compilation using clang. ([See PR #138](https://github.com/crud89/LiteFX/pull/138) and [PR #146](https://github.com/crud89/LiteFX/pull/146))
 - Allow static linking to the engine libraries. ([See PR #135](https://github.com/crud89/LiteFX/pull/135))
 - The namespace `rtti` has been renamed to `meta`. ([See PR #121](https://github.com/crud89/LiteFX/pull/121))
 - Improvements to C++ core guideline conformance. ([See PR #103](https://github.com/crud89/LiteFX/pull/103))

--- a/src/Backends/DirectX12/src/blas.cpp
+++ b/src/Backends/DirectX12/src/blas.cpp
@@ -198,7 +198,7 @@ void DirectX12BottomLevelAccelerationStructure::build(const DirectX12CommandBuff
     else if (maxSize < requiredMemory) [[unlikely]]
         throw ArgumentOutOfRangeException("maxSize", std::make_pair(0_ui64, maxSize), requiredMemory, "The maximum available size is not sufficient to contain the acceleration structure.");
     else if (buffer->size() < offset + requiredMemory) [[unlikely]]
-        throw ArgumentOutOfRangeException("buffer", std::make_pair(0uz, buffer->size()), offset + requiredMemory, "The buffer does not contain enough memory after offset {0} to fully contain the acceleration structure.", offset);
+        throw ArgumentOutOfRangeException("buffer", std::make_pair<UInt64, UInt64>(0u, buffer->size()), offset + requiredMemory, "The buffer does not contain enough memory after offset {0} to fully contain the acceleration structure.", offset);
 
     // Perform the build.
     commandBuffer.buildAccelerationStructure(*this, scratch, *memory, offset);
@@ -243,7 +243,7 @@ void DirectX12BottomLevelAccelerationStructure::update(const DirectX12CommandBuf
     else if (maxSize < requiredMemory) [[unlikely]]
         throw ArgumentOutOfRangeException("maxSize", std::make_pair(0_ui64, maxSize), requiredMemory, "The maximum available size is not sufficient to contain the acceleration structure.");
     else if (buffer->size() < offset + requiredMemory) [[unlikely]]
-        throw ArgumentOutOfRangeException("buffer", std::make_pair(0uz, buffer->size()), offset + requiredMemory, "The buffer does not contain enough memory after offset {0} to fully contain the acceleration structure.", offset);
+        throw ArgumentOutOfRangeException("buffer", std::make_pair<UInt64, UInt64>(0u, buffer->size()), offset + requiredMemory, "The buffer does not contain enough memory after offset {0} to fully contain the acceleration structure.", offset);
 
     // Perform the update.
     commandBuffer.updateAccelerationStructure(*this, scratch, *memory, offset);
@@ -279,7 +279,7 @@ void DirectX12BottomLevelAccelerationStructure::copy(const DirectX12CommandBuffe
     if (buffer == nullptr)
         memory = destination.m_impl->m_buffer->size() >= requiredMemory ? destination.m_impl->m_buffer : device->factory().createBuffer(BufferType::AccelerationStructure, ResourceHeap::Resource, requiredMemory, 1, ResourceUsage::AllowWrite);
     else if (buffer->size() < offset + requiredMemory) [[unlikely]]
-        throw ArgumentOutOfRangeException("buffer", std::make_pair(0uz, buffer->size()), offset + requiredMemory, "The buffer does not contain enough memory after offset {0} to fully contain the acceleration structure.", offset);
+        throw ArgumentOutOfRangeException("buffer", std::make_pair<UInt64, UInt64>(0u, buffer->size()), offset + requiredMemory, "The buffer does not contain enough memory after offset {0} to fully contain the acceleration structure.", offset);
 
     // Store the buffer and the offset.
     destination.m_impl->m_offset = offset;

--- a/src/Backends/DirectX12/src/blas.cpp
+++ b/src/Backends/DirectX12/src/blas.cpp
@@ -191,10 +191,10 @@ void DirectX12BottomLevelAccelerationStructure::build(const DirectX12CommandBuff
     if (scratchBuffer != nullptr && scratchBuffer->size() < requiredScratchMemory)
         throw InvalidArgumentException("scratchBuffer", "The provided scratch buffer does not contain enough memory to build the acceleration structure (contained memory: {0} bytes, required memory: {1} bytes).", scratchBuffer->size(), requiredScratchMemory);
     else if (scratchBuffer == nullptr)
-        scratch = device->factory().createBuffer(BufferType::Storage, ResourceHeap::Resource, requiredScratchMemory, 1, ResourceUsage::AllowWrite);
+        scratch = device->factory().createBuffer(BufferType::Storage, ResourceHeap::Resource, static_cast<size_t>(requiredScratchMemory), 1, ResourceUsage::AllowWrite);
 
     if (buffer == nullptr)
-        memory = m_impl->m_buffer && m_impl->m_buffer->size() >= requiredMemory ? m_impl->m_buffer : device->factory().createBuffer(BufferType::AccelerationStructure, ResourceHeap::Resource, requiredMemory, 1, ResourceUsage::AllowWrite);
+        memory = m_impl->m_buffer && m_impl->m_buffer->size() >= requiredMemory ? m_impl->m_buffer : device->factory().createBuffer(BufferType::AccelerationStructure, ResourceHeap::Resource, static_cast<size_t>(requiredMemory), 1, ResourceUsage::AllowWrite);
     else if (maxSize < requiredMemory) [[unlikely]]
         throw ArgumentOutOfRangeException("maxSize", std::make_pair(0_ui64, maxSize), requiredMemory, "The maximum available size is not sufficient to contain the acceleration structure.");
     else if (buffer->size() < offset + requiredMemory) [[unlikely]]
@@ -236,10 +236,10 @@ void DirectX12BottomLevelAccelerationStructure::update(const DirectX12CommandBuf
     if (scratchBuffer != nullptr && scratchBuffer->size() < requiredScratchMemory)
         throw InvalidArgumentException("scratchBuffer", "The provided scratch buffer does not contain enough memory to update the acceleration structure (contained memory: {0} bytes, required memory: {1} bytes).", scratchBuffer->size(), requiredScratchMemory);
     else if (scratchBuffer == nullptr)
-        scratch = device->factory().createBuffer(BufferType::Storage, ResourceHeap::Resource, requiredScratchMemory, 1, ResourceUsage::AllowWrite);
+        scratch = device->factory().createBuffer(BufferType::Storage, ResourceHeap::Resource, static_cast<size_t>(requiredScratchMemory), 1, ResourceUsage::AllowWrite);
 
     if (buffer == nullptr)
-        memory = m_impl->m_buffer->size() >= requiredMemory ? m_impl->m_buffer : device->factory().createBuffer(BufferType::AccelerationStructure, ResourceHeap::Resource, requiredMemory, 1, ResourceUsage::AllowWrite);
+        memory = m_impl->m_buffer->size() >= requiredMemory ? m_impl->m_buffer : device->factory().createBuffer(BufferType::AccelerationStructure, ResourceHeap::Resource, static_cast<size_t>(requiredMemory), 1, ResourceUsage::AllowWrite);
     else if (maxSize < requiredMemory) [[unlikely]]
         throw ArgumentOutOfRangeException("maxSize", std::make_pair(0_ui64, maxSize), requiredMemory, "The maximum available size is not sufficient to contain the acceleration structure.");
     else if (buffer->size() < offset + requiredMemory) [[unlikely]]
@@ -277,7 +277,7 @@ void DirectX12BottomLevelAccelerationStructure::copy(const DirectX12CommandBuffe
 
     // Validate the input arguments.
     if (buffer == nullptr)
-        memory = destination.m_impl->m_buffer->size() >= requiredMemory ? destination.m_impl->m_buffer : device->factory().createBuffer(BufferType::AccelerationStructure, ResourceHeap::Resource, requiredMemory, 1, ResourceUsage::AllowWrite);
+        memory = destination.m_impl->m_buffer->size() >= requiredMemory ? destination.m_impl->m_buffer : device->factory().createBuffer(BufferType::AccelerationStructure, ResourceHeap::Resource, static_cast<size_t>(requiredMemory), 1, ResourceUsage::AllowWrite);
     else if (buffer->size() < offset + requiredMemory) [[unlikely]]
         throw ArgumentOutOfRangeException("buffer", std::make_pair<UInt64, UInt64>(0u, buffer->size()), offset + requiredMemory, "The buffer does not contain enough memory after offset {0} to fully contain the acceleration structure.", offset);
 

--- a/src/Backends/DirectX12/src/image.cpp
+++ b/src/Backends/DirectX12/src/image.cpp
@@ -74,7 +74,7 @@ size_t DirectX12Image::size() const noexcept
 	}
 
 	if (m_impl->m_allocation) [[likely]]
-		return m_impl->m_allocation->GetSize();
+		return static_cast<size_t>(m_impl->m_allocation->GetSize());
 	else
 	{
 		auto elementSize = pixelSize * m_impl->m_extent.width() * m_impl->m_extent.height() * m_impl->m_extent.depth() * m_impl->m_layers;

--- a/src/Backends/DirectX12/src/ray_tracing_pipeline.cpp
+++ b/src/Backends/DirectX12/src/ray_tracing_pipeline.cpp
@@ -386,7 +386,7 @@ public:
 		auto localDataSize = std::ranges::max(m_shaderRecordCollection.shaderRecords() | std::views::filter(filterByGroupType) | std::views::transform([](auto& record) { return record->localDataSize(); }));
 
 		// Compute the record size by aligning the handle and payload sizes.
-		auto recordSize = Math::align<UInt64>(D3D12_SHADER_IDENTIFIER_SIZE_IN_BYTES + localDataSize, D3D12_RAYTRACING_SHADER_RECORD_BYTE_ALIGNMENT);
+		auto recordSize = Math::align<size_t>(D3D12_SHADER_IDENTIFIER_SIZE_IN_BYTES + static_cast<size_t>(localDataSize), D3D12_RAYTRACING_SHADER_RECORD_BYTE_ALIGNMENT);
 
 		// Insert empty records at the end of each table so that the table start offsets align with D3D12_RAYTRACING_SHADER_TABLE_BYTE_ALIGNMENT.
 		Dictionary<ShaderBindingGroup, UInt32> alignmentRecords;
@@ -485,7 +485,7 @@ public:
 					std::memcpy(recordData.data(), getRecordIdentifier(currentRecord), D3D12_SHADER_IDENTIFIER_SIZE_IN_BYTES);
 
 					// Write the payload and map everything into the buffer.
-					std::memcpy(recordData.data() + D3D12_SHADER_IDENTIFIER_SIZE_IN_BYTES, currentRecord->localData(), currentRecord->localDataSize()); // NOLINT(cppcoreguidelines-pro-bounds-pointer-arithmetic)
+					std::memcpy(recordData.data() + D3D12_SHADER_IDENTIFIER_SIZE_IN_BYTES, currentRecord->localData(), static_cast<size_t>(currentRecord->localDataSize())); // NOLINT(cppcoreguidelines-pro-bounds-pointer-arithmetic)
 					result->map(recordData.data(), recordSize, record++);
 				}
 

--- a/src/Backends/DirectX12/src/tlas.cpp
+++ b/src/Backends/DirectX12/src/tlas.cpp
@@ -143,10 +143,10 @@ void DirectX12TopLevelAccelerationStructure::build(const DirectX12CommandBuffer&
     if (scratchBuffer != nullptr && scratchBuffer->size() < requiredScratchMemory)
         throw InvalidArgumentException("scratchBuffer", "The provided scratch buffer does not contain enough memory to build the acceleration structure (contained memory: {0} bytes, required memory: {1} bytes).", scratchBuffer->size(), requiredScratchMemory);
     else if (scratchBuffer == nullptr)
-        scratch = device->factory().createBuffer(BufferType::Storage, ResourceHeap::Resource, requiredScratchMemory, 1, ResourceUsage::AllowWrite);
+        scratch = device->factory().createBuffer(BufferType::Storage, ResourceHeap::Resource, static_cast<size_t>(requiredScratchMemory), 1, ResourceUsage::AllowWrite);
 
     if (buffer == nullptr)
-        memory = m_impl->m_buffer && m_impl->m_buffer->size() >= requiredMemory ? m_impl->m_buffer : device->factory().createBuffer(BufferType::AccelerationStructure, ResourceHeap::Resource, requiredMemory, 1, ResourceUsage::AllowWrite);
+        memory = m_impl->m_buffer && m_impl->m_buffer->size() >= requiredMemory ? m_impl->m_buffer : device->factory().createBuffer(BufferType::AccelerationStructure, ResourceHeap::Resource, static_cast<size_t>(requiredMemory), 1, ResourceUsage::AllowWrite);
     else if (maxSize < requiredMemory) [[unlikely]]
         throw ArgumentOutOfRangeException("maxSize", std::make_pair(0_ui64, maxSize), requiredMemory, "The maximum available size is not sufficient to contain the acceleration structure.");
     else if (buffer->size() < offset + requiredMemory) [[unlikely]]
@@ -188,10 +188,10 @@ void DirectX12TopLevelAccelerationStructure::update(const DirectX12CommandBuffer
     if (scratchBuffer != nullptr && scratchBuffer->size() < requiredScratchMemory)
         throw InvalidArgumentException("scratchBuffer", "The provided scratch buffer does not contain enough memory to update the acceleration structure (contained memory: {0} bytes, required memory: {1} bytes).", scratchBuffer->size(), requiredScratchMemory);
     else if (scratchBuffer == nullptr)
-        scratch = device->factory().createBuffer(BufferType::Storage, ResourceHeap::Resource, requiredScratchMemory, 1, ResourceUsage::AllowWrite);
+        scratch = device->factory().createBuffer(BufferType::Storage, ResourceHeap::Resource, static_cast<size_t>(requiredScratchMemory), 1, ResourceUsage::AllowWrite);
 
     if (buffer == nullptr)
-        memory = m_impl->m_buffer->size() >= requiredMemory ? m_impl->m_buffer : device->factory().createBuffer(BufferType::AccelerationStructure, ResourceHeap::Resource, requiredMemory, 1, ResourceUsage::AllowWrite);
+        memory = m_impl->m_buffer->size() >= requiredMemory ? m_impl->m_buffer : device->factory().createBuffer(BufferType::AccelerationStructure, ResourceHeap::Resource, static_cast<size_t>(requiredMemory), 1, ResourceUsage::AllowWrite);
     else if (maxSize < requiredMemory) [[unlikely]]
         throw ArgumentOutOfRangeException("maxSize", std::make_pair(0_ui64, maxSize), requiredMemory, "The maximum available size is not sufficient to contain the acceleration structure.");
     else if (buffer->size() < offset + requiredMemory) [[unlikely]]
@@ -229,7 +229,7 @@ void DirectX12TopLevelAccelerationStructure::copy(const DirectX12CommandBuffer& 
 
     // Validate the input arguments.
     if (buffer == nullptr)
-        memory = destination.m_impl->m_buffer->size() >= requiredMemory ? destination.m_impl->m_buffer : device->factory().createBuffer(BufferType::AccelerationStructure, ResourceHeap::Resource, requiredMemory, 1, ResourceUsage::AllowWrite);
+        memory = destination.m_impl->m_buffer->size() >= requiredMemory ? destination.m_impl->m_buffer : device->factory().createBuffer(BufferType::AccelerationStructure, ResourceHeap::Resource, static_cast<size_t>(requiredMemory), 1, ResourceUsage::AllowWrite);
     else if (buffer->size() < offset + requiredMemory) [[unlikely]]
         throw ArgumentOutOfRangeException("buffer", std::make_pair<UInt64, UInt64>(0u, buffer->size()), offset + requiredMemory, "The buffer does not contain enough memory after offset {0} to fully contain the acceleration structure.", offset);
 

--- a/src/Backends/DirectX12/src/tlas.cpp
+++ b/src/Backends/DirectX12/src/tlas.cpp
@@ -150,7 +150,7 @@ void DirectX12TopLevelAccelerationStructure::build(const DirectX12CommandBuffer&
     else if (maxSize < requiredMemory) [[unlikely]]
         throw ArgumentOutOfRangeException("maxSize", std::make_pair(0_ui64, maxSize), requiredMemory, "The maximum available size is not sufficient to contain the acceleration structure.");
     else if (buffer->size() < offset + requiredMemory) [[unlikely]]
-        throw ArgumentOutOfRangeException("buffer", std::make_pair(0uz, buffer->size()), offset + requiredMemory, "The buffer does not contain enough memory after offset {0} to fully contain the acceleration structure.", offset);
+        throw ArgumentOutOfRangeException("buffer", std::make_pair<UInt64, UInt64>(0u, buffer->size()), offset + requiredMemory, "The buffer does not contain enough memory after offset {0} to fully contain the acceleration structure.", offset);
 
     // Perform the build.
     commandBuffer.buildAccelerationStructure(*this, scratch, *memory, offset);
@@ -195,7 +195,7 @@ void DirectX12TopLevelAccelerationStructure::update(const DirectX12CommandBuffer
     else if (maxSize < requiredMemory) [[unlikely]]
         throw ArgumentOutOfRangeException("maxSize", std::make_pair(0_ui64, maxSize), requiredMemory, "The maximum available size is not sufficient to contain the acceleration structure.");
     else if (buffer->size() < offset + requiredMemory) [[unlikely]]
-        throw ArgumentOutOfRangeException("buffer", std::make_pair(0uz, buffer->size()), offset + requiredMemory, "The buffer does not contain enough memory after offset {0} to fully contain the acceleration structure.", offset);
+        throw ArgumentOutOfRangeException("buffer", std::make_pair<UInt64, UInt64>(0u, buffer->size()), offset + requiredMemory, "The buffer does not contain enough memory after offset {0} to fully contain the acceleration structure.", offset);
 
     // Perform the update.
     commandBuffer.updateAccelerationStructure(*this, scratch, *memory, offset);
@@ -231,7 +231,7 @@ void DirectX12TopLevelAccelerationStructure::copy(const DirectX12CommandBuffer& 
     if (buffer == nullptr)
         memory = destination.m_impl->m_buffer->size() >= requiredMemory ? destination.m_impl->m_buffer : device->factory().createBuffer(BufferType::AccelerationStructure, ResourceHeap::Resource, requiredMemory, 1, ResourceUsage::AllowWrite);
     else if (buffer->size() < offset + requiredMemory) [[unlikely]]
-        throw ArgumentOutOfRangeException("buffer", std::make_pair(0uz, buffer->size()), offset + requiredMemory, "The buffer does not contain enough memory after offset {0} to fully contain the acceleration structure.", offset);
+        throw ArgumentOutOfRangeException("buffer", std::make_pair<UInt64, UInt64>(0u, buffer->size()), offset + requiredMemory, "The buffer does not contain enough memory after offset {0} to fully contain the acceleration structure.", offset);
 
     // Store the buffer and the offset.
     destination.m_impl->m_offset = offset;

--- a/src/Backends/Vulkan/include/litefx/backends/vulkan.hpp
+++ b/src/Backends/Vulkan/include/litefx/backends/vulkan.hpp
@@ -2626,10 +2626,10 @@ namespace LiteFX::Rendering::Backends {
         /// This function sets the debug name for an object to make it easier to identify when using an external debugger. This function will do nothing
         /// in release mode or if the device extension VK_EXT_debug_marker is not available.
         /// </remarks>
-        /// <param name="objectHandle">The handle of the object casted to an integer.</param>
         /// <param name="objectType">The type of the object.</param>
+        /// <param name="objectHandle">The handle of the object casted to an integer.</param>
         /// <param name="name">The debug name of the object.</param>
-        void setDebugName(UInt64 objectHandle, VkDebugReportObjectTypeEXT objectType, StringView name) const noexcept;
+        void setDebugName(VkDebugReportObjectTypeEXT objectType, UInt64 objectHandle, StringView name) const noexcept;
 
     public:
         /// <summary>
@@ -2651,7 +2651,7 @@ namespace LiteFX::Rendering::Backends {
         /// <param name="name">The debug name of the object.</param>
         template <typename THandle>
         inline void setDebugName(THandle objectHandle, VkDebugReportObjectTypeEXT objectType, StringView name) const noexcept {
-            this->setDebugName(std::bit_cast<UInt64>(objectHandle), objectType, name);
+            this->setDebugName(objectType, Vk::handleAddress(objectHandle), name); // NOLINT(cppcoreguidelines-pro-type-reinterpret-cast)
         }
 
         /// <summary>

--- a/src/Backends/Vulkan/include/litefx/backends/vulkan_api.hpp
+++ b/src/Backends/Vulkan/include/litefx/backends/vulkan_api.hpp
@@ -203,6 +203,27 @@ namespace LiteFX::Rendering::Backends {
         /// 
         /// </summary>
         VkImageLayout LITEFX_VULKAN_API getImageLayout(ImageLayout imageLayout);
+
+        /// <summary>
+        /// Returns the address of a dispatchable handle.
+        /// </summary>
+        /// <typeparam name="THandle">The type of the handle.</typeparam>
+        /// <param name="handle">The handle to convert.</param>
+        /// <returns>The address of the handle.</returns>
+        template <typename THandle>
+        constexpr UInt64 handleAddress(const THandle handle) noexcept {
+            return reinterpret_cast<std::uintptr_t>(handle); // NOLINT(cppcoreguidelines-pro-type-reinterpret-cast)
+        }
+
+        /// <summary>
+        /// Returns the address of a non-dispatchable handle.
+        /// </summary>
+        /// <param name="handle">The handle to convert.</param>
+        /// <returns>The address of the handle.</returns>
+        template <>
+        constexpr UInt64 handleAddress(const UInt64 handle) noexcept {
+            return handle;
+        }
     }
 
     /// <summary>

--- a/src/Backends/Vulkan/src/blas.cpp
+++ b/src/Backends/Vulkan/src/blas.cpp
@@ -187,10 +187,10 @@ void VulkanBottomLevelAccelerationStructure::build(const VulkanCommandBuffer& co
     if (scratchBuffer != nullptr && scratchBuffer->size() < requiredScratchMemory)
         throw InvalidArgumentException("scratchBuffer", "The provided scratch buffer does not contain enough memory to build the acceleration structure (contained memory: {0} bytes, required memory: {1} bytes).", scratchBuffer->size(), requiredScratchMemory);
     else if (scratchBuffer == nullptr)
-        scratch = device->factory().createBuffer(BufferType::Storage, ResourceHeap::Resource, requiredScratchMemory, 1, ResourceUsage::AllowWrite);
+        scratch = device->factory().createBuffer(BufferType::Storage, ResourceHeap::Resource, static_cast<size_t>(requiredScratchMemory), 1, ResourceUsage::AllowWrite);
 
     if (buffer == nullptr)
-        memory = m_impl->m_buffer && m_impl->m_buffer->size() >= requiredMemory ? m_impl->m_buffer : device->factory().createBuffer(BufferType::AccelerationStructure, ResourceHeap::Resource, requiredMemory, 1, ResourceUsage::AllowWrite);
+        memory = m_impl->m_buffer && m_impl->m_buffer->size() >= requiredMemory ? m_impl->m_buffer : device->factory().createBuffer(BufferType::AccelerationStructure, ResourceHeap::Resource, static_cast<size_t>(requiredMemory), 1, ResourceUsage::AllowWrite);
     else if (maxSize < requiredMemory) [[unlikely]]
         throw ArgumentOutOfRangeException("maxSize", std::make_pair(0_ui64, maxSize), requiredMemory, "The maximum available size is not sufficient to contain the acceleration structure.");
     else if (buffer->size() < offset + requiredMemory) [[unlikely]]
@@ -258,10 +258,10 @@ void VulkanBottomLevelAccelerationStructure::update(const VulkanCommandBuffer& c
     if (scratchBuffer != nullptr && scratchBuffer->size() < requiredScratchMemory)
         throw InvalidArgumentException("scratchBuffer", "The provided scratch buffer does not contain enough memory to update the acceleration structure (contained memory: {0} bytes, required memory: {1} bytes).", scratchBuffer->size(), requiredScratchMemory);
     else if (scratchBuffer == nullptr)
-        scratch = device->factory().createBuffer(BufferType::Storage, ResourceHeap::Resource, requiredScratchMemory, 1, ResourceUsage::AllowWrite);
+        scratch = device->factory().createBuffer(BufferType::Storage, ResourceHeap::Resource, static_cast<size_t>(requiredScratchMemory), 1, ResourceUsage::AllowWrite);
 
     if (buffer == nullptr)
-        memory = m_impl->m_buffer->size() >= requiredMemory ? m_impl->m_buffer : device->factory().createBuffer(BufferType::AccelerationStructure, ResourceHeap::Resource, requiredMemory, 1, ResourceUsage::AllowWrite);
+        memory = m_impl->m_buffer->size() >= requiredMemory ? m_impl->m_buffer : device->factory().createBuffer(BufferType::AccelerationStructure, ResourceHeap::Resource, static_cast<size_t>(requiredMemory), 1, ResourceUsage::AllowWrite);
     else if (maxSize < requiredMemory) [[unlikely]]
         throw ArgumentOutOfRangeException("maxSize", std::make_pair(0_ui64, maxSize), requiredMemory, "The maximum available size is not sufficient to contain the acceleration structure.");
     else if (buffer->size() < offset + requiredMemory) [[unlikely]]
@@ -318,7 +318,7 @@ void VulkanBottomLevelAccelerationStructure::copy(const VulkanCommandBuffer& com
     auto memory = buffer;
 
     if (buffer == nullptr)
-        memory = destination.m_impl->m_buffer->size() >= requiredMemory[0] ? destination.m_impl->m_buffer : device->factory().createBuffer(BufferType::AccelerationStructure, ResourceHeap::Resource, requiredMemory[0], 1, ResourceUsage::AllowWrite);
+        memory = destination.m_impl->m_buffer->size() >= requiredMemory[0] ? destination.m_impl->m_buffer : device->factory().createBuffer(BufferType::AccelerationStructure, ResourceHeap::Resource, static_cast<size_t>(requiredMemory[0]), 1, ResourceUsage::AllowWrite);
     else if (buffer->size() < offset + requiredMemory[0]) [[unlikely]]
         throw ArgumentOutOfRangeException("buffer", std::make_pair<UInt64, UInt64>(0u, buffer->size()), offset + requiredMemory[0], "The buffer does not contain enough memory after offset {0} to fully contain the acceleration structure.", offset);
 

--- a/src/Backends/Vulkan/src/blas.cpp
+++ b/src/Backends/Vulkan/src/blas.cpp
@@ -194,7 +194,7 @@ void VulkanBottomLevelAccelerationStructure::build(const VulkanCommandBuffer& co
     else if (maxSize < requiredMemory) [[unlikely]]
         throw ArgumentOutOfRangeException("maxSize", std::make_pair(0_ui64, maxSize), requiredMemory, "The maximum available size is not sufficient to contain the acceleration structure.");
     else if (buffer->size() < offset + requiredMemory) [[unlikely]]
-        throw ArgumentOutOfRangeException("buffer", std::make_pair(0uz, buffer->size()), offset + requiredMemory, "The buffer does not contain enough memory after offset {0} to fully contain the acceleration structure.", offset);
+        throw ArgumentOutOfRangeException("buffer", std::make_pair<UInt64, UInt64>(0u, buffer->size()), offset + requiredMemory, "The buffer does not contain enough memory after offset {0} to fully contain the acceleration structure.", offset);
 
     // If the acceleration structure allows for compaction, create a query pool in order to query the compacted size later.
     if (LITEFX_FLAG_IS_SET(m_impl->m_flags, AccelerationStructureFlags::AllowCompaction))
@@ -265,7 +265,7 @@ void VulkanBottomLevelAccelerationStructure::update(const VulkanCommandBuffer& c
     else if (maxSize < requiredMemory) [[unlikely]]
         throw ArgumentOutOfRangeException("maxSize", std::make_pair(0_ui64, maxSize), requiredMemory, "The maximum available size is not sufficient to contain the acceleration structure.");
     else if (buffer->size() < offset + requiredMemory) [[unlikely]]
-        throw ArgumentOutOfRangeException("buffer", std::make_pair(0uz, buffer->size()), offset + requiredMemory, "The buffer does not contain enough memory after offset {0} to fully contain the acceleration structure.", offset);
+        throw ArgumentOutOfRangeException("buffer", std::make_pair<UInt64, UInt64>(0u, buffer->size()), offset + requiredMemory, "The buffer does not contain enough memory after offset {0} to fully contain the acceleration structure.", offset);
 
     // If the acceleration structure allows for compaction, reset the query pool.
     if (LITEFX_FLAG_IS_SET(m_impl->m_flags, AccelerationStructureFlags::AllowCompaction))
@@ -320,7 +320,7 @@ void VulkanBottomLevelAccelerationStructure::copy(const VulkanCommandBuffer& com
     if (buffer == nullptr)
         memory = destination.m_impl->m_buffer->size() >= requiredMemory[0] ? destination.m_impl->m_buffer : device->factory().createBuffer(BufferType::AccelerationStructure, ResourceHeap::Resource, requiredMemory[0], 1, ResourceUsage::AllowWrite);
     else if (buffer->size() < offset + requiredMemory[0]) [[unlikely]]
-        throw ArgumentOutOfRangeException("buffer", std::make_pair(0uz, buffer->size()), offset + requiredMemory[0], "The buffer does not contain enough memory after offset {0} to fully contain the acceleration structure.", offset);
+        throw ArgumentOutOfRangeException("buffer", std::make_pair<UInt64, UInt64>(0u, buffer->size()), offset + requiredMemory[0], "The buffer does not contain enough memory after offset {0} to fully contain the acceleration structure.", offset);
 
     // Create or reset query pool on destination, if required. 
     if (LITEFX_FLAG_IS_SET(destination.flags(), AccelerationStructureFlags::AllowCompaction))

--- a/src/Backends/Vulkan/src/buffer.cpp
+++ b/src/Backends/Vulkan/src/buffer.cpp
@@ -48,7 +48,7 @@ VulkanBuffer::VulkanBuffer(VkBuffer buffer, BufferType type, UInt32 elements, si
 VulkanBuffer::~VulkanBuffer() noexcept
 {
 	::vmaDestroyBuffer(m_impl->m_allocator, this->handle(), m_impl->m_allocation);
-	LITEFX_TRACE(VULKAN_LOG, "Destroyed buffer {0}", static_cast<void*>(this->handle()));
+	LITEFX_TRACE(VULKAN_LOG, "Destroyed buffer {0}", Vk::handleAddress(this->handle()));
 }
 
 BufferType VulkanBuffer::type() const noexcept
@@ -154,7 +154,7 @@ SharedPtr<IVulkanBuffer> VulkanBuffer::allocate(const String& name, BufferType t
 	VmaAllocation allocation{};
 
 	raiseIfFailed(::vmaCreateBuffer(allocator, &createInfo, &allocationInfo, &buffer, &allocation, allocationResult), "Unable to allocate buffer.");
-	LITEFX_DEBUG(VULKAN_LOG, "Allocated buffer {0} with {4} bytes {{ Type: {1}, Elements: {2}, Element Size: {3}, Usage: {5} }}", name.empty() ? std::format("{0}", static_cast<void*>(buffer)) : name, type, elements, elementSize, elements * elementSize, usage);
+	LITEFX_DEBUG(VULKAN_LOG, "Allocated buffer {0} with {4} bytes {{ Type: {1}, Elements: {2}, Element Size: {3}, Usage: {5} }}", name.empty() ? std::format("{0}", Vk::handleAddress(buffer)) : name, type, elements, elementSize, elements * elementSize, usage);
 
 	return SharedObject::create<VulkanBuffer>(buffer, type, elements, elementSize, alignment, usage, device, allocator, allocation, name);
 }
@@ -204,7 +204,7 @@ SharedPtr<IVulkanVertexBuffer> VulkanVertexBuffer::allocate(const String& name, 
 	VmaAllocation allocation{};
 
 	raiseIfFailed(::vmaCreateBuffer(allocator, &createInfo, &allocationInfo, &buffer, &allocation, allocationResult), "Unable to allocate vertex buffer.");
-	LITEFX_DEBUG(VULKAN_LOG, "Allocated buffer {0} with {4} bytes {{ Type: {1}, Elements: {2}, Element Size: {3}, Usage: {5} }}", name.empty() ? std::format("{0}", static_cast<void*>(buffer)) : name, BufferType::Vertex, elements, layout.elementSize(), layout.elementSize() * elements, usage);
+	LITEFX_DEBUG(VULKAN_LOG, "Allocated buffer {0} with {4} bytes {{ Type: {1}, Elements: {2}, Element Size: {3}, Usage: {5} }}", name.empty() ? std::format("{0}", Vk::handleAddress(buffer)) : name, BufferType::Vertex, elements, layout.elementSize(), layout.elementSize() * elements, usage);
 
 	return SharedObject::create<VulkanVertexBuffer>(buffer, layout, elements, usage, device, allocator, allocation, name);
 }
@@ -254,7 +254,7 @@ SharedPtr<IVulkanIndexBuffer> VulkanIndexBuffer::allocate(const String& name, co
 	VmaAllocation allocation{};
 
 	raiseIfFailed(::vmaCreateBuffer(allocator, &createInfo, &allocationInfo, &buffer, &allocation, allocationResult), "Unable to allocate index buffer.");
-	LITEFX_DEBUG(VULKAN_LOG, "Allocated buffer {0} with {4} bytes {{ Type: {1}, Elements: {2}, Element Size: {3}, Usage: {5} }}", name.empty() ? std::format("{0}", static_cast<void*>(buffer)) : name, BufferType::Index, elements, layout.elementSize(), layout.elementSize() * elements, usage);
+	LITEFX_DEBUG(VULKAN_LOG, "Allocated buffer {0} with {4} bytes {{ Type: {1}, Elements: {2}, Element Size: {3}, Usage: {5} }}", name.empty() ? std::format("{0}", Vk::handleAddress(buffer)) : name, BufferType::Index, elements, layout.elementSize(), layout.elementSize() * elements, usage);
 
 	return SharedObject::create<VulkanIndexBuffer>(buffer, layout, elements, usage, device, allocator, allocation, name);
 }

--- a/src/Backends/Vulkan/src/device.cpp
+++ b/src/Backends/Vulkan/src/device.cpp
@@ -543,7 +543,7 @@ Span<const String> VulkanDevice::enabledExtensions() const noexcept
     return m_impl->m_extensions;
 }
 
-void VulkanDevice::setDebugName([[maybe_unused]] UInt64 handle, [[maybe_unused]] VkDebugReportObjectTypeEXT type, [[maybe_unused]] StringView name) const noexcept
+void VulkanDevice::setDebugName([[maybe_unused]] VkDebugReportObjectTypeEXT type, [[maybe_unused]] UInt64 handle, [[maybe_unused]] StringView name) const noexcept
 {
 #ifndef NDEBUG
     if (m_impl->debugMarkerSetObjectName != nullptr)

--- a/src/Backends/Vulkan/src/device.cpp
+++ b/src/Backends/Vulkan/src/device.cpp
@@ -372,72 +372,74 @@ public:
         raiseIfFailed(::vkCreateDevice(m_adapter->handle(), &createInfo, nullptr, &device), "Unable to create Vulkan device.");
 
         // Load extension methods.
+        // NOLINTBEGIN(cppcoreguidelines-pro-type-reinterpret-cast)
 #ifndef NDEBUG
-        debugMarkerSetObjectName = std::bit_cast<PFN_vkDebugMarkerSetObjectNameEXT>(::vkGetDeviceProcAddr(device, "vkDebugMarkerSetObjectNameEXT"));
+        debugMarkerSetObjectName = reinterpret_cast<PFN_vkDebugMarkerSetObjectNameEXT>(::vkGetDeviceProcAddr(device, "vkDebugMarkerSetObjectNameEXT"));
 #endif
 
         if (features.MeshShaders)
         {
             if (vkCmdDrawMeshTasks == nullptr)
-                vkCmdDrawMeshTasks = std::bit_cast<PFN_vkCmdDrawMeshTasksEXT>(::vkGetDeviceProcAddr(device, "vkCmdDrawMeshTasksEXT"));
+                vkCmdDrawMeshTasks = reinterpret_cast<PFN_vkCmdDrawMeshTasksEXT>(::vkGetDeviceProcAddr(device, "vkCmdDrawMeshTasksEXT"));
 
             if (vkCmdDrawMeshTasksIndirect)
-                vkCmdDrawMeshTasksIndirect = std::bit_cast<PFN_vkCmdDrawMeshTasksIndirectEXT>(::vkGetDeviceProcAddr(device, "vkCmdDrawMeshTasksIndirectEXT"));
+                vkCmdDrawMeshTasksIndirect = reinterpret_cast<PFN_vkCmdDrawMeshTasksIndirectEXT>(::vkGetDeviceProcAddr(device, "vkCmdDrawMeshTasksIndirectEXT"));
 
             if (vkCmdDrawMeshTasksIndirectCount)
-                vkCmdDrawMeshTasksIndirectCount = std::bit_cast<PFN_vkCmdDrawMeshTasksIndirectCountEXT>(::vkGetDeviceProcAddr(device, "vkCmdDrawMeshTasksIndirectCountEXT"));
+                vkCmdDrawMeshTasksIndirectCount = reinterpret_cast<PFN_vkCmdDrawMeshTasksIndirectCountEXT>(::vkGetDeviceProcAddr(device, "vkCmdDrawMeshTasksIndirectCountEXT"));
         }
 
         if (features.RayTracing)
         {
             if (vkGetAccelerationStructureBuildSizes == nullptr)
-                vkGetAccelerationStructureBuildSizes = std::bit_cast<PFN_vkGetAccelerationStructureBuildSizesKHR>(::vkGetDeviceProcAddr(device, "vkGetAccelerationStructureBuildSizesKHR"));
+                vkGetAccelerationStructureBuildSizes = reinterpret_cast<PFN_vkGetAccelerationStructureBuildSizesKHR>(::vkGetDeviceProcAddr(device, "vkGetAccelerationStructureBuildSizesKHR"));
 
             if (vkCreateAccelerationStructure == nullptr)
-                vkCreateAccelerationStructure = std::bit_cast<PFN_vkCreateAccelerationStructureKHR>(::vkGetDeviceProcAddr(device, "vkCreateAccelerationStructureKHR"));
+                vkCreateAccelerationStructure = reinterpret_cast<PFN_vkCreateAccelerationStructureKHR>(::vkGetDeviceProcAddr(device, "vkCreateAccelerationStructureKHR"));
 
             if (vkDestroyAccelerationStructure == nullptr)
-                vkDestroyAccelerationStructure = std::bit_cast<PFN_vkDestroyAccelerationStructureKHR>(::vkGetDeviceProcAddr(device, "vkDestroyAccelerationStructureKHR"));
+                vkDestroyAccelerationStructure = reinterpret_cast<PFN_vkDestroyAccelerationStructureKHR>(::vkGetDeviceProcAddr(device, "vkDestroyAccelerationStructureKHR"));
 
             if (vkCmdBuildAccelerationStructures == nullptr)
-                vkCmdBuildAccelerationStructures = std::bit_cast<PFN_vkCmdBuildAccelerationStructuresKHR>(::vkGetDeviceProcAddr(device, "vkCmdBuildAccelerationStructuresKHR"));
+                vkCmdBuildAccelerationStructures = reinterpret_cast<PFN_vkCmdBuildAccelerationStructuresKHR>(::vkGetDeviceProcAddr(device, "vkCmdBuildAccelerationStructuresKHR"));
 
             if (vkCmdCopyAccelerationStructure == nullptr)
-                vkCmdCopyAccelerationStructure = std::bit_cast<PFN_vkCmdCopyAccelerationStructureKHR>(::vkGetDeviceProcAddr(device, "vkCmdCopyAccelerationStructureKHR"));
+                vkCmdCopyAccelerationStructure = reinterpret_cast<PFN_vkCmdCopyAccelerationStructureKHR>(::vkGetDeviceProcAddr(device, "vkCmdCopyAccelerationStructureKHR"));
 
             if (vkCmdWriteAccelerationStructuresProperties == nullptr)
-                vkCmdWriteAccelerationStructuresProperties = std::bit_cast<PFN_vkCmdWriteAccelerationStructuresPropertiesKHR>(::vkGetDeviceProcAddr(device, "vkCmdWriteAccelerationStructuresPropertiesKHR"));
+                vkCmdWriteAccelerationStructuresProperties = reinterpret_cast<PFN_vkCmdWriteAccelerationStructuresPropertiesKHR>(::vkGetDeviceProcAddr(device, "vkCmdWriteAccelerationStructuresPropertiesKHR"));
 
             if (vkCreateRayTracingPipelines == nullptr)
-                vkCreateRayTracingPipelines = std::bit_cast<PFN_vkCreateRayTracingPipelinesKHR>(::vkGetDeviceProcAddr(device, "vkCreateRayTracingPipelinesKHR"));
+                vkCreateRayTracingPipelines = reinterpret_cast<PFN_vkCreateRayTracingPipelinesKHR>(::vkGetDeviceProcAddr(device, "vkCreateRayTracingPipelinesKHR"));
 
             if (vkGetRayTracingShaderGroupHandles == nullptr)
-                vkGetRayTracingShaderGroupHandles = std::bit_cast<PFN_vkGetRayTracingShaderGroupHandlesKHR>(::vkGetDeviceProcAddr(device, "vkGetRayTracingShaderGroupHandlesKHR"));
+                vkGetRayTracingShaderGroupHandles = reinterpret_cast<PFN_vkGetRayTracingShaderGroupHandlesKHR>(::vkGetDeviceProcAddr(device, "vkGetRayTracingShaderGroupHandlesKHR"));
 
             if (vkCmdTraceRays == nullptr)
-                vkCmdTraceRays = std::bit_cast<PFN_vkCmdTraceRaysKHR>(::vkGetDeviceProcAddr(device, "vkCmdTraceRaysKHR"));
+                vkCmdTraceRays = reinterpret_cast<PFN_vkCmdTraceRaysKHR>(::vkGetDeviceProcAddr(device, "vkCmdTraceRaysKHR"));
         }
 
         if (features.RayQueries)
         {
             if (vkGetAccelerationStructureBuildSizes == nullptr)
-                vkGetAccelerationStructureBuildSizes = std::bit_cast<PFN_vkGetAccelerationStructureBuildSizesKHR>(::vkGetDeviceProcAddr(device, "vkGetAccelerationStructureBuildSizesKHR"));
+                vkGetAccelerationStructureBuildSizes = reinterpret_cast<PFN_vkGetAccelerationStructureBuildSizesKHR>(::vkGetDeviceProcAddr(device, "vkGetAccelerationStructureBuildSizesKHR"));
 
             if (vkCreateAccelerationStructure == nullptr)
-                vkCreateAccelerationStructure = std::bit_cast<PFN_vkCreateAccelerationStructureKHR>(::vkGetDeviceProcAddr(device, "vkCreateAccelerationStructureKHR"));
+                vkCreateAccelerationStructure = reinterpret_cast<PFN_vkCreateAccelerationStructureKHR>(::vkGetDeviceProcAddr(device, "vkCreateAccelerationStructureKHR"));
 
             if (vkDestroyAccelerationStructure == nullptr)
-                vkDestroyAccelerationStructure = std::bit_cast<PFN_vkDestroyAccelerationStructureKHR>(::vkGetDeviceProcAddr(device, "vkDestroyAccelerationStructureKHR"));
+                vkDestroyAccelerationStructure = reinterpret_cast<PFN_vkDestroyAccelerationStructureKHR>(::vkGetDeviceProcAddr(device, "vkDestroyAccelerationStructureKHR"));
 
             if (vkCmdBuildAccelerationStructures == nullptr)
-                vkCmdBuildAccelerationStructures = std::bit_cast<PFN_vkCmdBuildAccelerationStructuresKHR>(::vkGetDeviceProcAddr(device, "vkCmdBuildAccelerationStructuresKHR"));
+                vkCmdBuildAccelerationStructures = reinterpret_cast<PFN_vkCmdBuildAccelerationStructuresKHR>(::vkGetDeviceProcAddr(device, "vkCmdBuildAccelerationStructuresKHR"));
 
             if (vkCmdCopyAccelerationStructure == nullptr)
-                vkCmdCopyAccelerationStructure = std::bit_cast<PFN_vkCmdCopyAccelerationStructureKHR>(::vkGetDeviceProcAddr(device, "vkCmdCopyAccelerationStructureKHR"));
+                vkCmdCopyAccelerationStructure = reinterpret_cast<PFN_vkCmdCopyAccelerationStructureKHR>(::vkGetDeviceProcAddr(device, "vkCmdCopyAccelerationStructureKHR"));
 
             if (vkCmdWriteAccelerationStructuresProperties == nullptr)
-                vkCmdWriteAccelerationStructuresProperties = std::bit_cast<PFN_vkCmdWriteAccelerationStructuresPropertiesKHR>(::vkGetDeviceProcAddr(device, "vkCmdWriteAccelerationStructuresPropertiesKHR"));
+                vkCmdWriteAccelerationStructuresProperties = reinterpret_cast<PFN_vkCmdWriteAccelerationStructuresPropertiesKHR>(::vkGetDeviceProcAddr(device, "vkCmdWriteAccelerationStructuresPropertiesKHR"));
         }
+        // NOLINTEND(cppcoreguidelines-pro-type-reinterpret-cast)
 
         return device;
     }

--- a/src/Backends/Vulkan/src/factory.cpp
+++ b/src/Backends/Vulkan/src/factory.cpp
@@ -160,14 +160,14 @@ SharedPtr<IVulkanBuffer> VulkanGraphicsFactory::createBuffer(const String& name,
 	bufferInfo.pQueueFamilyIndices = queueFamilies.data();
 
 #ifndef NDEBUG
-	auto buffer = VulkanBuffer::allocate(name, type, elements, elementSize, alignment, usage, *device, m_impl->m_allocator, bufferInfo, allocInfo);
+	auto buffer = VulkanBuffer::allocate(name, type, elements, elementSize, static_cast<size_t>(alignment), usage, *device, m_impl->m_allocator, bufferInfo, allocInfo);
 
 	if (!name.empty())
 		device->setDebugName(std::as_const(*buffer).handle(), VK_DEBUG_REPORT_OBJECT_TYPE_BUFFER_EXT, name);
 
 	return buffer;
 #else
-	return VulkanBuffer::allocate(name, type, elements, elementSize, alignment, usage, *device, m_impl->m_allocator, bufferInfo, allocInfo);
+	return VulkanBuffer::allocate(name, type, elements, elementSize, static_cast<size_t>(alignment), usage, *device, m_impl->m_allocator, bufferInfo, allocInfo);
 #endif
 }
 

--- a/src/Backends/Vulkan/src/image.cpp
+++ b/src/Backends/Vulkan/src/image.cpp
@@ -64,7 +64,7 @@ UInt32 VulkanImage::elements() const noexcept
 size_t VulkanImage::size() const noexcept
 {
 	if (m_impl->m_allocationInfo) [[likely]]
-		return m_impl->m_allocationInfo->GetSize();
+		return static_cast<size_t>(m_impl->m_allocationInfo->GetSize());
 	else
 	{
 		size_t pixelSize{ 0 };
@@ -104,7 +104,7 @@ size_t VulkanImage::elementSize() const noexcept
 size_t VulkanImage::elementAlignment() const noexcept
 {
 	if (m_impl->m_allocationInfo) [[likely]]
-		return m_impl->m_allocationInfo->GetAlignment();
+		return static_cast<size_t>(m_impl->m_allocationInfo->GetAlignment());
 	else
 		return 0;	// Not sure about the alignment. Probably need to query from device limits.
 }

--- a/src/Backends/Vulkan/src/image.cpp
+++ b/src/Backends/Vulkan/src/image.cpp
@@ -52,7 +52,7 @@ VulkanImage::~VulkanImage() noexcept
 	if (m_impl->m_allocator != nullptr && m_impl->m_allocationInfo != nullptr)
 	{
 		::vmaDestroyImage(m_impl->m_allocator, this->handle(), m_impl->m_allocationInfo);
-		LITEFX_TRACE(VULKAN_LOG, "Destroyed image {0}", static_cast<void*>(this->handle()));
+		LITEFX_TRACE(VULKAN_LOG, "Destroyed image {0}", Vk::handleAddress(this->handle()));
 	}
 }
 
@@ -303,7 +303,7 @@ SharedPtr<VulkanImage> VulkanImage::allocate(const String& name, const Size3d& e
 	VmaAllocation allocation{};
 
 	raiseIfFailed(::vmaCreateImage(allocator, &createInfo, &allocationInfo, &image, &allocation, allocationResult), "Unable to allocate texture.");
-	LITEFX_DEBUG(VULKAN_LOG, "Allocated image {0} with {1} bytes {{ Extent: {2}x{3} Px, Format: {4}, Levels: {5}, Layers: {6}, Samples: {8}, Usage: {7} }}", name.empty() ? std::format("{0}", static_cast<void*>(image)) : name, ::getSize(format) * extent.width() * extent.height(), extent.width(), extent.height(), format, levels, layers, usage, samples);
+	LITEFX_DEBUG(VULKAN_LOG, "Allocated image {0} with {1} bytes {{ Extent: {2}x{3} Px, Format: {4}, Levels: {5}, Layers: {6}, Samples: {8}, Usage: {7} }}", name.empty() ? std::format("{0}", Vk::handleAddress(image)) : name, ::getSize(format) * extent.width() * extent.height(), extent.width(), extent.height(), format, levels, layers, usage, samples);
 
 	return SharedObject::create<VulkanImage>(image, extent, format, dimensions, levels, layers, samples, usage, allocator, allocation, name);
 }

--- a/src/Backends/Vulkan/src/ray_tracing_pipeline.cpp
+++ b/src/Backends/Vulkan/src/ray_tracing_pipeline.cpp
@@ -191,11 +191,11 @@ public:
 
 		// Allocate a buffer for the shader binding table.
 		// NOTE: Updating the SBT to change shader-local data is currently unsupported. Instead, bind-less resources should be used.
-		auto result = m_device->factory().createBuffer(BufferType::ShaderBindingTable, ResourceHeap::Dynamic, recordSize, static_cast<UInt32>(totalRecordCount), ResourceUsage::TransferSource);
+		auto result = m_device->factory().createBuffer(BufferType::ShaderBindingTable, ResourceHeap::Dynamic, static_cast<size_t>(recordSize), static_cast<UInt32>(totalRecordCount), ResourceUsage::TransferSource);
 
 		// Write each record group by group.
 		UInt32 record{ 0 };
-		Array<Byte> recordData(recordSize, 0x00);
+		Array<Byte> recordData(static_cast<size_t>(recordSize), 0x00);
 
 		// Write each shader binding group that should be included.
 		for (auto group : { ShaderBindingGroup::RayGeneration, ShaderBindingGroup::Miss, ShaderBindingGroup::Callable, ShaderBindingGroup::HitGroup })
@@ -252,8 +252,8 @@ public:
 					raiseIfFailed(::vkGetRayTracingShaderGroupHandles(m_device->handle(), parent.handle(), id, 1, rayTracingProperties.shaderGroupHandleSize, recordData.data()), "Unable to query shader record handle.");
 
 					// Write the payload and map everything into the buffer.
-					std::memcpy(recordData.data() + rayTracingProperties.shaderGroupHandleSize, currentRecord->localData(), currentRecord->localDataSize()); // NOLINT(cppcoreguidelines-pro-bounds-pointer-arithmetic)
-					result->map(recordData.data(), recordSize, record++);
+					std::memcpy(recordData.data() + rayTracingProperties.shaderGroupHandleSize, currentRecord->localData(), static_cast<size_t>(currentRecord->localDataSize())); // NOLINT(cppcoreguidelines-pro-bounds-pointer-arithmetic)
+					result->map(recordData.data(), static_cast<size_t>(recordSize), record++);
 				}
 
 				// Increment record counter to address for empty records required to comply with alignment rules.

--- a/src/Backends/Vulkan/src/tlas.cpp
+++ b/src/Backends/Vulkan/src/tlas.cpp
@@ -120,7 +120,7 @@ void VulkanTopLevelAccelerationStructure::build(const VulkanCommandBuffer& comma
     else if (maxSize < requiredMemory) [[unlikely]]
         throw ArgumentOutOfRangeException("maxSize", std::make_pair(0_ui64, maxSize), requiredMemory, "The maximum available size is not sufficient to contain the acceleration structure.");
     else if (buffer->size() < offset + requiredMemory) [[unlikely]]
-        throw ArgumentOutOfRangeException("buffer", std::make_pair(0uz, buffer->size()), offset + requiredMemory, "The buffer does not contain enough memory after offset {0} to fully contain the acceleration structure.", offset);
+        throw ArgumentOutOfRangeException("buffer", std::make_pair<UInt64, UInt64>(0u, buffer->size()), offset + requiredMemory, "The buffer does not contain enough memory after offset {0} to fully contain the acceleration structure.", offset);
         
     // If the acceleration structure allows for compaction, create a query pool in order to query the compacted size later.
     if (LITEFX_FLAG_IS_SET(m_impl->m_flags, AccelerationStructureFlags::AllowCompaction))
@@ -183,7 +183,7 @@ void VulkanTopLevelAccelerationStructure::update(const VulkanCommandBuffer& comm
     else if (maxSize < requiredMemory) [[unlikely]]
         throw ArgumentOutOfRangeException("maxSize", std::make_pair(0_ui64, maxSize), requiredMemory, "The maximum available size is not sufficient to contain the acceleration structure.");
     else if (buffer->size() < offset + requiredMemory) [[unlikely]]
-        throw ArgumentOutOfRangeException("buffer", std::make_pair(0uz, buffer->size()), offset + requiredMemory, "The buffer does not contain enough memory after offset {0} to fully contain the acceleration structure.", offset);
+        throw ArgumentOutOfRangeException("buffer", std::make_pair<UInt64, UInt64>(0u, buffer->size()), offset + requiredMemory, "The buffer does not contain enough memory after offset {0} to fully contain the acceleration structure.", offset);
 
     // If the acceleration structure allows for compaction, reset the query pool.
     if (LITEFX_FLAG_IS_SET(m_impl->m_flags, AccelerationStructureFlags::AllowCompaction))
@@ -231,7 +231,7 @@ void VulkanTopLevelAccelerationStructure::copy(const VulkanCommandBuffer& comman
     if (buffer == nullptr)
         memory = destination.m_impl->m_buffer->size() >= requiredMemory[0] ? destination.m_impl->m_buffer : device->factory().createBuffer(BufferType::AccelerationStructure, ResourceHeap::Resource, requiredMemory[0], 1, ResourceUsage::AllowWrite);
     else if (buffer->size() < offset + requiredMemory[0]) [[unlikely]]
-        throw ArgumentOutOfRangeException("buffer", std::make_pair(0uz, buffer->size()), offset + requiredMemory[0], "The buffer does not contain enough memory after offset {0} to fully contain the acceleration structure.", offset);
+        throw ArgumentOutOfRangeException("buffer", std::make_pair<UInt64, UInt64>(0u, buffer->size()), offset + requiredMemory[0], "The buffer does not contain enough memory after offset {0} to fully contain the acceleration structure.", offset);
 
     // Create or reset query pool on destination, if required. 
     if (LITEFX_FLAG_IS_SET(destination.flags(), AccelerationStructureFlags::AllowCompaction))

--- a/src/Backends/Vulkan/src/tlas.cpp
+++ b/src/Backends/Vulkan/src/tlas.cpp
@@ -113,10 +113,10 @@ void VulkanTopLevelAccelerationStructure::build(const VulkanCommandBuffer& comma
     if (scratchBuffer != nullptr && scratchBuffer->size() < requiredScratchMemory)
         throw InvalidArgumentException("scratchBuffer", "The provided scratch buffer does not contain enough memory to build the acceleration structure (contained memory: {0} bytes, required memory: {1} bytes).", scratchBuffer->size(), requiredScratchMemory);
     else if (scratchBuffer == nullptr)
-        scratch = device->factory().createBuffer(BufferType::Storage, ResourceHeap::Resource, requiredScratchMemory, 1, ResourceUsage::AllowWrite);
+        scratch = device->factory().createBuffer(BufferType::Storage, ResourceHeap::Resource, static_cast<size_t>(requiredScratchMemory), 1, ResourceUsage::AllowWrite);
 
     if (buffer == nullptr)
-        memory = m_impl->m_buffer != nullptr && m_impl->m_buffer->size() >= requiredMemory ? m_impl->m_buffer : device->factory().createBuffer(BufferType::AccelerationStructure, ResourceHeap::Resource, requiredMemory, 1, ResourceUsage::AllowWrite);
+        memory = m_impl->m_buffer != nullptr && m_impl->m_buffer->size() >= requiredMemory ? m_impl->m_buffer : device->factory().createBuffer(BufferType::AccelerationStructure, ResourceHeap::Resource, static_cast<size_t>(requiredMemory), 1, ResourceUsage::AllowWrite);
     else if (maxSize < requiredMemory) [[unlikely]]
         throw ArgumentOutOfRangeException("maxSize", std::make_pair(0_ui64, maxSize), requiredMemory, "The maximum available size is not sufficient to contain the acceleration structure.");
     else if (buffer->size() < offset + requiredMemory) [[unlikely]]
@@ -176,10 +176,10 @@ void VulkanTopLevelAccelerationStructure::update(const VulkanCommandBuffer& comm
     if (scratchBuffer != nullptr && scratchBuffer->size() < requiredScratchMemory)
         throw InvalidArgumentException("scratchBuffer", "The provided scratch buffer does not contain enough memory to update the acceleration structure (contained memory: {0} bytes, required memory: {1} bytes).", scratchBuffer->size(), requiredScratchMemory);
     else if (scratchBuffer == nullptr)
-        scratch = device->factory().createBuffer(BufferType::Storage, ResourceHeap::Resource, requiredScratchMemory, 1, ResourceUsage::AllowWrite);
+        scratch = device->factory().createBuffer(BufferType::Storage, ResourceHeap::Resource, static_cast<size_t>(requiredScratchMemory), 1, ResourceUsage::AllowWrite);
 
     if (buffer == nullptr)
-        memory = m_impl->m_buffer->size() >= requiredMemory ? m_impl->m_buffer : device->factory().createBuffer(BufferType::AccelerationStructure, ResourceHeap::Resource, requiredMemory, 1, ResourceUsage::AllowWrite);
+        memory = m_impl->m_buffer->size() >= requiredMemory ? m_impl->m_buffer : device->factory().createBuffer(BufferType::AccelerationStructure, ResourceHeap::Resource, static_cast<size_t>(requiredMemory), 1, ResourceUsage::AllowWrite);
     else if (maxSize < requiredMemory) [[unlikely]]
         throw ArgumentOutOfRangeException("maxSize", std::make_pair(0_ui64, maxSize), requiredMemory, "The maximum available size is not sufficient to contain the acceleration structure.");
     else if (buffer->size() < offset + requiredMemory) [[unlikely]]
@@ -229,7 +229,7 @@ void VulkanTopLevelAccelerationStructure::copy(const VulkanCommandBuffer& comman
     auto memory = buffer;
 
     if (buffer == nullptr)
-        memory = destination.m_impl->m_buffer->size() >= requiredMemory[0] ? destination.m_impl->m_buffer : device->factory().createBuffer(BufferType::AccelerationStructure, ResourceHeap::Resource, requiredMemory[0], 1, ResourceUsage::AllowWrite);
+        memory = destination.m_impl->m_buffer->size() >= requiredMemory[0] ? destination.m_impl->m_buffer : device->factory().createBuffer(BufferType::AccelerationStructure, ResourceHeap::Resource, static_cast<size_t>(requiredMemory[0]), 1, ResourceUsage::AllowWrite);
     else if (buffer->size() < offset + requiredMemory[0]) [[unlikely]]
         throw ArgumentOutOfRangeException("buffer", std::make_pair<UInt64, UInt64>(0u, buffer->size()), offset + requiredMemory[0], "The buffer does not contain enough memory after offset {0} to fully contain the acceleration structure.", offset);
 

--- a/src/Rendering/include/litefx/rendering_formatters.hpp
+++ b/src/Rendering/include/litefx/rendering_formatters.hpp
@@ -26,7 +26,7 @@ struct LITEFX_RENDERING_API std::formatter<QueueType> : std::formatter<std::stri
 
 		if (t == QueueType::None)
 			names.emplace_back("None");
-		else if(LITEFX_FLAG_IS_SET(t == QueueType::Other))
+		else if(LITEFX_FLAG_IS_SET(t, QueueType::Other))
 			names.emplace_back("Other");
 		else 
 		{

--- a/src/Rendering/include/litefx/rendering_formatters.hpp
+++ b/src/Rendering/include/litefx/rendering_formatters.hpp
@@ -26,7 +26,7 @@ struct LITEFX_RENDERING_API std::formatter<QueueType> : std::formatter<std::stri
 
 		if (t == QueueType::None)
 			names.emplace_back("None");
-		else if(t == QueueType::Other)
+		else if(LITEFX_FLAG_IS_SET(t == QueueType::Other))
 			names.emplace_back("Other");
 		else 
 		{

--- a/src/Samples/RayQueries/src/sample.cpp
+++ b/src/Samples/RayQueries/src/sample.cpp
@@ -184,7 +184,7 @@ void SampleApp::initBuffers(IRenderBackend* /*backend*/)
     UInt64 opaqueSize{}, opaqueScratchSize{}, reflectiveSize{}, reflectiveScratchSize{};
     m_device->computeAccelerationStructureSizes(*opaque, opaqueSize, opaqueScratchSize);
     m_device->computeAccelerationStructureSizes(*reflective, reflectiveSize, reflectiveScratchSize);
-    auto blasBuffer = m_device->factory().createBuffer("BLAS", BufferType::AccelerationStructure, ResourceHeap::Resource, opaqueSize + reflectiveSize, 1u, ResourceUsage::AllowWrite);
+    auto blasBuffer = m_device->factory().createBuffer("BLAS", BufferType::AccelerationStructure, ResourceHeap::Resource, static_cast<size_t>(opaqueSize + reflectiveSize), 1u, ResourceUsage::AllowWrite);
 
     // Orient instances randomly.
     std::srand(static_cast<UInt32>(std::time(nullptr)));
@@ -207,7 +207,7 @@ void SampleApp::initBuffers(IRenderBackend* /*backend*/)
     // Create a scratch buffer.
     UInt64 tlasSize{}, tlasScratchSize{};
     m_device->computeAccelerationStructureSizes(*tlas, tlasSize, tlasScratchSize);
-    auto scratchBufferSize = std::max(std::max(opaqueScratchSize, reflectiveScratchSize), tlasScratchSize);
+    auto scratchBufferSize = static_cast<size_t>(std::max(std::max(opaqueScratchSize, reflectiveScratchSize), tlasScratchSize));
     auto scratchBuffer = m_device->factory().createBuffer(BufferType::Storage, ResourceHeap::Resource, scratchBufferSize, 1, ResourceUsage::AllowWrite);
 
     // Build the BLAS and the TLAS. We need to barrier in between both to prevent simultaneous scratch buffer writes.
@@ -269,7 +269,7 @@ void SampleApp::initBuffers(IRenderBackend* /*backend*/)
         auto opaqueCompactedSize = Math::align<UInt64>(opaque->size(), 256);
         auto reflectiveCompactedSize = Math::align<UInt64>(reflective->size(), 256);
         auto tlasCompactedSize = Math::align<UInt64>(tlas->size(), 256);
-        auto overallSize = opaqueCompactedSize + reflectiveCompactedSize + tlasCompactedSize;
+        auto overallSize = static_cast<size_t>(opaqueCompactedSize + reflectiveCompactedSize + tlasCompactedSize);
         // NOLINTEND(cppcoreguidelines-avoid-magic-numbers)
 
         // Allocate one buffer for all acceleration structures and allocate them individually.

--- a/src/Samples/RayTracing/src/sample.cpp
+++ b/src/Samples/RayTracing/src/sample.cpp
@@ -179,7 +179,7 @@ void SampleApp::initBuffers(IRenderBackend* /*backend*/)
     UInt64 opaqueSize{}, opaqueScratchSize{}, reflectiveSize{}, reflectiveScratchSize{};
     m_device->computeAccelerationStructureSizes(*opaque, opaqueSize, opaqueScratchSize);
     m_device->computeAccelerationStructureSizes(*reflective, reflectiveSize, reflectiveScratchSize);
-    auto blasBuffer = m_device->factory().createBuffer("BLAS", BufferType::AccelerationStructure, ResourceHeap::Resource, opaqueSize + reflectiveSize, 1u, ResourceUsage::AllowWrite);
+    auto blasBuffer = m_device->factory().createBuffer("BLAS", BufferType::AccelerationStructure, ResourceHeap::Resource, static_cast<size_t>(opaqueSize + reflectiveSize), 1u, ResourceUsage::AllowWrite);
 
     // Orient instances randomly.
     std::srand(static_cast<UInt32>(std::time(nullptr)));
@@ -202,7 +202,7 @@ void SampleApp::initBuffers(IRenderBackend* /*backend*/)
     // Create a scratch buffer.
     UInt64 tlasSize{}, tlasScratchSize{};
     m_device->computeAccelerationStructureSizes(*tlas, tlasSize, tlasScratchSize);
-    auto scratchBufferSize = std::max(std::max(opaqueScratchSize, reflectiveScratchSize), tlasScratchSize);
+    auto scratchBufferSize = static_cast<size_t>(std::max(std::max(opaqueScratchSize, reflectiveScratchSize), tlasScratchSize));
     auto scratchBuffer = m_device->factory().createBuffer(BufferType::Storage, ResourceHeap::Resource, scratchBufferSize, 1, ResourceUsage::AllowWrite);
 
     // Build the BLAS and the TLAS. We need to barrier in between both to prevent simultaneous scratch buffer writes.
@@ -277,7 +277,7 @@ void SampleApp::initBuffers(IRenderBackend* /*backend*/)
         auto opaqueCompactedSize = Math::align<UInt64>(opaque->size(), 256);
         auto reflectiveCompactedSize = Math::align<UInt64>(reflective->size(), 256);
         auto tlasCompactedSize = Math::align<UInt64>(tlas->size(), 256);
-        auto overallSize = opaqueCompactedSize + reflectiveCompactedSize + tlasCompactedSize;
+        auto overallSize = static_cast<size_t>(opaqueCompactedSize + reflectiveCompactedSize + tlasCompactedSize);
         // NOLINTEND(cppcoreguidelines-avoid-magic-numbers)
 
         // Allocate one buffer for all acceleration structures and allocate them individually.


### PR DESCRIPTION
**Describe the pull request**

This PR fixes the build failures for x86 builds in weekly CI. It introduces a helper method for safely requesting a handle address in Vulkan to fix overload and deduction issues. As a side change, it now uses the updated `llvm-install` action istead of running chocolatey, which should hopefully improve build times.

**Checklist**

- [x] Run static code analysis and fix potential issues it reports.
  - You can do this by building targets `windows-clangcl-x64-release` and `windows-clangcl-x86-release`.
  - Avoid using NOLINT comments; if unavoidable (e.g. for false-positives, etc.), please leave a comment within the PR body to explain it.
- [x] If this PR is work in progress, open it as a [draft PR](https://github.blog/2019-02-14-introducing-draft-pull-requests/).
- [x] If required, update the `.natvis` file(s) of the altered projects to reflect your changes.
- [x] Before submitting the PR, make sure to update the `.docs/release-logs/` for the next version with a summary of the changes.
  - Consider creating a draft PR to acquire it's URL.
  - If the PR addresses a bug that can be fixed without breaking API compatibility†, leave a comment so that we can target the proper branch.

† API compatibility means that code that compiles against the current version, should also compile against the next version.