### PR TITLE
Fix literal deprecation warnings.

### DIFF
--- a/docs/release-logs/0.5.1.md
+++ b/docs/release-logs/0.5.1.md
@@ -8,3 +8,4 @@
 **🐞 Bug Fixes:**
 
 - Fix issue where re-configuring the project would fail due to `CMAKE_CXX_COMPILER` or `CMAKE_C_COMPILER` cache variables are being reset. (see [PR #157](https://github.com/crud89/LiteFX/pull/157))
+- Fix deprecation warning for some literal operators. (See [PR #161](https://github.com/crud89/LiteFX/pull/161))

--- a/src/Core/include/litefx/string.hpp
+++ b/src/Core/include/litefx/string.hpp
@@ -76,7 +76,7 @@ namespace LiteFX {
     /// <param name="string">The string to hash.</param>
     /// <param name="chars">The number of characters in the string.</param>
     /// <returns>The FNVa hash for <paramref name="string" />.</returns>
-    consteval std::uint64_t operator"" _hash(const char* string, size_t chars) noexcept 
+    consteval std::uint64_t operator ""_hash(const char* string, size_t chars) noexcept 
     {
         return hash(StringView(string, chars));
     }
@@ -87,7 +87,7 @@ namespace LiteFX {
     /// <param name="string">The string to hash.</param>
     /// <param name="chars">The number of characters in the string.</param>
     /// <returns>The FNVa hash for <paramref name="string" />.</returns>
-    consteval std::uint64_t operator"" _hash(const wchar_t* string, size_t chars) noexcept 
+    consteval std::uint64_t operator ""_hash(const wchar_t* string, size_t chars) noexcept 
     {
         return hash(WStringView(string, chars));
     }

--- a/src/Math/include/litefx/math.hpp
+++ b/src/Math/include/litefx/math.hpp
@@ -80,7 +80,7 @@ namespace LiteFX::Math {
 	/// </summary>
 	/// <param name="arg">The value that should be assigned to the byte.</param>
 	/// <returns>The value as byte.</returns>
-	constexpr Byte operator "" _b(unsigned long long int arg) noexcept {
+	constexpr Byte operator ""_b(unsigned long long int arg) noexcept {
 		return static_cast<Byte>(arg);
 	}
 
@@ -89,7 +89,7 @@ namespace LiteFX::Math {
 	/// </summary>
 	/// <param name="arg">The value that should be assigned to the integer.</param>
 	/// <returns>The value as 16 bit integer.</returns>
-	constexpr Int16 operator "" _i16(unsigned long long int arg) noexcept {
+	constexpr Int16 operator ""_i16(unsigned long long int arg) noexcept {
 		return static_cast<Int16>(arg);
 	}
 
@@ -98,7 +98,7 @@ namespace LiteFX::Math {
 	/// </summary>
 	/// <param name="arg">The value that should be assigned to the integer.</param>
 	/// <returns>The value as 16 bit unsigned integer.</returns>
-	constexpr UInt16 operator "" _ui16(unsigned long long int arg) noexcept {
+	constexpr UInt16 operator ""_ui16(unsigned long long int arg) noexcept {
 		return static_cast<UInt16>(arg);
 	}
 
@@ -107,7 +107,7 @@ namespace LiteFX::Math {
 	/// </summary>
 	/// <param name="arg">The value that should be assigned to the integer.</param>
 	/// <returns>The value as 32 bit integer.</returns>
-	constexpr Int32 operator "" _i32(unsigned long long int arg) noexcept {
+	constexpr Int32 operator ""_i32(unsigned long long int arg) noexcept {
 		return static_cast<Int32>(arg);
 	}
 
@@ -116,7 +116,7 @@ namespace LiteFX::Math {
 	/// </summary>
 	/// <param name="arg">The value that should be assigned to the integer.</param>
 	/// <returns>The value as 32 bit unsigned integer.</returns>
-	constexpr UInt32 operator "" _ui32(unsigned long long int arg) noexcept {
+	constexpr UInt32 operator ""_ui32(unsigned long long int arg) noexcept {
 		return static_cast<UInt32>(arg);
 	}
 
@@ -125,7 +125,7 @@ namespace LiteFX::Math {
 	/// </summary>
 	/// <param name="arg">The value that should be assigned to the integer.</param>
 	/// <returns>The value as 64 bit integer.</returns>
-	constexpr Int64 operator "" _i64(unsigned long long int arg) noexcept {
+	constexpr Int64 operator ""_i64(unsigned long long int arg) noexcept {
 		return static_cast<Int64>(arg);
 	}
 
@@ -134,7 +134,7 @@ namespace LiteFX::Math {
 	/// </summary>
 	/// <param name="arg">The value that should be assigned to the integer.</param>
 	/// <returns>The value as 64 bit unsigned integer.</returns>
-	constexpr UInt64 operator "" _ui64(unsigned long long int arg) noexcept {
+	constexpr UInt64 operator ""_ui64(unsigned long long int arg) noexcept {
 		return static_cast<UInt64>(arg);
 	}
 
@@ -143,7 +143,7 @@ namespace LiteFX::Math {
 	/// </summary>
 	/// <param name="arg">The value that should be assigned to the floating point number.</param>
 	/// <returns>The value as floating point number.</returns>
-	constexpr Float operator "" _f32(long double arg) noexcept {
+	constexpr Float operator ""_f32(long double arg) noexcept {
 		return static_cast<Float>(arg);
 	}
 
@@ -152,7 +152,7 @@ namespace LiteFX::Math {
 	/// </summary>
 	/// <param name="arg">The value that should be assigned to the floating point number.</param>
 	/// <returns>The value as floating point number.</returns>
-	constexpr Double operator "" _f64(long double arg) noexcept {
+	constexpr Double operator ""_f64(long double arg) noexcept {
 		return static_cast<Double>(arg);
 	}
 


### PR DESCRIPTION
**Describe the pull request**

The new MSVC compiler issues warnings about most of the literal operators defined in the library (see [CWG 2521](https://cplusplus.github.io/CWG/issues/2521.html)). This PR fixes the affected definitions accordingly.