### PR TITLE
Provide binding hints to shader reflection to have better control over the pipeline layout.

### DIFF
--- a/docs/release-logs/0.5.1.md
+++ b/docs/release-logs/0.5.1.md
@@ -3,6 +3,7 @@
 - Improved descriptor management.
   - Common descriptor allocation and binding architecture. (See [PR #165](https://github.com/crud89/LiteFX/pull/165))
   - Unbounded arrays are no longer implicitly defined by setting the array element size to maximum. This allows to define multiple descriptor sets containing unbounded descriptor arrays without exceeding device limits in Vulkan. (See [PR #166](https://github.com/crud89/LiteFX/pull/166))
+  - Binding hints can now be passed to shader reflection to have better control over the pipeline layout without falling back to explicit definitions. (See [PR #168](https://github.com/crud89/LiteFX/pull/168))
 
 **🌋 Vulkan:**
 

--- a/src/Backends/DirectX12/include/litefx/backends/dx12.hpp
+++ b/src/Backends/DirectX12/include/litefx/backends/dx12.hpp
@@ -675,11 +675,11 @@ namespace LiteFX::Rendering::Backends {
         const Array<UniquePtr<const DirectX12ShaderModule>>& modules() const noexcept override;
 
         /// <inheritdoc />
-        virtual SharedPtr<DirectX12PipelineLayout> reflectPipelineLayout() const;
+        virtual SharedPtr<DirectX12PipelineLayout> reflectPipelineLayout(Enumerable<PipelineBindingHint> hints = {}) const;
 
     private:
-        SharedPtr<IPipelineLayout> parsePipelineLayout() const override {
-            return std::static_pointer_cast<IPipelineLayout>(this->reflectPipelineLayout());
+        SharedPtr<IPipelineLayout> parsePipelineLayout(Enumerable<PipelineBindingHint> hints) const override {
+            return std::static_pointer_cast<IPipelineLayout>(this->reflectPipelineLayout(hints));
         }
     };
 

--- a/src/Backends/DirectX12/include/litefx/backends/dx12.hpp
+++ b/src/Backends/DirectX12/include/litefx/backends/dx12.hpp
@@ -681,21 +681,6 @@ namespace LiteFX::Rendering::Backends {
         SharedPtr<IPipelineLayout> parsePipelineLayout() const override {
             return std::static_pointer_cast<IPipelineLayout>(this->reflectPipelineLayout());
         }
-
-    public:
-        /// <summary>
-        /// Suppresses the warning that is issued, if no root signature is found on a shader module when calling <see cref="reflectPipelineLayout" />.
-        /// </summary>
-        /// <remarks>
-        /// When a shader program is asked to build a pipeline layout, it first checks if a root signature is provided within the shader bytecode. If no root signature could 
-        /// be found, it falls back to using plain reflection to extract the descriptor sets. This has the drawback, that some features are not or only partially supported.
-        /// Most notably, it is not possible to reflect a pipeline layout that uses push/root constants this way. To ensure that you are not missing the root signature by 
-        /// accident, the engine warns you when it encounters this situation. However, if you are only using plain descriptor sets, this can result in noise warnings that 
-        /// clutter the log. You can call this function to disable the warnings explicitly.
-        /// </remarks>
-        /// <param name="disableWarning"><c>true</c> to stop issuing the warning or <c>false</c> to continue.</param>
-        /// <seealso cref="reflectPipelineLayout" />
-        static void suppressMissingRootSignatureWarning(bool disableWarning = true) noexcept;
     };
 
     /// <summary>

--- a/src/Backends/DirectX12/src/shader_program.cpp
+++ b/src/Backends/DirectX12/src/shader_program.cpp
@@ -476,7 +476,7 @@ public:
             for (size_t i{ 0 }; i < descriptorSet.descriptors.size(); ++i)
             {
                 // Get the current descriptor.
-                auto descriptor = descriptorSet.descriptors[i];
+                auto& descriptor = descriptorSet.descriptors[i];
 
                 // See if there's a hint about the binding.
                 auto hint = PipelineBindingHint::hint_type{ };

--- a/src/Backends/DirectX12/src/shader_program.cpp
+++ b/src/Backends/DirectX12/src/shader_program.cpp
@@ -473,7 +473,6 @@ public:
 
         // Patch the descriptor set layouts and push constant ranges based on the pipeline binding hints. This is done after shader reflection and root signature parsing.
         std::ranges::for_each(descriptorSetLayouts | std::views::values, [&](auto& descriptorSet) {
-            //for (auto descriptor = std::begin(descriptorSet.descriptors); descriptor != std::end(descriptorSet.descriptors); descriptor++)
             for (size_t i{ 0 }; i < descriptorSet.descriptors.size(); ++i)
             {
                 // Get the current descriptor.

--- a/src/Backends/DirectX12/src/shader_program.cpp
+++ b/src/Backends/DirectX12/src/shader_program.cpp
@@ -15,8 +15,6 @@ consteval UInt32 FOUR_CC(char ch0, char ch1, char ch2, char ch3)
     return static_cast<UInt32>((Byte)ch0) | static_cast<UInt32>((Byte)ch1) << 8 | static_cast<UInt32>((Byte)ch2) << 16 | static_cast<UInt32>((Byte)ch3) << 24; // NOLINT(cppcoreguidelines-avoid-magic-numbers)
 }
 
-static bool SUPPRESS_MISSING_ROOT_SIGNATURE_WARNING = false; // NOLINT(cppcoreguidelines-avoid-non-const-global-variables)
-
 constexpr BorderMode DECODE_BORDER_MODE(D3D12_TEXTURE_ADDRESS_MODE addressMode) noexcept
 {
     switch (addressMode)
@@ -353,7 +351,7 @@ public:
         return descriptor;
     }
 
-    SharedPtr<DirectX12PipelineLayout> reflectPipelineLayout()
+    SharedPtr<DirectX12PipelineLayout> reflectPipelineLayout(Enumerable<PipelineBindingHint> hints)
     {
         // First, filter the descriptor sets and push constant ranges.
         Dictionary<UInt32, DescriptorSetInfo> descriptorSetLayouts;
@@ -536,9 +534,9 @@ const Array<UniquePtr<const DirectX12ShaderModule>>& DirectX12ShaderProgram::mod
     return m_impl->m_modules;
 }
 
-SharedPtr<DirectX12PipelineLayout> DirectX12ShaderProgram::reflectPipelineLayout() const
+SharedPtr<DirectX12PipelineLayout> DirectX12ShaderProgram::reflectPipelineLayout(Enumerable<PipelineBindingHint> hints) const
 {
-    return m_impl->reflectPipelineLayout();
+    return m_impl->reflectPipelineLayout(hints);
 }
 
 #if defined(LITEFX_BUILD_DEFINE_BUILDERS)

--- a/src/Backends/DirectX12/src/shader_program.cpp
+++ b/src/Backends/DirectX12/src/shader_program.cpp
@@ -514,11 +514,6 @@ public:
     }
 };
 
-void DirectX12ShaderProgram::suppressMissingRootSignatureWarning(bool disableWarning) noexcept
-{
-    SUPPRESS_MISSING_ROOT_SIGNATURE_WARNING = disableWarning;
-}
-
 // ------------------------------------------------------------------------------------------------
 // Interface.
 // ------------------------------------------------------------------------------------------------

--- a/src/Backends/DirectX12/src/shader_program.cpp
+++ b/src/Backends/DirectX12/src/shader_program.cpp
@@ -43,8 +43,9 @@ private:
         UInt32 location;
         UInt32 elementSize;
         UInt32 elements;
+        bool unbounded = false;
         DescriptorType type;
-        Optional<D3D12_STATIC_SAMPLER_DESC> staticSamplerState;
+        Variant<std::monostate, D3D12_STATIC_SAMPLER_DESC, SharedPtr<DirectX12Sampler>> staticSamplerState = std::monostate{};
         bool local = false;
 
         bool equals(const DescriptorInfo& rhs)
@@ -53,6 +54,7 @@ private:
                 this->location == rhs.location &&
                 this->elements == rhs.elements &&
                 this->elementSize == rhs.elementSize &&
+                this->unbounded == rhs.unbounded &&
                 this->type == rhs.type;
         }
     };
@@ -265,6 +267,8 @@ public:
 
                 break;
             case D3D12_ROOT_PARAMETER_TYPE_DESCRIPTOR_TABLE:
+                // All descriptors that are not root constants will be put ultimately into descriptor tables by default with the current implementation. The layout will remain compatible this way. However, 
+                // it is currently not supported to embed a descriptor table into the root signature directly.
                 throw InvalidArgumentException("modules", "The shader modules root signature defines a descriptor table for parameter {0}, which is currently not supported. Convert each parameter of the table into a separate root parameter.", i);
             default: 
                 throw InvalidArgumentException("modules", "The shader modules root signature exposes an unknown root parameter type {1} for parameter {0}.", i, rootParameter.ParameterType);
@@ -344,15 +348,23 @@ public:
             .type = type
         };
 
-        // Unbounded arrays have a bind count of -1.
+        // Unbounded arrays have a bind count of 0.
         if (inputDesc.BindCount == 0)
+        {
+            descriptor.unbounded = true;
             descriptor.elements = std::numeric_limits<UInt32>::max();
+        }
 
         return descriptor;
     }
 
     SharedPtr<DirectX12PipelineLayout> reflectPipelineLayout(Enumerable<PipelineBindingHint> hints)
     {
+        // Put the hints into a map so we can easier look them up.
+        auto hintsMap = hints
+            | std::views::transform([](const auto& hint) -> std::pair<DescriptorBindingPoint, PipelineBindingHint> { return { hint.Binding, hint }; })
+            | std::ranges::to<std::map>();
+
         // First, filter the descriptor sets and push constant ranges.
         Dictionary<UInt32, DescriptorSetInfo> descriptorSetLayouts;
         Array<PushConstantRangeInfo> pushConstantRanges;
@@ -444,10 +456,8 @@ public:
             }
         });
 
-        // Attempt to find a shader module that exports a root signature. If none is found, issue a warning.
+        // Attempt to find a shader module that exports a root signature. A root signature ultimately overwrites any bindings emitted by reflection.
         // NOTE: Root signature is only ever expected to be provided in one shader module. If multiple are provided, it is not defined, which one will be picked.
-        bool hasRootSignature = false;
-
         for (const auto& shaderModule : m_modules)
         {
             ComPtr<ID3D12RootSignatureDeserializer> deserializer;
@@ -457,14 +467,73 @@ public:
                 // Reflect the root signature in order to define static samplers and push constants.
                 LITEFX_TRACE(DIRECTX12_LOG, "Found root signature in shader module {0}.", shaderModule->type());
                 this->reflectRootSignature(deserializer, descriptorSetLayouts, pushConstantRanges);
-                hasRootSignature = true;
                 break;
             }
         }
 
-        // Otherwise, fall back to traditional reflection to acquire the root signature.
-        if (!hasRootSignature && !SUPPRESS_MISSING_ROOT_SIGNATURE_WARNING)
-            LITEFX_WARNING(DIRECTX12_LOG, "None of the provided shader modules exports a root signature. Descriptor sets will be acquired using reflection. Some features (such as root/push constants) are not supported.");
+        // Patch the descriptor set layouts and push constant ranges based on the pipeline binding hints. This is done after shader reflection and root signature parsing.
+        std::ranges::for_each(descriptorSetLayouts | std::views::values, [&](auto& descriptorSet) {
+            for (auto descriptor = descriptorSet.descriptors.begin(); descriptor < descriptorSet.descriptors.end(); descriptor++)
+            {
+                // See if there's a hint about the binding.
+                auto hint = PipelineBindingHint::hint_type{ };
+                auto binding = DescriptorBindingPoint{ .Register = descriptor->location, .Space = descriptorSet.space };
+
+                if (hintsMap.contains(binding))
+                    hint = hintsMap[binding].Hint;
+
+                // Create patch lambdas.
+                auto samplerHintCallback = [&](const PipelineBindingHint::StaticSamplerHint& hint) {
+                    // Static samplers must be bound to a sampler descriptor and we prefer static samplers from the serialized root signature.
+                    auto sampler = std::dynamic_pointer_cast<DirectX12Sampler>(hint.StaticSampler);
+
+                    if (descriptor->type != DescriptorType::Sampler)
+                        LITEFX_WARNING(DIRECTX12_LOG, "A hint for binding {0} at space {1} indicates a static sampler, but the descriptor does not bind a sampler. The hint will be ignored.", descriptor->location, descriptorSet.space);
+                    else if (!std::holds_alternative<std::monostate>(descriptor->staticSamplerState))
+                        LITEFX_INFO(DIRECTX12_LOG, "A hint for binding {0} at space {1} indicates a static sampler and one was already loaded from the root signature. The hint will be ignored.", descriptor->location, descriptorSet.space);
+                    else if (sampler != nullptr)
+                        descriptor->staticSamplerState = sampler;
+                };
+
+                auto pushConstantsHintCallback = [&](const PipelineBindingHint::PushConstantsHint& hint) {
+                    // If a push constant range should be used, we need to convert the descriptor and remove it from the descriptor set.
+                    if (hint.AsPushConstants)
+                    {
+                        if (descriptor->type != DescriptorType::ConstantBuffer)
+                            LITEFX_WARNING(DIRECTX12_LOG, "A hint for binding {0} at space {1} indicates a push constants range, but the bound descriptor type is not a constant buffer. The hint will be ignored.", descriptor->location, descriptorSet.space);
+                        else
+                        {
+                            // Lookup the last registered range to compute the highest offset.
+                            UInt32 pushConstantOffset = 0;
+
+                            if (!pushConstantRanges.empty())
+                                pushConstantOffset = pushConstantRanges.back().offset + pushConstantRanges.back().size;
+
+                            auto rangeSize = descriptor->elements * descriptor->elementSize;
+                            pushConstantRanges.push_back(PushConstantRangeInfo{ .stage = descriptorSet.stage, .offset = pushConstantOffset, .size = rangeSize, .location = descriptor->location, .space = descriptorSet.space });
+
+                            // Remove the descriptor from the descriptor set.
+                            // TODO: This needs to be moved out of the loop.
+                            descriptorSet.descriptors.erase(descriptor);
+                        }
+                    }
+                };
+
+                auto unboundedArrayHintCallback = [&](const PipelineBindingHint::UnboundedArrayHint& hint) {
+                    // Unbounded arrays are supported by D3D12 reflection, so we just need to validate them. We also do not need to set an upper bound here, as D3D12 handles descriptors more loosely.
+                    if (!descriptor->unbounded)
+                        LITEFX_WARNING(DIRECTX12_LOG, "A hint for binding {0} at space {1} indicates an unbounded array, but the bound descriptor type either a static array or a single descriptor. The hint will be ignored.", descriptor->location, descriptorSet.space);
+                    else
+                        descriptor->elements = hint.MaxDescriptors;
+                };
+
+                // If the descriptor binds a sampler and the hint is a static sampler, patch it.
+                std::visit(type_switch{
+                    [](const std::monostate&) {}, // Default: don't patch anything
+                    samplerHintCallback, pushConstantsHintCallback, unboundedArrayHintCallback
+                }, hint);
+            }
+        });
 
         // Create the descriptor set layouts.
         auto descriptorSets = [](SharedPtr<const DirectX12Device> device, Dictionary<UInt32, DescriptorSetInfo> descriptorSetLayouts) -> std::generator<SharedPtr<DirectX12DescriptorSetLayout>> {
@@ -477,24 +546,33 @@ public:
                 auto descriptors = [](DescriptorSetInfo descriptorSet) -> std::generator<DirectX12DescriptorLayout> {
                     for (auto descriptor = descriptorSet.descriptors.begin(); descriptor != descriptorSet.descriptors.end(); ++descriptor)
                     {
-                        if (descriptor->staticSamplerState.has_value())
+                        if (std::holds_alternative<D3D12_STATIC_SAMPLER_DESC>(descriptor->staticSamplerState))
                         {
+                            auto samplerState = std::get<D3D12_STATIC_SAMPLER_DESC>(descriptor->staticSamplerState);
                             auto sampler = DirectX12Sampler::allocate(
-                                D3D12_DECODE_MAG_FILTER(descriptor->staticSamplerState->Filter) == D3D12_FILTER_TYPE_POINT ? FilterMode::Nearest : FilterMode::Linear,
-                                D3D12_DECODE_MIN_FILTER(descriptor->staticSamplerState->Filter) == D3D12_FILTER_TYPE_POINT ? FilterMode::Nearest : FilterMode::Linear,
-                                DECODE_BORDER_MODE(descriptor->staticSamplerState->AddressU), DECODE_BORDER_MODE(descriptor->staticSamplerState->AddressV), DECODE_BORDER_MODE(descriptor->staticSamplerState->AddressW),
-                                D3D12_DECODE_MIP_FILTER(descriptor->staticSamplerState->Filter) == D3D12_FILTER_TYPE_POINT ? MipMapMode::Nearest : MipMapMode::Linear,
-                                descriptor->staticSamplerState->MipLODBias, descriptor->staticSamplerState->MinLOD, descriptor->staticSamplerState->MaxLOD, static_cast<Float>(descriptor->staticSamplerState->MaxAnisotropy));
+                                D3D12_DECODE_MAG_FILTER(samplerState.Filter) == D3D12_FILTER_TYPE_POINT ? FilterMode::Nearest : FilterMode::Linear,
+                                D3D12_DECODE_MIN_FILTER(samplerState.Filter) == D3D12_FILTER_TYPE_POINT ? FilterMode::Nearest : FilterMode::Linear,
+                                DECODE_BORDER_MODE(samplerState.AddressU), DECODE_BORDER_MODE(samplerState.AddressV), DECODE_BORDER_MODE(samplerState.AddressW),
+                                D3D12_DECODE_MIP_FILTER(samplerState.Filter) == D3D12_FILTER_TYPE_POINT ? MipMapMode::Nearest : MipMapMode::Linear,
+                                samplerState.MipLODBias, samplerState.MinLOD, samplerState.MaxLOD, static_cast<Float>(samplerState.MaxAnisotropy));
+                            co_yield { *sampler, descriptor->location };
+                        }
+                        else if (std::holds_alternative<SharedPtr<DirectX12Sampler>>(descriptor->staticSamplerState))
+                        {
+                            auto sampler = std::get<SharedPtr<DirectX12Sampler>>(descriptor->staticSamplerState);
                             co_yield { *sampler, descriptor->location };
                         }
                         else
                         {
-                            co_yield { descriptor->type, descriptor->location, descriptor->elementSize, descriptor->elements, descriptor->elements == std::numeric_limits<UInt32>::max(), descriptor->local };
+                            // Any other descriptor, including non-static samplers.
+                            co_yield { descriptor->type, descriptor->location, descriptor->elementSize, descriptor->elements, descriptor->unbounded, descriptor->local };
                         }
                     }
                 }(std::move(it->second)) | std::ranges::to<Array<DirectX12DescriptorLayout>>();
 
-                co_yield DirectX12DescriptorSetLayout::create(*device, descriptors, space, stage);
+                // Only yield a descriptor set layout, if there are descriptors in it. They could have been removed earlier when converting them to a push constant range after applying a hint.
+                if (!descriptors.empty())
+                    co_yield DirectX12DescriptorSetLayout::create(*device, descriptors, space, stage);
             }
         }(m_device, std::move(descriptorSetLayouts)) | std::ranges::to<Array<SharedPtr<DirectX12DescriptorSetLayout>>>();
 

