### PR TITLE
Fix handling of partial scissor rects.

### DIFF
--- a/src/Backends/DirectX12/src/command_buffer.cpp
+++ b/src/Backends/DirectX12/src/command_buffer.cpp
@@ -254,16 +254,24 @@ void DirectX12CommandBuffer::setViewports(const IViewport* viewport) const
 
 void DirectX12CommandBuffer::setScissors(Span<const IScissor*> scissors) const
 {
-	auto scs = scissors |
-		std::views::transform([](const auto& scissor) { return CD3DX12_RECT(static_cast<LONG>(scissor->getRectangle().x()), static_cast<LONG>(scissor->getRectangle().y()), static_cast<LONG>(scissor->getRectangle().width()), static_cast<LONG>(scissor->getRectangle().height())); }) |
-		std::ranges::to<Array<D3D12_RECT>>();
+	auto scs = scissors 
+		| std::views::transform([](const auto& scissor) -> D3D12_RECT { return CD3DX12_RECT{
+				static_cast<LONG>(scissor->getRectangle().x()), static_cast<LONG>(scissor->getRectangle().y()),
+				static_cast<LONG>(scissor->getRectangle().x()) + static_cast<LONG>(scissor->getRectangle().width()),
+				static_cast<LONG>(scissor->getRectangle().y()) + static_cast<LONG>(scissor->getRectangle().height())
+			}; })
+		| std::ranges::to<Array<D3D12_RECT>>();
 
 	this->handle()->RSSetScissorRects(static_cast<UINT>(scs.size()), scs.data());
 }
 
 void DirectX12CommandBuffer::setScissors(const IScissor* scissor) const
 {
-	auto s = CD3DX12_RECT(static_cast<LONG>(scissor->getRectangle().x()), static_cast<LONG>(scissor->getRectangle().y()), static_cast<LONG>(scissor->getRectangle().width()), static_cast<LONG>(scissor->getRectangle().height()));
+	CD3DX12_RECT s {
+		static_cast<LONG>(scissor->getRectangle().x()), static_cast<LONG>(scissor->getRectangle().y()),
+		static_cast<LONG>(scissor->getRectangle().x()) + static_cast<LONG>(scissor->getRectangle().width()),
+		static_cast<LONG>(scissor->getRectangle().y()) + static_cast<LONG>(scissor->getRectangle().height())
+	};
 	this->handle()->RSSetScissorRects(1, &s);
 }
 

--- a/src/Tests/Backends.D3D12/CMakeLists.txt
+++ b/src/Tests/Backends.D3D12/CMakeLists.txt
@@ -136,6 +136,11 @@ DEFINE_TEST("device_sets_up_d3d12_acceleration_structures" FOLDER "Tests/Backend
 	DEPENDENCIES LiteFX.AppModel LiteFX.Rendering LiteFX.Logging LiteFX.Backends.DirectX12
 )
 
+DEFINE_TEST("d3d12_partial_scissor_rects_dont_fail" FOLDER "Tests/Backends/D3D12" EXECUTABLE_NAME "d3d12_partial_scissor_test" 
+	SOURCES "common.h" "partial_scissor_rect.cpp"
+	DEPENDENCIES LiteFX.AppModel LiteFX.Rendering LiteFX.Logging LiteFX.Backends.DirectX12
+)
+
 ADD_DEPENDENCIES(d3d12_app_init_test dxwarp)
 ADD_DEPENDENCIES(d3d12_input_assembler_test dxwarp)
 ADD_DEPENDENCIES(d3d12_rasterizer_test dxwarp)
@@ -151,3 +156,4 @@ ADD_DEPENDENCIES(d3d12_compute_test dxwarp)
 ADD_DEPENDENCIES(d3d12_alloc_descriptor_set_test dxwarp)
 ADD_DEPENDENCIES(d3d12_ray_tracing_test dxwarp)
 ADD_DEPENDENCIES(d3d12_acceleration_structure_test dxwarp)
+ADD_DEPENDENCIES(d3d12_partial_scissor_test dxwarp)

