### PR TITLE
Explicit resource tracking for command buffers.

### DIFF
--- a/docs/release-logs/0.4.1.md
+++ b/docs/release-logs/0.4.1.md
@@ -20,7 +20,7 @@
   - Descriptor sets can also be allocated without providing any binding index (in which case continuous counting is assumed) or resources (which enables late binding or resource updating).
   - Descriptor set binding has been simplified by caching last used pipeline on command buffers and providing the possibility to bind multiple descriptor sets at once.
   - Binding to descriptors that are not part of the layout does no longer throw an exception.
-- Improved handling of temporary command buffers. ([See PR #89](https://github.com/crud89/LiteFX/pull/89) and [PR # 123](https://github.com/crud89/LiteFX/pull/123))
+- Improved handling of temporary command buffers. ([See PR #89](https://github.com/crud89/LiteFX/pull/89), [PR # 123](https://github.com/crud89/LiteFX/pull/123) and [See PR #151](https://github.com/crud89/LiteFX/pull/151))
   - Command buffers can now be submitted with shared ownership to a command queue, which then stores them and releases the references, if the submit fence is passed (during `waitFor`).
   - Command buffer transfers can now receive resources with shared ownership. Resource references are released in a similar fashion.
   - It is no longer required to manually allocate staging buffers, as raw data can now be passed to transfers on command buffers directly.
@@ -46,7 +46,7 @@
 - Simplified math type interface. ([See PR #120](https://github.com/crud89/LiteFX/pull/120))
 - Add support for indirect draws/dispatches. ([See PR #118](https://github.com/crud89/LiteFX/pull/118))
 - Add native visualizers for improved debugging. ([See PR #137](https://github.com/crud89/LiteFX/pull/137))
-- Mip-map generation moved into graphics utility library. ([See PR #144](https://github.com/crud89/LiteFX/pull/144))
+- Mip-map generation moved into graphics utility library. ([See PR #144](https://github.com/crud89/LiteFX/pull/144) and [See PR #151](https://github.com/crud89/LiteFX/pull/151))
 - Support for CMake 4.0 and removal of deprecated build behaviour. ([See PR #149](https://github.com/crud89/LiteFX/pull/149))
 - Updated several dependencies. ([See PR #150](https://github.com/crud89/LiteFX/pull/150))
 

--- a/src/Backends/DirectX12/include/litefx/backends/dx12.hpp
+++ b/src/Backends/DirectX12/include/litefx/backends/dx12.hpp
@@ -1501,13 +1501,13 @@ namespace LiteFX::Rendering::Backends {
         void end() const override;
 
         /// <inheritdoc />
-        void track(SharedPtr<const IBuffer> buffer) const noexcept override;
+        void track(SharedPtr<const IBuffer> buffer) const override;
 
         /// <inheritdoc />
-        void track(SharedPtr<const IImage> image) const noexcept override;
+        void track(SharedPtr<const IImage> image) const override;
 
         /// <inheritdoc />
-        void track(SharedPtr<const ISampler> sampler) const noexcept override;
+        void track(SharedPtr<const ISampler> sampler) const override;
 
         /// <inheritdoc />
         bool isSecondary() const noexcept override;

--- a/src/Backends/DirectX12/include/litefx/backends/dx12.hpp
+++ b/src/Backends/DirectX12/include/litefx/backends/dx12.hpp
@@ -1501,6 +1501,15 @@ namespace LiteFX::Rendering::Backends {
         void end() const override;
 
         /// <inheritdoc />
+        void track(SharedPtr<const IBuffer> buffer) const noexcept override;
+
+        /// <inheritdoc />
+        void track(SharedPtr<const IImage> image) const noexcept override;
+
+        /// <inheritdoc />
+        void track(SharedPtr<const ISampler> sampler) const noexcept override;
+
+        /// <inheritdoc />
         bool isSecondary() const noexcept override;
 
         /// <inheritdoc />

--- a/src/Backends/DirectX12/src/command_buffer.cpp
+++ b/src/Backends/DirectX12/src/command_buffer.cpp
@@ -205,6 +205,24 @@ void DirectX12CommandBuffer::end() const
 	m_impl->m_recording = false;
 }
 
+void DirectX12CommandBuffer::track(SharedPtr<const IBuffer> buffer) const noexcept
+{
+	if (buffer != nullptr)
+		m_impl->m_sharedResources.push_back(buffer);
+}
+
+void DirectX12CommandBuffer::track(SharedPtr<const IImage> image) const noexcept
+{
+	if (image != nullptr)
+		m_impl->m_sharedResources.push_back(image);
+}
+
+void DirectX12CommandBuffer::track(SharedPtr<const ISampler> sampler) const noexcept
+{
+	if (sampler != nullptr)
+		m_impl->m_sharedResources.push_back(sampler);
+}
+
 bool DirectX12CommandBuffer::isSecondary() const noexcept
 {
 	return m_impl->m_secondary;

--- a/src/Backends/DirectX12/src/command_buffer.cpp
+++ b/src/Backends/DirectX12/src/command_buffer.cpp
@@ -205,20 +205,29 @@ void DirectX12CommandBuffer::end() const
 	m_impl->m_recording = false;
 }
 
-void DirectX12CommandBuffer::track(SharedPtr<const IBuffer> buffer) const noexcept
+void DirectX12CommandBuffer::track(SharedPtr<const IBuffer> buffer) const
 {
+	if (!m_impl->m_recording)
+		throw RuntimeException("Command buffers may only start resource tracking if they are currently recording.");
+
 	if (buffer != nullptr)
 		m_impl->m_sharedResources.push_back(buffer);
 }
 
-void DirectX12CommandBuffer::track(SharedPtr<const IImage> image) const noexcept
+void DirectX12CommandBuffer::track(SharedPtr<const IImage> image) const
 {
+	if (!m_impl->m_recording)
+		throw RuntimeException("Command buffers may only start resource tracking if they are currently recording.");
+
 	if (image != nullptr)
 		m_impl->m_sharedResources.push_back(image);
 }
 
-void DirectX12CommandBuffer::track(SharedPtr<const ISampler> sampler) const noexcept
+void DirectX12CommandBuffer::track(SharedPtr<const ISampler> sampler) const
 {
+	if (!m_impl->m_recording)
+		throw RuntimeException("Command buffers may only start resource tracking if they are currently recording.");
+
 	if (sampler != nullptr)
 		m_impl->m_sharedResources.push_back(sampler);
 }

--- a/src/Backends/Vulkan/include/litefx/backends/vulkan.hpp
+++ b/src/Backends/Vulkan/include/litefx/backends/vulkan.hpp
@@ -1474,13 +1474,13 @@ namespace LiteFX::Rendering::Backends {
         void end() const override;
 
         /// <inheritdoc />
-        void track(SharedPtr<const IBuffer> buffer) const noexcept override;
+        void track(SharedPtr<const IBuffer> buffer) const override;
 
         /// <inheritdoc />
-        void track(SharedPtr<const IImage> image) const noexcept override;
+        void track(SharedPtr<const IImage> image) const override;
 
         /// <inheritdoc />
-        void track(SharedPtr<const ISampler> sampler) const noexcept override;
+        void track(SharedPtr<const ISampler> sampler) const override;
 
         /// <inheritdoc />
         bool isSecondary() const noexcept override;

--- a/src/Backends/Vulkan/include/litefx/backends/vulkan.hpp
+++ b/src/Backends/Vulkan/include/litefx/backends/vulkan.hpp
@@ -1474,6 +1474,15 @@ namespace LiteFX::Rendering::Backends {
         void end() const override;
 
         /// <inheritdoc />
+        void track(SharedPtr<const IBuffer> buffer) const noexcept override;
+
+        /// <inheritdoc />
+        void track(SharedPtr<const IImage> image) const noexcept override;
+
+        /// <inheritdoc />
+        void track(SharedPtr<const ISampler> sampler) const noexcept override;
+
+        /// <inheritdoc />
         bool isSecondary() const noexcept override;
 
         /// <inheritdoc />

--- a/src/Backends/Vulkan/src/command_buffer.cpp
+++ b/src/Backends/Vulkan/src/command_buffer.cpp
@@ -314,20 +314,29 @@ void VulkanCommandBuffer::end() const
 	m_impl->m_recording = false;
 }
 
-void VulkanCommandBuffer::track(SharedPtr<const IBuffer> buffer) const noexcept
+void VulkanCommandBuffer::track(SharedPtr<const IBuffer> buffer) const
 {
+	if (!m_impl->m_recording)
+		throw RuntimeException("Command buffers may only start resource tracking if they are currently recording.");
+
 	if (buffer != nullptr)
 		m_impl->m_sharedResources.push_back(buffer);
 }
 
-void VulkanCommandBuffer::track(SharedPtr<const IImage> image) const noexcept
+void VulkanCommandBuffer::track(SharedPtr<const IImage> image) const
 {
+	if (!m_impl->m_recording)
+		throw RuntimeException("Command buffers may only start resource tracking if they are currently recording.");
+
 	if (image != nullptr)
 		m_impl->m_sharedResources.push_back(image);
 }
 
-void VulkanCommandBuffer::track(SharedPtr<const ISampler> sampler) const noexcept
+void VulkanCommandBuffer::track(SharedPtr<const ISampler> sampler) const
 {
+	if (!m_impl->m_recording)
+		throw RuntimeException("Command buffers may only start resource tracking if they are currently recording.");
+
 	if (sampler != nullptr)
 		m_impl->m_sharedResources.push_back(sampler);
 }

--- a/src/Backends/Vulkan/src/command_buffer.cpp
+++ b/src/Backends/Vulkan/src/command_buffer.cpp
@@ -314,6 +314,24 @@ void VulkanCommandBuffer::end() const
 	m_impl->m_recording = false;
 }
 
+void VulkanCommandBuffer::track(SharedPtr<const IBuffer> buffer) const noexcept
+{
+	if (buffer != nullptr)
+		m_impl->m_sharedResources.push_back(buffer);
+}
+
+void VulkanCommandBuffer::track(SharedPtr<const IImage> image) const noexcept
+{
+	if (image != nullptr)
+		m_impl->m_sharedResources.push_back(image);
+}
+
+void VulkanCommandBuffer::track(SharedPtr<const ISampler> sampler) const noexcept
+{
+	if (sampler != nullptr)
+		m_impl->m_sharedResources.push_back(sampler);
+}
+
 bool VulkanCommandBuffer::isSecondary() const noexcept
 {
 	return m_impl->m_secondary;

--- a/src/Graphics/src/blitter_d3d12.cpp
+++ b/src/Graphics/src/blitter_d3d12.cpp
@@ -122,7 +122,7 @@ void Blitter<DirectX12Backend>::generateMipMaps(IDirectX12Image& image, DirectX1
 	commandBuffer.barrier(startBarrier);
 	auto resource = resourceBindings.begin();
 
-	for (UInt32 l(0); l < image.layers(); ++l, ++resource)
+	for (UInt32 l(0); l < image.layers(); ++l)
 	{
 		auto size = image.extent();
 

--- a/src/Graphics/src/blitter_d3d12.cpp
+++ b/src/Graphics/src/blitter_d3d12.cpp
@@ -108,6 +108,7 @@ void Blitter<DirectX12Backend>::generateMipMaps(IDirectX12Image& image, DirectX1
 	const auto& parametersLayout = resourceBindingsLayout.descriptor(0);
 	auto parameters = device->factory().createBuffer(parametersLayout.type(), ResourceHeap::Dynamic, parametersLayout.elementSize(), image.levels());
 	parameters->map(parametersBlock, sizeof(Parameters));
+	commandBuffer.track(parameters);
 
 	// Create and bind the sampler.
 	const auto& samplerBindingsLayout = pipeline.layout()->descriptorSet(1);

--- a/src/Rendering/include/litefx/rendering_api.hpp
+++ b/src/Rendering/include/litefx/rendering_api.hpp
@@ -6554,6 +6554,45 @@ namespace LiteFX::Rendering {
         /// <returns>`true`, if the command buffer is a secondary command buffer, or `false` otherwise.</returns>
         virtual bool isSecondary() const noexcept = 0;
 
+        /// <summary>
+        /// Sets up tracking for a buffer, so that it will not be destroyed until the command buffer has been executed.
+        /// </summary>
+        /// <remarks>
+        /// When working with resources, often times you only need them for a single execution cycle of a command buffer. Having to manually check if the command buffer has been 
+        /// executed (by waiting for it's submission fence on the target queue) and releasing the resource afterwards can be difficult and intricate. Resource tracking allows the
+        /// command buffer to store a reference of a resource and releasing it at some point after the command buffer has been executed automatically. Note that this does not 
+        /// automatically destroy the resource, which only happens if all references to it are released. However, if the only reference left is the one that is tracked by the 
+        /// command buffer, this process also destroys the resource.
+        /// </remarks>
+        /// <param name="buffer">The buffer to track.</param>
+        virtual void track(SharedPtr<const IBuffer> buffer) const noexcept = 0;
+
+        /// <summary>
+        /// Sets up tracking for an image, so that it will not be destroyed until the command buffer has been executed.
+        /// </summary>
+        /// <remarks>
+        /// When working with resources, often times you only need them for a single execution cycle of a command buffer. Having to manually check if the command buffer has been 
+        /// executed (by waiting for it's submission fence on the target queue) and releasing the resource afterwards can be difficult and intricate. Resource tracking allows the
+        /// command buffer to store a reference of a resource and releasing it at some point after the command buffer has been executed automatically. Note that this does not 
+        /// automatically destroy the resource, which only happens if all references to it are released. However, if the only reference left is the one that is tracked by the 
+        /// command buffer, this process also destroys the resource.
+        /// </remarks>
+        /// <param name="image">The image to track.</param>
+        virtual void track(SharedPtr<const IImage> image) const noexcept = 0;
+
+        /// <summary>
+        /// Sets up tracking for a sampler state, so that it will not be destroyed until the command buffer has been executed.
+        /// </summary>
+        /// <remarks>
+        /// When working with resources, often times you only need them for a single execution cycle of a command buffer. Having to manually check if the command buffer has been 
+        /// executed (by waiting for it's submission fence on the target queue) and releasing the resource afterwards can be difficult and intricate. Resource tracking allows the
+        /// command buffer to store a reference of a resource and releasing it at some point after the command buffer has been executed automatically. Note that this does not 
+        /// automatically destroy the resource, which only happens if all references to it are released. However, if the only reference left is the one that is tracked by the 
+        /// command buffer, this process also destroys the resource.
+        /// </remarks>
+        /// <param name="sampler">The sampler to track.</param>
+        virtual void track(SharedPtr<const ISampler> sampler) const noexcept = 0;
+
     public:
         /// <summary>
         /// Gets a pointer to the command queue that this command buffer was allocated from or `nullptr`, if the queue has already been released.

--- a/src/Rendering/include/litefx/rendering_api.hpp
+++ b/src/Rendering/include/litefx/rendering_api.hpp
@@ -6563,35 +6563,31 @@ namespace LiteFX::Rendering {
         /// command buffer to store a reference of a resource and releasing it at some point after the command buffer has been executed automatically. Note that this does not 
         /// automatically destroy the resource, which only happens if all references to it are released. However, if the only reference left is the one that is tracked by the 
         /// command buffer, this process also destroys the resource.
+        /// 
+        /// Resources can only be tracked, if the command buffer is currently recording. The command buffer will not track uninitialized resources, i.e., a submitted `nullptr`
+        /// will be discarded.
         /// </remarks>
         /// <param name="buffer">The buffer to track.</param>
-        virtual void track(SharedPtr<const IBuffer> buffer) const noexcept = 0;
+        /// <exception cref="RuntimeException">Thrown, if the command buffer is not currently recording.</exception>
+        /// <seealso cref="track(SharedPtr&le;const IImage&ge;)" />
+        /// <seealso cref="track(SharedPtr&le;const ISampler&ge;)" />
+        virtual void track(SharedPtr<const IBuffer> buffer) const = 0;
 
         /// <summary>
         /// Sets up tracking for an image, so that it will not be destroyed until the command buffer has been executed.
         /// </summary>
-        /// <remarks>
-        /// When working with resources, often times you only need them for a single execution cycle of a command buffer. Having to manually check if the command buffer has been 
-        /// executed (by waiting for it's submission fence on the target queue) and releasing the resource afterwards can be difficult and intricate. Resource tracking allows the
-        /// command buffer to store a reference of a resource and releasing it at some point after the command buffer has been executed automatically. Note that this does not 
-        /// automatically destroy the resource, which only happens if all references to it are released. However, if the only reference left is the one that is tracked by the 
-        /// command buffer, this process also destroys the resource.
-        /// </remarks>
         /// <param name="image">The image to track.</param>
-        virtual void track(SharedPtr<const IImage> image) const noexcept = 0;
+        /// <exception cref="RuntimeException">Thrown, if the command buffer is not currently recording.</exception>
+        /// <seealso cref="track(SharedPtr&le;const IBuffer&ge;)" />
+        virtual void track(SharedPtr<const IImage> image) const = 0;
 
         /// <summary>
         /// Sets up tracking for a sampler state, so that it will not be destroyed until the command buffer has been executed.
         /// </summary>
-        /// <remarks>
-        /// When working with resources, often times you only need them for a single execution cycle of a command buffer. Having to manually check if the command buffer has been 
-        /// executed (by waiting for it's submission fence on the target queue) and releasing the resource afterwards can be difficult and intricate. Resource tracking allows the
-        /// command buffer to store a reference of a resource and releasing it at some point after the command buffer has been executed automatically. Note that this does not 
-        /// automatically destroy the resource, which only happens if all references to it are released. However, if the only reference left is the one that is tracked by the 
-        /// command buffer, this process also destroys the resource.
-        /// </remarks>
         /// <param name="sampler">The sampler to track.</param>
-        virtual void track(SharedPtr<const ISampler> sampler) const noexcept = 0;
+        /// <exception cref="RuntimeException">Thrown, if the command buffer is not currently recording.</exception>
+        /// <seealso cref="track(SharedPtr&le;const IBuffer&ge;)" />
+        virtual void track(SharedPtr<const ISampler> sampler) const = 0;
 
     public:
         /// <summary>


### PR DESCRIPTION
**Describe the pull request**

When working with temporary resources, it is often times intricate and difficult to manage their lifetime, they need to wait for the command buffer to finish execution before being able to safely release them. Command buffers already provide an implicit tracking mechanism for transferred resources. However, dynamic buffers don't need to be transferred and thus cannot be passed to this collection. This PR adds a `track` method to command buffers, which allows them to explicitly track a resource. The D3D12 mip-map blitter makes use of this to track the parameter sets.