### PR TITLE
Use `environment` variables to specify compiler preference.

### DIFF
--- a/docs/release-logs/0.4.2.md
+++ b/docs/release-logs/0.4.2.md
@@ -1,0 +1,5 @@
+﻿# LiteFX 0.4.2 - Alpha 04 Patch 1
+
+**🐞 Bug Fixes:**
+
+- Fix issue where re-configuring the project would fail due to `CMAKE_CXX_COMPILER` or `CMAKE_C_COMPILER` cache variables are being reset. (see [PR #157](https://github.com/crud89/LiteFX/pull/157))

--- a/src/cmake/presets/compilers.json
+++ b/src/cmake/presets/compilers.json
@@ -8,15 +8,15 @@
       "name": "msvc",
       "hidden": true,
       "inherits": "windows",
-      "cacheVariables": {
-        "CMAKE_CXX_COMPILER": "cl"
+      "environment": {
+        "CXX": "cl"
       }
     },
     {
       "name": "clang",
       "hidden": true,
-      "cacheVariables": {
-        "CMAKE_CXX_COMPILER": "clang++"
+      "environment": {
+        "CXX": "clang++"
       },
       "vendor": {
         "microsoft.com/VisualStudioSettings/CMake/1.0": {
@@ -27,9 +27,11 @@
     {
       "name": "clangcl",
       "hidden": true,
+      "environment": {
+        "CC": "clang-cl",
+        "CXX": "clang-cl"
+      },
       "cacheVariables": {
-        "CMAKE_C_COMPILER": "clang-cl",
-        "CMAKE_CXX_COMPILER": "clang-cl",
         "CMAKE_CXX_CLANG_TIDY": "clang-tidy;--config-file=${sourceDir}/.clang-tidy;--extra-arg=/EHsc"
       },
       "vendor": {


### PR DESCRIPTION
**Describe the pull request**

This moves the compiler preference in the CMake presets into `environment` rather than `cacheVariables`, which fixes an issue that could cause re-configuration to fail. For details see #156.

**Related issues**

Fixes #156.