--- a/src/Tests/Backends.D3D12/partial_scissor_rect.cpp
+++ b/src/Tests/Backends.D3D12/partial_scissor_rect.cpp
@@ -1,0 +1,140 @@
+#include "common.h"
+
+#define FRAMEBUFFER_WIDTH  800
+#define FRAMEBUFFER_HEIGHT 600
+
+HWND _window{ nullptr };
+
+SharedPtr<Viewport> _viewport;
+SharedPtr<Scissor> _scissor;
+SharedPtr<DirectX12Device> _device;
+
+void TestApp::onInit()
+{
+    // Create a callback for backend startup and shutdown.
+    auto startCallback = [](DirectX12Backend* backend) {
+        // Create viewport and scissors.
+        _viewport = makeShared<Viewport>(RectF(0.f, 0.f, static_cast<Float>(FRAMEBUFFER_WIDTH), static_cast<Float>(FRAMEBUFFER_HEIGHT)));
+        _scissor = makeShared<Scissor>(RectF(0.f, 0.f, static_cast<Float>(FRAMEBUFFER_WIDTH), static_cast<Float>(FRAMEBUFFER_HEIGHT)));
+
+        // Find adapter and create surface.
+        auto adapter = backend->findAdapter(std::nullopt);
+        auto surface = backend->createSurface(_window);
+
+        // Create the device.
+        _device = backend->createDevice("Default", *adapter, std::move(surface), Format::B8G8R8A8_UNORM, _viewport->getRectangle().extent(), 3, false).shared_from_this();
+
+        // Setup a 100x100 pixel scissor in the lower right corner of the frame buffer.
+        auto scissor1 = Scissor(RectF { FRAMEBUFFER_WIDTH - 100, FRAMEBUFFER_HEIGHT - 100, 100, 100 });
+
+        // Create a command buffer, set the scissor and submit.
+        auto commandBuffer1 = _device->defaultQueue(QueueType::Graphics).createCommandBuffer(true);
+        commandBuffer1->setScissors(&scissor1);
+        commandBuffer1->submit();
+
+        // Repeat the trest, but with multiple scissor rects.
+        auto scissor2 = Scissor(RectF{ FRAMEBUFFER_WIDTH - 200, FRAMEBUFFER_HEIGHT - 200, 200, 200 });
+        auto scissors = std::array<const IScissor*, 2> { &scissor1, &scissor2 };
+        auto commandBuffer2 = _device->defaultQueue(QueueType::Graphics).createCommandBuffer(true);
+        commandBuffer2->setScissors(scissors);
+        commandBuffer2->submit();
+
+        return true;
+    };
+
+    auto stopCallback = [](DirectX12Backend* backend) {
+        _device.reset();
+        backend->releaseDevice("Default");
+    };
+
+    // Register the DirectX 12 backend de-/initializer.
+    this->onBackendStart<DirectX12Backend>(startCallback);
+    this->onBackendStop<DirectX12Backend>(stopCallback);
+}
+
+void TestApp::onStartup()
+{
+}
+
+void TestApp::onShutdown()
+{
+}
+
+void TestApp::onResize(const void* /*sender*/, ResizeEventArgs /*e*/)
+{
+}
+
+LRESULT CALLBACK WndProc(HWND hwnd, UINT msg, WPARAM wParam, LPARAM lParam)
+{
+    switch (msg)
+    {
+    case WM_CLOSE:
+        DestroyWindow(hwnd);
+        break;
+    case WM_DESTROY:
+        PostQuitMessage(0);
+        break;
+    default:
+        return DefWindowProc(hwnd, msg, wParam, lParam);
+    }
+
+    return 0;
+}
+
+int main(int /*argc*/, char* /*argv*/[])
+{
+    // Register a window class.
+    HINSTANCE instance = ::GetModuleHandle(nullptr);
+    const auto windowClassName = "Test App Window Class";
+
+    WNDCLASSEX windowClass{
+        .cbSize = sizeof(WNDCLASSEX),
+        .lpfnWndProc = ::WndProc,
+        .hInstance = instance,
+        .hIcon = ::LoadIcon(nullptr, IDI_APPLICATION),
+        .hCursor = LoadCursor(nullptr, IDC_ARROW),
+        .hbrBackground = (HBRUSH)(COLOR_WINDOW + 1),
+        .lpszClassName = windowClassName,
+        .hIconSm = LoadIcon(NULL, IDI_APPLICATION)
+    };
+
+    if (!::RegisterClassEx(&windowClass))
+    {
+        std::cerr << "Unable to register window class." << std::endl;
+        return EXIT_FAILURE;
+    }
+
+    // Create a window instance.
+    _window = ::CreateWindowEx(WS_EX_CLIENTEDGE, windowClassName, "Test App",
+        WS_OVERLAPPEDWINDOW, CW_USEDEFAULT, CW_USEDEFAULT, FRAMEBUFFER_WIDTH, FRAMEBUFFER_HEIGHT,
+        nullptr, nullptr, instance, nullptr);
+
+    if (_window == NULL)
+    {
+        std::cerr << "Unable to create test window." << std::endl;
+        return EXIT_FAILURE;
+    }
+
+    // Show the window.
+    ::ShowWindow(_window, SW_SHOWNORMAL);
+    ::UpdateWindow(_window);
+
+    // Create the app.
+    try
+    {
+        UniquePtr<App> app = App::build<TestApp>()
+            .logTo<ConsoleSink>(LogLevel::Error)
+            .logTo<TerminationSink>(LogLevel::Error) // Exit on error.
+            .useBackend<DirectX12Backend>(true); // Use WARP.
+
+        app->run();
+    }
+    catch (const LiteFX::Exception& ex)
+    {
+        std::cerr << "Unhandled exception: " << ex.what() << '\n' << "at: " << ex.trace() << std::endl;
+
+        return EXIT_FAILURE;
+    }
+
+    return EXIT_SUCCESS;
+}


### PR DESCRIPTION
**Describe the pull request**

The D3D12 backend sets up scissor rectangles wrong, if they are not starting in the coordinate space origin. This PR introduces a PR that catches this issue as well as a proper fix.

**Related issues**

Fixes #153  
