### PR TITLE
Implement descriptor buffers.

### DIFF
--- a/docs/release-logs/0.5.1.md
+++ b/docs/release-logs/0.5.1.md
@@ -1,5 +1,14 @@
 ﻿# LiteFX 0.5.1 - Alpha 05
 
+- Improved descriptor management.
+  -  Common descriptor allocation and binding architecture. (See [PR #165](https://github.com/crud89/LiteFX/pull/165))
+
+**🌋 Vulkan:**
+
+- Implement descriptor management using `VK_EXT_descriptor_buffer`. (See [PR #165](https://github.com/crud89/LiteFX/pull/165))
+- Fixed issue that caused the native Vulkan swap chain to not properly transition present targets, if the DirectX 12 backend was enabled. (See [PR #165](https://github.com/crud89/LiteFX/pull/165))
+- Fixed destruction of descriptor set layout handles. ([PR #165](https://github.com/crud89/LiteFX/pull/165))
+
 **❎ DirectX 12:**
 
 - Fixed an issue where scissor rects that did not start at the window origin were incorrectly passed to the pipeline. (See [PR #158](https://github.com/crud89/LiteFX/pull/158))

--- a/src/Backends/DirectX12/include/litefx/backends/dx12.hpp
+++ b/src/Backends/DirectX12/include/litefx/backends/dx12.hpp
@@ -741,10 +741,10 @@ namespace LiteFX::Rendering::Backends {
 
     public:
         /// <inheritdoc />
-        virtual UInt32 globalHeapOffset() const noexcept override;
+        UInt32 globalHeapOffset() const noexcept override;
 
         /// <inheritdoc />
-        virtual UInt32 globalHeapAddressRange() const noexcept override;
+        UInt32 globalHeapAddressRange() const noexcept override;
 
         /// <inheritdoc />
         void update(UInt32 binding, const IDirectX12Buffer& buffer, UInt32 bufferElement = 0, UInt32 elements = 0, UInt32 firstDescriptor = 0) const override;

--- a/src/Backends/DirectX12/include/litefx/backends/dx12.hpp
+++ b/src/Backends/DirectX12/include/litefx/backends/dx12.hpp
@@ -714,9 +714,8 @@ namespace LiteFX::Rendering::Backends {
         /// Initializes a new descriptor set.
         /// </summary>
         /// <param name="layout">The parent descriptor set layout.</param>
-        /// <param name="bufferHeap">A CPU-visible descriptor heap that contains all buffer descriptors of the descriptor set.</param>
-        /// <param name="samplerHeap">A CPU-visible descriptor heap that contains all sampler descriptors of the descriptor set.</param>
-        explicit DirectX12DescriptorSet(const DirectX12DescriptorSetLayout& layout, ComPtr<ID3D12DescriptorHeap>&& bufferHeap, ComPtr<ID3D12DescriptorHeap>&& samplerHeap);
+        /// <param name="localHeap">A CPU-visible descriptor heap that contains all descriptors of the descriptor set.</param>
+        explicit DirectX12DescriptorSet(const DirectX12DescriptorSetLayout& layout, ComPtr<ID3D12DescriptorHeap>&& localHeap);
 
         /// <inheritdoc />
         DirectX12DescriptorSet(DirectX12DescriptorSet&&) noexcept = delete;
@@ -742,6 +741,12 @@ namespace LiteFX::Rendering::Backends {
 
     public:
         /// <inheritdoc />
+        virtual UInt32 globalHeapOffset() const noexcept override;
+
+        /// <inheritdoc />
+        virtual UInt32 globalHeapAddressRange() const noexcept override;
+
+        /// <inheritdoc />
         void update(UInt32 binding, const IDirectX12Buffer& buffer, UInt32 bufferElement = 0, UInt32 elements = 0, UInt32 firstDescriptor = 0) const override;
 
         /// <inheritdoc />
@@ -755,28 +760,10 @@ namespace LiteFX::Rendering::Backends {
 
     public:
         /// <summary>
-        /// Returns the local (CPU-visible) heap that contains the buffer descriptors.
+        /// Returns the local (CPU-visible) heap that contains the set's descriptors.
         /// </summary>
-        /// <returns>The local (CPU-visible) heap that contains the buffer descriptors, or <c>nullptr</c>, if the descriptor set does not contain any buffers.</returns>
-        virtual const ComPtr<ID3D12DescriptorHeap>& bufferHeap() const noexcept;
-
-        /// <summary>
-        /// Returns the offset of the buffer descriptors in the global descriptor heap.
-        /// </summary>
-        /// <returns>The offset of the buffer descriptors in the global descriptor heap.</returns>
-        virtual UInt32 bufferOffset() const noexcept;
-
-        /// <summary>
-        /// Returns the local (CPU-visible) heap that contains the sampler descriptors.
-        /// </summary>
-        /// <returns>The local (CPU-visible) heap that contains the sampler descriptors, or <c>nullptr</c>, if the descriptor set does not contain any samplers.</returns>
-        virtual const ComPtr<ID3D12DescriptorHeap>& samplerHeap() const noexcept;
-
-        /// <summary>
-        /// Returns the offset of the sampler descriptors in the global descriptor heap.
-        /// </summary>
-        /// <returns>The offset of the sampler descriptors in the global descriptor heap.</returns>
-        virtual UInt32 samplerOffset() const noexcept;
+        /// <returns>The local (CPU-visible) heap that contains the set's descriptors.</returns>
+        virtual const ComPtr<ID3D12DescriptorHeap>& localHeap() const noexcept;
     };
 
     /// <summary>

--- a/src/Backends/DirectX12/include/litefx/backends/dx12.hpp
+++ b/src/Backends/DirectX12/include/litefx/backends/dx12.hpp
@@ -2639,59 +2639,6 @@ namespace LiteFX::Rendering::Backends {
         const ID3D12DescriptorHeap* globalSamplerHeap() const noexcept;
 
         /// <summary>
-        /// Allocates a range of descriptors in the global descriptor heaps for the provided <paramref name="descriptorSet" />.
-        /// </summary>
-        /// <param name="descriptorSet">The descriptor set containing the descriptors to update.</param>
-        /// <param name="bufferOffset">The offset of the descriptor range in the buffer heap.</param>
-        /// <param name="samplerOffset">The offset of the descriptor range in the sampler heap.</param>
-        void allocateGlobalDescriptors(const DirectX12DescriptorSet& descriptorSet, UInt32& bufferOffset, UInt32& samplerOffset) const;
-
-        /// <summary>
-        /// Releases a range of descriptors from the global descriptor heaps.
-        /// </summary>
-        /// <remarks>
-        /// This is done, if a descriptor set layout is destroyed, of a descriptor set, which contains an unbounded array is freed. It will cause the global 
-        /// descriptor heaps to fragment, which may result in inefficient future descriptor allocations and should be avoided. Consider caching descriptor
-        /// sets with unbounded arrays instead. Also avoid relying on creating and releasing pipeline layouts during runtime. Instead, it may be more efficient
-        /// to write shaders that support multiple pipeline variations, that can be kept alive for the lifetime of the whole application.
-        /// </remarks>
-        void releaseGlobalDescriptors(const DirectX12DescriptorSet& descriptorSet) const;
-
-        /// <summary>
-        /// Updates a range of descriptors in the global buffer descriptor heap with the descriptors from <paramref name="descriptorSet" />.
-        /// </summary>
-        /// <param name="descriptorSet">The descriptor set to copy the descriptors from.</param>
-        /// <param name="firstDescriptor">The index of the first descriptor to copy.</param>
-        /// <param name="descriptors">The number of descriptors to copy.</param>
-        void updateBufferDescriptors(const DirectX12DescriptorSet& descriptorSet, UInt32 firstDescriptor, UInt32 descriptors) const noexcept;
-
-        /// <summary>
-        /// Updates a sampler descriptors in the global buffer descriptor heap with a descriptor from <paramref name="descriptorSet" />.
-        /// </summary>
-        /// <param name="descriptorSet">The descriptor set to copy the descriptors from.</param>
-        /// <param name="firstDescriptor">The index of the first descriptor to copy.</param>
-        /// <param name="descriptors">The number of descriptors to copy.</param>
-        void updateSamplerDescriptors(const DirectX12DescriptorSet& descriptorSet, UInt32 firstDescriptor, UInt32 descriptors) const noexcept;
-
-        /// <summary>
-        /// Binds the descriptors of the descriptor set to the global descriptor heaps.
-        /// </summary>
-        /// <remarks>
-        /// Note that after binding the descriptor set, the descriptors must not be updated anymore, unless they are elements on unbounded descriptor arrays, 
-        /// in which case you have to ensure manually to not update them, as long as they may still be in use!
-        /// </remarks>
-        /// <param name="commandBuffer">The command buffer to bind the descriptor set on.</param>
-        /// <param name="descriptorSet">The descriptor set to bind.</param>
-        /// <param name="pipeline">The pipeline to bind the descriptor set to.</param>
-        void bindDescriptorSet(const DirectX12CommandBuffer& commandBuffer, const DirectX12DescriptorSet& descriptorSet, const DirectX12PipelineState& pipeline) const noexcept;
-
-        /// <summary>
-        /// Binds the global descriptor heap.
-        /// </summary>
-        /// <param name="commandBuffer">The command buffer to issue the bind command on.</param>
-        void bindGlobalDescriptorHeaps(const DirectX12CommandBuffer& commandBuffer) const noexcept;
-
-        /// <summary>
         /// Returns the command signatures for indirect dispatch and draw calls.
         /// </summary>
         /// <param name="dispatchSignature">The command signature used to execute indirect dispatches.</param>
@@ -2747,6 +2694,21 @@ namespace LiteFX::Rendering::Backends {
 
         /// <inheritdoc />
         void computeAccelerationStructureSizes(const DirectX12TopLevelAccelerationStructure& tlas, UInt64& bufferSize, UInt64& scratchSize, bool forUpdate = false) const override;
+
+        /// <inheritdoc />
+        void allocateGlobalDescriptors(const DirectX12DescriptorSet& descriptorSet, UInt32& heapOffset, UInt32& heapSize) const override;
+
+        /// <inheritdoc />
+        void releaseGlobalDescriptors(const DirectX12DescriptorSet& descriptorSet) const override;
+
+        /// <inheritdoc />
+        void updateGlobalDescriptors(const DirectX12DescriptorSet& descriptorSet, UInt32 binding, UInt32 offset, UInt32 descriptors) const override;
+
+        /// <inheritdoc />
+        void bindDescriptorSet(const DirectX12CommandBuffer& commandBuffer, const DirectX12DescriptorSet& descriptorSet, const DirectX12PipelineState& pipeline) const noexcept override;
+
+        /// <inheritdoc />
+        void bindGlobalDescriptorHeaps(const DirectX12CommandBuffer& commandBuffer) const noexcept override;
 
 #if defined(LITEFX_BUILD_DEFINE_BUILDERS)
     public:

--- a/src/Backends/DirectX12/include/litefx/backends/dx12.hpp
+++ b/src/Backends/DirectX12/include/litefx/backends/dx12.hpp
@@ -955,16 +955,6 @@ namespace LiteFX::Rendering::Backends {
         /// <returns>A pointer to the parent device or `nullptr`, if it has been released.</returns>
         virtual SharedPtr<const DirectX12Device> device() const noexcept;
 
-    protected:
-        /// <summary>
-        /// Returns <c>true</c>, if the descriptor set contains an (unbounded) runtime array.
-        /// </summary>
-        /// <remarks>
-        /// A descriptor set is a runtime array, if it contains exactly one descriptor, which is an unbounded array, i.e. which has a descriptor count of `-1` (or `0xFFFFFFFF`).
-        /// </remarks>
-        /// <returns><c>true</c>, if the descriptor set contains an (unbounded) runtime array and <c>false</c> otherwise.</returns>
-        virtual bool isRuntimeArray() const noexcept;
-
     public:
         /// <inheritdoc />
         const Array<DirectX12DescriptorLayout>& descriptors() const noexcept override;
@@ -998,6 +988,9 @@ namespace LiteFX::Rendering::Backends {
 
         /// <inheritdoc />
         UInt32 inputAttachments() const noexcept override;
+
+        /// <inheritdoc />
+        bool containsUnboundedArray() const noexcept override;
 
     public:
         /// <inheritdoc />

--- a/src/Backends/DirectX12/include/litefx/backends/dx12.hpp
+++ b/src/Backends/DirectX12/include/litefx/backends/dx12.hpp
@@ -928,15 +928,6 @@ namespace LiteFX::Rendering::Backends {
 
     public:
         /// <summary>
-        /// Returns the index of the first descriptor for a certain binding. The offset is relative to the heap for the descriptor (i.e. sampler for sampler descriptors and
-        /// CBV/SRV/UAV for other descriptors).
-        /// </summary>
-        /// <param name="binding">The binding of the descriptor.</param>
-        /// <returns>The index of the first descriptor for the binding.</returns>
-        /// <exception cref="ArgumentOutOfRangeException">Thrown, if the descriptor set does not contain a descriptor bound to the binding point specified by <paramref name="binding"/>.</exception>
-        virtual UInt32 descriptorOffsetForBinding(UInt32 binding) const;
-
-        /// <summary>
         /// Returns the parent device or `nullptr`, if it has been released.
         /// </summary>
         /// <returns>A pointer to the parent device or `nullptr`, if it has been released.</returns>
@@ -978,6 +969,9 @@ namespace LiteFX::Rendering::Backends {
 
         /// <inheritdoc />
         bool containsUnboundedArray() const noexcept override;
+
+        /// <inheritdoc />
+        UInt32 getDescriptorOffset(UInt32 binding, UInt32 element = 0) const override;
 
     public:
         /// <inheritdoc />

--- a/src/Backends/DirectX12/src/buffer.cpp
+++ b/src/Backends/DirectX12/src/buffer.cpp
@@ -132,7 +132,7 @@ void DirectX12Buffer::write(const void* const data, size_t size, size_t offset)
 	D3D12_RANGE mappedRange{ };
 	void* buffer{ nullptr };
 	raiseIfFailed(this->handle()->Map(0, &mappedRange, &buffer), "Unable to map buffer memory.");
-	std::memcpy(std::next(static_cast<Byte*>(buffer), offset), data, size);
+	std::memcpy(std::next(static_cast<Byte*>(buffer), offset), data, size); // NOLINT(bugprone-narrowing-conversions,cppcoreguidelines-narrowing-conversions)
 	this->handle()->Unmap(0, nullptr);
 }
 
@@ -141,7 +141,7 @@ void DirectX12Buffer::read(void* data, size_t size, size_t offset)
 	D3D12_RANGE mappedRange{ };
 	void* buffer{ nullptr };
 	raiseIfFailed(this->handle()->Map(0, &mappedRange, &buffer), "Unable to map buffer memory.");
-	std::memcpy(data, std::next(static_cast<Byte*>(buffer), offset), size);
+	std::memcpy(data, std::next(static_cast<Byte*>(buffer), offset), size); // NOLINT(bugprone-narrowing-conversions,cppcoreguidelines-narrowing-conversions)
 	this->handle()->Unmap(0, nullptr);
 }
 

--- a/src/Backends/DirectX12/src/buffer.cpp
+++ b/src/Backends/DirectX12/src/buffer.cpp
@@ -97,17 +97,12 @@ void DirectX12Buffer::map(const void* const data, size_t size, UInt32 element)
 	if (this->size() - (element * this->alignedElementSize()) < size) [[unlikely]]
 		throw InvalidArgumentException("size", "The provided data size would overflow the buffer (buffer offset: 0x{1:X}; {2} bytes remaining but size was set to {0}).", size, element * this->alignedElementSize(), this->size() - (element * this->alignedElementSize()));
 
-	D3D12_RANGE mappedRange = { };
-	char* buffer{};
-	void* bufferPtr = static_cast<void*>(buffer);
-	raiseIfFailed(this->handle()->Map(0, &mappedRange, &bufferPtr), "Unable to map buffer memory.");
-	std::memcpy(static_cast<char*>(bufferPtr) + (element * this->alignedElementSize()), data, size); // NOLINT(cppcoreguidelines-pro-bounds-pointer-arithmetic)
-	this->handle()->Unmap(0, nullptr);
+	this->write(data, size, element * this->alignedElementSize());
 }
 
 void DirectX12Buffer::map(Span<const void* const> data, size_t elementSize, UInt32 firstElement)
 {
-	std::ranges::for_each(data, [this, &elementSize, i = firstElement](const void* const mem) mutable { this->map(mem, elementSize, i++); });
+	std::ranges::for_each(data, [this, &elementSize, i = firstElement](auto mem) mutable { this->map(mem, elementSize, i++); });
 }
 
 void DirectX12Buffer::map(void* data, size_t size, UInt32 element, bool write)
@@ -121,22 +116,33 @@ void DirectX12Buffer::map(void* data, size_t size, UInt32 element, bool write)
 	if (this->size() - (element * this->alignedElementSize()) < size) [[unlikely]]
 		throw InvalidArgumentException("size", "The provided data size would overflow the buffer (buffer offset: 0x{1:X}; {2} bytes remaining but size was set to {0}).", size, element * this->alignedElementSize(), this->size() - (element * this->alignedElementSize()));
 
-	D3D12_RANGE mappedRange = { };
-	char* buffer{};
-	void* bufferPtr = static_cast<void*>(buffer);
-	raiseIfFailed(this->handle()->Map(0, &mappedRange, &bufferPtr), "Unable to map buffer memory.");
-
 	if (write)
-		std::memcpy(static_cast<char*>(bufferPtr) + (element * this->alignedElementSize()), data, size); // NOLINT(cppcoreguidelines-pro-bounds-pointer-arithmetic)
+		this->write(data, size, element * this->alignedElementSize());
 	else
-		std::memcpy(data, static_cast<char*>(bufferPtr) + (element * this->alignedElementSize()), size); // NOLINT(cppcoreguidelines-pro-bounds-pointer-arithmetic)
-
-	this->handle()->Unmap(0, nullptr);
+		this->read(data, size, element * this->alignedElementSize());
 }
 
 void DirectX12Buffer::map(Span<void*> data, size_t elementSize, UInt32 firstElement, bool write)
 {
-	std::ranges::for_each(data, [this, &elementSize, &write, i = firstElement](void* mem) mutable { this->map(mem, elementSize, i++, write); });
+	std::ranges::for_each(data, [this, &elementSize, &write, i = firstElement](auto mem) mutable { this->map(mem, elementSize, i++, write); });
+}
+
+void DirectX12Buffer::write(const void* const data, size_t size, size_t offset)
+{
+	D3D12_RANGE mappedRange{ };
+	void* buffer{ nullptr };
+	raiseIfFailed(this->handle()->Map(0, &mappedRange, &buffer), "Unable to map buffer memory.");
+	std::memcpy(std::next(static_cast<Byte*>(buffer), offset), data, size);
+	this->handle()->Unmap(0, nullptr);
+}
+
+void DirectX12Buffer::read(void* data, size_t size, size_t offset)
+{
+	D3D12_RANGE mappedRange{ };
+	void* buffer{ nullptr };
+	raiseIfFailed(this->handle()->Map(0, &mappedRange, &buffer), "Unable to map buffer memory.");
+	std::memcpy(data, std::next(static_cast<Byte*>(buffer), offset), size);
+	this->handle()->Unmap(0, nullptr);
 }
 
 AllocatorPtr DirectX12Buffer::allocator() const noexcept

--- a/src/Backends/DirectX12/src/buffer.h
+++ b/src/Backends/DirectX12/src/buffer.h
@@ -79,6 +79,12 @@ namespace LiteFX::Rendering::Backends {
 		/// <inheritdoc />
 		void map(Span<void*> data, size_t elementSize, UInt32 firstElement = 0, bool write = true) override;
 
+		/// <inheritdoc />
+		void write(const void* const data, size_t size, size_t offset = 0) override;
+
+		/// <inheritdoc />
+		void read(void* data, size_t size, size_t offset = 0) override;
+
 		// DirectX 12 buffer.
 	protected:
 		virtual AllocatorPtr allocator() const noexcept;

--- a/src/Backends/DirectX12/src/descriptor_set_layout.cpp
+++ b/src/Backends/DirectX12/src/descriptor_set_layout.cpp
@@ -204,11 +204,6 @@ UInt32 DirectX12DescriptorSetLayout::descriptorOffsetForBinding(UInt32 binding) 
     return m_impl->m_bindingToDescriptor[binding];
 }
 
-bool DirectX12DescriptorSetLayout::isRuntimeArray() const noexcept
-{
-    return m_impl->m_isRuntimeArray;
-}
-
 SharedPtr<const DirectX12Device> DirectX12DescriptorSetLayout::device() const noexcept
 {
     return m_impl->m_device.lock();
@@ -270,6 +265,11 @@ UInt32 DirectX12DescriptorSetLayout::staticSamplers() const noexcept
 UInt32 DirectX12DescriptorSetLayout::inputAttachments() const noexcept
 {
     return static_cast<UInt32>(std::ranges::count_if(m_impl->m_layouts, [](const auto& layout) { return layout.descriptorType() == DescriptorType::InputAttachment; }));
+}
+
+bool DirectX12DescriptorSetLayout::containsUnboundedArray() const noexcept
+{
+    return m_impl->m_isRuntimeArray;
 }
 
 UniquePtr<DirectX12DescriptorSet> DirectX12DescriptorSetLayout::allocate(UInt32 descriptors, std::initializer_list<DescriptorBinding> bindings) const

--- a/src/Backends/DirectX12/src/descriptor_set_layout.cpp
+++ b/src/Backends/DirectX12/src/descriptor_set_layout.cpp
@@ -241,14 +241,6 @@ DirectX12DescriptorSetLayout::DirectX12DescriptorSetLayout(const DirectX12Descri
 
 DirectX12DescriptorSetLayout::~DirectX12DescriptorSetLayout() noexcept = default;
 
-UInt32 DirectX12DescriptorSetLayout::descriptorOffsetForBinding(UInt32 binding) const
-{
-    if (!m_impl->m_bindingToDescriptor.contains(binding)) [[unlikely]]
-        throw InvalidArgumentException("binding", "The descriptor set does not contain a descriptor at binding {0}.", binding);
-
-    return m_impl->m_bindingToDescriptor[binding];
-}
-
 SharedPtr<const DirectX12Device> DirectX12DescriptorSetLayout::device() const noexcept
 {
     return m_impl->m_device.lock();
@@ -315,6 +307,14 @@ UInt32 DirectX12DescriptorSetLayout::inputAttachments() const noexcept
 bool DirectX12DescriptorSetLayout::containsUnboundedArray() const noexcept
 {
     return m_impl->m_isRuntimeArray;
+}
+
+UInt32 DirectX12DescriptorSetLayout::getDescriptorOffset(UInt32 binding, UInt32 element) const
+{
+    if (!m_impl->m_bindingToDescriptor.contains(binding)) [[unlikely]]
+        throw InvalidArgumentException("binding", "The descriptor set does not contain a descriptor at binding {0}.", binding);
+
+    return m_impl->m_bindingToDescriptor[binding] + element;
 }
 
 UniquePtr<DirectX12DescriptorSet> DirectX12DescriptorSetLayout::allocate(UInt32 descriptors, std::initializer_list<DescriptorBinding> bindings) const

--- a/src/Backends/DirectX12/src/descriptor_set_layout.cpp
+++ b/src/Backends/DirectX12/src/descriptor_set_layout.cpp
@@ -74,6 +74,9 @@ public:
                 m_descriptors += layout.descriptors();
             }
         });
+
+        LITEFX_TRACE(DIRECTX12_LOG, "Creating descriptor set {0} layout with {1} bindings {{ Uniform: {2}, Storage: {3}, Images: {4}, Sampler: {5}, Input Attachments: {6}, Texel Buffers: {7} }}...",
+            m_space, m_layouts.size(), this->uniforms(), this->storages(), this->images(), this->samplers(), this->inputAttachments(), this->buffers());
     }
 
 public:
@@ -168,6 +171,41 @@ public:
         // Return the descriptor set.
         return descriptorSet;
     }
+
+    inline UInt32 uniforms() const noexcept
+    {
+        return static_cast<UInt32>(std::ranges::count_if(m_layouts, [](const auto& layout) { return layout.descriptorType() == DescriptorType::ConstantBuffer; }));
+    }
+
+    inline UInt32 storages() const noexcept
+    {
+        return static_cast<UInt32>(std::ranges::count_if(m_layouts, [](const auto& layout) { return layout.descriptorType() == DescriptorType::StructuredBuffer || layout.descriptorType() == DescriptorType::RWStructuredBuffer || layout.descriptorType() == DescriptorType::ByteAddressBuffer || layout.descriptorType() == DescriptorType::RWByteAddressBuffer; }));
+    }
+
+    inline UInt32 buffers() const noexcept
+    {
+        return static_cast<UInt32>(std::ranges::count_if(m_layouts, [](const auto& layout) { return layout.descriptorType() == DescriptorType::Buffer || layout.descriptorType() == DescriptorType::RWBuffer; }));
+    }
+
+    inline UInt32 images() const noexcept
+    {
+        return static_cast<UInt32>(std::ranges::count_if(m_layouts, [](const auto& layout) { return layout.descriptorType() == DescriptorType::Texture || layout.descriptorType() == DescriptorType::RWTexture; }));
+    }
+
+    inline UInt32 samplers() const noexcept
+    {
+        return static_cast<UInt32>(std::ranges::count_if(m_layouts, [](const auto& layout) { return layout.descriptorType() == DescriptorType::Sampler && layout.staticSampler() == nullptr; }));
+    }
+
+    inline UInt32 staticSamplers() const noexcept
+    {
+        return static_cast<UInt32>(std::ranges::count_if(m_layouts, [](const auto& layout) { return layout.descriptorType() == DescriptorType::Sampler && layout.staticSampler() != nullptr; }));
+    }
+
+    inline UInt32 inputAttachments() const noexcept
+    {
+        return static_cast<UInt32>(std::ranges::count_if(m_layouts, [](const auto& layout) { return layout.descriptorType() == DescriptorType::InputAttachment; }));
+    }
 };
 
 // ------------------------------------------------------------------------------------------------
@@ -234,37 +272,37 @@ ShaderStage DirectX12DescriptorSetLayout::shaderStages() const noexcept
 
 UInt32 DirectX12DescriptorSetLayout::uniforms() const noexcept
 {
-    return static_cast<UInt32>(std::ranges::count_if(m_impl->m_layouts, [](const auto& layout) { return layout.descriptorType() == DescriptorType::ConstantBuffer; }));
+    return m_impl->uniforms();
 }
 
 UInt32 DirectX12DescriptorSetLayout::storages() const noexcept
 {
-    return static_cast<UInt32>(std::ranges::count_if(m_impl->m_layouts, [](const auto& layout) { return layout.descriptorType() == DescriptorType::StructuredBuffer || layout.descriptorType() == DescriptorType::RWStructuredBuffer || layout.descriptorType() == DescriptorType::ByteAddressBuffer || layout.descriptorType() == DescriptorType::RWByteAddressBuffer; }));
+    return m_impl->storages();
 }
 
 UInt32 DirectX12DescriptorSetLayout::buffers() const noexcept
 {
-    return static_cast<UInt32>(std::ranges::count_if(m_impl->m_layouts, [](const auto& layout) { return layout.descriptorType() == DescriptorType::Buffer || layout.descriptorType() == DescriptorType::RWBuffer; }));
+    return m_impl->buffers();
 }
 
 UInt32 DirectX12DescriptorSetLayout::images() const noexcept
 {
-    return static_cast<UInt32>(std::ranges::count_if(m_impl->m_layouts, [](const auto& layout) { return layout.descriptorType() == DescriptorType::Texture || layout.descriptorType() == DescriptorType::RWTexture; }));
+    return m_impl->images();
 }
 
 UInt32 DirectX12DescriptorSetLayout::samplers() const noexcept
 {
-    return static_cast<UInt32>(std::ranges::count_if(m_impl->m_layouts, [](const auto& layout) { return layout.descriptorType() == DescriptorType::Sampler && layout.staticSampler() == nullptr; }));
+    return m_impl->samplers();
 }
 
 UInt32 DirectX12DescriptorSetLayout::staticSamplers() const noexcept
 {
-    return static_cast<UInt32>(std::ranges::count_if(m_impl->m_layouts, [](const auto& layout) { return layout.descriptorType() == DescriptorType::Sampler && layout.staticSampler() != nullptr; }));
+    return m_impl->staticSamplers();
 }
 
 UInt32 DirectX12DescriptorSetLayout::inputAttachments() const noexcept
 {
-    return static_cast<UInt32>(std::ranges::count_if(m_impl->m_layouts, [](const auto& layout) { return layout.descriptorType() == DescriptorType::InputAttachment; }));
+    return m_impl->inputAttachments();
 }
 
 bool DirectX12DescriptorSetLayout::containsUnboundedArray() const noexcept

--- a/src/Backends/DirectX12/src/device.cpp
+++ b/src/Backends/DirectX12/src/device.cpp
@@ -267,7 +267,7 @@ const ID3D12DescriptorHeap* DirectX12Device::globalSamplerHeap() const noexcept
 	return m_impl->m_globalSamplerHeap.Get();
 }
 
-void DirectX12Device::allocateGlobalDescriptors(const DirectX12DescriptorSet& descriptorSet, UInt32& bufferOffset, UInt32& samplerOffset) const
+void DirectX12Device::allocateGlobalDescriptors(const DirectX12DescriptorSet& descriptorSet, UInt32& offset, UInt32& size) const
 {
 	// NOTE: Freeing descriptor sets with leaves the heap(s) in fragmented state. This should be prevented, however we also keep track of the released offset/count pairs to re-allocate 
 	//       them later. Re-allocation could follow those steps:
@@ -275,89 +275,87 @@ void DirectX12Device::allocateGlobalDescriptors(const DirectX12DescriptorSet& de
 	//       - If we're overflowing: find perfect offset/pair matches for the requested set.
 	//       - If none is available: allocate from a fragmented area. Resize it afterwards with a new offset and reduced count.
 	//       - If all of the above fail, then we're out of descriptors.
-	std::lock_guard<std::mutex> lock(m_impl->m_bufferBindMutex);
+std::lock_guard<std::mutex> lock(m_impl->m_bufferBindMutex);
 
-	// Get the current descriptor sizes and compute the offsets.
-	UInt32 buffers{ 0 }, samplers{ 0 };
+// Get the current descriptor sizes and compute the offsets.
+// NOTE: The descriptor set layout checks for invalid mixture of samplers and resources, so we only get one or the other here.
+size = descriptorSet.localHeap()->GetDesc().NumDescriptors;
 
-	if (descriptorSet.bufferHeap() != nullptr)
-		buffers = descriptorSet.bufferHeap()->GetDesc().NumDescriptors;
+if (size == 0)
+throw InvalidArgumentException("descriptorSet", "Cannot allocate space for empty descriptor set on global descriptor heap.");
 
-	if (descriptorSet.samplerHeap() != nullptr)
-		samplers = descriptorSet.samplerHeap()->GetDesc().NumDescriptors;
-
-	if (m_impl->m_bufferOffset + buffers <= m_impl->m_globalBufferHeapSize) [[likely]]
+if (descriptorSet.layout().samplers() > 0 || descriptorSet.layout().staticSamplers() > 0)
+{
+	if (m_impl->m_samplerOffset + size <= m_impl->m_globalSamplerHeapSize) [[likely]]
 	{
-		bufferOffset = m_impl->m_bufferOffset;
-		m_impl->m_bufferOffset += buffers;
+		offset = m_impl->m_samplerOffset;
+		m_impl->m_samplerOffset += size;
 	}
 	else [[unlikely]]
 	{
-		m_impl->m_bufferOffset = m_impl->m_globalBufferHeapSize;
-
 		// Find a fitting offset from the fragment heap.
-		if (auto match = std::ranges::find_if(m_impl->m_bufferDescriptorFragments, [&buffers](const auto& pair) { return pair.second == buffers; }); match != m_impl->m_bufferDescriptorFragments.end())
+		if (auto match = std::ranges::find_if(m_impl->m_samplerDescriptorFragments, [&size](const auto& pair) { return pair.second == size; }); match != m_impl->m_samplerDescriptorFragments.end())
 		{
-			bufferOffset = match->first;
-			m_impl->m_bufferDescriptorFragments.erase(match);
-		}
-		else if (match = std::ranges::find_if(m_impl->m_bufferDescriptorFragments, [&buffers](const auto& pair) { return pair.second > buffers; }); match != m_impl->m_bufferDescriptorFragments.end())
-		{
-			bufferOffset = match->first;
-			match->first += buffers;
-			match->second -= buffers;
-		}
-		else [[unlikely]]
-		{
-			throw RuntimeException("Unable to allocate more descriptors.");
-		}
-	}
-
-	if (m_impl->m_samplerOffset + samplers <= m_impl->m_globalSamplerHeapSize) [[likely]]
-	{
-		samplerOffset = m_impl->m_samplerOffset;
-		m_impl->m_samplerOffset += samplers;
-	}
-	else [[unlikely]]
-	{
-		m_impl->m_samplerOffset = m_impl->m_globalSamplerHeapSize;
-
-		// Find a fitting offset from the fragment heap.
-		if (auto match = std::ranges::find_if(m_impl->m_samplerDescriptorFragments, [&samplers](const auto& pair) { return pair.second == samplers; }); match != m_impl->m_samplerDescriptorFragments.end())
-		{
-			samplerOffset = match->first;
+			offset = match->first;
 			m_impl->m_samplerDescriptorFragments.erase(match);
 		}
-		else if (match = std::ranges::find_if(m_impl->m_samplerDescriptorFragments, [&samplers](const auto& pair) { return pair.second > samplers; }); match != m_impl->m_samplerDescriptorFragments.end())
+		else if (match = std::ranges::find_if(m_impl->m_samplerDescriptorFragments, [&size](const auto& pair) { return pair.second > size; }); match != m_impl->m_samplerDescriptorFragments.end())
 		{
-			samplerOffset = match->first;
-			match->first += samplers;
-			match->second -= samplers;
+			offset = match->first;
+			match->first += size;
+			match->second -= size;
 		}
 		else [[unlikely]]
 		{
-			throw RuntimeException("Unable to allocate more descriptors.");
+			throw RuntimeException("Unable to allocate more descriptors on global sampler heap.");
 		}
 	}
+}
+else
+{
+	if (m_impl->m_bufferOffset + size <= m_impl->m_globalBufferHeapSize) [[likely]]
+	{
+		offset = m_impl->m_bufferOffset;
+		m_impl->m_bufferOffset += size;
+	}
+	else [[unlikely]]
+	{
+		// Find a fitting offset from the fragment heap.
+		if (auto match = std::ranges::find_if(m_impl->m_bufferDescriptorFragments, [&size](const auto& pair) { return pair.second == size; }); match != m_impl->m_bufferDescriptorFragments.end())
+		{
+			offset = match->first;
+			m_impl->m_bufferDescriptorFragments.erase(match);
+		}
+		else if (match = std::ranges::find_if(m_impl->m_bufferDescriptorFragments, [&size](const auto& pair) { return pair.second > size; }); match != m_impl->m_bufferDescriptorFragments.end())
+		{
+			offset = match->first;
+			match->first += size;
+			match->second -= size;
+		}
+		else [[unlikely]]
+		{
+			throw RuntimeException("Unable to allocate more descriptors on global buffer heap.");
+		}
+	}
+}
 }
 
 void DirectX12Device::releaseGlobalDescriptors(const DirectX12DescriptorSet& descriptorSet) const
 {
 	std::lock_guard<std::mutex> lock(m_impl->m_bufferBindMutex);
 
-	if (descriptorSet.bufferHeap() != nullptr)
-		m_impl->m_bufferDescriptorFragments.emplace_back(descriptorSet.bufferOffset(), descriptorSet.bufferHeap()->GetDesc().NumDescriptors);
-
-	if (descriptorSet.samplerHeap() != nullptr)
-		m_impl->m_samplerDescriptorFragments.emplace_back(descriptorSet.samplerOffset(), descriptorSet.samplerHeap()->GetDesc().NumDescriptors);
+	if (descriptorSet.layout().samplers() > 0 || descriptorSet.layout().staticSamplers() > 0)
+		m_impl->m_samplerDescriptorFragments.emplace_back(descriptorSet.globalHeapOffset(), descriptorSet.globalHeapAddressRange());
+	else
+		m_impl->m_bufferDescriptorFragments.emplace_back(descriptorSet.globalHeapOffset(), descriptorSet.globalHeapAddressRange());
 }
 
 void DirectX12Device::updateBufferDescriptors(const DirectX12DescriptorSet& descriptorSet, UInt32 firstDescriptor, UInt32 descriptors) const noexcept
 {
 	if (descriptors > 0) [[likely]]
 	{
-		CD3DX12_CPU_DESCRIPTOR_HANDLE targetHandle(m_impl->m_globalBufferHeap->GetCPUDescriptorHandleForHeapStart(), static_cast<INT>(descriptorSet.bufferOffset() + firstDescriptor), m_impl->m_bufferDescriptorIncrement);
-		CD3DX12_CPU_DESCRIPTOR_HANDLE sourceHandle(descriptorSet.bufferHeap()->GetCPUDescriptorHandleForHeapStart(), static_cast<INT>(firstDescriptor), m_impl->m_bufferDescriptorIncrement);
+		CD3DX12_CPU_DESCRIPTOR_HANDLE targetHandle(m_impl->m_globalBufferHeap->GetCPUDescriptorHandleForHeapStart(), static_cast<INT>(descriptorSet.globalHeapOffset() + firstDescriptor), m_impl->m_bufferDescriptorIncrement);
+		CD3DX12_CPU_DESCRIPTOR_HANDLE sourceHandle(descriptorSet.localHeap()->GetCPUDescriptorHandleForHeapStart(), static_cast<INT>(firstDescriptor), m_impl->m_bufferDescriptorIncrement);
 		this->handle()->CopyDescriptorsSimple(descriptors, targetHandle, sourceHandle, D3D12_DESCRIPTOR_HEAP_TYPE_CBV_SRV_UAV);
 	}
 }
@@ -366,22 +364,14 @@ void DirectX12Device::updateSamplerDescriptors(const DirectX12DescriptorSet& des
 {
 	if (descriptors > 0) [[likely]]
 	{
-		CD3DX12_CPU_DESCRIPTOR_HANDLE targetHandle(m_impl->m_globalSamplerHeap->GetCPUDescriptorHandleForHeapStart(), static_cast<INT>(descriptorSet.samplerOffset() + firstDescriptor), m_impl->m_samplerDescriptorIncrement);
-		CD3DX12_CPU_DESCRIPTOR_HANDLE sourceHandle(descriptorSet.samplerHeap()->GetCPUDescriptorHandleForHeapStart(), static_cast<INT>(firstDescriptor), m_impl->m_samplerDescriptorIncrement);
+		CD3DX12_CPU_DESCRIPTOR_HANDLE targetHandle(m_impl->m_globalSamplerHeap->GetCPUDescriptorHandleForHeapStart(), static_cast<INT>(descriptorSet.globalHeapOffset() + firstDescriptor), m_impl->m_samplerDescriptorIncrement);
+		CD3DX12_CPU_DESCRIPTOR_HANDLE sourceHandle(descriptorSet.localHeap()->GetCPUDescriptorHandleForHeapStart(), static_cast<INT>(firstDescriptor), m_impl->m_samplerDescriptorIncrement);
 		this->handle()->CopyDescriptorsSimple(descriptors, targetHandle, sourceHandle, D3D12_DESCRIPTOR_HEAP_TYPE_SAMPLER);
 	}
 }
 
 void DirectX12Device::bindDescriptorSet(const DirectX12CommandBuffer& commandBuffer, const DirectX12DescriptorSet& descriptorSet, const DirectX12PipelineState& pipeline) const noexcept
 {
-	UInt32 buffers = 0, samplers = 0;
-
-	if (descriptorSet.bufferHeap() != nullptr)
-		buffers = descriptorSet.bufferHeap()->GetDesc().NumDescriptors;
-
-	if (descriptorSet.samplerHeap() != nullptr)
-		samplers = descriptorSet.samplerHeap()->GetDesc().NumDescriptors;
-
 	// Get the root parameter index.
 	auto rootParameterIndex = pipeline.layout()->rootParameterIndex(descriptorSet.layout());
 
@@ -394,22 +384,21 @@ void DirectX12Device::bindDescriptorSet(const DirectX12CommandBuffer& commandBuf
 	// Deduct, whether to set the graphics or compute descriptor tables.
 	// TODO: Maybe we could store a simple boolean on the pipeline state to make this easier.
 	const bool isGraphicsSet = dynamic_cast<const DirectX12RenderPipeline*>(&pipeline) != nullptr;
-	 
+
 	// Copy the descriptors to the global heaps and set the root table parameters.
-	if (buffers > 0)
+	if (descriptorSet.layout().samplers() > 0 || descriptorSet.layout().staticSamplers() > 0)
 	{
-		CD3DX12_GPU_DESCRIPTOR_HANDLE targetGpuHandle(m_impl->m_globalBufferHeap->GetGPUDescriptorHandleForHeapStart(), static_cast<INT>(descriptorSet.bufferOffset()), m_impl->m_bufferDescriptorIncrement);
+		// The parameter index equals the target descriptor set space.
+		CD3DX12_GPU_DESCRIPTOR_HANDLE targetGpuHandle(m_impl->m_globalSamplerHeap->GetGPUDescriptorHandleForHeapStart(), static_cast<INT>(descriptorSet.globalHeapOffset()), m_impl->m_samplerDescriptorIncrement);
 
 		if (isGraphicsSet)
 			commandBuffer.handle()->SetGraphicsRootDescriptorTable(rootParameterIndex.value(), targetGpuHandle);
 		else
 			commandBuffer.handle()->SetComputeRootDescriptorTable(rootParameterIndex.value(), targetGpuHandle);
 	}
-
-	if (samplers > 0)
+	else
 	{
-		// The parameter index equals the target descriptor set space.
-		CD3DX12_GPU_DESCRIPTOR_HANDLE targetGpuHandle(m_impl->m_globalSamplerHeap->GetGPUDescriptorHandleForHeapStart(), static_cast<INT>(descriptorSet.samplerOffset()), m_impl->m_samplerDescriptorIncrement);
+		CD3DX12_GPU_DESCRIPTOR_HANDLE targetGpuHandle(m_impl->m_globalBufferHeap->GetGPUDescriptorHandleForHeapStart(), static_cast<INT>(descriptorSet.globalHeapOffset()), m_impl->m_bufferDescriptorIncrement);
 
 		if (isGraphicsSet)
 			commandBuffer.handle()->SetGraphicsRootDescriptorTable(rootParameterIndex.value(), targetGpuHandle);

--- a/src/Backends/DirectX12/src/ray_tracing_pipeline.cpp
+++ b/src/Backends/DirectX12/src/ray_tracing_pipeline.cpp
@@ -411,7 +411,7 @@ public:
 
 		// Write each record group by group.
 		UInt32 record{ 0 };
-		Array<Byte> recordData(recordSize, 0x00);
+		Array<Byte> recordData(recordSize, 0x00_b);
 
 		// Write each shader binding group that should be included.
 		for (auto group : { ShaderBindingGroup::RayGeneration, ShaderBindingGroup::Miss, ShaderBindingGroup::Callable, ShaderBindingGroup::HitGroup })
@@ -487,7 +487,7 @@ public:
 					std::memcpy(recordData.data(), getRecordIdentifier(currentRecord), D3D12_SHADER_IDENTIFIER_SIZE_IN_BYTES);
 
 					// Write the payload and map everything into the buffer.
-					std::memcpy(recordData.data() + D3D12_SHADER_IDENTIFIER_SIZE_IN_BYTES, currentRecord->localData(), static_cast<size_t>(currentRecord->localDataSize())); // NOLINT(cppcoreguidelines-pro-bounds-pointer-arithmetic)
+					std::memcpy(std::next(recordData.data(), D3D12_SHADER_IDENTIFIER_SIZE_IN_BYTES), currentRecord->localData(), static_cast<size_t>(currentRecord->localDataSize()));
 					result->map(recordData.data(), recordSize, record++);
 				}
 

--- a/src/Backends/DirectX12/src/render_pass.cpp
+++ b/src/Backends/DirectX12/src/render_pass.cpp
@@ -176,7 +176,7 @@ public:
             std::get<1>(m_activeContext) = std::nullopt;
         else
         {
-            CD3DX12_CLEAR_VALUE clearValue{ DX12::getFormat(m_depthStencilTarget->format()), m_depthStencilTarget->clearValues().x(), static_cast<Byte>(m_depthStencilTarget->clearValues().y()) };
+            CD3DX12_CLEAR_VALUE clearValue{ DX12::getFormat(m_depthStencilTarget->format()), m_depthStencilTarget->clearValues().x(), static_cast<UInt8>(m_depthStencilTarget->clearValues().y()) };
             
             D3D12_RENDER_PASS_ENDING_ACCESS depthEndAccess, stencilEndAccess;
             D3D12_RENDER_PASS_BEGINNING_ACCESS depthBeginAccess = m_depthStencilTarget->clearBuffer() && ::hasDepth(m_depthStencilTarget->format()) ?

--- a/src/Backends/Vulkan/include/litefx/backends/vulkan.hpp
+++ b/src/Backends/Vulkan/include/litefx/backends/vulkan.hpp
@@ -775,10 +775,10 @@ namespace LiteFX::Rendering::Backends {
 
     public:
         /// <inheritdoc />
-        virtual UInt32 globalHeapOffset() const noexcept override;
+        UInt32 globalHeapOffset() const noexcept override;
 
         /// <inheritdoc />
-        virtual UInt32 globalHeapAddressRange() const noexcept override;
+        UInt32 globalHeapAddressRange() const noexcept override;
 
         /// <inheritdoc />
         void update(UInt32 binding, const IVulkanBuffer& buffer, UInt32 bufferElement = 0, UInt32 elements = 0, UInt32 firstDescriptor = 0) const override;

--- a/src/Backends/Vulkan/include/litefx/backends/vulkan.hpp
+++ b/src/Backends/Vulkan/include/litefx/backends/vulkan.hpp
@@ -1003,6 +1003,9 @@ namespace LiteFX::Rendering::Backends {
         /// <inheritdoc />
         bool containsUnboundedArray() const noexcept override;
 
+        /// <inheritdoc />
+        UInt32 getDescriptorOffset(UInt32 binding, UInt32 element = 0) const override;
+
     public:
         /// <inheritdoc />
         UniquePtr<VulkanDescriptorSet> allocate(UInt32 descriptors, std::initializer_list<DescriptorBinding> bindings) const override;

--- a/src/Backends/Vulkan/include/litefx/backends/vulkan.hpp
+++ b/src/Backends/Vulkan/include/litefx/backends/vulkan.hpp
@@ -2515,20 +2515,18 @@ namespace LiteFX::Rendering::Backends {
         /// Creates a descriptor heap.
         /// </summary>
         /// <param name="heapSize">The size of the descriptor heap buffer in bytes.</param>
-        /// <param name="onCpu">If set to `true`, the heap can be mapped from the CPU.</param>
         /// <param name="forSamplers">If set to `true`, the heap does only accept samplers. Must be set to `false` for all other resource types.</param>
         /// <returns>A buffer that provides memory for the descriptor heap.</returns>
-        SharedPtr<IVulkanBuffer> createDescriptorHeap(size_t heapSize, bool onCpu, bool forSamplers) const;
+        SharedPtr<IVulkanBuffer> createDescriptorHeap(size_t heapSize, bool forSamplers) const;
 
         /// <summary>
         /// Creates a descriptor heap.
         /// </summary>
         /// <param name="name">The name of the descriptor heap.</param>
         /// <param name="heapSize">The size of the descriptor heap buffer in bytes.</param>
-        /// <param name="onCpu">If set to `true`, the heap can be mapped from the CPU.</param>
         /// <param name="forSamplers">If set to `true`, the heap does only accept samplers. Must be set to `false` for all other resource types.</param>
         /// <returns>A buffer that provides memory for the descriptor heap.</returns>
-        SharedPtr<IVulkanBuffer> createDescriptorHeap(const String& name, size_t heapSize, bool onCpu, bool forSamplers) const;
+        SharedPtr<IVulkanBuffer> createDescriptorHeap(const String& name, size_t heapSize, bool forSamplers) const;
 
     public:
         /// <inheritdoc />
@@ -2773,6 +2771,21 @@ namespace LiteFX::Rendering::Backends {
 
         /// <inheritdoc />
         void computeAccelerationStructureSizes(const VulkanTopLevelAccelerationStructure& tlas, UInt64& bufferSize, UInt64& scratchSize, bool forUpdate = false) const override;
+
+        /// <inheritdoc />
+        void allocateGlobalDescriptors(const VulkanDescriptorSet& descriptorSet, UInt32& heapOffset, UInt32& heapSize) const override;
+
+        /// <inheritdoc />
+        void releaseGlobalDescriptors(const VulkanDescriptorSet& descriptorSet) const override;
+
+        /// <inheritdoc />
+        void updateGlobalDescriptors(const VulkanDescriptorSet& descriptorSet, UInt32 binding, UInt32 offset, UInt32 descriptors) const override;
+
+        /// <inheritdoc />
+        void bindDescriptorSet(const VulkanCommandBuffer& commandBuffer, const VulkanDescriptorSet& descriptorSet, const VulkanPipelineState& pipeline) const noexcept override;
+
+        /// <inheritdoc />
+        void bindGlobalDescriptorHeaps(const VulkanCommandBuffer& commandBuffer) const noexcept override;
 
 #if defined(LITEFX_BUILD_DEFINE_BUILDERS)
     public:

--- a/src/Backends/Vulkan/include/litefx/backends/vulkan.hpp
+++ b/src/Backends/Vulkan/include/litefx/backends/vulkan.hpp
@@ -1398,13 +1398,6 @@ namespace LiteFX::Rendering::Backends {
         /// </summary>
         /// <param name="commandBuffer">The command buffer to set the current pipeline state on.</param>
         virtual void use(const VulkanCommandBuffer& commandBuffer) const = 0;
-
-        /// <summary>
-        /// Binds a descriptor set on a command buffer.
-        /// </summary>
-        /// <param name="commandBuffer">The command buffer to issue the bind command on.</param>
-        /// <param name="descriptorSets">The descriptor sets to bind.</param>
-        virtual void bind(const VulkanCommandBuffer& commandBuffer, Span<const VulkanDescriptorSet*> descriptorSets) const = 0;
     };
 
     /// <summary>
@@ -1865,9 +1858,6 @@ namespace LiteFX::Rendering::Backends {
     public:
         /// <inheritdoc />
         void use(const VulkanCommandBuffer& commandBuffer) const override;
-
-        /// <inheritdoc />
-        void bind(const VulkanCommandBuffer& commandBuffer, Span<const VulkanDescriptorSet*> descriptorSets) const override;
     };
 
     /// <summary>
@@ -1923,9 +1913,6 @@ namespace LiteFX::Rendering::Backends {
     public:
         /// <inheritdoc />
         void use(const VulkanCommandBuffer& commandBuffer) const override;
-
-        /// <inheritdoc />
-        void bind(const VulkanCommandBuffer& commandBuffer, Span<const VulkanDescriptorSet*> descriptorSets) const override;
     };
     
     /// <summary>
@@ -2003,9 +1990,6 @@ namespace LiteFX::Rendering::Backends {
     public:
         /// <inheritdoc />
         void use(const VulkanCommandBuffer& commandBuffer) const override;
-
-        /// <inheritdoc />
-        void bind(const VulkanCommandBuffer& commandBuffer, Span<const VulkanDescriptorSet*> descriptorSets) const override;
     };
 
     /// <summary>

--- a/src/Backends/Vulkan/include/litefx/backends/vulkan.hpp
+++ b/src/Backends/Vulkan/include/litefx/backends/vulkan.hpp
@@ -775,6 +775,12 @@ namespace LiteFX::Rendering::Backends {
 
     public:
         /// <inheritdoc />
+        virtual UInt32 globalHeapOffset() const noexcept override;
+
+        /// <inheritdoc />
+        virtual UInt32 globalHeapAddressRange() const noexcept override;
+
+        /// <inheritdoc />
         void update(UInt32 binding, const IVulkanBuffer& buffer, UInt32 bufferElement = 0, UInt32 elements = 0, UInt32 firstDescriptor = 0) const override;
 
         /// <inheritdoc />

--- a/src/Backends/Vulkan/include/litefx/backends/vulkan.hpp
+++ b/src/Backends/Vulkan/include/litefx/backends/vulkan.hpp
@@ -1403,6 +1403,12 @@ namespace LiteFX::Rendering::Backends {
 
     public:
         /// <summary>
+        /// Returns the type of the pipeline.
+        /// </summary>
+        /// <returns>The type of the pipeline.</returns>
+        virtual VkPipelineBindPoint pipelineType() const noexcept = 0;
+
+        /// <summary>
         /// Sets the current pipeline state on the <paramref name="commandBuffer" />.
         /// </summary>
         /// <param name="commandBuffer">The command buffer to set the current pipeline state on.</param>
@@ -1866,6 +1872,9 @@ namespace LiteFX::Rendering::Backends {
         // VulkanPipelineState interface.
     public:
         /// <inheritdoc />
+        VkPipelineBindPoint pipelineType() const noexcept override;
+
+        /// <inheritdoc />
         void use(const VulkanCommandBuffer& commandBuffer) const override;
     };
 
@@ -1920,6 +1929,9 @@ namespace LiteFX::Rendering::Backends {
 
         // VulkanPipelineState interface.
     public:
+        /// <inheritdoc />
+        VkPipelineBindPoint pipelineType() const noexcept override;
+
         /// <inheritdoc />
         void use(const VulkanCommandBuffer& commandBuffer) const override;
     };
@@ -1997,6 +2009,9 @@ namespace LiteFX::Rendering::Backends {
 
         // VulkanPipelineState interface.
     public:
+        /// <inheritdoc />
+        VkPipelineBindPoint pipelineType() const noexcept override;
+
         /// <inheritdoc />
         void use(const VulkanCommandBuffer& commandBuffer) const override;
     };

--- a/src/Backends/Vulkan/include/litefx/backends/vulkan.hpp
+++ b/src/Backends/Vulkan/include/litefx/backends/vulkan.hpp
@@ -2695,6 +2695,13 @@ namespace LiteFX::Rendering::Backends {
         /// <returns>The indices of the queue families that support queue workloads specified by <paramref name="type" />.</returns>
         Enumerable<UInt32> queueFamilyIndices(QueueType type = QueueType::None) const;
 
+        /// <summary>
+        /// Resolves the binary size for a descriptor of <paramref name="type" />.
+        /// </summary>
+        /// <param name="type">The type of the descriptor.</param>
+        /// <returns>The size of the descriptor.</returns>
+        UInt32 descriptorSize(DescriptorType type) const;
+
         // GraphicsDevice interface.
     public:
         /// <inheritdoc />

--- a/src/Backends/Vulkan/include/litefx/backends/vulkan.hpp
+++ b/src/Backends/Vulkan/include/litefx/backends/vulkan.hpp
@@ -971,6 +971,9 @@ namespace LiteFX::Rendering::Backends {
         /// <inheritdoc />
         UInt32 inputAttachments() const noexcept override;
 
+        /// <inheritdoc />
+        bool containsUnboundedArray() const noexcept override;
+
     public:
         /// <inheritdoc />
         UniquePtr<VulkanDescriptorSet> allocate(UInt32 descriptors, std::initializer_list<DescriptorBinding> bindings) const override;
@@ -2493,7 +2496,7 @@ namespace LiteFX::Rendering::Backends {
         /// <param name="onCpu">If set to `true`, the heap can be mapped from the CPU.</param>
         /// <param name="forSamplers">If set to `true`, the heap does only accept samplers. Must be set to `false` for all other resource types.</param>
         /// <returns>A buffer that provides memory for the descriptor heap.</returns>
-        SharedPtr<IVulkanBuffer> createDescriptorHeap(size_t heapSize, bool onCpu, bool forSamplers) const noexcept;
+        SharedPtr<IVulkanBuffer> createDescriptorHeap(size_t heapSize, bool onCpu, bool forSamplers) const;
 
         /// <summary>
         /// Creates a descriptor heap.
@@ -2503,7 +2506,7 @@ namespace LiteFX::Rendering::Backends {
         /// <param name="onCpu">If set to `true`, the heap can be mapped from the CPU.</param>
         /// <param name="forSamplers">If set to `true`, the heap does only accept samplers. Must be set to `false` for all other resource types.</param>
         /// <returns>A buffer that provides memory for the descriptor heap.</returns>
-        SharedPtr<IVulkanBuffer> createDescriptorHeap(const String& name, size_t heapSize, bool onCpu, bool forSamplers) const noexcept;
+        SharedPtr<IVulkanBuffer> createDescriptorHeap(const String& name, size_t heapSize, bool onCpu, bool forSamplers) const;
 
     public:
         /// <inheritdoc />

--- a/src/Backends/Vulkan/src/buffer.h
+++ b/src/Backends/Vulkan/src/buffer.h
@@ -69,6 +69,12 @@ namespace LiteFX::Rendering::Backends {
 
 		/// <inheritdoc />
 		void map(Span<void*> data, size_t elementSize, UInt32 firstElement = 0, bool write = true) override;
+		
+		/// <inheritdoc />
+		void write(const void* const data, size_t size, size_t offset = 0) override;
+
+		/// <inheritdoc />
+		void read(void* data, size_t size, size_t offset = 0) override;
 
 		// VulkanBuffer.
 	public:

--- a/src/Backends/Vulkan/src/compute_pipeline.cpp
+++ b/src/Backends/Vulkan/src/compute_pipeline.cpp
@@ -99,6 +99,11 @@ SharedPtr<const VulkanPipelineLayout> VulkanComputePipeline::layout() const noex
 	return m_impl->m_layout;
 }
 
+VkPipelineBindPoint VulkanComputePipeline::pipelineType() const noexcept
+{
+	return VK_PIPELINE_BIND_POINT_COMPUTE;
+}
+
 void VulkanComputePipeline::use(const VulkanCommandBuffer& commandBuffer) const
 {
 	::vkCmdBindPipeline(commandBuffer.handle(), VK_PIPELINE_BIND_POINT_COMPUTE, this->handle());

--- a/src/Backends/Vulkan/src/compute_pipeline.cpp
+++ b/src/Backends/Vulkan/src/compute_pipeline.cpp
@@ -104,34 +104,6 @@ void VulkanComputePipeline::use(const VulkanCommandBuffer& commandBuffer) const
 	::vkCmdBindPipeline(commandBuffer.handle(), VK_PIPELINE_BIND_POINT_COMPUTE, this->handle());
 }
 
-void VulkanComputePipeline::bind(const VulkanCommandBuffer& commandBuffer, Span<const VulkanDescriptorSet*> descriptorSets) const
-{
-	// Filter out uninitialized sets.
-	auto sets = descriptorSets | std::views::filter([](auto set) { return set != nullptr; }) | std::ranges::to<Array<const VulkanDescriptorSet*>>();
-
-	if (sets.empty()) [[unlikely]]
-		return; // Nothing to do on empty sets.
-	else if (sets.size() == 1)
-		::vkCmdBindDescriptorSets(commandBuffer.handle(), VK_PIPELINE_BIND_POINT_COMPUTE, std::as_const(*m_impl->m_layout).handle(), sets.front()->layout().space(), 1, &sets.front()->handle(), 0, nullptr);
-	else
-	{
-		// Sort the descriptor sets by space, as we might be able to pass the sets more efficiently if they are sorted and continuous.
-		std::ranges::sort(sets, [](auto lhs, auto rhs) { return lhs->layout().space() > rhs->layout().space(); });
-
-		// In a sorted range, last - (first - 1) equals the size of the range only if there are no duplicates and no gaps.
-		auto startSpace = sets.back()->layout().space();
-
-		if (startSpace - (sets.front()->layout().space() - 1) != static_cast<UInt32>(sets.size()))
-			std::ranges::for_each(sets, [&](auto set) { ::vkCmdBindDescriptorSets(commandBuffer.handle(), VK_PIPELINE_BIND_POINT_COMPUTE, std::as_const(*m_impl->m_layout).handle(), set->layout().space(), 1, &set->handle(), 0, nullptr); });
-		else
-		{
-			// Obtain the handles and bind the sets.
-			auto handles = sets | std::views::transform([](auto set) { return set->handle(); }) | std::ranges::to<Array<VkDescriptorSet>>();
-			::vkCmdBindDescriptorSets(commandBuffer.handle(), VK_PIPELINE_BIND_POINT_COMPUTE, std::as_const(*m_impl->m_layout).handle(), startSpace, static_cast<UInt32>(handles.size()), handles.data(), 0, nullptr);
-		}
-	}
-}
-
 #if defined(LITEFX_BUILD_DEFINE_BUILDERS)
 // ------------------------------------------------------------------------------------------------
 // Builder interface.

--- a/src/Backends/Vulkan/src/compute_pipeline.cpp
+++ b/src/Backends/Vulkan/src/compute_pipeline.cpp
@@ -45,10 +45,12 @@ public:
 			| std::ranges::to<Array<VkPipelineShaderStageCreateInfo>>();
 
 		// Setup pipeline state.
-		VkComputePipelineCreateInfo pipelineInfo = {};
-		pipelineInfo.sType = VK_STRUCTURE_TYPE_COMPUTE_PIPELINE_CREATE_INFO;
-		pipelineInfo.layout = std::as_const(*m_layout.get()).handle();
-		pipelineInfo.stage = shaderStages.front();
+		VkComputePipelineCreateInfo pipelineInfo = {
+			.sType = VK_STRUCTURE_TYPE_COMPUTE_PIPELINE_CREATE_INFO,
+			.flags = VK_PIPELINE_CREATE_DESCRIPTOR_BUFFER_BIT_EXT,
+			.stage = shaderStages.front(),
+			.layout = std::as_const(*m_layout.get()).handle()
+		};
 
 		VkPipeline pipeline{};
 		raiseIfFailed(::vkCreateComputePipelines(m_device->handle(), VK_NULL_HANDLE, 1, &pipelineInfo, nullptr, &pipeline), "Unable to create compute pipeline.");

--- a/src/Backends/Vulkan/src/convert.cpp
+++ b/src/Backends/Vulkan/src/convert.cpp
@@ -1103,6 +1103,12 @@ VkAccessFlags2 LITEFX_VULKAN_API LiteFX::Rendering::Backends::Vk::getResourceAcc
 	return access;
 }
 
+#ifndef USE_VULKAN_INTEROP_SWAP_CHAIN
+#if defined(LITEFX_BUILD_VULKAN_INTEROP_SWAP_CHAIN) && defined(LITEFX_BUILD_DIRECTX_12_BACKEND)
+#define USE_VULKAN_INTEROP_SWAP_CHAIN
+#endif
+#endif
+
 VkImageLayout LITEFX_VULKAN_API LiteFX::Rendering::Backends::Vk::getImageLayout(ImageLayout imageLayout)
 {
 	switch (imageLayout) {
@@ -1115,14 +1121,16 @@ VkImageLayout LITEFX_VULKAN_API LiteFX::Rendering::Backends::Vk::getImageLayout(
 	case ImageLayout::DepthWrite: return VK_IMAGE_LAYOUT_DEPTH_STENCIL_ATTACHMENT_OPTIMAL;
 	case ImageLayout::RenderTarget:
 	case ImageLayout::ResolveSource:
-#ifdef LITEFX_BUILD_DIRECTX_12_BACKEND // Images from interop swap chain must not be transitioned into present state.
+#ifdef USE_VULKAN_INTEROP_SWAP_CHAIN // Images from interop swap chain must not be transitioned into present state.
 	case ImageLayout::Present:
 #endif
 	case ImageLayout::ResolveDestination: return VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL;
-#ifndef LITEFX_BUILD_DIRECTX_12_BACKEND
+#ifndef USE_VULKAN_INTEROP_SWAP_CHAIN
 	case ImageLayout::Present: return VK_IMAGE_LAYOUT_PRESENT_SRC_KHR;
 #endif
 	case ImageLayout::Undefined: return VK_IMAGE_LAYOUT_UNDEFINED;
 	default: throw InvalidArgumentException("imageLayout", "Unsupported image layout.");
 	}
 }
+
+#undef USE_VULKAN_INTEROP_SWAP_CHAIN

--- a/src/Backends/Vulkan/src/descriptor_set.cpp
+++ b/src/Backends/Vulkan/src/descriptor_set.cpp
@@ -130,11 +130,8 @@ void VulkanDescriptorSet::update(UInt32 binding, const IVulkanBuffer& buffer, UI
         throw InvalidArgumentException("binding", "Invalid descriptor type. The binding {0} does not point to a buffer descriptor.", binding);
 
     // Check if all elements can be bound to a bounded array.
-    if (descriptorLayout->descriptors() > 1 && descriptorLayout->descriptors() < (firstDescriptor + elementCount)) [[unlikely]]
+    if (descriptorLayout->descriptors() < (firstDescriptor + elementCount)) [[unlikely]]
         throw ArgumentOutOfRangeException("elements", "The descriptor layout can only bind up to {0} descriptors at binding {3}, however the request was to bind {1} descriptors starting at {2}.", descriptorLayout->descriptors(), elementCount, firstDescriptor, binding);
-
-    // Acquire the binding offset.
-    auto descriptorOffset = static_cast<VkDeviceSize>(m_impl->m_layout->getDescriptorOffset(binding));
 
     // Offset to first array index. Arrays are tightly packed, so we simply add the descriptor size for each element.
     size_t descriptorSize = m_impl->m_layout->device().descriptorSize(descriptorLayout->descriptorType());
@@ -142,6 +139,9 @@ void VulkanDescriptorSet::update(UInt32 binding, const IVulkanBuffer& buffer, UI
     // Update the descriptor each element.
     for (UInt32 i{ 0 }; i < elementCount; ++i)
     {
+        // Acquire the binding offset.
+        auto descriptorOffset = static_cast<VkDeviceSize>(m_impl->m_layout->getDescriptorOffset(binding, firstDescriptor + i));
+
         // Create the address info object.
         VkDescriptorAddressInfoEXT addressInfo = {
             .sType = VK_STRUCTURE_TYPE_DESCRIPTOR_ADDRESS_INFO_EXT,
@@ -180,7 +180,7 @@ void VulkanDescriptorSet::update(UInt32 binding, const IVulkanBuffer& buffer, UI
         }
 
         // Create the descriptor in the descriptor buffer.
-        vkGetDescriptor(m_impl->m_layout->device().handle(), &descriptorInfo, descriptorSize, m_impl->m_descriptorBuffer.data());
+        vkGetDescriptor(m_impl->m_layout->device().handle(), &descriptorInfo, descriptorSize, std::next(m_impl->m_descriptorBuffer.data(), descriptorOffset));
     }
 
     // Update the invalidated range on the global descriptor heap.
@@ -189,178 +189,193 @@ void VulkanDescriptorSet::update(UInt32 binding, const IVulkanBuffer& buffer, UI
 
 void VulkanDescriptorSet::update(UInt32 binding, const IVulkanImage& texture, UInt32 descriptor, UInt32 firstLevel, UInt32 levels, UInt32 firstLayer, UInt32 layers) const
 {
-    throw;
+    // Find the descriptor.
+    auto descriptors = m_impl->m_layout->descriptors();
+    auto descriptorLayout = std::ranges::find_if(descriptors, [&binding](auto& layout) { return layout.binding() == binding; });
 
-    //// Find the descriptor.
-    //auto descriptors = m_impl->m_layout->descriptors();
-    //auto match = std::ranges::find_if(descriptors, [&binding](auto& layout) { return layout.binding() == binding; });
+    if (descriptorLayout == descriptors.end()) [[unlikely]]
+    {
+        LITEFX_WARNING(VULKAN_LOG, "The descriptor set {0} does not contain a descriptor at binding {1}.", m_impl->m_layout->space(), binding);
+        return;
+    }
 
-    //if (match == descriptors.end()) [[unlikely]]
-    //{
-    //    LITEFX_WARNING(VULKAN_LOG, "The descriptor set {0} does not contain a descriptor at binding {1}.", m_impl->m_layout->space(), binding);
-    //    return;
-    //}
-    //
-    //const auto& layout = *match;
+    // Check if the descriptor type is valid for the requested operation.
+    if (descriptorLayout->descriptorType() != DescriptorType::Texture &&
+        descriptorLayout->descriptorType() != DescriptorType::RWTexture &&
+        descriptorLayout->descriptorType() != DescriptorType::InputAttachment) [[unlikely]]
+        throw InvalidArgumentException("binding", "Invalid descriptor type. The binding {0} does not point to an image descriptor.", binding);
 
-    //VkDescriptorImageInfo imageInfo{ };
-    //VkWriteDescriptorSet descriptorWrite{ };
-    //descriptorWrite.sType = VK_STRUCTURE_TYPE_WRITE_DESCRIPTOR_SET;
-    //descriptorWrite.dstSet = this->handle();
-    //descriptorWrite.dstBinding = binding;
-    //descriptorWrite.dstArrayElement = descriptor;
-    //descriptorWrite.descriptorCount = 1;
-    //descriptorWrite.pImageInfo = &imageInfo;
+    // Check if all elements can be bound to a bounded array.
+    if (descriptorLayout->descriptors() <= descriptor) [[unlikely]]
+        throw ArgumentOutOfRangeException("descriptor", "The descriptor layout can only bind up to {0} descriptors at binding {3}, however the request was to bind {1} descriptors starting at {2}.", descriptorLayout->descriptors(), 1, descriptor, binding);
+    
+    // Remove the image view, if there is one bound to the current descriptor.
+    if (m_impl->m_imageViews.contains(binding))
+    {
+        ::vkDestroyImageView(m_impl->m_layout->device().handle(), m_impl->m_imageViews[binding], nullptr);
+        m_impl->m_imageViews.erase(binding);
+    }
 
-    //switch (layout.descriptorType())
-    //{
-    //case DescriptorType::Texture:
-    //    imageInfo.imageLayout = VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL;
-    //    descriptorWrite.descriptorType = VK_DESCRIPTOR_TYPE_SAMPLED_IMAGE;
-    //    break;
-    //case DescriptorType::RWTexture:
-    //    imageInfo.imageLayout = VK_IMAGE_LAYOUT_GENERAL;
-    //    descriptorWrite.descriptorType = VK_DESCRIPTOR_TYPE_STORAGE_IMAGE;
-    //    break;
-    //case DescriptorType::InputAttachment:
-    //    imageInfo.imageLayout = VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL;
-    //    descriptorWrite.descriptorType = VK_DESCRIPTOR_TYPE_INPUT_ATTACHMENT;
-    //    break;
-    //default: [[unlikely]]
-    //    throw InvalidArgumentException("binding", "Invalid descriptor type. The binding {0} does not point to a texture descriptor.", binding);
-    //}
+    // Create a new image view.
+    const UInt32 numLevels = levels == 0 ? texture.levels() - firstLevel : levels;
+    const UInt32 numLayers = layers == 0 ? texture.layers() - firstLayer : layers;
 
-    //// Remove the image view, if there is one bound to the current descriptor.
-    //if (m_impl->m_imageViews.contains(binding))
-    //{
-    //    ::vkDestroyImageView(m_impl->m_layout->device().handle(), m_impl->m_imageViews[binding], nullptr);
-    //    m_impl->m_imageViews.erase(binding);
-    //}
-    //
-    //// Create a new image view.
-    //const UInt32 numLevels = levels == 0 ? texture.levels() - firstLevel : levels;
-    //const UInt32 numLayers = layers == 0 ? texture.layers() - firstLayer : layers;
+    VkImageViewCreateInfo imageViewDesc = {
+        .sType = VK_STRUCTURE_TYPE_IMAGE_VIEW_CREATE_INFO,
+        .pNext = nullptr,
+        .image = texture.handle(),
+        .viewType = Vk::getImageViewType(texture.dimensions(), numLayers), // TODO: What if we want to bind an array with one layer only, though?!... `DescriptorLayout` should get an "isArray" property.
+        .format = Vk::getFormat(texture.format()),
+        .components = VkComponentMapping {
+            .r = VK_COMPONENT_SWIZZLE_IDENTITY,
+            .g = VK_COMPONENT_SWIZZLE_IDENTITY,
+            .b = VK_COMPONENT_SWIZZLE_IDENTITY,
+            .a = VK_COMPONENT_SWIZZLE_IDENTITY
+        },
+        .subresourceRange = VkImageSubresourceRange {
+            .baseMipLevel = firstLevel,
+            .levelCount = numLevels,
+            .baseArrayLayer = firstLayer,
+            .layerCount = numLayers
+        }
+    };
 
-    //VkImageViewCreateInfo imageViewDesc = {
-    //    .sType = VK_STRUCTURE_TYPE_IMAGE_VIEW_CREATE_INFO,
-    //    .pNext = nullptr,
-    //    .image = texture.handle(),
-    //    .viewType = Vk::getImageViewType(texture.dimensions(), numLayers), // TODO: What if we want to bind an array with one layer only, though?!... `DescriptorLayout` should get an "isArray" property.
-    //    .format = Vk::getFormat(texture.format()),
-    //    .components = VkComponentMapping {
-    //        .r = VK_COMPONENT_SWIZZLE_IDENTITY,
-    //        .g = VK_COMPONENT_SWIZZLE_IDENTITY,
-    //        .b = VK_COMPONENT_SWIZZLE_IDENTITY,
-    //        .a = VK_COMPONENT_SWIZZLE_IDENTITY
-    //    },
-    //    .subresourceRange = VkImageSubresourceRange {
-    //        .baseMipLevel = firstLevel,
-    //        .levelCount = numLevels,
-    //        .baseArrayLayer = firstLayer,
-    //        .layerCount = numLayers
-    //    }
-    //};
+    if (!::hasDepth(texture.format()) && !::hasStencil(texture.format()))
+        imageViewDesc.subresourceRange.aspectMask = VK_IMAGE_ASPECT_COLOR_BIT;
+    else
+    {
+        // TODO: This probably wont work, instead we need separate views here. Maybe we could add a "plane" parameter that addresses the depth/stencil view.
+        if (::hasDepth(texture.format()))
+            imageViewDesc.subresourceRange.aspectMask |= VK_IMAGE_ASPECT_DEPTH_BIT;
 
-    //if (!::hasDepth(texture.format()) && !::hasStencil(texture.format()))
-    //    imageViewDesc.subresourceRange.aspectMask = VK_IMAGE_ASPECT_COLOR_BIT;
-    //else
-    //{
-    //    // TODO: This probably wont work, instead we need separate views here. Maybe we could add a "plane" parameter that addresses the depth/stencil view.
-    //    if (::hasDepth(texture.format()))
-    //        imageViewDesc.subresourceRange.aspectMask |= VK_IMAGE_ASPECT_DEPTH_BIT;
+        if (::hasStencil(texture.format()))
+            imageViewDesc.subresourceRange.aspectMask |= VK_IMAGE_ASPECT_STENCIL_BIT;
+    }
 
-    //    if (::hasStencil(texture.format()))
-    //        imageViewDesc.subresourceRange.aspectMask |= VK_IMAGE_ASPECT_STENCIL_BIT;
-    //}
+    VkImageView imageView{};
+    raiseIfFailed(::vkCreateImageView(m_impl->m_layout->device().handle(), &imageViewDesc, nullptr, &imageView), "Unable to create image view.");
+    m_impl->m_imageViews[binding] = imageView;
 
-    //VkImageView imageView{};
-    //raiseIfFailed(::vkCreateImageView(m_impl->m_layout->device().handle(), &imageViewDesc, nullptr, &imageView), "Unable to create image view.");
-    //m_impl->m_imageViews[binding] = imageView;
-    //imageInfo.imageView = imageView;
+    // Acquire the binding offset.
+    auto descriptorOffset = static_cast<VkDeviceSize>(m_impl->m_layout->getDescriptorOffset(binding, descriptor));
 
-    //::vkUpdateDescriptorSets(m_impl->m_layout->device().handle(), 1, &descriptorWrite, 0, nullptr);
+    // Offset to first array index. Arrays are tightly packed, so we simply add the descriptor size for each element.
+    size_t descriptorSize = m_impl->m_layout->device().descriptorSize(descriptorLayout->descriptorType());
+
+    // Create the image info object.
+    VkDescriptorImageInfo imageInfo = {
+        .imageView = imageView,
+        .imageLayout = VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL // NOTE: We do have to change this for RWTexture.
+    };
+
+    // Setup the descriptor info.
+    VkDescriptorGetInfoEXT descriptorInfo = { .sType = VK_STRUCTURE_TYPE_DESCRIPTOR_GET_INFO_EXT };
+
+    // TODO: Texel buffers need a format, which is currently not supported.
+    switch (descriptorLayout->descriptorType())
+    {
+    case DescriptorType::Texture:
+        descriptorInfo.type = VK_DESCRIPTOR_TYPE_SAMPLED_IMAGE;
+        descriptorInfo.data.pSampledImage = &imageInfo;
+        break;
+    case DescriptorType::RWTexture:
+        imageInfo.imageLayout = VK_IMAGE_LAYOUT_GENERAL;
+        descriptorInfo.type = VK_DESCRIPTOR_TYPE_STORAGE_IMAGE;
+        descriptorInfo.data.pStorageImage = &imageInfo;
+        break;
+    case DescriptorType::InputAttachment:
+        descriptorInfo.type = VK_DESCRIPTOR_TYPE_INPUT_ATTACHMENT;
+        descriptorInfo.data.pInputAttachmentImage = &imageInfo;
+        break;
+    }
+
+    // Create the descriptor in the descriptor buffer.
+    vkGetDescriptor(m_impl->m_layout->device().handle(), &descriptorInfo, descriptorSize, std::next(m_impl->m_descriptorBuffer.data(), descriptorOffset));
+
+    // Update the invalidated range on the global descriptor heap.
+    m_impl->m_layout->device().updateGlobalDescriptors(*this, binding, descriptor, 1u);
 }
 
 void VulkanDescriptorSet::update(UInt32 binding, const IVulkanSampler& sampler, UInt32 descriptor) const
 {
-    throw;
+    // Find the descriptor.
+    auto descriptors = m_impl->m_layout->descriptors();
+    auto descriptorLayout = std::ranges::find_if(descriptors, [&binding](auto& layout) { return layout.binding() == binding; });
 
-    //// Find the descriptor.
-    //auto descriptors = m_impl->m_layout->descriptors();
-    //auto descriptorLayout = std::ranges::find_if(descriptors, [&binding](auto& layout) { return layout.binding() == binding; });
+    if (descriptorLayout == descriptors.end()) [[unlikely]]
+    {
+        LITEFX_WARNING(VULKAN_LOG, "The descriptor set {0} does not contain a descriptor at binding {1}.", m_impl->m_layout->space(), binding);
+        return;
+    }
 
-    //if (descriptorLayout == descriptors.end()) [[unlikely]]
-    //{
-    //    LITEFX_WARNING(VULKAN_LOG, "The descriptor set {0} does not contain a descriptor at binding {1}.", m_impl->m_layout->space(), binding);
-    //    return;
-    //}
+    // Check if the descriptor type is valid for the requested operation.
+    if (descriptorLayout->descriptorType() != DescriptorType::Sampler) [[unlikely]]
+        throw InvalidArgumentException("binding", "Invalid descriptor type. The binding {0} does not point to a sampler descriptor.", binding);
 
-    //// Check if the descriptor type is valid for the requested operation.
-    //if (descriptorLayout->descriptorType() != DescriptorType::Sampler) [[unlikely]]
-    //    throw InvalidArgumentException("binding", "Invalid descriptor type. The binding {0} does not point to a sampler descriptor.", binding);
+    // Check if all elements can be bound to a bounded array.
+    if (descriptorLayout->descriptors() <= descriptor) [[unlikely]]
+        throw ArgumentOutOfRangeException("descriptor", "The descriptor layout can only bind up to {0} descriptors at binding {3}, however the request was to bind {1} descriptors starting at {2}.", descriptorLayout->descriptors(), 1, descriptor, binding);
 
-    //// Check if all elements can be bound to a bounded array.
-    //if (descriptorLayout->descriptors() > 1 && descriptorLayout->descriptors() <= descriptor) [[unlikely]]
-    //    throw ArgumentOutOfRangeException("descriptor", "The descriptor layout can only bind up to {0} descriptors at binding {3}, however the request was to bind {1} descriptors starting at {2}.", descriptorLayout->descriptors(), 1, descriptor, binding);
+    // Acquire the binding offset.
+    auto descriptorOffset = static_cast<VkDeviceSize>(m_impl->m_layout->getDescriptorOffset(binding, descriptor));
 
-    //// Acquire the binding offset.
-    //auto descriptorOffset = ...;
-    ////vkGetDescriptorSetLayoutBindingOffset(m_impl->m_layout->device().handle(), m_impl->m_layout->handle(), binding, &descriptorOffset);
+    // Offset to first array index. Arrays are tightly packed, so we simply add the descriptor size for each element.
+    size_t descriptorSize = m_impl->m_layout->device().descriptorSize(descriptorLayout->descriptorType());
 
-    //// Offset to first array index. Arrays are tightly packed, so we simply add the descriptor size for each element.
-    //size_t descriptorSize = m_impl->m_layout->device().descriptorSize(descriptorLayout->descriptorType());
+    // Setup the descriptor info.
+    VkDescriptorGetInfoEXT descriptorInfo = { 
+        .sType = VK_STRUCTURE_TYPE_DESCRIPTOR_GET_INFO_EXT,
+        .type = VK_DESCRIPTOR_TYPE_SAMPLER,
+        .data = { .pSampler = &sampler.handle() }
+    };
 
-    //// Setup the descriptor info.
-    //VkDescriptorGetInfoEXT descriptorInfo = { 
-    //    .sType = VK_STRUCTURE_TYPE_DESCRIPTOR_GET_INFO_EXT,
-    //    .type = VK_DESCRIPTOR_TYPE_SAMPLER,
-    //    .data = { .pSampler = &sampler.handle() }
-    //};
+    // Create the descriptor in the descriptor buffer.
+    vkGetDescriptor(m_impl->m_layout->device().handle(), &descriptorInfo, descriptorSize, std::next(m_impl->m_descriptorBuffer.data(), descriptorOffset));
 
-    //// Create the descriptor in the descriptor buffer.
-    //vkGetDescriptor(m_impl->m_layout->device().handle(), &descriptorInfo, descriptorSize, m_impl->m_descriptorBuffer.get());
+    // Update the invalidated range on the global descriptor heap.
+    m_impl->m_layout->device().updateGlobalDescriptors(*this, binding, descriptor, 1u);
 }
 
 void VulkanDescriptorSet::update(UInt32 binding, const IVulkanAccelerationStructure& accelerationStructure, UInt32 descriptor) const
 {
-    throw;
+    // Check if the acceleration structure has been initialized.
+    if (accelerationStructure.buffer() == nullptr || accelerationStructure.handle() == VK_NULL_HANDLE) [[unlikely]]
+        throw InvalidArgumentException("accelerationStructure", "The acceleration structure buffer has not yet been allocated.");
 
-    //// Check if the acceleration structure has been initialized.
-    //if (accelerationStructure.buffer() == nullptr || accelerationStructure.handle() == VK_NULL_HANDLE) [[unlikely]]
-    //    throw InvalidArgumentException("accelerationStructure", "The acceleration structure buffer has not yet been allocated.");
+    // Find the descriptor.
+    auto descriptors = m_impl->m_layout->descriptors();
+    auto descriptorLayout = std::ranges::find_if(descriptors, [&binding](auto& layout) { return layout.binding() == binding; });
 
-    //// Find the descriptor.
-    //auto descriptors = m_impl->m_layout->descriptors();
-    //auto descriptorLayout = std::ranges::find_if(descriptors, [&binding](auto& layout) { return layout.binding() == binding; });
+    if (descriptorLayout == descriptors.end()) [[unlikely]]
+    {
+        LITEFX_WARNING(VULKAN_LOG, "The descriptor set {0} does not contain a descriptor at binding {1}.", m_impl->m_layout->space(), binding);
+        return;
+    }
 
-    //if (descriptorLayout == descriptors.end()) [[unlikely]]
-    //{
-    //    LITEFX_WARNING(VULKAN_LOG, "The descriptor set {0} does not contain a descriptor at binding {1}.", m_impl->m_layout->space(), binding);
-    //    return;
-    //}
+    // Check if the descriptor type is valid for the requested operation.
+    if (descriptorLayout->descriptorType() != DescriptorType::AccelerationStructure) [[unlikely]]
+        throw InvalidArgumentException("binding", "Invalid descriptor type. The binding {0} does not point to an acceleration structure descriptor.", binding);
 
-    //// Check if the descriptor type is valid for the requested operation.
-    //if (descriptorLayout->descriptorType() != DescriptorType::AccelerationStructure) [[unlikely]]
-    //    throw InvalidArgumentException("binding", "Invalid descriptor type. The binding {0} does not point to an acceleration structure descriptor.", binding);
+    // Check if all elements can be bound to a bounded array.
+    if (descriptorLayout->descriptors() <= descriptor) [[unlikely]]
+        throw ArgumentOutOfRangeException("descriptor", "The descriptor layout can only bind up to {0} descriptors at binding {3}, however the request was to bind {1} descriptors starting at {2}.", descriptorLayout->descriptors(), 1, descriptor, binding);
 
-    //// Check if all elements can be bound to a bounded array.
-    //if (descriptorLayout->descriptors() > 1 && descriptorLayout->descriptors() <= descriptor) [[unlikely]]
-    //    throw ArgumentOutOfRangeException("descriptor", "The descriptor layout can only bind up to {0} descriptors at binding {3}, however the request was to bind {1} descriptors starting at {2}.", descriptorLayout->descriptors(), 1, descriptor, binding);
+    // Acquire the binding offset.
+    auto descriptorOffset = static_cast<VkDeviceSize>(m_impl->m_layout->getDescriptorOffset(binding, descriptor));
 
-    //// Acquire the binding offset.
-    //auto descriptorOffset = ...;
-    ////vkGetDescriptorSetLayoutBindingOffset(m_impl->m_layout->device().handle(), m_impl->m_layout->handle(), binding, &descriptorOffset);
+    // Offset to first array index. Arrays are tightly packed, so we simply add the descriptor size for each element.
+    size_t descriptorSize = m_impl->m_layout->device().descriptorSize(descriptorLayout->descriptorType());
 
-    //// Offset to first array index. Arrays are tightly packed, so we simply add the descriptor size for each element.
-    //size_t descriptorSize = m_impl->m_layout->device().descriptorSize(descriptorLayout->descriptorType());
+    // Setup the descriptor info.
+    VkDescriptorGetInfoEXT descriptorInfo = { 
+        .sType = VK_STRUCTURE_TYPE_DESCRIPTOR_GET_INFO_EXT,
+        .type = VK_DESCRIPTOR_TYPE_ACCELERATION_STRUCTURE_KHR,
+        .data = { .accelerationStructure = accelerationStructure.buffer()->virtualAddress() }
+    };
 
-    //// Setup the descriptor info.
-    //VkDescriptorGetInfoEXT descriptorInfo = { 
-    //    .sType = VK_STRUCTURE_TYPE_DESCRIPTOR_GET_INFO_EXT,
-    //    .type = VK_DESCRIPTOR_TYPE_ACCELERATION_STRUCTURE_KHR,
-    //    .data = { .accelerationStructure = accelerationStructure.buffer()->virtualAddress() }
-    //};
+    // Create the descriptor in the descriptor buffer.
+    vkGetDescriptor(m_impl->m_layout->device().handle(), &descriptorInfo, descriptorSize, std::next(m_impl->m_descriptorBuffer.data(), descriptorOffset));
 
-    //// Create the descriptor in the descriptor buffer.
-    //vkGetDescriptor(m_impl->m_layout->device().handle(), &descriptorInfo, descriptorSize, m_impl->m_descriptorBuffer.get());
+    // Update the invalidated range on the global descriptor heap.
+    m_impl->m_layout->device().updateGlobalDescriptors(*this, binding, descriptor, 1u);
 }

--- a/src/Backends/Vulkan/src/descriptor_set.cpp
+++ b/src/Backends/Vulkan/src/descriptor_set.cpp
@@ -181,7 +181,7 @@ void VulkanDescriptorSet::update(UInt32 binding, const IVulkanBuffer& buffer, UI
         }
 
         // Create the descriptor in the descriptor buffer.
-        vkGetDescriptor(m_impl->m_layout->device().handle(), &descriptorInfo, descriptorSize, std::next(m_impl->m_descriptorBuffer.data(), descriptorOffset)); // NOLINT(bugprone-narrowing-conversions,cppcoreguidelines-narrowing-conversions)
+        vkGetDescriptor(m_impl->m_layout->device().handle(), &descriptorInfo, descriptorSize, std::next(m_impl->m_descriptorBuffer.data(), static_cast<size_t>(descriptorOffset))); // NOLINT(bugprone-narrowing-conversions,cppcoreguidelines-narrowing-conversions)
     }
 
     // Update the invalidated range on the global descriptor heap.
@@ -293,7 +293,7 @@ void VulkanDescriptorSet::update(UInt32 binding, const IVulkanImage& texture, UI
     }
 
     // Create the descriptor in the descriptor buffer.
-    vkGetDescriptor(m_impl->m_layout->device().handle(), &descriptorInfo, descriptorSize, std::next(m_impl->m_descriptorBuffer.data(), descriptorOffset)); // NOLINT(bugprone-narrowing-conversions,cppcoreguidelines-narrowing-conversions)
+    vkGetDescriptor(m_impl->m_layout->device().handle(), &descriptorInfo, descriptorSize, std::next(m_impl->m_descriptorBuffer.data(), static_cast<size_t>(descriptorOffset))); // NOLINT(bugprone-narrowing-conversions,cppcoreguidelines-narrowing-conversions)
 
     // Update the invalidated range on the global descriptor heap.
     m_impl->m_layout->device().updateGlobalDescriptors(*this, binding, descriptor, 1u);
@@ -333,7 +333,7 @@ void VulkanDescriptorSet::update(UInt32 binding, const IVulkanSampler& sampler, 
     };
 
     // Create the descriptor in the descriptor buffer.
-    vkGetDescriptor(m_impl->m_layout->device().handle(), &descriptorInfo, descriptorSize, std::next(m_impl->m_descriptorBuffer.data(), descriptorOffset)); // NOLINT(bugprone-narrowing-conversions,cppcoreguidelines-narrowing-conversions)
+    vkGetDescriptor(m_impl->m_layout->device().handle(), &descriptorInfo, descriptorSize, std::next(m_impl->m_descriptorBuffer.data(), static_cast<size_t>(descriptorOffset))); // NOLINT(bugprone-narrowing-conversions,cppcoreguidelines-narrowing-conversions)
 
     // Update the invalidated range on the global descriptor heap.
     m_impl->m_layout->device().updateGlobalDescriptors(*this, binding, descriptor, 1u);
@@ -377,7 +377,7 @@ void VulkanDescriptorSet::update(UInt32 binding, const IVulkanAccelerationStruct
     };
 
     // Create the descriptor in the descriptor buffer.
-    vkGetDescriptor(m_impl->m_layout->device().handle(), &descriptorInfo, descriptorSize, std::next(m_impl->m_descriptorBuffer.data(), descriptorOffset)); // NOLINT(bugprone-narrowing-conversions,cppcoreguidelines-narrowing-conversions)
+    vkGetDescriptor(m_impl->m_layout->device().handle(), &descriptorInfo, descriptorSize, std::next(m_impl->m_descriptorBuffer.data(), static_cast<size_t>(descriptorOffset))); // NOLINT(bugprone-narrowing-conversions,cppcoreguidelines-narrowing-conversions)
 
     // Update the invalidated range on the global descriptor heap.
     m_impl->m_layout->device().updateGlobalDescriptors(*this, binding, descriptor, 1u);

--- a/src/Backends/Vulkan/src/descriptor_set.cpp
+++ b/src/Backends/Vulkan/src/descriptor_set.cpp
@@ -16,20 +16,38 @@ public:
     friend class VulkanDescriptorSet;
 
 private:
-    Dictionary<UInt32, VkBufferView> m_bufferViews{};
     Dictionary<UInt32, VkImageView> m_imageViews{};
     SharedPtr<const VulkanDescriptorSetLayout> m_layout;
-
-    UniquePtr<std::byte[]> m_descriptorBuffer;
+    Array<Byte> m_descriptorBuffer;
+    UInt32 m_unboundedArraySize;
 
 public:
-    VulkanDescriptorSetImpl(const VulkanDescriptorSetLayout& layout) :
-        m_layout(layout.shared_from_this())
+    VulkanDescriptorSetImpl(const VulkanDescriptorSetLayout& layout, Array<Byte>&& buffer) :
+        m_layout(layout.shared_from_this()), m_unboundedArraySize(0)
+    {
+        m_descriptorBuffer = std::move(buffer);
+    }
+
+    VulkanDescriptorSetImpl(const VulkanDescriptorSetLayout& layout, UInt32 unboundedArraySize) :
+        m_layout(layout.shared_from_this()), m_unboundedArraySize(unboundedArraySize)
     {
         // Allocate the descriptor set binding buffer.
         VkDeviceSize descriptorSetSize;
-        vkGetDescriptorSetLayoutSize(m_layout->device().handle(), m_layout->handle(), &descriptorSetSize);
-        m_descriptorBuffer = std::make_unique_for_overwrite<std::byte[]>(static_cast<size_t>(descriptorSetSize));
+
+        if (!layout.containsUnboundedArray())
+            vkGetDescriptorSetLayoutSize(m_layout->device().handle(), m_layout->handle(), &descriptorSetSize);
+        else
+        {
+            // If the layout contains an unbounded array size, the actual required address space needs to be computed. We exploit the guarantee that unbounded arrays are always put last in 
+            // the descriptor set, so we compute the offset, descriptor size and from this the total amount of required memory.
+            // First, we need to lookup the binding for the unbounded array. If we cannot match any binding here, we've conceptually messed up somewhere earlier, in which case no error handling
+            // could save us, so we gently ignore the chance of not matching anything.
+            auto descriptorLayout = std::ranges::find_if(layout.descriptors(), [](auto& layout) { return layout.descriptors() == -1; });
+            vkGetDescriptorSetLayoutBindingOffset(layout.device().handle(), layout.handle(), descriptorLayout->binding(), &descriptorSetSize);
+            descriptorSetSize += unboundedArraySize * layout.device().descriptorSize(descriptorLayout->descriptorType());
+        }
+
+        m_descriptorBuffer.resize(static_cast<size_t>(descriptorSetSize), 0_b);
     }
 };
 
@@ -37,19 +55,19 @@ public:
 // Shared interface.
 // ------------------------------------------------------------------------------------------------
 
-VulkanDescriptorSet::VulkanDescriptorSet(const VulkanDescriptorSetLayout& layout, VkDescriptorSet descriptorSet) :
-    Resource<VkDescriptorSet>(descriptorSet), m_impl(layout)
+VulkanDescriptorSet::VulkanDescriptorSet(const VulkanDescriptorSetLayout& layout, Array<Byte>&& buffer) :
+    m_impl(layout, std::forward<Array<Byte>>(buffer))
 {
-    if (descriptorSet == VK_NULL_HANDLE)
-        throw ArgumentNotInitializedException("descriptorSet", "The descriptor set handle must be initialized.");
+}
+
+VulkanDescriptorSet::VulkanDescriptorSet(const VulkanDescriptorSetLayout& layout, UInt32 unboundedArraySize) :
+    m_impl(layout, unboundedArraySize)
+{
 }
 
 VulkanDescriptorSet::~VulkanDescriptorSet() noexcept
 {
     const auto& device = m_impl->m_layout->device();
-
-    for (auto& bufferView : m_impl->m_bufferViews)
-        ::vkDestroyBufferView(device.handle(), bufferView.second, nullptr);
 
     for (auto& imageView : m_impl->m_imageViews)
         ::vkDestroyImageView(device.handle(), imageView.second, nullptr);
@@ -60,6 +78,16 @@ VulkanDescriptorSet::~VulkanDescriptorSet() noexcept
 const VulkanDescriptorSetLayout& VulkanDescriptorSet::layout() const noexcept
 {
     return *m_impl->m_layout;
+}
+
+Array<Byte>&& VulkanDescriptorSet::releaseBuffer() const noexcept
+{
+    return std::move(m_impl->m_descriptorBuffer);
+}
+
+Span<const Byte> VulkanDescriptorSet::descriptorBuffer() const noexcept
+{
+    return m_impl->m_descriptorBuffer;
 }
 
 void VulkanDescriptorSet::update(UInt32 binding, const IVulkanBuffer& buffer, UInt32 bufferElement, UInt32 elements, UInt32 firstDescriptor) const
@@ -86,7 +114,7 @@ void VulkanDescriptorSet::update(UInt32 binding, const IVulkanBuffer& buffer, UI
 
     // Check if all elements can be bound to a bounded array.
     if (descriptorLayout->descriptors() > 1 && descriptorLayout->descriptors() < (firstDescriptor + elements)) [[unlikely]]
-        ArgumentOutOfRangeException("elements", "The descriptor layout can only bind up to {0} descriptors at binding {3}, however the request was to bind {1} descriptors starting at {2}.", descriptorLayout->descriptors(), elements, firstDescriptor, binding);
+        throw ArgumentOutOfRangeException("elements", "The descriptor layout can only bind up to {0} descriptors at binding {3}, however the request was to bind {1} descriptors starting at {2}.", descriptorLayout->descriptors(), elements, firstDescriptor, binding);
 
     // Acquire the binding offset.
     VkDeviceSize descriptorOffset;
@@ -109,19 +137,22 @@ void VulkanDescriptorSet::update(UInt32 binding, const IVulkanBuffer& buffer, UI
         // Setup the descriptor info.
         VkDescriptorGetInfoEXT descriptorInfo = { .sType = VK_STRUCTURE_TYPE_DESCRIPTOR_GET_INFO_EXT };
 
+        // TODO: Texel buffers need a format, which is currently not supported.
         switch (descriptorLayout->descriptorType())
         {
-        case DescriptorType::Buffer:
-            descriptorInfo.type = VK_DESCRIPTOR_TYPE_UNIFORM_TEXEL_BUFFER;
-            descriptorInfo.data.pUniformTexelBuffer = &addressInfo;
-            break;
         case DescriptorType::ConstantBuffer:
             descriptorInfo.type = VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER;
             descriptorInfo.data.pUniformBuffer = &addressInfo;
             break;
+        case DescriptorType::Buffer:
+            descriptorInfo.type = VK_DESCRIPTOR_TYPE_UNIFORM_TEXEL_BUFFER;
+            descriptorInfo.data.pUniformTexelBuffer = &addressInfo;
+            addressInfo.format = VK_FORMAT_R8G8B8A8_UINT;
+            break;
         case DescriptorType::RWBuffer:
             descriptorInfo.type = VK_DESCRIPTOR_TYPE_STORAGE_TEXEL_BUFFER;
             descriptorInfo.data.pStorageTexelBuffer = &addressInfo;
+            addressInfo.format = VK_FORMAT_R8G8B8A8_UINT;
             break;
         case DescriptorType::ByteAddressBuffer:
         case DescriptorType::RWByteAddressBuffer:
@@ -133,178 +164,186 @@ void VulkanDescriptorSet::update(UInt32 binding, const IVulkanBuffer& buffer, UI
         }
 
         // Create the descriptor in the descriptor buffer.
-        vkGetDescriptor(m_impl->m_layout->device().handle(), &descriptorInfo, descriptorSize, m_impl->m_descriptorBuffer.get());
+        vkGetDescriptor(m_impl->m_layout->device().handle(), &descriptorInfo, descriptorSize, m_impl->m_descriptorBuffer.data());
     }
+
+    // TODO: Update the invalidated range on the global descriptor heap.
 }
 
 void VulkanDescriptorSet::update(UInt32 binding, const IVulkanImage& texture, UInt32 descriptor, UInt32 firstLevel, UInt32 levels, UInt32 firstLayer, UInt32 layers) const
 {
-    // Find the descriptor.
-    auto descriptors = m_impl->m_layout->descriptors();
-    auto match = std::ranges::find_if(descriptors, [&binding](auto& layout) { return layout.binding() == binding; });
+    throw;
 
-    if (match == descriptors.end()) [[unlikely]]
-    {
-        LITEFX_WARNING(VULKAN_LOG, "The descriptor set {0} does not contain a descriptor at binding {1}.", m_impl->m_layout->space(), binding);
-        return;
-    }
-    
-    const auto& layout = *match;
+    //// Find the descriptor.
+    //auto descriptors = m_impl->m_layout->descriptors();
+    //auto match = std::ranges::find_if(descriptors, [&binding](auto& layout) { return layout.binding() == binding; });
 
-    VkDescriptorImageInfo imageInfo{ };
-    VkWriteDescriptorSet descriptorWrite{ };
-    descriptorWrite.sType = VK_STRUCTURE_TYPE_WRITE_DESCRIPTOR_SET;
-    descriptorWrite.dstSet = this->handle();
-    descriptorWrite.dstBinding = binding;
-    descriptorWrite.dstArrayElement = descriptor;
-    descriptorWrite.descriptorCount = 1;
-    descriptorWrite.pImageInfo = &imageInfo;
+    //if (match == descriptors.end()) [[unlikely]]
+    //{
+    //    LITEFX_WARNING(VULKAN_LOG, "The descriptor set {0} does not contain a descriptor at binding {1}.", m_impl->m_layout->space(), binding);
+    //    return;
+    //}
+    //
+    //const auto& layout = *match;
 
-    switch (layout.descriptorType())
-    {
-    case DescriptorType::Texture:
-        imageInfo.imageLayout = VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL;
-        descriptorWrite.descriptorType = VK_DESCRIPTOR_TYPE_SAMPLED_IMAGE;
-        break;
-    case DescriptorType::RWTexture:
-        imageInfo.imageLayout = VK_IMAGE_LAYOUT_GENERAL;
-        descriptorWrite.descriptorType = VK_DESCRIPTOR_TYPE_STORAGE_IMAGE;
-        break;
-    case DescriptorType::InputAttachment:
-        imageInfo.imageLayout = VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL;
-        descriptorWrite.descriptorType = VK_DESCRIPTOR_TYPE_INPUT_ATTACHMENT;
-        break;
-    default: [[unlikely]]
-        throw InvalidArgumentException("binding", "Invalid descriptor type. The binding {0} does not point to a texture descriptor.", binding);
-    }
+    //VkDescriptorImageInfo imageInfo{ };
+    //VkWriteDescriptorSet descriptorWrite{ };
+    //descriptorWrite.sType = VK_STRUCTURE_TYPE_WRITE_DESCRIPTOR_SET;
+    //descriptorWrite.dstSet = this->handle();
+    //descriptorWrite.dstBinding = binding;
+    //descriptorWrite.dstArrayElement = descriptor;
+    //descriptorWrite.descriptorCount = 1;
+    //descriptorWrite.pImageInfo = &imageInfo;
 
-    // Remove the image view, if there is one bound to the current descriptor.
-    if (m_impl->m_imageViews.contains(binding))
-    {
-        ::vkDestroyImageView(m_impl->m_layout->device().handle(), m_impl->m_imageViews[binding], nullptr);
-        m_impl->m_imageViews.erase(binding);
-    }
-    
-    // Create a new image view.
-    const UInt32 numLevels = levels == 0 ? texture.levels() - firstLevel : levels;
-    const UInt32 numLayers = layers == 0 ? texture.layers() - firstLayer : layers;
+    //switch (layout.descriptorType())
+    //{
+    //case DescriptorType::Texture:
+    //    imageInfo.imageLayout = VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL;
+    //    descriptorWrite.descriptorType = VK_DESCRIPTOR_TYPE_SAMPLED_IMAGE;
+    //    break;
+    //case DescriptorType::RWTexture:
+    //    imageInfo.imageLayout = VK_IMAGE_LAYOUT_GENERAL;
+    //    descriptorWrite.descriptorType = VK_DESCRIPTOR_TYPE_STORAGE_IMAGE;
+    //    break;
+    //case DescriptorType::InputAttachment:
+    //    imageInfo.imageLayout = VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL;
+    //    descriptorWrite.descriptorType = VK_DESCRIPTOR_TYPE_INPUT_ATTACHMENT;
+    //    break;
+    //default: [[unlikely]]
+    //    throw InvalidArgumentException("binding", "Invalid descriptor type. The binding {0} does not point to a texture descriptor.", binding);
+    //}
 
-    VkImageViewCreateInfo imageViewDesc = {
-        .sType = VK_STRUCTURE_TYPE_IMAGE_VIEW_CREATE_INFO,
-        .pNext = nullptr,
-        .image = texture.handle(),
-        .viewType = Vk::getImageViewType(texture.dimensions(), numLayers), // TODO: What if we want to bind an array with one layer only, though?!... `DescriptorLayout` should get an "isArray" property.
-        .format = Vk::getFormat(texture.format()),
-        .components = VkComponentMapping {
-            .r = VK_COMPONENT_SWIZZLE_IDENTITY,
-            .g = VK_COMPONENT_SWIZZLE_IDENTITY,
-            .b = VK_COMPONENT_SWIZZLE_IDENTITY,
-            .a = VK_COMPONENT_SWIZZLE_IDENTITY
-        },
-        .subresourceRange = VkImageSubresourceRange {
-            .baseMipLevel = firstLevel,
-            .levelCount = numLevels,
-            .baseArrayLayer = firstLayer,
-            .layerCount = numLayers
-        }
-    };
+    //// Remove the image view, if there is one bound to the current descriptor.
+    //if (m_impl->m_imageViews.contains(binding))
+    //{
+    //    ::vkDestroyImageView(m_impl->m_layout->device().handle(), m_impl->m_imageViews[binding], nullptr);
+    //    m_impl->m_imageViews.erase(binding);
+    //}
+    //
+    //// Create a new image view.
+    //const UInt32 numLevels = levels == 0 ? texture.levels() - firstLevel : levels;
+    //const UInt32 numLayers = layers == 0 ? texture.layers() - firstLayer : layers;
 
-    if (!::hasDepth(texture.format()) && !::hasStencil(texture.format()))
-        imageViewDesc.subresourceRange.aspectMask = VK_IMAGE_ASPECT_COLOR_BIT;
-    else
-    {
-        // TODO: This probably wont work, instead we need separate views here. Maybe we could add a "plane" parameter that addresses the depth/stencil view.
-        if (::hasDepth(texture.format()))
-            imageViewDesc.subresourceRange.aspectMask |= VK_IMAGE_ASPECT_DEPTH_BIT;
+    //VkImageViewCreateInfo imageViewDesc = {
+    //    .sType = VK_STRUCTURE_TYPE_IMAGE_VIEW_CREATE_INFO,
+    //    .pNext = nullptr,
+    //    .image = texture.handle(),
+    //    .viewType = Vk::getImageViewType(texture.dimensions(), numLayers), // TODO: What if we want to bind an array with one layer only, though?!... `DescriptorLayout` should get an "isArray" property.
+    //    .format = Vk::getFormat(texture.format()),
+    //    .components = VkComponentMapping {
+    //        .r = VK_COMPONENT_SWIZZLE_IDENTITY,
+    //        .g = VK_COMPONENT_SWIZZLE_IDENTITY,
+    //        .b = VK_COMPONENT_SWIZZLE_IDENTITY,
+    //        .a = VK_COMPONENT_SWIZZLE_IDENTITY
+    //    },
+    //    .subresourceRange = VkImageSubresourceRange {
+    //        .baseMipLevel = firstLevel,
+    //        .levelCount = numLevels,
+    //        .baseArrayLayer = firstLayer,
+    //        .layerCount = numLayers
+    //    }
+    //};
 
-        if (::hasStencil(texture.format()))
-            imageViewDesc.subresourceRange.aspectMask |= VK_IMAGE_ASPECT_STENCIL_BIT;
-    }
+    //if (!::hasDepth(texture.format()) && !::hasStencil(texture.format()))
+    //    imageViewDesc.subresourceRange.aspectMask = VK_IMAGE_ASPECT_COLOR_BIT;
+    //else
+    //{
+    //    // TODO: This probably wont work, instead we need separate views here. Maybe we could add a "plane" parameter that addresses the depth/stencil view.
+    //    if (::hasDepth(texture.format()))
+    //        imageViewDesc.subresourceRange.aspectMask |= VK_IMAGE_ASPECT_DEPTH_BIT;
 
-    VkImageView imageView{};
-    raiseIfFailed(::vkCreateImageView(m_impl->m_layout->device().handle(), &imageViewDesc, nullptr, &imageView), "Unable to create image view.");
-    m_impl->m_imageViews[binding] = imageView;
-    imageInfo.imageView = imageView;
+    //    if (::hasStencil(texture.format()))
+    //        imageViewDesc.subresourceRange.aspectMask |= VK_IMAGE_ASPECT_STENCIL_BIT;
+    //}
 
-    ::vkUpdateDescriptorSets(m_impl->m_layout->device().handle(), 1, &descriptorWrite, 0, nullptr);
+    //VkImageView imageView{};
+    //raiseIfFailed(::vkCreateImageView(m_impl->m_layout->device().handle(), &imageViewDesc, nullptr, &imageView), "Unable to create image view.");
+    //m_impl->m_imageViews[binding] = imageView;
+    //imageInfo.imageView = imageView;
+
+    //::vkUpdateDescriptorSets(m_impl->m_layout->device().handle(), 1, &descriptorWrite, 0, nullptr);
 }
 
 void VulkanDescriptorSet::update(UInt32 binding, const IVulkanSampler& sampler, UInt32 descriptor) const
 {
-    // Find the descriptor.
-    auto descriptors = m_impl->m_layout->descriptors();
-    auto descriptorLayout = std::ranges::find_if(descriptors, [&binding](auto& layout) { return layout.binding() == binding; });
+    throw;
 
-    if (descriptorLayout == descriptors.end()) [[unlikely]]
-    {
-        LITEFX_WARNING(VULKAN_LOG, "The descriptor set {0} does not contain a descriptor at binding {1}.", m_impl->m_layout->space(), binding);
-        return;
-    }
+    //// Find the descriptor.
+    //auto descriptors = m_impl->m_layout->descriptors();
+    //auto descriptorLayout = std::ranges::find_if(descriptors, [&binding](auto& layout) { return layout.binding() == binding; });
 
-    // Check if the descriptor type is valid for the requested operation.
-    if (descriptorLayout->descriptorType() != DescriptorType::Sampler) [[unlikely]]
-        throw InvalidArgumentException("binding", "Invalid descriptor type. The binding {0} does not point to a sampler descriptor.", binding);
+    //if (descriptorLayout == descriptors.end()) [[unlikely]]
+    //{
+    //    LITEFX_WARNING(VULKAN_LOG, "The descriptor set {0} does not contain a descriptor at binding {1}.", m_impl->m_layout->space(), binding);
+    //    return;
+    //}
 
-    // Check if all elements can be bound to a bounded array.
-    if (descriptorLayout->descriptors() > 1 && descriptorLayout->descriptors() <= descriptor) [[unlikely]]
-        ArgumentOutOfRangeException("descriptor", "The descriptor layout can only bind up to {0} descriptors at binding {3}, however the request was to bind {1} descriptors starting at {2}.", descriptorLayout->descriptors(), 1, descriptor, binding);
+    //// Check if the descriptor type is valid for the requested operation.
+    //if (descriptorLayout->descriptorType() != DescriptorType::Sampler) [[unlikely]]
+    //    throw InvalidArgumentException("binding", "Invalid descriptor type. The binding {0} does not point to a sampler descriptor.", binding);
 
-    // Acquire the binding offset.
-    VkDeviceSize descriptorOffset;
-    vkGetDescriptorSetLayoutBindingOffset(m_impl->m_layout->device().handle(), m_impl->m_layout->handle(), binding, &descriptorOffset);
+    //// Check if all elements can be bound to a bounded array.
+    //if (descriptorLayout->descriptors() > 1 && descriptorLayout->descriptors() <= descriptor) [[unlikely]]
+    //    throw ArgumentOutOfRangeException("descriptor", "The descriptor layout can only bind up to {0} descriptors at binding {3}, however the request was to bind {1} descriptors starting at {2}.", descriptorLayout->descriptors(), 1, descriptor, binding);
 
-    // Offset to first array index. Arrays are tightly packed, so we simply add the descriptor size for each element.
-    size_t descriptorSize = m_impl->m_layout->device().descriptorSize(descriptorLayout->descriptorType());
+    //// Acquire the binding offset.
+    //VkDeviceSize descriptorOffset;
+    //vkGetDescriptorSetLayoutBindingOffset(m_impl->m_layout->device().handle(), m_impl->m_layout->handle(), binding, &descriptorOffset);
 
-    // Setup the descriptor info.
-    VkDescriptorGetInfoEXT descriptorInfo = { 
-        .sType = VK_STRUCTURE_TYPE_DESCRIPTOR_GET_INFO_EXT,
-        .type = VK_DESCRIPTOR_TYPE_SAMPLER,
-        .data = { .pSampler = &sampler.handle() }
-    };
+    //// Offset to first array index. Arrays are tightly packed, so we simply add the descriptor size for each element.
+    //size_t descriptorSize = m_impl->m_layout->device().descriptorSize(descriptorLayout->descriptorType());
 
-    // Create the descriptor in the descriptor buffer.
-    vkGetDescriptor(m_impl->m_layout->device().handle(), &descriptorInfo, descriptorSize, m_impl->m_descriptorBuffer.get());
+    //// Setup the descriptor info.
+    //VkDescriptorGetInfoEXT descriptorInfo = { 
+    //    .sType = VK_STRUCTURE_TYPE_DESCRIPTOR_GET_INFO_EXT,
+    //    .type = VK_DESCRIPTOR_TYPE_SAMPLER,
+    //    .data = { .pSampler = &sampler.handle() }
+    //};
+
+    //// Create the descriptor in the descriptor buffer.
+    //vkGetDescriptor(m_impl->m_layout->device().handle(), &descriptorInfo, descriptorSize, m_impl->m_descriptorBuffer.get());
 }
 
 void VulkanDescriptorSet::update(UInt32 binding, const IVulkanAccelerationStructure& accelerationStructure, UInt32 descriptor) const
 {
-    // Check if the acceleration structure has been initialized.
-    if (accelerationStructure.buffer() == nullptr || accelerationStructure.handle() == VK_NULL_HANDLE) [[unlikely]]
-        throw InvalidArgumentException("accelerationStructure", "The acceleration structure buffer has not yet been allocated.");
+    throw;
 
-    // Find the descriptor.
-    auto descriptors = m_impl->m_layout->descriptors();
-    auto descriptorLayout = std::ranges::find_if(descriptors, [&binding](auto& layout) { return layout.binding() == binding; });
+    //// Check if the acceleration structure has been initialized.
+    //if (accelerationStructure.buffer() == nullptr || accelerationStructure.handle() == VK_NULL_HANDLE) [[unlikely]]
+    //    throw InvalidArgumentException("accelerationStructure", "The acceleration structure buffer has not yet been allocated.");
 
-    if (descriptorLayout == descriptors.end()) [[unlikely]]
-    {
-        LITEFX_WARNING(VULKAN_LOG, "The descriptor set {0} does not contain a descriptor at binding {1}.", m_impl->m_layout->space(), binding);
-        return;
-    }
+    //// Find the descriptor.
+    //auto descriptors = m_impl->m_layout->descriptors();
+    //auto descriptorLayout = std::ranges::find_if(descriptors, [&binding](auto& layout) { return layout.binding() == binding; });
 
-    // Check if the descriptor type is valid for the requested operation.
-    if (descriptorLayout->descriptorType() != DescriptorType::AccelerationStructure) [[unlikely]]
-        throw InvalidArgumentException("binding", "Invalid descriptor type. The binding {0} does not point to an acceleration structure descriptor.", binding);
+    //if (descriptorLayout == descriptors.end()) [[unlikely]]
+    //{
+    //    LITEFX_WARNING(VULKAN_LOG, "The descriptor set {0} does not contain a descriptor at binding {1}.", m_impl->m_layout->space(), binding);
+    //    return;
+    //}
 
-    // Check if all elements can be bound to a bounded array.
-    if (descriptorLayout->descriptors() > 1 && descriptorLayout->descriptors() <= descriptor) [[unlikely]]
-        ArgumentOutOfRangeException("descriptor", "The descriptor layout can only bind up to {0} descriptors at binding {3}, however the request was to bind {1} descriptors starting at {2}.", descriptorLayout->descriptors(), 1, descriptor, binding);
+    //// Check if the descriptor type is valid for the requested operation.
+    //if (descriptorLayout->descriptorType() != DescriptorType::AccelerationStructure) [[unlikely]]
+    //    throw InvalidArgumentException("binding", "Invalid descriptor type. The binding {0} does not point to an acceleration structure descriptor.", binding);
 
-    // Acquire the binding offset.
-    VkDeviceSize descriptorOffset;
-    vkGetDescriptorSetLayoutBindingOffset(m_impl->m_layout->device().handle(), m_impl->m_layout->handle(), binding, &descriptorOffset);
+    //// Check if all elements can be bound to a bounded array.
+    //if (descriptorLayout->descriptors() > 1 && descriptorLayout->descriptors() <= descriptor) [[unlikely]]
+    //    throw ArgumentOutOfRangeException("descriptor", "The descriptor layout can only bind up to {0} descriptors at binding {3}, however the request was to bind {1} descriptors starting at {2}.", descriptorLayout->descriptors(), 1, descriptor, binding);
 
-    // Offset to first array index. Arrays are tightly packed, so we simply add the descriptor size for each element.
-    size_t descriptorSize = m_impl->m_layout->device().descriptorSize(descriptorLayout->descriptorType());
+    //// Acquire the binding offset.
+    //VkDeviceSize descriptorOffset;
+    //vkGetDescriptorSetLayoutBindingOffset(m_impl->m_layout->device().handle(), m_impl->m_layout->handle(), binding, &descriptorOffset);
 
-    // Setup the descriptor info.
-    VkDescriptorGetInfoEXT descriptorInfo = { 
-        .sType = VK_STRUCTURE_TYPE_DESCRIPTOR_GET_INFO_EXT,
-        .type = VK_DESCRIPTOR_TYPE_ACCELERATION_STRUCTURE_KHR,
-        .data = { .accelerationStructure = accelerationStructure.buffer()->virtualAddress() }
-    };
+    //// Offset to first array index. Arrays are tightly packed, so we simply add the descriptor size for each element.
+    //size_t descriptorSize = m_impl->m_layout->device().descriptorSize(descriptorLayout->descriptorType());
 
-    // Create the descriptor in the descriptor buffer.
-    vkGetDescriptor(m_impl->m_layout->device().handle(), &descriptorInfo, descriptorSize, m_impl->m_descriptorBuffer.get());
+    //// Setup the descriptor info.
+    //VkDescriptorGetInfoEXT descriptorInfo = { 
+    //    .sType = VK_STRUCTURE_TYPE_DESCRIPTOR_GET_INFO_EXT,
+    //    .type = VK_DESCRIPTOR_TYPE_ACCELERATION_STRUCTURE_KHR,
+    //    .data = { .accelerationStructure = accelerationStructure.buffer()->virtualAddress() }
+    //};
+
+    //// Create the descriptor in the descriptor buffer.
+    //vkGetDescriptor(m_impl->m_layout->device().handle(), &descriptorInfo, descriptorSize, m_impl->m_descriptorBuffer.get());
 }

--- a/src/Backends/Vulkan/src/descriptor_set.cpp
+++ b/src/Backends/Vulkan/src/descriptor_set.cpp
@@ -19,7 +19,7 @@ private:
     Dictionary<UInt32, VkImageView> m_imageViews{};
     SharedPtr<const VulkanDescriptorSetLayout> m_layout;
     Array<Byte> m_descriptorBuffer;
-    UInt32 m_unboundedArraySize;
+    UInt32 m_unboundedArraySize, m_offset{ 0 }, m_heapSize{ 0 };
 
 public:
     VulkanDescriptorSetImpl(const VulkanDescriptorSetLayout& layout, Array<Byte>&& buffer) :
@@ -88,6 +88,16 @@ Array<Byte>&& VulkanDescriptorSet::releaseBuffer() const noexcept
 Span<const Byte> VulkanDescriptorSet::descriptorBuffer() const noexcept
 {
     return m_impl->m_descriptorBuffer;
+}
+
+UInt32 VulkanDescriptorSet::globalHeapOffset() const noexcept
+{
+    return m_impl->m_offset;
+}
+
+UInt32 VulkanDescriptorSet::globalHeapAddressRange() const noexcept
+{
+    return m_impl->m_heapSize;
 }
 
 void VulkanDescriptorSet::update(UInt32 binding, const IVulkanBuffer& buffer, UInt32 bufferElement, UInt32 elements, UInt32 firstDescriptor) const

--- a/src/Backends/Vulkan/src/descriptor_set_layout.cpp
+++ b/src/Backends/Vulkan/src/descriptor_set_layout.cpp
@@ -386,7 +386,10 @@ VulkanDescriptorSetLayout::VulkanDescriptorSetLayout(const VulkanDescriptorSetLa
     this->handle() = m_impl->initialize();
 }
 
-VulkanDescriptorSetLayout::~VulkanDescriptorSetLayout() noexcept = default;
+VulkanDescriptorSetLayout::~VulkanDescriptorSetLayout() noexcept
+{
+    ::vkDestroyDescriptorSetLayout(m_impl->m_device->handle(), this->handle(), nullptr);
+}
 
 const VulkanDevice& VulkanDescriptorSetLayout::device() const noexcept
 {

--- a/src/Backends/Vulkan/src/descriptor_set_layout.cpp
+++ b/src/Backends/Vulkan/src/descriptor_set_layout.cpp
@@ -250,7 +250,7 @@ public:
         };
 
         // Allow for descriptors to update after they have been bound. This also means, we have to manually take care of not to update a descriptor before it got used.
-        descriptorSetLayoutInfo.flags = VK_DESCRIPTOR_SET_LAYOUT_CREATE_UPDATE_AFTER_BIND_POOL_BIT | VK_DESCRIPTOR_SET_LAYOUT_CREATE_DESCRIPTOR_BUFFER_BIT_EXT;
+        descriptorSetLayoutInfo.flags = VK_DESCRIPTOR_SET_LAYOUT_CREATE_DESCRIPTOR_BUFFER_BIT_EXT;
 
         if (hasStaticSampler)
             descriptorSetLayoutInfo.flags |= VK_DESCRIPTOR_SET_LAYOUT_CREATE_EMBEDDED_IMMUTABLE_SAMPLERS_BIT_EXT;

--- a/src/Backends/Vulkan/src/descriptor_set_layout.cpp
+++ b/src/Backends/Vulkan/src/descriptor_set_layout.cpp
@@ -223,12 +223,6 @@ public:
                 }
             }
 
-            // Allow update after binding for all buffers except constant/uniform buffers.
-            // NOTE: This is a hack, as older NVidia cards do not support this. However, there is a feature we could query for this. If you find a card or situation where this is actually required,
-            //       please open an issue!
-            if (type != DescriptorType::ConstantBuffer)
-                bindingFlags.back() |= VK_DESCRIPTOR_BINDING_UPDATE_AFTER_BIND_BIT;
-
             bindings.push_back(binding);
         });
 

--- a/src/Backends/Vulkan/src/descriptor_set_layout.cpp
+++ b/src/Backends/Vulkan/src/descriptor_set_layout.cpp
@@ -457,7 +457,7 @@ UInt32 VulkanDescriptorSetLayout::getDescriptorOffset(UInt32 binding, UInt32 ele
 {
     if (auto descriptorLayout = std::ranges::find_if(m_impl->m_descriptorLayouts, [&binding](auto& layout) { return layout.binding() == binding; }); descriptorLayout != m_impl->m_descriptorLayouts.end())
     {
-        VkDeviceSize descriptorOffset;
+        VkDeviceSize descriptorOffset{};
         vkGetDescriptorSetLayoutBindingOffset(this->device().handle(), this->handle(), binding, &descriptorOffset);
         descriptorOffset += static_cast<VkDeviceSize>(this->device().descriptorSize(descriptorLayout->descriptorType()) * element);
 

--- a/src/Backends/Vulkan/src/descriptor_set_layout.cpp
+++ b/src/Backends/Vulkan/src/descriptor_set_layout.cpp
@@ -503,6 +503,11 @@ UInt32 VulkanDescriptorSetLayout::inputAttachments() const noexcept
     return m_impl->m_poolSizes[VK_DESCRIPTOR_TYPE_INPUT_ATTACHMENT].descriptorCount;
 }
 
+bool VulkanDescriptorSetLayout::containsUnboundedArray() const noexcept
+{
+    return m_impl->usesDescriptorIndexing();
+}
+
 UniquePtr<VulkanDescriptorSet> VulkanDescriptorSetLayout::allocate(UInt32 descriptors, std::initializer_list<DescriptorBinding> bindings) const
 {
     return m_impl->allocate(this->shared_from_this(), descriptors, bindings);

--- a/src/Backends/Vulkan/src/descriptor_set_layout.cpp
+++ b/src/Backends/Vulkan/src/descriptor_set_layout.cpp
@@ -17,6 +17,12 @@ public:
     friend class VulkanDescriptorSetLayoutBuilder;
     friend class VulkanDescriptorSetLayout;
 
+    // TODO: This is a temporary workaround to satisfy the validation layer during ray-tracing tests. While we do completely manage descriptor memory ourselves now, we still
+    //       have to provide a `descriptorCount` when creating the descriptor set layout. For unbounded arrays, this acts as an upper limit and counts towards the accumulated
+    //       limits in the validation layers. Unfortunately we cannot get rid of this at the moment, so we use a fixed value it for now. We do need to expose this to clients
+    //       in the future though, to allow for more granular fine-tuning.
+    static const UInt32 DEFAULT_UNBOUNDED_ARRAY_CAPACITY = 500'000;
+
 private:
     Array<VulkanDescriptorLayout> m_descriptorLayouts;
     Queue<Array<Byte>> m_freeDescriptorSets;
@@ -199,24 +205,24 @@ public:
                 switch (binding.descriptorType)
                 {
                 case VK_DESCRIPTOR_TYPE_STORAGE_BUFFER:
-                    binding.descriptorCount = maxStorageBuffers;
+                    binding.descriptorCount = std::min(DEFAULT_UNBOUNDED_ARRAY_CAPACITY, maxStorageBuffers);
                     break;
                 case VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER:
-                    binding.descriptorCount = maxUniformBuffers;
+                    binding.descriptorCount = std::min(DEFAULT_UNBOUNDED_ARRAY_CAPACITY, maxUniformBuffers);
                     break;
                 case VK_DESCRIPTOR_TYPE_STORAGE_TEXEL_BUFFER:
                 case VK_DESCRIPTOR_TYPE_STORAGE_IMAGE:
-                    binding.descriptorCount = maxStorageImages;
+                    binding.descriptorCount = std::min(DEFAULT_UNBOUNDED_ARRAY_CAPACITY, maxStorageImages);
                     break;
                 case VK_DESCRIPTOR_TYPE_UNIFORM_TEXEL_BUFFER:
                 case VK_DESCRIPTOR_TYPE_SAMPLED_IMAGE:
-                    binding.descriptorCount = maxSampledImages;
+                    binding.descriptorCount = std::min(DEFAULT_UNBOUNDED_ARRAY_CAPACITY, maxSampledImages);
                     break;
                 case VK_DESCRIPTOR_TYPE_INPUT_ATTACHMENT:
-                    binding.descriptorCount = maxAttachments;
+                    binding.descriptorCount = std::min(DEFAULT_UNBOUNDED_ARRAY_CAPACITY, maxAttachments);
                     break;
                 case VK_DESCRIPTOR_TYPE_SAMPLER:
-                    binding.descriptorCount = maxSamplers;
+                    binding.descriptorCount = std::min(DEFAULT_UNBOUNDED_ARRAY_CAPACITY, maxSamplers);
                     break;
                 default:
                     break;

--- a/src/Backends/Vulkan/src/device.cpp
+++ b/src/Backends/Vulkan/src/device.cpp
@@ -779,7 +779,7 @@ void VulkanDevice::updateGlobalDescriptors(const VulkanDescriptorSet& descriptor
     auto descriptorBuffer = descriptorSet.descriptorBuffer();
     auto descriptorOffset = std::next(descriptorBuffer.data(), firstDescriptor);
     auto descriptorSize = this->descriptorSize(descriptorSet.layout().descriptor(binding).descriptorType());
-    auto mappedRange = static_cast<size_t>(descriptors * descriptorSize);
+    auto mappedRange = static_cast<size_t>(descriptors) * descriptorSize;
 
     if (descriptorSet.layout().samplers() > 0 || descriptorSet.layout().staticSamplers() > 0)
         m_impl->m_globalSamplerHeap->write(descriptorOffset, mappedRange, static_cast<size_t>(descriptorSet.globalHeapOffset()) + firstDescriptor);

--- a/src/Backends/Vulkan/src/device.cpp
+++ b/src/Backends/Vulkan/src/device.cpp
@@ -540,8 +540,8 @@ public:
         ::vkGetPhysicalDeviceProperties2(m_adapter->handle(), &deviceProperties);
 
         // Align the heap sizes to the descriptor buffer offset alignment.
-        m_globalBufferHeapSize = align(m_globalBufferHeapSize, m_descriptorBufferProperties.descriptorBufferOffsetAlignment);
-        m_globalSamplerHeapSize = align(m_globalSamplerHeapSize, m_descriptorBufferProperties.descriptorBufferOffsetAlignment);
+        m_globalBufferHeapSize = align(m_globalBufferHeapSize, static_cast<size_t>(m_descriptorBufferProperties.descriptorBufferOffsetAlignment));
+        m_globalSamplerHeapSize = align(m_globalSamplerHeapSize, static_cast<size_t>(m_descriptorBufferProperties.descriptorBufferOffsetAlignment));
 
         // Create the descriptor buffers for both heaps.
         m_globalBufferHeap = m_factory->createDescriptorHeap("Global Buffer Heap", m_globalBufferHeapSize, false);

--- a/src/Backends/Vulkan/src/device.cpp
+++ b/src/Backends/Vulkan/src/device.cpp
@@ -23,6 +23,8 @@ PFN_vkCmdTraceRaysKHR vkCmdTraceRays{ nullptr };
 PFN_vkGetDescriptorSetLayoutSizeEXT vkGetDescriptorSetLayoutSize{ nullptr };
 PFN_vkGetDescriptorSetLayoutBindingOffsetEXT vkGetDescriptorSetLayoutBindingOffset{ nullptr };
 PFN_vkGetDescriptorEXT vkGetDescriptor{ nullptr };
+PFN_vkCmdBindDescriptorBuffersEXT vkCmdBindDescriptorBuffers{ nullptr };
+PFN_vkCmdSetDescriptorBufferOffsetsEXT vkCmdSetDescriptorBufferOffsets{ nullptr };
 // NOLINTEND(cppcoreguidelines-avoid-non-const-global-variables)
 
 // ------------------------------------------------------------------------------------------------
@@ -135,6 +137,8 @@ private:
     size_t m_globalBufferHeapSize, m_globalSamplerHeapSize, m_bufferOffset{ 0 }, m_samplerOffset{ 0 };
     VkPhysicalDeviceDescriptorBufferPropertiesEXT m_descriptorBufferProperties { .sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_DESCRIPTOR_BUFFER_PROPERTIES_EXT };
     SharedPtr<IVulkanBuffer> m_globalBufferHeap, m_globalSamplerHeap;
+    mutable std::mutex m_bufferBindMutex;
+    Array<std::pair<UInt32, UInt32>> m_bufferDescriptorFragments, m_samplerDescriptorFragments;
 
 public:
     VulkanDeviceImpl(const VulkanGraphicsAdapter& adapter, UniquePtr<VulkanSurface>&& surface, const GraphicsDeviceFeatures& features, Span<String> extensions, size_t globalBufferHeapSize, size_t globalSamplerHeapSize) :
@@ -390,10 +394,17 @@ public:
             .extendedDynamicState = true
         };
 
+        // Enable descriptor buffer.
+        VkPhysicalDeviceDescriptorBufferFeaturesEXT descriptorBufferFeatures = {
+            .sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_DESCRIPTOR_BUFFER_FEATURES_EXT,
+            .pNext = &extendedDynamicStateFeatures,
+            .descriptorBuffer = true
+        };
+
         // Define the device itself.
         VkDeviceCreateInfo createInfo = {
             .sType = VK_STRUCTURE_TYPE_DEVICE_CREATE_INFO,
-            .pNext = &extendedDynamicStateFeatures,
+            .pNext = &descriptorBufferFeatures,
             .queueCreateInfoCount = static_cast<UInt32>(queueCreateInfos.size()),
             .pQueueCreateInfos = queueCreateInfos.data(),
             .enabledExtensionCount = static_cast<UInt32>(requiredExtensions.size()),
@@ -483,6 +494,12 @@ public:
         if (vkGetDescriptor == nullptr)
             vkGetDescriptor = reinterpret_cast<PFN_vkGetDescriptorEXT>(::vkGetDeviceProcAddr(device, "vkGetDescriptorEXT"));
 
+        if (vkCmdBindDescriptorBuffers == nullptr)
+            vkCmdBindDescriptorBuffers = reinterpret_cast<PFN_vkCmdBindDescriptorBuffersEXT>(::vkGetDeviceProcAddr(device, "vkCmdBindDescriptorBuffersEXT"));
+
+        if (vkCmdSetDescriptorBufferOffsets == nullptr)
+            vkCmdSetDescriptorBufferOffsets = reinterpret_cast<PFN_vkCmdSetDescriptorBufferOffsetsEXT>(::vkGetDeviceProcAddr(device, "vkCmdSetDescriptorBufferOffsetsEXT"));
+
         // NOLINTEND(cppcoreguidelines-pro-type-reinterpret-cast)
         
         // Return the device instance.
@@ -527,8 +544,8 @@ public:
         m_globalSamplerHeapSize = align(m_globalSamplerHeapSize, m_descriptorBufferProperties.descriptorBufferOffsetAlignment);
 
         // Create the descriptor buffers for both heaps.
-        m_globalBufferHeap = m_factory->createDescriptorHeap("Global Buffer Heap", m_globalBufferHeapSize, false, false);
-        m_globalSamplerHeap = m_factory->createDescriptorHeap("Global Sampler Heap", m_globalSamplerHeapSize, false, true);
+        m_globalBufferHeap = m_factory->createDescriptorHeap("Global Buffer Heap", m_globalBufferHeapSize, false);
+        m_globalSamplerHeap = m_factory->createDescriptorHeap("Global Sampler Heap", m_globalSamplerHeapSize, true);
     }
 
 public:
@@ -666,6 +683,134 @@ UInt32 VulkanDevice::descriptorSize(DescriptorType type) const
     default:
         throw InvalidArgumentException("type", "The provided descriptor type cannot be mapped to a descriptor heap.");
     }
+}
+
+void VulkanDevice::allocateGlobalDescriptors(const VulkanDescriptorSet& descriptorSet, UInt32& offset, UInt32& size) const
+{
+    // NOTE: Freeing descriptor sets with leaves the heap(s) in fragmented state. This should be prevented, however we also keep track of the released offset/count pairs to re-allocate 
+    //       them later. Re-allocation could follow those steps:
+    //       - First, try to append to the current descriptor range.
+    //       - If we're overflowing: find perfect offset/pair matches for the requested set.
+    //       - If none is available: allocate from a fragmented area. Resize it afterwards with a new offset and reduced count.
+    //       - If all of the above fail, then we're out of descriptors.
+    std::lock_guard<std::mutex> lock(m_impl->m_bufferBindMutex);
+
+    // Get the current descriptor sizes and compute the offsets.
+    // NOTE: The descriptor set layout checks for invalid mixture of samplers and resources, so we only get one or the other here.
+    auto descriptorBuffer = descriptorSet.descriptorBuffer();
+    auto alignedHeapSize = size = static_cast<UInt32>(align(descriptorBuffer.size(), static_cast<size_t>(m_impl->m_descriptorBufferProperties.descriptorBufferOffsetAlignment)));
+
+    if (alignedHeapSize == 0)
+        throw InvalidArgumentException("descriptorSet", "Cannot allocate space for empty descriptor set on global descriptor heap.");
+
+    if (descriptorSet.layout().samplers() > 0 || descriptorSet.layout().staticSamplers() > 0)
+    {
+        auto alignedEndOffset = m_impl->m_samplerOffset + alignedHeapSize;
+
+        if (alignedEndOffset <= m_impl->m_globalSamplerHeapSize) [[likely]]
+        {
+            offset = static_cast<UInt32>(m_impl->m_samplerOffset);
+            m_impl->m_samplerOffset = alignedEndOffset;
+        }
+        else [[unlikely]]
+        {
+            // Find a fitting offset from the fragment heap.
+            if (auto match = std::ranges::find_if(m_impl->m_samplerDescriptorFragments, [&alignedHeapSize](const auto& pair) { return pair.second == alignedHeapSize; }); match != m_impl->m_samplerDescriptorFragments.end())
+            {
+                offset = match->first;
+                m_impl->m_samplerDescriptorFragments.erase(match);
+            }
+            else if (match = std::ranges::find_if(m_impl->m_samplerDescriptorFragments, [&alignedHeapSize](const auto& pair) { return pair.second > alignedHeapSize; }); match != m_impl->m_samplerDescriptorFragments.end())
+            {
+                offset = match->first;
+                match->first += alignedHeapSize;
+                match->second -= alignedHeapSize;
+            }
+            else [[unlikely]]
+            {
+                throw RuntimeException("Unable to allocate more descriptors on global sampler heap.");
+            }
+        }
+    }
+    else // We're allocating for non-sampler resources.
+    {
+        auto alignedEndOffset = m_impl->m_bufferOffset + alignedHeapSize;
+
+        if (m_impl->m_bufferOffset <= m_impl->m_globalBufferHeapSize) [[likely]]
+        {
+            offset = static_cast<UInt32>(m_impl->m_bufferOffset);
+            m_impl->m_bufferOffset = alignedEndOffset;
+        }
+        else [[unlikely]]
+        {
+            // Find a fitting offset from the fragment heap.
+            if (auto match = std::ranges::find_if(m_impl->m_bufferDescriptorFragments, [&alignedHeapSize](const auto& pair) { return pair.second == alignedHeapSize; }); match != m_impl->m_bufferDescriptorFragments.end())
+            {
+                offset = match->first;
+                m_impl->m_bufferDescriptorFragments.erase(match);
+            }
+            else if (match = std::ranges::find_if(m_impl->m_bufferDescriptorFragments, [&alignedHeapSize](const auto& pair) { return pair.second > alignedHeapSize; }); match != m_impl->m_bufferDescriptorFragments.end())
+            {
+                offset = match->first;
+                match->first += alignedHeapSize;
+                match->second -= alignedHeapSize;
+            }
+            else [[unlikely]]
+            {
+                throw RuntimeException("Unable to allocate more descriptors on global buffer heap.");
+            }
+        }
+    }
+}
+
+void VulkanDevice::releaseGlobalDescriptors(const VulkanDescriptorSet& descriptorSet) const
+{
+    std::lock_guard<std::mutex> lock(m_impl->m_bufferBindMutex);
+
+    if (descriptorSet.layout().samplers() > 0 || descriptorSet.layout().staticSamplers() > 0)
+        m_impl->m_samplerDescriptorFragments.emplace_back(descriptorSet.globalHeapOffset(), descriptorSet.globalHeapAddressRange());
+    else
+        m_impl->m_bufferDescriptorFragments.emplace_back(descriptorSet.globalHeapOffset(), descriptorSet.globalHeapAddressRange());
+}
+
+void VulkanDevice::updateGlobalDescriptors(const VulkanDescriptorSet& descriptorSet, UInt32 binding, UInt32 offset, UInt32 descriptors) const
+{
+    auto firstDescriptor = descriptorSet.layout().getDescriptorOffset(binding, offset);
+    auto descriptorBuffer = descriptorSet.descriptorBuffer();
+    auto descriptorOffset = std::next(descriptorBuffer.data(), firstDescriptor);
+    auto descriptorSize = this->descriptorSize(descriptorSet.layout().descriptor(binding).descriptorType());
+    auto mappedRange = static_cast<size_t>(descriptors * descriptorSize);
+
+    if (descriptorSet.layout().samplers() > 0 || descriptorSet.layout().staticSamplers() > 0)
+        m_impl->m_globalSamplerHeap->write(descriptorOffset, mappedRange, static_cast<size_t>(descriptorSet.globalHeapOffset()) + firstDescriptor);
+    else
+        m_impl->m_globalBufferHeap->write(descriptorOffset, mappedRange, static_cast<size_t>(descriptorSet.globalHeapOffset()) + firstDescriptor);
+}
+
+void VulkanDevice::bindDescriptorSet(const VulkanCommandBuffer& commandBuffer, const VulkanDescriptorSet& descriptorSet, const VulkanPipelineState& pipeline) const noexcept
+{
+    // We only use one descriptor buffer for resources and one for samplers, which makes setting offsets pretty straightforward. The indices are defined by 
+    // the `bindGlobalDescriptorHeaps` implementation below. The offsets are then simply mapped to linear memory. The offset is assigned to a descriptor set
+    // during allocation.
+    const bool isSamplerSet = descriptorSet.layout().samplers() > 0 || descriptorSet.layout().staticSamplers() > 0;
+    UInt32 bufferIndex = isSamplerSet ? 1 : 0; // Again, see `bindGlobalDescriptorHeaps` below - samplers are stored in the heap bound at index 1 there.
+    auto bufferOffset = static_cast<VkDeviceSize>(descriptorSet.globalHeapOffset());
+
+    // Set the descriptor buffer offsets for the descriptor sets.
+    vkCmdSetDescriptorBufferOffsets(commandBuffer.handle(), pipeline.pipelineType(), pipeline.layout()->handle(), descriptorSet.layout().space(), 1u, &bufferIndex, &bufferOffset);
+}
+
+void VulkanDevice::bindGlobalDescriptorHeaps(const VulkanCommandBuffer& commandBuffer) const noexcept
+{
+    // Create the descriptor buffer binding infos.
+    // NOTE: The order is important here! If we change this, `bindDescriptorSet` must be updated as well.
+    auto descriptorHeaps = std::array {
+        VkDescriptorBufferBindingInfoEXT { .sType = VK_STRUCTURE_TYPE_DESCRIPTOR_BUFFER_BINDING_INFO_EXT, .address = m_impl->m_globalBufferHeap->virtualAddress(), .usage = VK_BUFFER_USAGE_RESOURCE_DESCRIPTOR_BUFFER_BIT_EXT },
+        VkDescriptorBufferBindingInfoEXT { .sType = VK_STRUCTURE_TYPE_DESCRIPTOR_BUFFER_BINDING_INFO_EXT, .address = m_impl->m_globalSamplerHeap->virtualAddress(), .usage = VK_BUFFER_USAGE_SAMPLER_DESCRIPTOR_BUFFER_BIT_EXT }
+    };
+
+    // Bind the descriptor buffers.
+    vkCmdBindDescriptorBuffers(commandBuffer.handle(), static_cast<UInt32>(descriptorHeaps.size()), descriptorHeaps.data());
 }
 
 VulkanSwapChain& VulkanDevice::swapChain() noexcept

--- a/src/Backends/Vulkan/src/factory.cpp
+++ b/src/Backends/Vulkan/src/factory.cpp
@@ -54,12 +54,12 @@ VulkanGraphicsFactory::VulkanGraphicsFactory(const VulkanDevice& device) :
 
 VulkanGraphicsFactory::~VulkanGraphicsFactory() noexcept = default;
 
-SharedPtr<IVulkanBuffer> VulkanGraphicsFactory::createDescriptorHeap(size_t heapSize, bool onCpu, bool forSamplers) const
+SharedPtr<IVulkanBuffer> VulkanGraphicsFactory::createDescriptorHeap(size_t heapSize, bool forSamplers) const
 {
-	return this->createDescriptorHeap("", heapSize, onCpu, forSamplers);
+	return this->createDescriptorHeap("", heapSize, forSamplers);
 }
 
-SharedPtr<IVulkanBuffer> VulkanGraphicsFactory::createDescriptorHeap(const String& name, size_t heapSize, bool onCpu, bool forSamplers) const
+SharedPtr<IVulkanBuffer> VulkanGraphicsFactory::createDescriptorHeap(const String& name, size_t heapSize, bool forSamplers) const
 {
 	// Check if the device is still valid.
 	auto device = m_impl->m_device.lock();
@@ -78,7 +78,7 @@ SharedPtr<IVulkanBuffer> VulkanGraphicsFactory::createDescriptorHeap(const Strin
 
 	VmaAllocationCreateInfo allocInfo = {
 		.flags = VMA_ALLOCATION_CREATE_DEDICATED_MEMORY_BIT,
-		.usage = onCpu ? VMA_MEMORY_USAGE_CPU_ONLY : VMA_MEMORY_USAGE_GPU_ONLY
+		.usage = VMA_MEMORY_USAGE_CPU_TO_GPU
 	};
 
 	// If the buffer is used as a static resource or staging buffer, it needs to be accessible concurrently by the graphics and transfer queues.

--- a/src/Backends/Vulkan/src/factory.cpp
+++ b/src/Backends/Vulkan/src/factory.cpp
@@ -54,12 +54,12 @@ VulkanGraphicsFactory::VulkanGraphicsFactory(const VulkanDevice& device) :
 
 VulkanGraphicsFactory::~VulkanGraphicsFactory() noexcept = default;
 
-SharedPtr<IVulkanBuffer> VulkanGraphicsFactory::createDescriptorHeap(size_t heapSize, bool onCpu, bool forSamplers) const noexcept
+SharedPtr<IVulkanBuffer> VulkanGraphicsFactory::createDescriptorHeap(size_t heapSize, bool onCpu, bool forSamplers) const
 {
 	return this->createDescriptorHeap("", heapSize, onCpu, forSamplers);
 }
 
-SharedPtr<IVulkanBuffer> VulkanGraphicsFactory::createDescriptorHeap(const String& name, size_t heapSize, bool onCpu, bool forSamplers) const noexcept
+SharedPtr<IVulkanBuffer> VulkanGraphicsFactory::createDescriptorHeap(const String& name, size_t heapSize, bool onCpu, bool forSamplers) const
 {
 	// Check if the device is still valid.
 	auto device = m_impl->m_device.lock();

--- a/src/Backends/Vulkan/src/factory.cpp
+++ b/src/Backends/Vulkan/src/factory.cpp
@@ -54,6 +54,52 @@ VulkanGraphicsFactory::VulkanGraphicsFactory(const VulkanDevice& device) :
 
 VulkanGraphicsFactory::~VulkanGraphicsFactory() noexcept = default;
 
+SharedPtr<IVulkanBuffer> VulkanGraphicsFactory::createDescriptorHeap(size_t heapSize, bool onCpu, bool forSamplers) const noexcept
+{
+	return this->createDescriptorHeap("", heapSize, onCpu, forSamplers);
+}
+
+SharedPtr<IVulkanBuffer> VulkanGraphicsFactory::createDescriptorHeap(const String& name, size_t heapSize, bool onCpu, bool forSamplers) const noexcept
+{
+	// Check if the device is still valid.
+	auto device = m_impl->m_device.lock();
+
+	if (device == nullptr) [[unlikely]]
+		throw RuntimeException("Cannot allocate buffer from a released device instance.");
+
+	// Create the buffer.
+	VkBufferUsageFlags usageFlags = { static_cast<VkBufferUsageFlags>(forSamplers ? VK_BUFFER_USAGE_SAMPLER_DESCRIPTOR_BUFFER_BIT_EXT : VK_BUFFER_USAGE_RESOURCE_DESCRIPTOR_BUFFER_BIT_EXT) | VK_BUFFER_USAGE_SHADER_DEVICE_ADDRESS_BIT };
+	VkBufferCreateInfo bufferInfo = { 
+		.sType = VK_STRUCTURE_TYPE_BUFFER_CREATE_INFO,
+		.pNext = nullptr,
+		.size = heapSize,
+		.usage = usageFlags
+	};
+
+	VmaAllocationCreateInfo allocInfo = {
+		.flags = VMA_ALLOCATION_CREATE_DEDICATED_MEMORY_BIT,
+		.usage = onCpu ? VMA_MEMORY_USAGE_CPU_ONLY : VMA_MEMORY_USAGE_GPU_ONLY
+	};
+
+	// If the buffer is used as a static resource or staging buffer, it needs to be accessible concurrently by the graphics and transfer queues.
+	auto queueFamilies = device->queueFamilyIndices() | std::ranges::to<std::vector>();
+
+	bufferInfo.sharingMode = queueFamilies.size() > 1 ? VK_SHARING_MODE_CONCURRENT : VK_SHARING_MODE_EXCLUSIVE; // Does not matter anyway if only one queue family is present, but satisfies validation layers.
+	bufferInfo.queueFamilyIndexCount = static_cast<UInt32>(queueFamilies.size());
+	bufferInfo.pQueueFamilyIndices = queueFamilies.data();
+
+#ifndef NDEBUG
+	auto buffer = VulkanBuffer::allocate(name, BufferType::Other, 1u, heapSize, 1u, ResourceUsage::Default, *device, m_impl->m_allocator, bufferInfo, allocInfo);
+
+	if (!name.empty())
+		device->setDebugName(std::as_const(*buffer).handle(), VK_DEBUG_REPORT_OBJECT_TYPE_BUFFER_EXT, name);
+
+	return buffer;
+#else
+	return VulkanBuffer::allocate(name, BufferType::Other, 1u, heapSize, 1u, ResourceUsage::Default, *device, m_impl->m_allocator, bufferInfo, allocInfo);
+#endif
+}
+
 SharedPtr<IVulkanBuffer> VulkanGraphicsFactory::createBuffer(BufferType type, ResourceHeap heap, size_t elementSize, UInt32 elements, ResourceUsage usage) const
 {
 	return this->createBuffer("", type, heap, elementSize, elements, usage);

--- a/src/Backends/Vulkan/src/queue.cpp
+++ b/src/Backends/Vulkan/src/queue.cpp
@@ -136,7 +136,7 @@ void VulkanQueue::beginDebugRegion(const String& label, const Vectors::ByteVecto
 	VkDebugUtilsLabelEXT labelInfo {
 		.sType = VK_STRUCTURE_TYPE_DEBUG_UTILS_LABEL_EXT,
 		.pLabelName = label.c_str(),
-		.color = { static_cast<float>(color.x()) / static_cast<float>(std::numeric_limits<Byte>::max()), static_cast<float>(color.y()) / static_cast<float>(std::numeric_limits<Byte>::max()), static_cast<float>(color.z()) / static_cast<float>(std::numeric_limits<Byte>::max()), 1.0f }
+		.color = { static_cast<float>(color.x()) / static_cast<float>(std::numeric_limits<UInt8>::max()), static_cast<float>(color.y()) / static_cast<float>(std::numeric_limits<UInt8>::max()), static_cast<float>(color.z()) / static_cast<float>(std::numeric_limits<UInt8>::max()), 1.0f }
 	};
 	
 	::vkQueueBeginDebugUtilsLabel(this->handle(), &labelInfo);
@@ -152,7 +152,7 @@ void VulkanQueue::setDebugMarker(const String& label, const Vectors::ByteVector3
 	VkDebugUtilsLabelEXT labelInfo{
 		.sType = VK_STRUCTURE_TYPE_DEBUG_UTILS_LABEL_EXT,
 		.pLabelName = label.c_str(),
-		.color = { static_cast<float>(color.x()) / static_cast<float>(std::numeric_limits<Byte>::max()), static_cast<float>(color.y()) / static_cast<float>(std::numeric_limits<Byte>::max()), static_cast<float>(color.z()) / static_cast<float>(std::numeric_limits<Byte>::max()), 1.0f }
+		.color = { static_cast<float>(color.x()) / static_cast<float>(std::numeric_limits<UInt8>::max()), static_cast<float>(color.y()) / static_cast<float>(std::numeric_limits<UInt8>::max()), static_cast<float>(color.z()) / static_cast<float>(std::numeric_limits<UInt8>::max()), 1.0f }
 	};
 
 	::vkQueueInsertDebugUtilsLabel(this->handle(), &labelInfo);

--- a/src/Backends/Vulkan/src/ray_tracing_pipeline.cpp
+++ b/src/Backends/Vulkan/src/ray_tracing_pipeline.cpp
@@ -327,6 +327,11 @@ SharedPtr<IVulkanBuffer> VulkanRayTracingPipeline::allocateShaderBindingTable(Sh
 	return m_impl->allocateShaderBindingTable(*this, offsets, groups);
 }
 
+VkPipelineBindPoint VulkanRayTracingPipeline::pipelineType() const noexcept
+{
+	return VK_PIPELINE_BIND_POINT_RAY_TRACING_KHR;
+}
+
 void VulkanRayTracingPipeline::use(const VulkanCommandBuffer& commandBuffer) const
 {
 	::vkCmdBindPipeline(commandBuffer.handle(), VK_PIPELINE_BIND_POINT_RAY_TRACING_KHR, this->handle());

--- a/src/Backends/Vulkan/src/ray_tracing_pipeline.cpp
+++ b/src/Backends/Vulkan/src/ray_tracing_pipeline.cpp
@@ -122,6 +122,7 @@ public:
 		// Setup pipeline.
 		VkRayTracingPipelineCreateInfoKHR pipelineInfo = {
 			.sType = VK_STRUCTURE_TYPE_RAY_TRACING_PIPELINE_CREATE_INFO_KHR,
+			.flags = VK_PIPELINE_CREATE_DESCRIPTOR_BUFFER_BIT_EXT,
 			.stageCount = static_cast<UInt32>(shaderStages.size()),
 			.pStages = shaderStages.data(),
 			.groupCount = static_cast<UInt32>(shaderGroups.size()),

--- a/src/Backends/Vulkan/src/ray_tracing_pipeline.cpp
+++ b/src/Backends/Vulkan/src/ray_tracing_pipeline.cpp
@@ -196,7 +196,7 @@ public:
 
 		// Write each record group by group.
 		UInt32 record{ 0 };
-		Array<Byte> recordData(static_cast<size_t>(recordSize), 0x00);
+		Array<Byte> recordData(static_cast<size_t>(recordSize), 0x00_b);
 
 		// Write each shader binding group that should be included.
 		for (auto group : { ShaderBindingGroup::RayGeneration, ShaderBindingGroup::Miss, ShaderBindingGroup::Callable, ShaderBindingGroup::HitGroup })
@@ -253,7 +253,7 @@ public:
 					raiseIfFailed(::vkGetRayTracingShaderGroupHandles(m_device->handle(), parent.handle(), id, 1, rayTracingProperties.shaderGroupHandleSize, recordData.data()), "Unable to query shader record handle.");
 
 					// Write the payload and map everything into the buffer.
-					std::memcpy(recordData.data() + rayTracingProperties.shaderGroupHandleSize, currentRecord->localData(), static_cast<size_t>(currentRecord->localDataSize())); // NOLINT(cppcoreguidelines-pro-bounds-pointer-arithmetic)
+					std::memcpy(std::next(recordData.data(), rayTracingProperties.shaderGroupHandleSize), currentRecord->localData(), static_cast<size_t>(currentRecord->localDataSize()));
 					result->map(recordData.data(), static_cast<size_t>(recordSize), record++);
 				}
 

--- a/src/Backends/Vulkan/src/ray_tracing_pipeline.cpp
+++ b/src/Backends/Vulkan/src/ray_tracing_pipeline.cpp
@@ -332,34 +332,6 @@ void VulkanRayTracingPipeline::use(const VulkanCommandBuffer& commandBuffer) con
 	::vkCmdBindPipeline(commandBuffer.handle(), VK_PIPELINE_BIND_POINT_RAY_TRACING_KHR, this->handle());
 }
 
-void VulkanRayTracingPipeline::bind(const VulkanCommandBuffer& commandBuffer, Span<const VulkanDescriptorSet*> descriptorSets) const
-{
-	// Filter out uninitialized sets.
-	auto sets = descriptorSets | std::views::filter([](auto set) { return set != nullptr; }) | std::ranges::to<Array<const VulkanDescriptorSet*>>();
-
-	if (sets.empty()) [[unlikely]]
-		return; // Nothing to do on empty sets.
-	else if (sets.size() == 1)
-		::vkCmdBindDescriptorSets(commandBuffer.handle(), VK_PIPELINE_BIND_POINT_RAY_TRACING_KHR, std::as_const(*m_impl->m_layout).handle(), sets.front()->layout().space(), 1, &sets.front()->handle(), 0, nullptr);
-	else
-	{
-		// Sort the descriptor sets by space, as we might be able to pass the sets more efficiently if they are sorted and continuous.
-		std::ranges::sort(sets, [](auto lhs, auto rhs) { return lhs->layout().space() > rhs->layout().space(); });
-
-		// In a sorted range, last - (first - 1) equals the size of the range only if there are no duplicates and no gaps.
-		auto startSpace = sets.back()->layout().space();
-
-		if (startSpace - (sets.front()->layout().space() - 1) != static_cast<UInt32>(sets.size()))
-			std::ranges::for_each(sets, [&](auto set) { ::vkCmdBindDescriptorSets(commandBuffer.handle(), VK_PIPELINE_BIND_POINT_RAY_TRACING_KHR, std::as_const(*m_impl->m_layout).handle(), set->layout().space(), 1, &set->handle(), 0, nullptr); });
-		else
-		{
-			// Obtain the handles and bind the sets.
-			auto handles = sets | std::views::transform([](auto set) { return set->handle(); }) | std::ranges::to<Array<VkDescriptorSet>>();
-			::vkCmdBindDescriptorSets(commandBuffer.handle(), VK_PIPELINE_BIND_POINT_RAY_TRACING_KHR, std::as_const(*m_impl->m_layout).handle(), startSpace, static_cast<UInt32>(handles.size()), handles.data(), 0, nullptr);
-		}
-	}
-}
-
 #if defined(LITEFX_BUILD_DEFINE_BUILDERS)
 // ------------------------------------------------------------------------------------------------
 // Builder interface.

--- a/src/Backends/Vulkan/src/render_pipeline.cpp
+++ b/src/Backends/Vulkan/src/render_pipeline.cpp
@@ -267,6 +267,7 @@ public:
 		VkGraphicsPipelineCreateInfo pipelineInfo = {
 			.sType = VK_STRUCTURE_TYPE_GRAPHICS_PIPELINE_CREATE_INFO,
 			.pNext = &renderingInfo,
+			.flags = VK_PIPELINE_CREATE_DESCRIPTOR_BUFFER_BIT_EXT,
 			.stageCount = static_cast<UInt32>(shaderStages.size()),
 			.pStages = shaderStages.data(),
 			.pVertexInputState = &inputState,

--- a/src/Backends/Vulkan/src/render_pipeline.cpp
+++ b/src/Backends/Vulkan/src/render_pipeline.cpp
@@ -530,34 +530,6 @@ void VulkanRenderPipeline::use(const VulkanCommandBuffer& commandBuffer) const
 	m_impl->bindInputAttachments(*this, commandBuffer);
 }
 
-void VulkanRenderPipeline::bind(const VulkanCommandBuffer& commandBuffer, Span<const VulkanDescriptorSet*> descriptorSets) const
-{
-	// Filter out uninitialized sets.
-	auto sets = descriptorSets | std::views::filter([](auto set) { return set != nullptr; }) | std::ranges::to<Array<const VulkanDescriptorSet*>>();
-
-	if (sets.empty()) [[unlikely]]
-		return; // Nothing to do on empty sets.
-	else if (sets.size() == 1)
-		::vkCmdBindDescriptorSets(commandBuffer.handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, std::as_const(*m_impl->m_layout).handle(), sets.front()->layout().space(), 1, &sets.front()->handle(), 0, nullptr);
-	else
-	{
-		// Sort the descriptor sets by space, as we might be able to pass the sets more efficiently if they are sorted and continuous.
-		std::ranges::sort(sets, [](auto lhs, auto rhs) { return lhs->layout().space() > rhs->layout().space(); });
-
-		// In a sorted range, last - (first - 1) equals the size of the range only if there are no duplicates and no gaps.
-		auto startSpace = sets.back()->layout().space();
-
-		if (startSpace - (sets.front()->layout().space() - 1) != static_cast<UInt32>(sets.size()))
-			std::ranges::for_each(sets, [&](auto set) { ::vkCmdBindDescriptorSets(commandBuffer.handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, std::as_const(*m_impl->m_layout).handle(), set->layout().space(), 1, &set->handle(), 0, nullptr); });
-		else
-		{
-			// Obtain the handles and bind the sets.
-			auto handles = sets | std::views::transform([](auto set) { return set->handle(); }) | std::ranges::to<Array<VkDescriptorSet>>();
-			::vkCmdBindDescriptorSets(commandBuffer.handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, std::as_const(*m_impl->m_layout).handle(), startSpace, static_cast<UInt32>(handles.size()), handles.data(), 0, nullptr);
-		}
-	}
-}
-
 #if defined(LITEFX_BUILD_DEFINE_BUILDERS)
 // ------------------------------------------------------------------------------------------------
 // Builder interface.

--- a/src/Backends/Vulkan/src/render_pipeline.cpp
+++ b/src/Backends/Vulkan/src/render_pipeline.cpp
@@ -420,7 +420,7 @@ public:
 		// Bind the input attachment sets.
 		//commandBuffer.bind(m_inputAttachmentBindings.at(interfacePointer) | std::views::transform([](auto& set) { return set.get(); }));
 		auto descriptorSets = m_inputAttachmentBindings.at(interfacePointer) | std::views::transform([](auto& set) { return set.get(); }) | std::ranges::to<Array<const VulkanDescriptorSet*>>();
-		parent.bind(commandBuffer, descriptorSets);
+		commandBuffer.bind(descriptorSets, parent);
 	}
 
 	void onFrameBufferResize(const void* sender, const IFrameBuffer::ResizeEventArgs& /*args*/)
@@ -513,6 +513,11 @@ void VulkanRenderPipeline::updateSamples(MultiSamplingLevel samples)
 
 	// Rebuild the pipeline.
 	this->handle() = m_impl->initialize(*this, samples);
+}
+
+VkPipelineBindPoint VulkanRenderPipeline::pipelineType() const noexcept
+{
+	return VK_PIPELINE_BIND_POINT_GRAPHICS;
 }
 
 void VulkanRenderPipeline::use(const VulkanCommandBuffer& commandBuffer) const

--- a/src/Math/include/litefx/math.hpp
+++ b/src/Math/include/litefx/math.hpp
@@ -31,9 +31,14 @@ namespace LiteFX::Math {
 	using namespace LiteFX;
 
 	/// <summary>
+	/// A type for a single byte of raw memory.
+	/// </summary>
+	using Byte = std::byte;
+
+	/// <summary>
 	/// A type for an unsigned 8 bit integer.
 	/// </summary>
-	using Byte = uint8_t;
+	using UInt8 = uint8_t;
 
 	/// <summary>
 	/// A type for a signed 16 bit integer.
@@ -82,6 +87,15 @@ namespace LiteFX::Math {
 	/// <returns>The value as byte.</returns>
 	constexpr Byte operator ""_b(unsigned long long int arg) noexcept {
 		return static_cast<Byte>(arg);
+	}
+
+	/// <summary>
+	/// A literal to define a 8 bit unsigned integer.
+	/// </summary>
+	/// <param name="arg">The value that should be assigned to the integer.</param>
+	/// <returns>The value as integer.</returns>
+	constexpr UInt8 operator ""_ui8(unsigned long long int arg) noexcept {
+		return static_cast<UInt8>(arg);
 	}
 
 	/// <summary>
@@ -604,22 +618,22 @@ namespace LiteFX::Math {
 		/// <summary>
 		/// A vector that contains a single byte.
 		/// </summary>
-		using ByteVector1 = TVector1<Byte>;
+		using ByteVector1 = TVector1<UInt8>;
 
 		/// <summary>
 		/// A vector that contains two bytes.
 		/// </summary>
-		using ByteVector2 = TVector2<Byte>;
+		using ByteVector2 = TVector2<UInt8>;
 
 		/// <summary>
 		/// A vector that contains three bytes.
 		/// </summary>
-		using ByteVector3 = TVector3<Byte>;
+		using ByteVector3 = TVector3<UInt8>;
 
 		/// <summary>
 		/// A vector that contains four bytes.
 		/// </summary>
-		using ByteVector4 = TVector4<Byte>;
+		using ByteVector4 = TVector4<UInt8>;
 
 		/// <summary>
 		/// A vector that contains a single 16 bit signed integer.

--- a/src/Rendering/include/litefx/rendering.hpp
+++ b/src/Rendering/include/litefx/rendering.hpp
@@ -1435,6 +1435,8 @@ namespace LiteFX::Rendering {
         using swap_chain_type = TSwapChain;
         using command_queue_type = TCommandQueue;
         using command_buffer_type = command_queue_type::command_buffer_type;
+        using descriptor_set_type = command_buffer_type::descriptor_set_type;
+        using pipeline_type = command_buffer_type::pipeline_type;
         using factory_type = TFactory;
         using barrier_type = TBarrier;
         using descriptor_layout_type = factory_type::descriptor_layout_type;
@@ -1522,6 +1524,21 @@ namespace LiteFX::Rendering {
         /// <inheritdoc />
         virtual void computeAccelerationStructureSizes(const top_level_acceleration_structure_type& tlas, UInt64 & bufferSize, UInt64 & scratchSize, bool forUpdate = false) const = 0;
 
+        /// <inheritdoc />
+        virtual void allocateGlobalDescriptors(const descriptor_set_type& descriptorSet, UInt32& heapOffset, UInt32& heapSize) const = 0;
+
+        /// <inheritdoc />
+        virtual void releaseGlobalDescriptors(const descriptor_set_type& descriptorSet) const = 0;
+
+        /// <inheritdoc />
+        virtual void updateGlobalDescriptors(const descriptor_set_type& descriptorSet, UInt32 binding, UInt32 offset, UInt32 descriptors) const = 0;
+
+        /// <inheritdoc />
+        virtual void bindDescriptorSet(const command_buffer_type& commandBuffer, const descriptor_set_type& descriptorSet, const pipeline_type& pipeline) const noexcept = 0;
+
+        /// <inheritdoc />
+        virtual void bindGlobalDescriptorHeaps(const command_buffer_type& commandBuffer) const noexcept = 0;
+
     private:
         inline void getAccelerationStructureSizes(const IBottomLevelAccelerationStructure& blas, UInt64& bufferSize, UInt64& scratchSize, bool forUpdate) const override {
             this->computeAccelerationStructureSizes(dynamic_cast<const bottom_level_acceleration_structure_type&>(blas), bufferSize, scratchSize, forUpdate);
@@ -1529,6 +1546,26 @@ namespace LiteFX::Rendering {
 
         inline void getAccelerationStructureSizes(const ITopLevelAccelerationStructure& tlas, UInt64& bufferSize, UInt64& scratchSize, bool forUpdate) const override {
             this->computeAccelerationStructureSizes(dynamic_cast<const top_level_acceleration_structure_type&>(tlas), bufferSize, scratchSize, forUpdate);
+        }
+        
+        inline void doAllocateGlobalDescriptors(const IDescriptorSet& descriptorSet, UInt32& heapOffset, UInt32& heapSize) const override {
+            this->allocateGlobalDescriptors(dynamic_cast<const descriptor_set_type&>(descriptorSet), heapOffset, heapSize);
+        }
+
+        inline void doReleaseGlobalDescriptors(const IDescriptorSet& descriptorSet) const override {
+            this->releaseGlobalDescriptors(dynamic_cast<const descriptor_set_type&>(descriptorSet));
+        }
+
+        inline void doUpdateGlobalDescriptors(const IDescriptorSet& descriptorSet, UInt32 binding, UInt32 offset, UInt32 descriptors) const override {
+            this->updateGlobalDescriptors(dynamic_cast<const descriptor_set_type&>(descriptorSet), binding, offset, descriptors);
+        }
+
+        inline void doBindDescriptorSet(const ICommandBuffer& commandBuffer, const IDescriptorSet& descriptorSet, const IPipeline& pipeline) const noexcept override {
+            this->bindDescriptorSet(dynamic_cast<const command_buffer_type&>(commandBuffer), dynamic_cast<const descriptor_set_type&>(descriptorSet), dynamic_cast<const pipeline_type&>(pipeline));
+        }
+
+        inline void doBindGlobalDescriptorHeaps(const ICommandBuffer& commandBuffer) const noexcept override {
+            this->bindGlobalDescriptorHeaps(dynamic_cast<const command_buffer_type&>(commandBuffer));
         }
 
 #if defined(LITEFX_BUILD_DEFINE_BUILDERS)

--- a/src/Rendering/include/litefx/rendering_api.hpp
+++ b/src/Rendering/include/litefx/rendering_api.hpp
@@ -5489,6 +5489,12 @@ namespace LiteFX::Rendering {
         /// <returns>The number of input attachment descriptors.</returns>
         virtual UInt32 inputAttachments() const noexcept = 0;
 
+        /// <summary>
+        /// Returns `true`, if the descriptor set layout contains an unbounded runtime array and `false` otherwise.
+        /// </summary>
+        /// <returns>`true`, if the descriptor set layout contains an unbounded runtime array and `false` otherwise</returns>
+        virtual bool containsUnboundedArray() const noexcept = 0;
+
     public:
         /// <summary>
         /// Allocates a new descriptor set or returns an instance of an unused descriptor set.

--- a/src/Rendering/include/litefx/rendering_api.hpp
+++ b/src/Rendering/include/litefx/rendering_api.hpp
@@ -5263,6 +5263,25 @@ namespace LiteFX::Rendering {
 
     public:
         /// <summary>
+        /// Returns the offset into the global descriptor heap.
+        /// </summary>
+        /// <remarks>
+        /// The heap offset may differ between used backends and does not necessarily correspond to memory.
+        /// </remarks>
+        /// <returns>The offset into the global descriptor heap.</returns>
+        virtual UInt32 globalHeapOffset() const noexcept = 0;
+
+        /// <summary>
+        /// Returns the amount size of the range in the global descriptor heap address space.
+        /// </summary>
+        /// <remarks>
+        /// The heap size may differ between used backends and does not necessarily correspond to memory.
+        /// </remarks>
+        /// <returns>The size of the range in the global descriptor heap.</returns>
+        /// <seealso cref="globalHeapOffset" />
+        virtual UInt32 globalHeapAddressRange() const noexcept = 0;
+
+        /// <summary>
         /// Updates one or more buffer descriptors within the current descriptor set.
         /// </summary>
         /// <param name="binding">The buffer binding point.</param>

--- a/src/Rendering/include/litefx/rendering_api.hpp
+++ b/src/Rendering/include/litefx/rendering_api.hpp
@@ -4080,6 +4080,22 @@ namespace LiteFX::Rendering {
         /// <param name="firstElement">The first element of the array to map.</param>
         /// <param name="write">If `true`, <paramref name="data" /> is copied into the internal memory. If `false` the internal memory is copied into <paramref name="data" />.</param>
         virtual void map(Span<void*> data, size_t elementSize, UInt32 firstElement = 0, bool write = true) = 0;
+
+        /// <summary>
+        /// Writes a span of memory in <paramref name="data" /> into the internal memory of this object, starting at <paramref name="offset" />.
+        /// </summary>
+        /// <param name="data">The span of bytes containing the data to write.</param>
+        /// <param name="size">The size of the memory block at <paramref name="data" />.</param>
+        /// <param name="offset">The offset at which to start writing.</param>
+        virtual void write(const void* const data, size_t size, size_t offset = 0) = 0;
+
+        /// <summary>
+        /// Writes a span of memory in <paramref name="data" /> into the internal memory of this object, starting at <paramref name="offset" />.
+        /// </summary>
+        /// <param name="data">The span of bytes containing the data to write.</param>
+        /// <param name="size">The size of the memory block at <paramref name="data" />.</param>
+        /// <param name="offset">The offset at which to start writing.</param>
+        virtual void read(void* data, size_t size, size_t offset = 0) = 0;
     };
 
     /// <summary>

--- a/src/Rendering/include/litefx/rendering_api.hpp
+++ b/src/Rendering/include/litefx/rendering_api.hpp
@@ -3236,12 +3236,12 @@ namespace LiteFX::Rendering {
             /// <summary>
             /// Specifies the bits to write to the stencil state (default: <c>0xFF</c>).
             /// </summary>
-            Byte WriteMask{ 0xFF }; // NOLINT(cppcoreguidelines-avoid-magic-numbers)
+            UInt8 WriteMask{ 0xFF }; // NOLINT(cppcoreguidelines-avoid-magic-numbers)
 
             /// <summary>
             /// Specifies the bits to read from the stencil state (default: <c>0xFF</c>).
             /// </summary>
-            Byte ReadMask{ 0xFF }; // NOLINT(cppcoreguidelines-avoid-magic-numbers)
+            UInt8 ReadMask{ 0xFF }; // NOLINT(cppcoreguidelines-avoid-magic-numbers)
 
             /// <summary>
             /// Describes the stencil test for faces that point towards the camera.
@@ -4893,7 +4893,7 @@ namespace LiteFX::Rendering {
             /// <summary>
             /// A user-defined mask value that is matched with another mask value during ray-tracing to include or discard the instance.
             /// </summary>
-            Byte Mask : 8 = 0xFF;
+            UInt8 Mask : 8 = 0xFF;
 
             /// <summary>
             /// An offset added to the address of the shader-local data of the shader record that is invoked for the instance, *after* the <see cref="IBottomLevelAccelerationStructure" /> indexing
@@ -4950,7 +4950,7 @@ namespace LiteFX::Rendering {
         /// <param name="hitGroupOffset">An offset added to the shader-local data for a hit-group shader record.</param>
         /// <param name="mask">A user defined mask value that can be used to include or exclude the instance during a ray-tracing pass.</param>
         /// <param name="flags">The flags that control the behavior of the instance.</param>
-        inline void addInstance(const SharedPtr<const IBottomLevelAccelerationStructure>& blas, UInt32 id, UInt32 hitGroupOffset = 0, Byte mask = 0xFF, InstanceFlags flags = InstanceFlags::None) noexcept { // NOLINT(cppcoreguidelines-avoid-magic-numbers)
+        inline void addInstance(const SharedPtr<const IBottomLevelAccelerationStructure>& blas, UInt32 id, UInt32 hitGroupOffset = 0, UInt8 mask = 0xFF, InstanceFlags flags = InstanceFlags::None) noexcept { // NOLINT(cppcoreguidelines-avoid-magic-numbers)
             this->addInstance(Instance { .BottomLevelAccelerationStructure = blas, .Id = id, .Mask = mask, .HitGroupOffset = hitGroupOffset, .Flags = flags });
         }
         
@@ -4963,7 +4963,7 @@ namespace LiteFX::Rendering {
         /// <param name="hitGroupOffset">An offset added to the shader-local data for a hit-group shader record.</param>
         /// <param name="mask">A user defined mask value that can be used to include or exclude the instance during a ray-tracing pass.</param>
         /// <param name="flags">The flags that control the behavior of the instance.</param>
-        inline void addInstance(const SharedPtr<const IBottomLevelAccelerationStructure>& blas, const TMatrix3x4<Float>& transform, UInt32 id, UInt32 hitGroupOffset = 0, Byte mask = 0xFF, InstanceFlags flags = InstanceFlags::None) noexcept { // NOLINT(cppcoreguidelines-avoid-magic-numbers)
+        inline void addInstance(const SharedPtr<const IBottomLevelAccelerationStructure>& blas, const TMatrix3x4<Float>& transform, UInt32 id, UInt32 hitGroupOffset = 0, UInt8 mask = 0xFF, InstanceFlags flags = InstanceFlags::None) noexcept { // NOLINT(cppcoreguidelines-avoid-magic-numbers)
             this->addInstance(Instance { .BottomLevelAccelerationStructure = blas, .Transform = transform, .Id = id, .Mask = mask, .HitGroupOffset = hitGroupOffset, .Flags = flags });
         }
 
@@ -5039,7 +5039,7 @@ namespace LiteFX::Rendering {
         /// <param name="flags">The flags that control the behavior of the instance.</param>
         /// <returns>A reference to the current TLAS.</returns>
         template<typename TSelf>
-        inline auto withInstance(this TSelf&& self, const SharedPtr<const IBottomLevelAccelerationStructure>& blas, UInt32 id, UInt32 hitGroupOffset = 0, Byte mask = 0xFF, InstanceFlags flags = InstanceFlags::None) noexcept -> TSelf&& { // NOLINT(cppcoreguidelines-avoid-magic-numbers)
+        inline auto withInstance(this TSelf&& self, const SharedPtr<const IBottomLevelAccelerationStructure>& blas, UInt32 id, UInt32 hitGroupOffset = 0, UInt8 mask = 0xFF, InstanceFlags flags = InstanceFlags::None) noexcept -> TSelf&& { // NOLINT(cppcoreguidelines-avoid-magic-numbers)
             self.addInstance(Instance { .BottomLevelAccelerationStructure = blas, .Id = id, .Mask = mask, .HitGroupOffset = hitGroupOffset, .Flags = flags });
             return std::forward<TSelf>(self);
         }
@@ -5055,7 +5055,7 @@ namespace LiteFX::Rendering {
         /// <param name="flags">The flags that control the behavior of the instance.</param>
         /// <returns>A reference to the current TLAS.</returns>
         template<typename TSelf>
-        inline auto withInstance(this TSelf&& self, const SharedPtr<const IBottomLevelAccelerationStructure>& blas, const TMatrix3x4<Float>& transform, UInt32 id, UInt32 hitGroupOffset = 0, Byte mask = 0xFF, InstanceFlags flags = InstanceFlags::None) noexcept -> TSelf&& { // NOLINT(cppcoreguidelines-avoid-magic-numbers)
+        inline auto withInstance(this TSelf&& self, const SharedPtr<const IBottomLevelAccelerationStructure>& blas, const TMatrix3x4<Float>& transform, UInt32 id, UInt32 hitGroupOffset = 0, UInt8 mask = 0xFF, InstanceFlags flags = InstanceFlags::None) noexcept -> TSelf&& { // NOLINT(cppcoreguidelines-avoid-magic-numbers)
             self.addInstance(Instance { .BottomLevelAccelerationStructure = blas, .Transform = transform, .Id = id, .Mask = mask, .HitGroupOffset = hitGroupOffset, .Flags = flags });
             return std::forward<TSelf>(self);
         }
@@ -8587,7 +8587,7 @@ namespace LiteFX::Rendering {
         /// </summary>
         /// <seealso cref="beginDebugRegion" />
         /// <seealso cref="setDebugMarker" />
-        static constexpr Vectors::ByteVector3 DEFAULT_DEBUG_COLOR = { 128_b, 128_b, 128_b };
+        static constexpr Vectors::ByteVector3 DEFAULT_DEBUG_COLOR = { 128_ui8, 128_ui8, 128_ui8 };
 
         /// <summary>
         /// Starts a new debug region.

--- a/src/Rendering/include/litefx/rendering_api.hpp
+++ b/src/Rendering/include/litefx/rendering_api.hpp
@@ -9380,9 +9380,70 @@ namespace LiteFX::Rendering {
             this->getAccelerationStructureSizes(tlas, bufferSize, scratchSize, forUpdate);
         }
 
+        /// <summary>
+        /// Allocates a range of descriptors in the global descriptor heaps for the provided <paramref name="descriptorSet" />.
+        /// </summary>
+        /// <param name="descriptorSet">The descriptor set containing the descriptors to update.</param>
+        /// <param name="heapOffset">The offset of the descriptor range in the global descriptor heap.</param>
+        /// <param name="heapSize">The size of the address range in the global descriptor heap.</param>
+        inline void allocateGlobalDescriptors(const IDescriptorSet& descriptorSet, UInt32& heapOffset, UInt32& heapSize) const {
+            this->doAllocateGlobalDescriptors(descriptorSet, heapOffset, heapSize);
+        }
+
+        /// <summary>
+        /// Releases a range of descriptors from the global descriptor heaps.
+        /// </summary>
+        /// <remarks>
+        /// This is done, if a descriptor set layout is destroyed, of a descriptor set, which contains an unbounded array is freed. It will cause the global 
+        /// descriptor heaps to fragment, which may result in inefficient future descriptor allocations and should be avoided. Consider caching descriptor
+        /// sets with unbounded arrays instead. Also avoid relying on creating and releasing pipeline layouts during runtime. Instead, it may be more efficient
+        /// to write shaders that support multiple pipeline variations, that can be kept alive for the lifetime of the whole application.
+        /// </remarks>
+        inline void releaseGlobalDescriptors(const IDescriptorSet& descriptorSet) const {
+            this->doReleaseGlobalDescriptors(descriptorSet);
+        }
+
+        /// <summary>
+        /// Updates a range of descriptors in the global buffer descriptor heap with the descriptors from <paramref name="descriptorSet" />.
+        /// </summary>
+        /// <param name="descriptorSet">The descriptor set to copy the descriptors from.</param>
+        /// <param name="binding">The binding point for which to update the descriptors.</param>
+        /// <param name="offset">The index of the first descriptor in a descriptor array at the binding point.</param>
+        /// <param name="descriptors">The number of descriptors in a descriptor array to copy, starting at the offset.</param>
+        inline void updateGlobalDescriptors(const IDescriptorSet& descriptorSet, UInt32 binding, UInt32 offset, UInt32 descriptors) const {
+            this->doUpdateGlobalDescriptors(descriptorSet, binding, offset, descriptors);
+        }
+
+        /// <summary>
+        /// Binds the descriptors of the descriptor set to the global descriptor heaps.
+        /// </summary>
+        /// <remarks>
+        /// Note that after binding the descriptor set, the descriptors must not be updated anymore, unless they are elements on unbounded descriptor arrays, 
+        /// in which case you have to ensure manually to not update them, as long as they may still be in use!
+        /// </remarks>
+        /// <param name="commandBuffer">The command buffer to bind the descriptor set on.</param>
+        /// <param name="descriptorSet">The descriptor set to bind.</param>
+        /// <param name="pipeline">The pipeline to bind the descriptor set to.</param>
+        inline void bindDescriptorSet(const ICommandBuffer& commandBuffer, const IDescriptorSet& descriptorSet, const IPipeline& pipeline) const noexcept {
+            this->doBindDescriptorSet(commandBuffer, descriptorSet, pipeline);
+        }
+
+        /// <summary>
+        /// Binds the global descriptor heap.
+        /// </summary>
+        /// <param name="commandBuffer">The command buffer to issue the bind command on.</param>
+        inline void bindGlobalDescriptorHeaps(const ICommandBuffer& commandBuffer) const noexcept {
+            this->doBindGlobalDescriptorHeaps(commandBuffer);
+        }
+
     private:
         virtual void getAccelerationStructureSizes(const IBottomLevelAccelerationStructure& blas, UInt64& bufferSize, UInt64& scratchSize, bool forUpdate) const = 0;
         virtual void getAccelerationStructureSizes(const ITopLevelAccelerationStructure& tlas, UInt64& bufferSize, UInt64& scratchSize, bool forUpdate) const = 0;
+        virtual void doAllocateGlobalDescriptors(const IDescriptorSet& descriptorSet, UInt32& heapOffset, UInt32& heapSize) const = 0;
+        virtual void doReleaseGlobalDescriptors(const IDescriptorSet& descriptorSet) const = 0;
+        virtual void doUpdateGlobalDescriptors(const IDescriptorSet& descriptorSet, UInt32 binding, UInt32 offset, UInt32 descriptors) const = 0;
+        virtual void doBindDescriptorSet(const ICommandBuffer& commandBuffer, const IDescriptorSet& descriptorSet, const IPipeline& pipeline) const noexcept = 0;
+        virtual void doBindGlobalDescriptorHeaps(const ICommandBuffer& commandBuffer) const noexcept = 0;
 
     public:
         /// <summary>

--- a/src/Rendering/include/litefx/rendering_api.hpp
+++ b/src/Rendering/include/litefx/rendering_api.hpp
@@ -5530,6 +5530,14 @@ namespace LiteFX::Rendering {
         /// <returns>`true`, if the descriptor set layout contains an unbounded runtime array and `false` otherwise</returns>
         virtual bool containsUnboundedArray() const noexcept = 0;
 
+        /// <summary>
+        /// Returns the offset for a descriptor within a descriptor set of this layout.
+        /// </summary>
+        /// <param name="binding">The binding point for the descriptor.</param>
+        /// <param name="element">The index of the array element of a descriptor array.</param>
+        /// <returns>The offset from the beginning of the descriptor set.</returns>
+        virtual UInt32 getDescriptorOffset(UInt32 binding, UInt32 element = 0) const = 0;
+
     public:
         /// <summary>
         /// Allocates a new descriptor set or returns an instance of an unused descriptor set.


### PR DESCRIPTION
**Describe the pull request**

This PR implements a common descriptor management architecture by implementing [VK_EXT_descriptor_buffer](https://registry.khronos.org/vulkan/specs/latest/man/html/VK_EXT_descriptor_buffer.html) in the Vulkan backend. The new approach provides two central descriptor buffers at the device instance, similar to the descriptor heaps for the D3D12 backend. All related functions have been moved to the graphics device base interfaces. As descriptors are not required to have the same size, it is not possible to allocate equal chunks from the descriptor heaps. For this reason, the buffer interface has been extended with two new methods that can be used to read and write raw memory directly.

This PR also fixes two minor issues:
- Descriptor set layouts are now properly destroyed.
- The native Vulkan swap chain now uses the proper present target layout, if the D3D12 backend is not built.

**ToDo**

- [x] Fix ray tracing and ray queries samples. (Non-issue, see: https://github.com/KhronosGroup/Vulkan-ValidationLayers/issues/10721)
- [x] Validate samples
- [x] Validate tests

**Related issues**

- #163 
- #162 