--- a/src/Backends/Vulkan/include/litefx/backends/vulkan.hpp
+++ b/src/Backends/Vulkan/include/litefx/backends/vulkan.hpp
@@ -701,11 +701,11 @@ namespace LiteFX::Rendering::Backends {
         const Array<UniquePtr<const VulkanShaderModule>>& modules() const noexcept override;
 
         /// <inheritdoc />
-        virtual SharedPtr<VulkanPipelineLayout> reflectPipelineLayout() const;
+        virtual SharedPtr<VulkanPipelineLayout> reflectPipelineLayout(Enumerable<PipelineBindingHint> hints = {}) const;
 
     private:
-        SharedPtr<IPipelineLayout> parsePipelineLayout() const override {
-            return std::static_pointer_cast<IPipelineLayout>(this->reflectPipelineLayout());
+        SharedPtr<IPipelineLayout> parsePipelineLayout(Enumerable<PipelineBindingHint> hints) const override {
+            return std::static_pointer_cast<IPipelineLayout>(this->reflectPipelineLayout(hints));
         }
     };
 

--- a/src/Backends/Vulkan/src/shader_program.cpp
+++ b/src/Backends/Vulkan/src/shader_program.cpp
@@ -66,6 +66,7 @@ private:
         UInt32 elements;
         UInt32 inputAttachmentIndex;
         DescriptorType type;
+        SharedPtr<IVulkanSampler> staticSampler;
         bool unbounded;
 
         bool equals(const DescriptorInfo& rhs)
@@ -198,6 +199,11 @@ public:
 
     SharedPtr<VulkanPipelineLayout> reflectPipelineLayout(Enumerable<PipelineBindingHint> hints)
     {
+        // Put the hints into a map so we can easier look them up.
+        auto hintsMap = hints
+            | std::views::transform([](const auto& hint) -> std::pair<DescriptorBindingPoint, PipelineBindingHint> { return { hint.Binding, hint }; })
+            | std::ranges::to<std::map>();
+
         // First, filter the descriptor sets and push constant ranges.
         Dictionary<UInt32, DescriptorSetInfo> descriptorSetLayouts;
         Array<PushConstantRangeInfo> pushConstantRanges;
@@ -288,13 +294,13 @@ public:
                     UInt32 descriptors = 1;
 
                     if (descriptor->type_description->op == SpvOp::SpvOpTypeRuntimeArray)
-                        descriptors = std::numeric_limits<UInt32>::max();   // Unbounded. TODO: Provide a hint to initialize the upper limit here.
+                        descriptors = std::numeric_limits<UInt32>::max();
                     else
                         for (UInt32 d(0); d < descriptor->array.dims_count; ++d)
                             descriptors *= descriptor->array.dims[d];
 
                     // Create the descriptor layout.
-                    return DescriptorInfo{ .location = descriptor->binding, .elementSize = descriptor->block.padded_size, .elements = descriptors, .inputAttachmentIndex = inputAttachmentIndex, .type = type, .unbounded = descriptor->type_description->op == SpvOp::SpvOpTypeRuntimeArray };
+                    return DescriptorInfo { .location = descriptor->binding, .elementSize = descriptor->block.padded_size, .elements = descriptors, .inputAttachmentIndex = inputAttachmentIndex, .type = type, .unbounded = descriptor->type_description->op == SpvOp::SpvOpTypeRuntimeArray };
                 });
 
                 if (!descriptorSetLayouts.contains(descriptorSet->set))
