### PR TITLE
Validate and offset descriptor indices when binding image and sampler arrays.

### DIFF
--- a/docs/release-logs/0.4.2.md
+++ b/docs/release-logs/0.4.2.md
@@ -1,5 +1,0 @@
-﻿# LiteFX 0.4.2 - Alpha 04 Patch 1
-
-**🐞 Bug Fixes:**
-
-- Fix issue where re-configuring the project would fail due to `CMAKE_CXX_COMPILER` or `CMAKE_C_COMPILER` cache variables are being reset. (see [PR #157](https://github.com/crud89/LiteFX/pull/157))

--- a/docs/release-logs/0.5.1.md
+++ b/docs/release-logs/0.5.1.md
@@ -1,0 +1,10 @@
+﻿# LiteFX 0.5.1 - Alpha 05
+
+**❎ DirectX 12:**
+
+- Fixed an issue where scissor rects that did not start at the window origin were incorrectly passed to the pipeline. (See [PR #158](https://github.com/crud89/LiteFX/pull/158))
+- Fixed an issue that caused image and sampler arrays to be mapped incorrectly to the underlying descriptor sets. (See [PR #159](https://github.com/crud89/LiteFX/pull/159))
+
+**🐞 Bug Fixes:**
+
+- Fix issue where re-configuring the project would fail due to `CMAKE_CXX_COMPILER` or `CMAKE_C_COMPILER` cache variables are being reset. (see [PR #157](https://github.com/crud89/LiteFX/pull/157))


### PR DESCRIPTION
**Describe the pull request**

This resolves an issue where sampler and image arrays are not properly bound. This happend because the index to the first descriptor was not correctly offset. This PR validates if the target descriptor is valid for a descriptor array at a specific binding and properly computes the descriptor offset before copying the desriptor to the global heap(s).

Unfortunately no test for this issue is implemented, as this does neither trigger the validation layer, nor any state changes in the engine itself.

**Related issues**

Fixes #154 