@@ -330,6 +336,61 @@ public:
             });
         });
 
+        // Patch the descriptor set layouts and push constant ranges based on the pipeline binding hints.
+        std::ranges::for_each(descriptorSetLayouts | std::views::values, [&](auto& descriptorSet) {
+            for (size_t i{ 0 }; i < descriptorSet.descriptors.size(); ++i)
+            {
+                // Get the current descriptor.
+                auto descriptor = descriptorSet.descriptors[i];
+
+                // See if there's a hint about the binding.
+                auto hint = PipelineBindingHint::hint_type{ };
+                auto binding = DescriptorBindingPoint{ .Register = descriptor.location, .Space = descriptorSet.space };
+
+                if (hintsMap.contains(binding))
+                    hint = hintsMap[binding].Hint;
+
+                // Create patch lambdas.
+                auto samplerHintCallback = [&](const PipelineBindingHint::StaticSamplerHint& hint) {
+                    // Vulkan does not deduce immutable samplers from reflection, so we can define it using this hint. However, we need to make sure it addresses a sampler 
+                    // binding first.
+                    auto sampler = std::dynamic_pointer_cast<IVulkanSampler>(hint.StaticSampler);
+
+                    if (descriptor.type != DescriptorType::Sampler)
+                        LITEFX_WARNING(VULKAN_LOG, "A hint for binding {0} at space {1} indicates a static sampler, but the descriptor does not bind a sampler. The hint will be ignored.", descriptor.location, descriptorSet.space);
+                    else if (sampler != nullptr)
+                        descriptor.staticSampler = sampler;
+                };
+
+                auto pushConstantsHintCallback = [&](const PipelineBindingHint::PushConstantsHint& hint) {
+                    // Push constant ranges are always parsed from shader reflection, so we merely validate them using the hint. In Vulkan, push constants are not mapped to 
+                    // a descriptor set. Hitting this point means that a descriptor at this binding has been defined, so if we end up here, we issue a warning, as the hint
+                    // contradicts the layout.
+                    if (hint.AsPushConstants)
+                        LITEFX_WARNING(VULKAN_LOG, "A hint for binding {0} at space {1} indicates a push constants range, but a standard descriptor was bound here. In Vulkan push constants do not bind to a descriptor set, but a hint for the descriptor set indicates that the binding should be reserved for one anyway, perhaps to preserve compatibility with other backends. The hint will be ignored.", descriptor.location, descriptorSet.space);
+                };
+
+                auto unboundedArrayHintCallback = [&](const PipelineBindingHint::UnboundedArrayHint& hint) {
+                    // In Vulkan, unbounded arrays are obtained through shader reflection, however, to comply with device limits, a descriptor count for the upper limit of 
+                    // descriptors in the pipeline layout must be set. Only few implementations actually support arbitrarily (i.e., max UInt32) large arrays. It's a good
+                    // practice to provide a reasonable guess using a hint. 
+                    // If the binding does not refer to a static array, we must not overwrite the descriptor count, so we issue a warning. The same holds true for scalar
+                    // descriptors.
+                    
+                    if (!descriptor.unbounded)
+                        LITEFX_WARNING(VULKAN_LOG, "A hint for binding {0} at space {1} indicates an unbounded array, but the bound descriptor type either a static array or a single descriptor. The hint will be ignored.", descriptor.location, descriptorSet.space);
+                    else
+                        descriptor.elements = hint.MaxDescriptors;
+                };
+
+                // If the descriptor binds a sampler and the hint is a static sampler, patch it.
+                std::visit(type_switch{
+                    [](const std::monostate&) {}, // Default: don't patch anything
+                    samplerHintCallback, pushConstantsHintCallback, unboundedArrayHintCallback
+                }, hint);
+            }
+        });
+
         // Create the descriptor set layouts.
         auto descriptorSets = [](SharedPtr<const VulkanDevice> device, Dictionary<UInt32, DescriptorSetInfo> descriptorSetLayouts) -> std::generator<SharedPtr<VulkanDescriptorSetLayout>> {
             for (auto it = descriptorSetLayouts.begin(); it != descriptorSetLayouts.end(); ++it) {
@@ -338,10 +399,14 @@ public:
 
                 // Create the descriptor layouts.
                 auto descriptorLayouts = [](DescriptorSetInfo descriptorSet) -> std::generator<VulkanDescriptorLayout> {
-                    for (auto descriptor = descriptorSet.descriptors.begin(); descriptor != descriptorSet.descriptors.end(); ++descriptor)
-                        co_yield descriptor->type == DescriptorType::InputAttachment ?
-                            VulkanDescriptorLayout { descriptor->type, descriptor->location, descriptor->inputAttachmentIndex} :
-                            VulkanDescriptorLayout { descriptor->type, descriptor->location, descriptor->elementSize, descriptor->elements, descriptor->unbounded };
+                    for (auto descriptor = descriptorSet.descriptors.begin(); descriptor != descriptorSet.descriptors.end(); ++descriptor) {
+                        if (descriptor->type == DescriptorType::Sampler && descriptor->staticSampler != nullptr)
+                            co_yield VulkanDescriptorLayout { *descriptor->staticSampler, descriptor->location };
+                        else if (descriptor->type == DescriptorType::InputAttachment)
+                            co_yield VulkanDescriptorLayout { descriptor->type, descriptor->location, descriptor->inputAttachmentIndex };
+                        else [[likely]]
+                            co_yield VulkanDescriptorLayout { descriptor->type, descriptor->location, descriptor->elementSize, descriptor->elements, descriptor->unbounded };
+                    }
                 }(std::move(it->second)) | std::ranges::to<Array<VulkanDescriptorLayout>>();
 
                 co_yield VulkanDescriptorSetLayout::create(*device, descriptorLayouts, space, stage);

--- a/src/Backends/Vulkan/src/shader_program.cpp
+++ b/src/Backends/Vulkan/src/shader_program.cpp
@@ -61,13 +61,13 @@ private:
 private:
     struct DescriptorInfo {
     public:
-        UInt32 location;
-        UInt32 elementSize;
-        UInt32 elements;
-        UInt32 inputAttachmentIndex;
-        DescriptorType type;
-        SharedPtr<IVulkanSampler> staticSampler;
-        bool unbounded;
+        UInt32 location{};
+        UInt32 elementSize{};
+        UInt32 elements{};
+        UInt32 inputAttachmentIndex{};
+        DescriptorType type{};
+        SharedPtr<IVulkanSampler> staticSampler{};
+        bool unbounded{false};
 
         bool equals(const DescriptorInfo& rhs)
         {
@@ -341,7 +341,7 @@ public:
             for (size_t i{ 0 }; i < descriptorSet.descriptors.size(); ++i)
             {
                 // Get the current descriptor.
-                auto descriptor = descriptorSet.descriptors[i];
+                auto& descriptor = descriptorSet.descriptors[i];
 
                 // See if there's a hint about the binding.
                 auto hint = PipelineBindingHint::hint_type{ };

--- a/src/Backends/Vulkan/src/shader_program.cpp
+++ b/src/Backends/Vulkan/src/shader_program.cpp
@@ -196,7 +196,7 @@ public:
             throw InvalidArgumentException("modules", "A shader program that contains only a fragment/pixel shader is not valid.");
     }
 
-    SharedPtr<VulkanPipelineLayout> reflectPipelineLayout()
+    SharedPtr<VulkanPipelineLayout> reflectPipelineLayout(Enumerable<PipelineBindingHint> hints)
     {
         // First, filter the descriptor sets and push constant ranges.
         Dictionary<UInt32, DescriptorSetInfo> descriptorSetLayouts;
@@ -384,9 +384,9 @@ const Array<UniquePtr<const VulkanShaderModule>>& VulkanShaderProgram::modules()
     return m_impl->m_modules;
 }
 
-SharedPtr<VulkanPipelineLayout> VulkanShaderProgram::reflectPipelineLayout() const
+SharedPtr<VulkanPipelineLayout> VulkanShaderProgram::reflectPipelineLayout(Enumerable<PipelineBindingHint> hints) const
 {
-    return m_impl->reflectPipelineLayout();
+    return m_impl->reflectPipelineLayout(hints);
 }
 
 #if defined(LITEFX_BUILD_DEFINE_BUILDERS)

--- a/src/Rendering/include/litefx/rendering_api.hpp
+++ b/src/Rendering/include/litefx/rendering_api.hpp
@@ -2755,6 +2755,7 @@ namespace LiteFX::Rendering {
         /// equal, the operator returns `equal`.
         /// </returns>
         inline auto operator<=>(const DescriptorBindingPoint& other) const noexcept {
+            // NOLINTBEGIN(bugprone-branch-clone)
             if (this->Space < other.Space)
                 return std::strong_ordering::less;
             else if (this->Space > other.Space)
@@ -2765,6 +2766,7 @@ namespace LiteFX::Rendering {
                 return std::strong_ordering::greater;
             else // Space and Register are equal.
                 return std::strong_ordering::equal;
+            // NOLINTEND(bugprone-branch-clone)
         }
 
         /// <summary>
@@ -6436,7 +6438,7 @@ namespace LiteFX::Rendering {
         /// <param name="sampler">The sampler state used to initialize the static sampler with.</param>
         /// <returns>The initialized shader binding hint.</returns>
         static inline auto staticSampler(DescriptorBindingPoint at, SharedPtr<ISampler> sampler) noexcept -> PipelineBindingHint {
-            return { .Binding = at, .Hint = StaticSamplerHint { sampler } };
+            return { .Binding = at, .Hint = StaticSamplerHint { std::move(sampler) } };
         }
 
         /// <summary>
@@ -6447,7 +6449,7 @@ namespace LiteFX::Rendering {
         /// <param name="sampler">The sampler state used to initialize the static sampler with.</param>
         /// <returns>The initialized shader binding hint.</returns>
         static inline auto staticSampler(UInt32 space, UInt32 binding, SharedPtr<ISampler> sampler) noexcept -> PipelineBindingHint {
-            return { .Binding = {.Register = binding, .Space = space }, .Hint = StaticSamplerHint { sampler } };
+            return { .Binding = {.Register = binding, .Space = space }, .Hint = StaticSamplerHint { std::move(sampler) } };
         }
     };
 

--- a/src/Rendering/include/litefx/rendering_api.hpp
+++ b/src/Rendering/include/litefx/rendering_api.hpp
@@ -2743,6 +2743,38 @@ namespace LiteFX::Rendering {
         /// Stores the descriptor space (or set index) of the binding point.
         /// </summary>
         UInt32 Space { 0 };
+
+    public:
+        /// <summary>
+        /// Implements three-way comparison for descriptor binding points.
+        /// </summary>
+        /// <param name="other">The other binding point to compare against.</param>
+        /// <returns>
+        /// `less`, if the `Space` property of the instance is lower than the `Space` property of <paramref name="other" />, and `greater` if the opposite is true 
+        /// and they are not equal. If the `Space` properties are equal, the `Register` properties are compared accordingly. If both, `Space` and `Register` are 
+        /// equal, the operator returns `equal`.
+        /// </returns>
+        inline auto operator<=>(const DescriptorBindingPoint& other) const noexcept {
+            if (this->Space < other.Space)
+                return std::strong_ordering::less;
+            else if (this->Space > other.Space)
+                return std::strong_ordering::greater;
+            else if (this->Register < other.Register)
+                return std::strong_ordering::less;
+            else if(this->Register > other.Register)
+                return std::strong_ordering::greater;
+            else // Space and Register are equal.
+                return std::strong_ordering::equal;
+        }
+
+        /// <summary>
+        /// Implements equality comparison for descriptor binding points.
+        /// </summary>
+        /// <param name="other">The other binding point to compare against.</param>
+        /// <returns>`true`, if the `Space` and `Register` values for both binding points are equal, otherwise `false`.</returns>
+        inline bool operator==(const DescriptorBindingPoint& other) const noexcept {
+            return other.Space == this->Space && other.Register == this->Register;
+        }
     };
 
     /// <summary>
@@ -6297,6 +6329,129 @@ namespace LiteFX::Rendering {
     };
 
     /// <summary>
+    /// A hint used during shader reflection to control the pipeline layout.
+    /// </summary>
+    /// <remarks>
+    /// Hints are generally used to express the desired layout to backends that cannot infer them implicitly. They do not imply an enforcement of the layout otherwise. For example, 
+    /// hinting a push constants range when performing shader reflection in Vulkan, where push constants are supported by the reflection library, will not affect the ultimate decision on 
+    /// whether the layout will contain a push constants range. In this case, shader reflection will always emit a push constants range.
+    /// 
+    /// Backends do emit diagnostic log messages, if a hint is given that it will ignore. Hints for descriptors that are not bound will silently be ignored.
+    /// </remarks>
+    /// <seealso cref="IShaderProgram::reflectPipelineLayout" />
+    struct LITEFX_RENDERING_API PipelineBindingHint {
+
+        /// <summary>
+        /// Defines a hint that is used to mark an unbounded descriptor array.
+        /// </summary>
+        struct UnboundedArrayHint {
+            /// <summary>
+            /// If the binding point binds an array, this property can be used to turn it into an unbounded array and set the maximum number of descriptors that can be bound to the array. 
+            /// This is especially useful to comply with Vulkan device limits.
+            /// </summary>
+            UInt32 MaxDescriptors{ 0 };
+        };
+
+        /// <summary>
+        /// Defines a hint that is used to mark a push constants range.
+        /// </summary>
+        struct PushConstantsHint {
+            /// <summary>
+            /// If the binding point binds a constant or uniform buffer, setting this property to `true` will configure the binding point it as part of the root constants for the pipeline 
+            /// layout. If this property is set to `false`, the hint will have no effect.
+            /// </summary>
+            bool AsPushConstants{ false };
+        };
+
+        /// <summary>
+        /// Defines a hint that is used to bind a static sampler state to a sampler descriptor.
+        /// </summary>
+        struct StaticSamplerHint {
+            /// <summary>
+            /// If the binding point binds a sampler, setting this property will bind a static or constant sampler, if supported by the backend.
+            /// </summary>
+            SharedPtr<ISampler> StaticSampler{ nullptr };
+        };
+
+        /// <summary>
+        /// Defines the type of the pipeline binding hint.
+        /// </summary>
+        using hint_type = Variant<std::monostate, UnboundedArrayHint, PushConstantsHint, StaticSamplerHint>;
+
+        /// <summary>
+        /// The binding point the hint applies to.
+        /// </summary>
+        DescriptorBindingPoint Binding{ };
+
+        /// <summary>
+        /// Stores the underlying hint.
+        /// </summary>
+        hint_type Hint = std::monostate{};
+
+    public:
+        /// <summary>
+        /// Initializes a hint that binds an unbounded runtime array.
+        /// </summary>
+        /// <param name="at">The binding point the hint applies to.</param>
+        /// <param name="maxDescriptors">The maximum number of descriptors that can be bound to the runtime array at the binding point.</param>
+        /// <returns>The initialized shader binding hint.</returns>
+        static inline auto runtimeArray(DescriptorBindingPoint at, UInt32 maxDescriptors) noexcept -> PipelineBindingHint {
+            return { .Binding = at, .Hint = UnboundedArrayHint { maxDescriptors } };
+        }
+
+        /// <summary>
+        /// Initializes a hint that binds an unbounded runtime array.
+        /// </summary>
+        /// <param name="space">The descriptor space of the binding point.</param>
+        /// <param name="binding">The register of the descriptor binding point.</param>
+        /// <param name="maxDescriptors">The maximum number of descriptors that can be bound to the runtime array at the binding point.</param>
+        /// <returns>The initialized shader binding hint.</returns>
+        static inline auto runtimeArray(UInt32 space, UInt32 binding, UInt32 maxDescriptors) noexcept -> PipelineBindingHint {
+            return { .Binding = {.Register = binding, .Space = space }, .Hint = UnboundedArrayHint { maxDescriptors } };
+        }
+
+        /// <summary>
+        /// Initializes a hint that binds push constants.
+        /// </summary>
+        /// <param name="at">The binding point the hint applies to.</param>
+        /// <returns>The initialized shader binding hint.</returns>
+        static inline auto pushConstants(DescriptorBindingPoint at) noexcept -> PipelineBindingHint {
+            return { .Binding = at, .Hint = PushConstantsHint { true } };
+        }
+
+        /// <summary>
+        /// Initializes a hint that binds push constants.
+        /// </summary>
+        /// <param name="space">The descriptor space of the binding point.</param>
+        /// <param name="binding">The register of the descriptor binding point.</param>
+        /// <returns>The initialized shader binding hint.</returns>
+        static inline auto pushConstants(UInt32 space, UInt32 binding) noexcept -> PipelineBindingHint {
+            return { .Binding = {.Register = binding, .Space = space }, .Hint = PushConstantsHint { true } };
+        }
+
+        /// <summary>
+        /// Initializes a hint that binds a static sampler, if supported by the backend.
+        /// </summary>
+        /// <param name="at">The binding point the hint applies to.</param>
+        /// <param name="sampler">The sampler state used to initialize the static sampler with.</param>
+        /// <returns>The initialized shader binding hint.</returns>
+        static inline auto staticSampler(DescriptorBindingPoint at, SharedPtr<ISampler> sampler) noexcept -> PipelineBindingHint {
+            return { .Binding = at, .Hint = StaticSamplerHint { sampler } };
+        }
+
+        /// <summary>
+        /// Initializes a hint that binds a static sampler, if supported by the backend.
+        /// </summary>
+        /// <param name="space">The descriptor space of the binding point.</param>
+        /// <param name="binding">The register of the descriptor binding point.</param>
+        /// <param name="sampler">The sampler state used to initialize the static sampler with.</param>
+        /// <returns>The initialized shader binding hint.</returns>
+        static inline auto staticSampler(UInt32 space, UInt32 binding, SharedPtr<ISampler> sampler) noexcept -> PipelineBindingHint {
+            return { .Binding = {.Register = binding, .Space = space }, .Hint = StaticSamplerHint { sampler } };
+        }
+    };
+
+    /// <summary>
     /// The interface for a shader program.
     /// </summary>
     /// <remarks>
@@ -6412,10 +6567,12 @@ namespace LiteFX::Rendering {
         /// </item>
         /// </list>
         /// </remarks>
+        /// <param name="hints">A series of individual binding hints to use to deduce explicit binding information.</param>
         /// <returns>The pipeline layout extracted from shader reflection.</returns>
+        /// <seealso cref="PipelineBindingHint" />
         /// <seealso href="https://github.com/crud89/LiteFX/wiki/Shader-Development" />
-        inline SharedPtr<IPipelineLayout> reflectPipelineLayout() const {
-            return this->parsePipelineLayout();
+        inline SharedPtr<IPipelineLayout> reflectPipelineLayout(Enumerable<PipelineBindingHint> hints = {}) const {
+            return this->parsePipelineLayout(hints);
         };
 
         /// <summary>
@@ -6428,7 +6585,7 @@ namespace LiteFX::Rendering {
 
     private:
         virtual Enumerable<const IShaderModule&> getModules() const = 0;
-        virtual SharedPtr<IPipelineLayout> parsePipelineLayout() const = 0;
+        virtual SharedPtr<IPipelineLayout> parsePipelineLayout(Enumerable<PipelineBindingHint> hints) const = 0;
     };
 
     /// <summary>

--- a/src/Samples/BasicRendering/src/sample.cpp
+++ b/src/Samples/BasicRendering/src/sample.cpp
@@ -233,9 +233,6 @@ void SampleApp::onInit()
 #endif // LITEFX_BUILD_VULKAN_BACKEND
 
 #ifdef LITEFX_BUILD_DIRECTX_12_BACKEND
-    // We do not need to provide a root signature for shader reflection (refer to the project wiki for more information: https://github.com/crud89/LiteFX/wiki/Shader-Development).
-    DirectX12ShaderProgram::suppressMissingRootSignatureWarning();
-
     // Register the DirectX 12 backend de-/initializer.
     this->onBackendStart<DirectX12Backend>(startCallback);
     this->onBackendStop<DirectX12Backend>(stopCallback);

--- a/src/Samples/Bindless/src/sample.cpp
+++ b/src/Samples/Bindless/src/sample.cpp
@@ -281,9 +281,6 @@ void SampleApp::onInit()
 #endif // LITEFX_BUILD_VULKAN_BACKEND
 
 #ifdef LITEFX_BUILD_DIRECTX_12_BACKEND
-    // We do not need to provide a root signature for shader reflection (refer to the project wiki for more information: https://github.com/crud89/LiteFX/wiki/Shader-Development).
-    DirectX12ShaderProgram::suppressMissingRootSignatureWarning();
-
     // Register the DirectX 12 backend de-/initializer.
     this->onBackendStart<DirectX12Backend>(startCallback);
     this->onBackendStop<DirectX12Backend>(stopCallback);

--- a/src/Samples/Bindless/src/sample.cpp
+++ b/src/Samples/Bindless/src/sample.cpp
@@ -125,7 +125,7 @@ void initRenderGraph(TRenderBackend* backend, SharedPtr<IInputAssembler>& inputA
             .cullOrder(CullOrder::ClockWise)
             .lineWidth(1.f)
             .depthState(DepthStencilState::DepthState{ .Operation = CompareOperation::LessEqual }))
-        .layout(shaderProgram->reflectPipelineLayout())
+        .layout(shaderProgram->reflectPipelineLayout(std::array { PipelineBindingHint::runtimeArray(DescriptorSets::InstanceData, 0u, NUM_INSTANCES) }))
         .shaderProgram(shaderProgram);
 
     // Add the resources to the device state.

--- a/src/Samples/Compute/src/sample.cpp
+++ b/src/Samples/Compute/src/sample.cpp
@@ -255,9 +255,6 @@ void SampleApp::onInit()
 #endif // LITEFX_BUILD_VULKAN_BACKEND
 
 #ifdef LITEFX_BUILD_DIRECTX_12_BACKEND
-    // We do not need to provide a root signature for shader reflection (refer to the project wiki for more information: https://github.com/crud89/LiteFX/wiki/Shader-Development).
-    DirectX12ShaderProgram::suppressMissingRootSignatureWarning();
-
     // Register the DirectX 12 backend de-/initializer.
     this->onBackendStart<DirectX12Backend>(startCallback);
     this->onBackendStop<DirectX12Backend>(stopCallback);

--- a/src/Samples/Indirect/src/sample.cpp
+++ b/src/Samples/Indirect/src/sample.cpp
@@ -367,9 +367,6 @@ void SampleApp::onInit()
 #endif // LITEFX_BUILD_VULKAN_BACKEND
 
 #ifdef LITEFX_BUILD_DIRECTX_12_BACKEND
-    // We do not need to provide a root signature for shader reflection (refer to the project wiki for more information: https://github.com/crud89/LiteFX/wiki/Shader-Development).
-    DirectX12ShaderProgram::suppressMissingRootSignatureWarning();
-
     // Register the DirectX 12 backend de-/initializer.
     this->onBackendStart<DirectX12Backend>(startCallback);
     this->onBackendStop<DirectX12Backend>(stopCallback);

--- a/src/Samples/MeshShader/src/sample.cpp
+++ b/src/Samples/MeshShader/src/sample.cpp
@@ -207,9 +207,6 @@ void SampleApp::onInit()
 #endif // LITEFX_BUILD_VULKAN_BACKEND
 
 #ifdef LITEFX_BUILD_DIRECTX_12_BACKEND
-    // We do not need to provide a root signature for shader reflection (refer to the project wiki for more information: https://github.com/crud89/LiteFX/wiki/Shader-Development).
-    DirectX12ShaderProgram::suppressMissingRootSignatureWarning();
-
     // Register the DirectX 12 backend de-/initializer.
     this->onBackendStart<DirectX12Backend>(startCallback);
     this->onBackendStop<DirectX12Backend>(stopCallback);

--- a/src/Samples/Multisampling/src/sample.cpp
+++ b/src/Samples/Multisampling/src/sample.cpp
@@ -235,9 +235,6 @@ void SampleApp::onInit()
 #endif // LITEFX_BUILD_VULKAN_BACKEND
 
 #ifdef LITEFX_BUILD_DIRECTX_12_BACKEND
-    // We do not need to provide a root signature for shader reflection (refer to the project wiki for more information: https://github.com/crud89/LiteFX/wiki/Shader-Development).
-    DirectX12ShaderProgram::suppressMissingRootSignatureWarning();
-
     // Register the DirectX 12 backend de-/initializer.
     this->onBackendStart<DirectX12Backend>(startCallback);
     this->onBackendStop<DirectX12Backend>(stopCallback);

--- a/src/Samples/Multithreading/src/sample.cpp
+++ b/src/Samples/Multithreading/src/sample.cpp
@@ -248,9 +248,6 @@ void SampleApp::onInit()
 #endif // LITEFX_BUILD_VULKAN_BACKEND
 
 #ifdef LITEFX_BUILD_DIRECTX_12_BACKEND
-    // We do not need to provide a root signature for shader reflection (refer to the project wiki for more information: https://github.com/crud89/LiteFX/wiki/Shader-Development).
-    DirectX12ShaderProgram::suppressMissingRootSignatureWarning();
-
     // Register the DirectX 12 backend de-/initializer.
     this->onBackendStart<DirectX12Backend>(startCallback);
     this->onBackendStop<DirectX12Backend>(stopCallback);

--- a/src/Samples/PushConstants/shaders/push_constants_vs.hlsl
+++ b/src/Samples/PushConstants/shaders/push_constants_vs.hlsl
@@ -1,11 +1,5 @@
 #pragma pack_matrix(row_major)
 
-// For DXIL we need to define a root signature, in order for shader reflection to properly pick up the push constants.
-#define ROOT_SIGNATURE \
-    "RootFlags(ALLOW_INPUT_ASSEMBLER_INPUT_LAYOUT), " \
-    "CBV(b0, space = 0, flags = DATA_STATIC_WHILE_SET_AT_EXECUTE), " \
-    "RootConstants(num32BitConstants = 20, b0, space = 1, visibility = SHADER_VISIBILITY_VERTEX)"
-
 struct VertexData 
 {
     float4 Position : SV_POSITION;
@@ -37,7 +31,6 @@ ConstantBuffer<CameraData>    camera    : register(b0, space0);
 ConstantBuffer<TransformData> transform : register(b0, space1);
 #endif
 
-[RootSignature(ROOT_SIGNATURE)]
 VertexData main(in VertexInput input)
 {
     VertexData vertex;

--- a/src/Samples/PushConstants/src/sample.cpp
+++ b/src/Samples/PushConstants/src/sample.cpp
@@ -122,7 +122,7 @@ void initRenderGraph(TRenderBackend* backend, SharedPtr<IInputAssembler>& inputA
             .cullOrder(CullOrder::ClockWise)
             .lineWidth(1.f)
             .depthState(DepthStencilState::DepthState{ .Operation = CompareOperation::LessEqual }))
-        .layout(shaderProgram->reflectPipelineLayout())
+        .layout(shaderProgram->reflectPipelineLayout(std::array { PipelineBindingHint::pushConstants(1u, 0u) }))
         .shaderProgram(shaderProgram);
 
     // Add the resources to the device state.

--- a/src/Samples/RayQueries/src/sample.cpp
+++ b/src/Samples/RayQueries/src/sample.cpp
@@ -418,9 +418,6 @@ void SampleApp::onInit()
 #endif // LITEFX_BUILD_VULKAN_BACKEND
 
 #ifdef LITEFX_BUILD_DIRECTX_12_BACKEND
-    // We do not need to provide a root signature for shader reflection (refer to the project wiki for more information: https://github.com/crud89/LiteFX/wiki/Shader-Development).
-    DirectX12ShaderProgram::suppressMissingRootSignatureWarning();
-
     // Register the DirectX 12 backend de-/initializer.
     this->onBackendStart<DirectX12Backend>(startCallback);
     this->onBackendStop<DirectX12Backend>(stopCallback);

--- a/src/Samples/RayTracing/src/sample.cpp
+++ b/src/Samples/RayTracing/src/sample.cpp
@@ -423,9 +423,6 @@ void SampleApp::onInit()
 #endif // LITEFX_BUILD_VULKAN_BACKEND
 
 #ifdef LITEFX_BUILD_DIRECTX_12_BACKEND
-    // We do not need to provide a root signature for shader reflection (refer to the project wiki for more information: https://github.com/crud89/LiteFX/wiki/Shader-Development).
-    DirectX12ShaderProgram::suppressMissingRootSignatureWarning();
-
     // Register the DirectX 12 backend de-/initializer.
     this->onBackendStart<DirectX12Backend>(startCallback);
     this->onBackendStop<DirectX12Backend>(stopCallback);

--- a/src/Samples/Textures/src/sample.cpp
+++ b/src/Samples/Textures/src/sample.cpp
@@ -307,9 +307,6 @@ void SampleApp::onInit()
 #endif // LITEFX_BUILD_VULKAN_BACKEND
 
 #ifdef LITEFX_BUILD_DIRECTX_12_BACKEND
-    // We do not need to provide a root signature for shader reflection (refer to the project wiki for more information: https://github.com/crud89/LiteFX/wiki/Shader-Development).
-    DirectX12ShaderProgram::suppressMissingRootSignatureWarning();
-
     // Register the DirectX 12 backend de-/initializer.
     this->onBackendStart<DirectX12Backend>(startCallback);
     this->onBackendStop<DirectX12Backend>(stopCallback);

--- a/src/Samples/UniformArrays/src/sample.cpp
+++ b/src/Samples/UniformArrays/src/sample.cpp
@@ -289,9 +289,6 @@ void SampleApp::onInit()
 #endif // LITEFX_BUILD_VULKAN_BACKEND
 
 #ifdef LITEFX_BUILD_DIRECTX_12_BACKEND
-    // We do not need to provide a root signature for shader reflection (refer to the project wiki for more information: https://github.com/crud89/LiteFX/wiki/Shader-Development).
-    DirectX12ShaderProgram::suppressMissingRootSignatureWarning();
-
     // Register the DirectX 12 backend de-/initializer.
     this->onBackendStart<DirectX12Backend>(startCallback);
     this->onBackendStop<DirectX12Backend>(stopCallback);

--- a/src/Tests/Backends.D3D12/setup_push_constants.cpp
+++ b/src/Tests/Backends.D3D12/setup_push_constants.cpp
@@ -62,7 +62,7 @@ void TestApp::onInit()
         UniquePtr<DirectX12RenderPipeline> renderPipeline = _device->buildRenderPipeline(*renderPass, "Geometry")
             .inputAssembler(inputAssembler)
             .rasterizer(rasterizer)
-            .layout(shaderProgram->reflectPipelineLayout())
+            .layout(shaderProgram->reflectPipelineLayout(std::array { PipelineBindingHint::pushConstants(1u, 0u) }))
             .shaderProgram(shaderProgram);
 
         // Validate render pipeline.

--- a/src/Tests/Backends.D3D12/shaders/test_pc_vs.hlsl
+++ b/src/Tests/Backends.D3D12/shaders/test_pc_vs.hlsl
@@ -1,11 +1,5 @@
 #pragma pack_matrix(row_major)
 
-// For DXIL we need to define a root signature, in order for shader reflection to properly pick up the push constants.
-#define ROOT_SIGNATURE \
-    "RootFlags(ALLOW_INPUT_ASSEMBLER_INPUT_LAYOUT), " \
-    "CBV(b0, space = 0, flags = DATA_STATIC_WHILE_SET_AT_EXECUTE), " \
-    "RootConstants(num32BitConstants = 16, b0, space = 1, visibility = SHADER_VISIBILITY_VERTEX)"
-
 struct VertexData
 {
     float4 Position : SV_POSITION;
@@ -34,7 +28,6 @@ struct TransformData
 ConstantBuffer<CameraData> camera : register(b0, space0);
 ConstantBuffer<TransformData> transform : register(b0, space1);
 
-[RootSignature(ROOT_SIGNATURE)]
 VertexData main(in VertexInput input)
 {
     VertexData vertex;

--- a/src/Tests/Backends.Vk/setup_raytracing_pipeline.cpp
+++ b/src/Tests/Backends.Vk/setup_raytracing_pipeline.cpp
@@ -63,7 +63,7 @@ void TestApp::onInit()
             .maxBounces(16)                       // Important: If changed, the closest hit shader also needs to be updated!
             .maxPayloadSize(sizeof(Float) * 5)    // See HitInfo in raytracing_common.hlsli
             .maxAttributeSize(sizeof(Float) * 2)  // See Attributes in raytracing_common.hlsli
-            .layout(shaderProgram->reflectPipelineLayout());
+            .layout(shaderProgram->reflectPipelineLayout(std::array { PipelineBindingHint::runtimeArray(2u, 0u, 100u) }));
 
         // Validate the ray tracing pipeline.
         if (rayTracingPipeline->maxAttributeSize() != 8)


### PR DESCRIPTION
**Describe the pull request**

This PR introduces a new `PipelineBindingHint` structure that can be passed to shader reflection in order to control aspects of the resulting pipeline layout that can not be implicitly inferred from the shader metadata. Currently this includes:

- Turning a descriptor set into a push constant range. This is especially helpful for the D3D12 backend, as it removes the need to define explicit root signatures in the shaders.
- Providing a static/immutable sampler state to sampler bindings. This works for both backends. In D3D12 this removes the need to define a root signature in the shader. In Vulkan, this was previously impossible without explicitly defining the pipeline layout.
- Providing a upper limit for the descriptor count of unbounded arrays. This is especially helpful for the Vulkan backend, where one would frequently run into different validation errors, as the descriptor count of an unbounded array still counts towards the device limits, even if the actual allocated memory is managed independently from this after #163. Setting the descriptor count to a low number instead does not work either, as the driver reserves address space based on the descriptor count. With this addition, clients gain better control over the individual array definitions without having to explicitly define the whole pipeline layout.

Additionally, hints serve as a rudimentary validation logic. They are used to communicate "intend", so if the layout deviates from this expressed intend, diagnostic log messages (mostly warnings) will be issued.

**Related issues**

- Towards #164 
- Closes #167 