### PR TITLE
Allow mixed descriptor sets containing samplers and resources.

### DIFF
--- a/docs/release-logs/0.5.1.md
+++ b/docs/release-logs/0.5.1.md
@@ -4,6 +4,7 @@
   - Common descriptor allocation and binding architecture. (See [PR #165](https://github.com/crud89/LiteFX/pull/165))
   - Unbounded arrays are no longer implicitly defined by setting the array element size to maximum. This allows to define multiple descriptor sets containing unbounded descriptor arrays without exceeding device limits in Vulkan. (See [PR #166](https://github.com/crud89/LiteFX/pull/166))
   - Binding hints can now be passed to shader reflection to have better control over the pipeline layout without falling back to explicit definitions. (See [PR #168](https://github.com/crud89/LiteFX/pull/168))
+  - Descriptor sets can now mix samplers and other resources in a single set. (See [PR #170](https://github.com/crud89/LiteFX/pull/170))
 
 **🌋 Vulkan:**
 
@@ -20,3 +21,4 @@
 
 - Fix issue where re-configuring the project would fail due to `CMAKE_CXX_COMPILER` or `CMAKE_C_COMPILER` cache variables are being reset. (see [PR #157](https://github.com/crud89/LiteFX/pull/157))
 - Fix deprecation warning for some literal operators. (See [PR #161](https://github.com/crud89/LiteFX/pull/161))
+- Fix debug layer warning about invalid stencil target access when a depth-only render target was used. (See [PR #170](https://github.com/crud89/LiteFX/pull/170))

--- a/src/Backends/DirectX12/src/descriptor_set.cpp
+++ b/src/Backends/DirectX12/src/descriptor_set.cpp
@@ -22,10 +22,10 @@ public:
     DirectX12DescriptorSetImpl(const DirectX12DescriptorSetLayout& layout, ComPtr<ID3D12DescriptorHeap>&& resourceHeap, ComPtr<ID3D12DescriptorHeap>&& samplerHeap) :
         m_resourceHeap{ .Heap = std::move(resourceHeap) }, m_samplerHeap{ .Heap = std::move(samplerHeap) }, m_layout(layout.shared_from_this())
     {
-        if (m_layout->bindsResources() && m_resourceHeap.Heap == nullptr)
+        if (m_layout->bindsResources() && m_resourceHeap.Heap == nullptr) [[unlikely]]
             throw ArgumentNotInitializedException("resourceHeap", "The local resource heap must be initialized, if the descriptor set binds resources.");
 
-        if (m_layout->bindsSamplers() && m_samplerHeap.Heap == nullptr)
+        if (m_layout->bindsSamplers() && m_samplerHeap.Heap == nullptr) [[unlikely]]
             throw ArgumentNotInitializedException("samplerHeap", "The local sampler heap must be initialized, if the descriptor set binds samplers.");
     }
 

--- a/src/Backends/DirectX12/src/descriptor_set.cpp
+++ b/src/Backends/DirectX12/src/descriptor_set.cpp
@@ -11,16 +11,22 @@ public:
     friend class DirectX12DescriptorSet;
 
 private:
-    ComPtr<ID3D12DescriptorHeap> m_localHeap;
-    UInt32 m_heapOffset{ 0 }, m_heapSize{ 0 };
+    struct LocalHeap {
+        ComPtr<ID3D12DescriptorHeap> Heap{};
+        UInt32 Offset{ 0 }, Size{ 0 };
+    } m_resourceHeap{}, m_samplerHeap{};
+
     SharedPtr<const DirectX12DescriptorSetLayout> m_layout;
 
 public:
-    DirectX12DescriptorSetImpl(const DirectX12DescriptorSetLayout& layout, ComPtr<ID3D12DescriptorHeap>&& localHeap) :
-        m_localHeap(std::move(localHeap)), m_layout(layout.shared_from_this())
+    DirectX12DescriptorSetImpl(const DirectX12DescriptorSetLayout& layout, ComPtr<ID3D12DescriptorHeap>&& resourceHeap, ComPtr<ID3D12DescriptorHeap>&& samplerHeap) :
+        m_resourceHeap{ .Heap = std::move(resourceHeap) }, m_samplerHeap{ .Heap = std::move(samplerHeap) }, m_layout(layout.shared_from_this())
     {
-        if (m_localHeap == nullptr)
-            throw ArgumentNotInitializedException("localHeap", "The local descriptor heap handle must be initialized.");
+        if (m_layout->bindsResources() && m_resourceHeap.Heap == nullptr)
+            throw ArgumentNotInitializedException("resourceHeap", "The local resource heap must be initialized, if the descriptor set binds resources.");
+
+        if (m_layout->bindsSamplers() && m_samplerHeap.Heap == nullptr)
+            throw ArgumentNotInitializedException("samplerHeap", "The local sampler heap must be initialized, if the descriptor set binds samplers.");
     }
 
 public:
@@ -56,10 +62,14 @@ public:
 // Shared interface.
 // ------------------------------------------------------------------------------------------------
 
-DirectX12DescriptorSet::DirectX12DescriptorSet(const DirectX12DescriptorSetLayout& layout, ComPtr<ID3D12DescriptorHeap>&& localHeap) :
-    m_impl(layout, std::move(localHeap))
+DirectX12DescriptorSet::DirectX12DescriptorSet(const DirectX12DescriptorSetLayout& layout, ComPtr<ID3D12DescriptorHeap>&& resourceHeap, ComPtr<ID3D12DescriptorHeap>&& samplerHeap) :
+    m_impl(layout, std::move(resourceHeap), std::move(samplerHeap))
 {
-    layout.device()->allocateGlobalDescriptors(*this, m_impl->m_heapOffset, m_impl->m_heapSize);
+    if (layout.bindsResources())
+        layout.device()->allocateGlobalDescriptors(*this, DescriptorHeapType::Resource, m_impl->m_resourceHeap.Offset, m_impl->m_resourceHeap.Size);
+
+    if (layout.bindsSamplers())
+        layout.device()->allocateGlobalDescriptors(*this, DescriptorHeapType::Sampler, m_impl->m_samplerHeap.Offset, m_impl->m_samplerHeap.Size);
 }
 
 DirectX12DescriptorSet::~DirectX12DescriptorSet() noexcept
@@ -73,14 +83,30 @@ const DirectX12DescriptorSetLayout& DirectX12DescriptorSet::layout() const noexc
     return *m_impl->m_layout;
 }
 
-UInt32 DirectX12DescriptorSet::globalHeapOffset() const noexcept
+UInt32 DirectX12DescriptorSet::globalHeapOffset(DescriptorHeapType heapType) const noexcept
 {
-    return m_impl->m_heapOffset;
+    switch (heapType)
+    {
+    case DescriptorHeapType::Resource:
+        return m_impl->m_resourceHeap.Offset;
+    case DescriptorHeapType::Sampler:
+        return m_impl->m_samplerHeap.Offset;
+    default:
+        return std::numeric_limits<UInt32>::max();
+    }
 }
 
-UInt32 DirectX12DescriptorSet::globalHeapAddressRange() const noexcept
+UInt32 DirectX12DescriptorSet::globalHeapAddressRange(DescriptorHeapType heapType) const noexcept
 {
-    return m_impl->m_heapSize;
+    switch (heapType)
+    {
+    case DescriptorHeapType::Resource:
+        return m_impl->m_resourceHeap.Size;
+    case DescriptorHeapType::Sampler:
+        return m_impl->m_samplerHeap.Size;
+    default:
+        return 0u;
+    }
 }
 
 void DirectX12DescriptorSet::update(UInt32 binding, const IDirectX12Buffer& buffer, UInt32 bufferElement, UInt32 elements, UInt32 firstDescriptor) const
@@ -104,7 +130,7 @@ void DirectX12DescriptorSet::update(UInt32 binding, const IDirectX12Buffer& buff
     auto device = m_impl->m_layout->device();
     auto offset = m_impl->m_layout->getDescriptorOffset(binding, firstDescriptor);
     auto descriptorSize = device->handle()->GetDescriptorHandleIncrementSize(D3D12_DESCRIPTOR_HEAP_TYPE_CBV_SRV_UAV);
-    CD3DX12_CPU_DESCRIPTOR_HANDLE descriptorHandle(m_impl->m_localHeap->GetCPUDescriptorHandleForHeapStart(), static_cast<INT>(offset), descriptorSize);
+    CD3DX12_CPU_DESCRIPTOR_HANDLE descriptorHandle(m_impl->m_resourceHeap.Heap->GetCPUDescriptorHandleForHeapStart(), static_cast<INT>(offset), descriptorSize);
 
     switch (descriptorLayout.descriptorType())
     {
@@ -254,7 +280,7 @@ void DirectX12DescriptorSet::update(UInt32 binding, const IDirectX12Image& textu
 
     auto offset = m_impl->m_layout->getDescriptorOffset(binding, descriptor);
     auto device = m_impl->m_layout->device();
-    CD3DX12_CPU_DESCRIPTOR_HANDLE descriptorHandle(m_impl->m_localHeap->GetCPUDescriptorHandleForHeapStart(), static_cast<INT>(offset), device->handle()->GetDescriptorHandleIncrementSize(D3D12_DESCRIPTOR_HEAP_TYPE_CBV_SRV_UAV));
+    CD3DX12_CPU_DESCRIPTOR_HANDLE descriptorHandle(m_impl->m_resourceHeap.Heap->GetCPUDescriptorHandleForHeapStart(), static_cast<INT>(offset), device->handle()->GetDescriptorHandleIncrementSize(D3D12_DESCRIPTOR_HEAP_TYPE_CBV_SRV_UAV));
 
     // Get the number of levels and layers.
     const UInt32 numLevels = levels == 0 ? texture.levels() - firstLevel : levels;
@@ -432,6 +458,9 @@ void DirectX12DescriptorSet::update(UInt32 binding, const IDirectX12Sampler& sam
         return;
     }
 
+    if (match->descriptorType() != DescriptorType::Sampler) [[unlikely]]
+        throw InvalidArgumentException("binding", "Invalid descriptor type. The binding {0} does not point to an sampler descriptor.", binding);
+
     auto offset = m_impl->m_layout->getDescriptorOffset(binding, descriptor);
 
     D3D12_SAMPLER_DESC samplerInfo = {
@@ -448,7 +477,7 @@ void DirectX12DescriptorSet::update(UInt32 binding, const IDirectX12Sampler& sam
     };
 
     auto device = m_impl->m_layout->device();
-    CD3DX12_CPU_DESCRIPTOR_HANDLE descriptorHandle(m_impl->m_localHeap->GetCPUDescriptorHandleForHeapStart(), static_cast<INT>(offset), device->handle()->GetDescriptorHandleIncrementSize(D3D12_DESCRIPTOR_HEAP_TYPE_SAMPLER));
+    CD3DX12_CPU_DESCRIPTOR_HANDLE descriptorHandle(m_impl->m_samplerHeap.Heap->GetCPUDescriptorHandleForHeapStart(), static_cast<INT>(offset), device->handle()->GetDescriptorHandleIncrementSize(D3D12_DESCRIPTOR_HEAP_TYPE_SAMPLER));
     device->handle()->CreateSampler(&samplerInfo, descriptorHandle);
     device->updateGlobalDescriptors(*this, binding, descriptor, 1u);
 }
@@ -478,7 +507,7 @@ void DirectX12DescriptorSet::update(UInt32 binding, const IDirectX12Acceleration
     auto offset = m_impl->m_layout->getDescriptorOffset(binding, descriptor);
     auto device = m_impl->m_layout->device();
     auto descriptorSize = device->handle()->GetDescriptorHandleIncrementSize(D3D12_DESCRIPTOR_HEAP_TYPE_CBV_SRV_UAV);
-    CD3DX12_CPU_DESCRIPTOR_HANDLE descriptorHandle(m_impl->m_localHeap->GetCPUDescriptorHandleForHeapStart(), static_cast<INT>(offset), descriptorSize);
+    CD3DX12_CPU_DESCRIPTOR_HANDLE descriptorHandle(m_impl->m_resourceHeap.Heap->GetCPUDescriptorHandleForHeapStart(), static_cast<INT>(offset), descriptorSize);
 
     D3D12_SHADER_RESOURCE_VIEW_DESC bufferView = {
         .Format = DXGI_FORMAT_UNKNOWN,
@@ -493,7 +522,15 @@ void DirectX12DescriptorSet::update(UInt32 binding, const IDirectX12Acceleration
     m_impl->m_layout->device()->updateGlobalDescriptors(*this, binding, descriptor, 1u);
 }
 
-const ComPtr<ID3D12DescriptorHeap>& DirectX12DescriptorSet::localHeap() const noexcept
+const ComPtr<ID3D12DescriptorHeap> DirectX12DescriptorSet::localHeap(DescriptorHeapType heapType) const noexcept
 {
-    return m_impl->m_localHeap;
+    switch (heapType)
+    {
+    case DescriptorHeapType::Resource:
+        return m_impl->m_resourceHeap.Heap;
+    case DescriptorHeapType::Sampler:
+        return m_impl->m_samplerHeap.Heap;
+    default:
+        return nullptr;
+    }
 }

--- a/src/Backends/DirectX12/src/device.cpp
+++ b/src/Backends/DirectX12/src/device.cpp
@@ -342,6 +342,7 @@ void DirectX12Device::allocateGlobalDescriptors(const DirectX12DescriptorSet& de
 
 		break;
 	default:
+		LITEFX_WARNING(DIRECTX12_LOG, "The descriptor heap type must be one of the following: {{ `Resource`, `Sampler` }}, but it was: `{0}`.", heapType);
 		return;
 	}
 }

--- a/src/Backends/DirectX12/src/pipeline_layout.cpp
+++ b/src/Backends/DirectX12/src/pipeline_layout.cpp
@@ -20,7 +20,7 @@ private:
     /// <summary>
     /// The flags for a root parameter entry.
     /// </summary>
-    enum class RootParameterFlags : UInt32
+    enum class RootParameterFlags : UInt32 // NOLINT(performance-enum-size)
     {
         /// <summary>
         /// Indicates that the root parameter is a root/push constant. Must not be combined with <see cref="IsResourceTable" /> or <see cref="IsSamplerTable" />.

--- a/src/Backends/DirectX12/src/pipeline_layout.cpp
+++ b/src/Backends/DirectX12/src/pipeline_layout.cpp
@@ -36,6 +36,11 @@ private:
         /// Indicates that the root parameter is a sampler table. Must not be combined with <see cref="IsRootConstant" /> or <see cref="IsResourceTable" />.
         /// </summary>
         IsSamplerTable = 0x00000020,
+
+        // TODO: We could use those to support directly binding descriptors to the root signature instead of using tables.
+        //CBV = 0x00000100,
+        //SRV = 0x00000200,
+        //UAV = 0x00000400,
     };
 
     /// <summary>

--- a/src/Backends/DirectX12/src/render_pass.cpp
+++ b/src/Backends/DirectX12/src/render_pass.cpp
@@ -177,23 +177,29 @@ public:
         else
         {
             CD3DX12_CLEAR_VALUE clearValue{ DX12::getFormat(m_depthStencilTarget->format()), m_depthStencilTarget->clearValues().x(), static_cast<UInt8>(m_depthStencilTarget->clearValues().y()) };
-            
-            D3D12_RENDER_PASS_ENDING_ACCESS depthEndAccess, stencilEndAccess;
-            D3D12_RENDER_PASS_BEGINNING_ACCESS depthBeginAccess = m_depthStencilTarget->clearBuffer() && ::hasDepth(m_depthStencilTarget->format()) ?
-                D3D12_RENDER_PASS_BEGINNING_ACCESS{ .Type = D3D12_RENDER_PASS_BEGINNING_ACCESS_TYPE_CLEAR, .Clear = { clearValue } } :
-                D3D12_RENDER_PASS_BEGINNING_ACCESS{ D3D12_RENDER_PASS_BEGINNING_ACCESS_TYPE_PRESERVE, { } };
 
-            depthEndAccess = m_depthStencilTarget->isVolatile() ?
-                D3D12_RENDER_PASS_ENDING_ACCESS{ D3D12_RENDER_PASS_ENDING_ACCESS_TYPE_DISCARD, { } } :
-                D3D12_RENDER_PASS_ENDING_ACCESS{ D3D12_RENDER_PASS_ENDING_ACCESS_TYPE_PRESERVE, { } };
-
-            D3D12_RENDER_PASS_BEGINNING_ACCESS stencilBeginAccess = m_depthStencilTarget->clearStencil() && ::hasStencil(m_depthStencilTarget->format()) ?
-                D3D12_RENDER_PASS_BEGINNING_ACCESS{ .Type = D3D12_RENDER_PASS_BEGINNING_ACCESS_TYPE_CLEAR, .Clear = { clearValue } } :
-                D3D12_RENDER_PASS_BEGINNING_ACCESS{ D3D12_RENDER_PASS_BEGINNING_ACCESS_TYPE_PRESERVE, { } };
+            D3D12_RENDER_PASS_BEGINNING_ACCESS depthBeginAccess { D3D12_RENDER_PASS_BEGINNING_ACCESS_TYPE_NO_ACCESS }, stencilBeginAccess { D3D12_RENDER_PASS_BEGINNING_ACCESS_TYPE_NO_ACCESS };
+            D3D12_RENDER_PASS_ENDING_ACCESS depthEndAccess { D3D12_RENDER_PASS_ENDING_ACCESS_TYPE_NO_ACCESS }, stencilEndAccess { D3D12_RENDER_PASS_ENDING_ACCESS_TYPE_NO_ACCESS };
             
-            stencilEndAccess = m_depthStencilTarget->isVolatile() ?
-                D3D12_RENDER_PASS_ENDING_ACCESS{ D3D12_RENDER_PASS_ENDING_ACCESS_TYPE_DISCARD, { } } :
-                D3D12_RENDER_PASS_ENDING_ACCESS{ D3D12_RENDER_PASS_ENDING_ACCESS_TYPE_PRESERVE, { } };
+            if (::hasDepth(m_depthStencilTarget->format()))
+            {
+                depthBeginAccess = m_depthStencilTarget->clearBuffer() ?
+                    D3D12_RENDER_PASS_BEGINNING_ACCESS{ .Type = D3D12_RENDER_PASS_BEGINNING_ACCESS_TYPE_CLEAR, .Clear = { clearValue } } :
+                    D3D12_RENDER_PASS_BEGINNING_ACCESS{ D3D12_RENDER_PASS_BEGINNING_ACCESS_TYPE_PRESERVE, { } };
+                depthEndAccess = m_depthStencilTarget->isVolatile() ?
+                    D3D12_RENDER_PASS_ENDING_ACCESS{ D3D12_RENDER_PASS_ENDING_ACCESS_TYPE_DISCARD, { } } :
+                    D3D12_RENDER_PASS_ENDING_ACCESS{ D3D12_RENDER_PASS_ENDING_ACCESS_TYPE_PRESERVE, { } };
+            }
+
+            if (::hasStencil(m_depthStencilTarget->format()))
+            {
+                stencilBeginAccess = m_depthStencilTarget->clearStencil() ?
+                    D3D12_RENDER_PASS_BEGINNING_ACCESS{ .Type = D3D12_RENDER_PASS_BEGINNING_ACCESS_TYPE_CLEAR, .Clear = { clearValue } } :
+                    D3D12_RENDER_PASS_BEGINNING_ACCESS{ D3D12_RENDER_PASS_BEGINNING_ACCESS_TYPE_PRESERVE, { } };
+                stencilEndAccess = m_depthStencilTarget->isVolatile() ?
+                    D3D12_RENDER_PASS_ENDING_ACCESS{ D3D12_RENDER_PASS_ENDING_ACCESS_TYPE_DISCARD, { } } :
+                    D3D12_RENDER_PASS_ENDING_ACCESS{ D3D12_RENDER_PASS_ENDING_ACCESS_TYPE_PRESERVE, { } };
+            }
 
             std::get<1>(m_activeContext) = D3D12_RENDER_PASS_DEPTH_STENCIL_DESC{ frameBuffer.descriptorHandle(*m_depthStencilTarget), depthBeginAccess, stencilBeginAccess, depthEndAccess, stencilEndAccess };
         }

--- a/src/Backends/Vulkan/src/descriptor_set.cpp
+++ b/src/Backends/Vulkan/src/descriptor_set.cpp
@@ -62,13 +62,13 @@ public:
 VulkanDescriptorSet::VulkanDescriptorSet(const VulkanDescriptorSetLayout& layout, Array<Byte>&& buffer) :
     m_impl(layout, std::move(buffer))
 {
-    layout.device().allocateGlobalDescriptors(*this, m_impl->m_offset, m_impl->m_heapSize);
+    layout.device().allocateGlobalDescriptors(*this, DescriptorHeapType::Resource, m_impl->m_offset, m_impl->m_heapSize); // NOTE: Heap type does not matter for Vulkan backend.
 }
 
 VulkanDescriptorSet::VulkanDescriptorSet(const VulkanDescriptorSetLayout& layout, UInt32 unboundedArraySize) :
     m_impl(layout, unboundedArraySize)
 {
-    layout.device().allocateGlobalDescriptors(*this, m_impl->m_offset, m_impl->m_heapSize);
+    layout.device().allocateGlobalDescriptors(*this, DescriptorHeapType::Resource, m_impl->m_offset, m_impl->m_heapSize); // NOTE: Heap type does not matter for Vulkan backend.
 }
 
 VulkanDescriptorSet::~VulkanDescriptorSet() noexcept
@@ -96,14 +96,28 @@ Span<const Byte> VulkanDescriptorSet::descriptorBuffer() const noexcept
     return m_impl->m_descriptorBuffer;
 }
 
-UInt32 VulkanDescriptorSet::globalHeapOffset() const noexcept
+UInt32 VulkanDescriptorSet::globalHeapOffset(DescriptorHeapType heapType) const noexcept
 {
-    return m_impl->m_offset;
+    switch (heapType)
+    {
+    case DescriptorHeapType::Resource:
+    case DescriptorHeapType::Sampler:
+        return m_impl->m_offset;
+    default:
+        return std::numeric_limits<UInt32>::max();
+    }
 }
 
-UInt32 VulkanDescriptorSet::globalHeapAddressRange() const noexcept
+UInt32 VulkanDescriptorSet::globalHeapAddressRange(DescriptorHeapType heapType) const noexcept
 {
-    return m_impl->m_heapSize;
+    switch (heapType)
+    {
+    case DescriptorHeapType::Resource:
+    case DescriptorHeapType::Sampler:
+        return m_impl->m_heapSize;
+    default:
+        return 0u;
+    }
 }
 
 void VulkanDescriptorSet::update(UInt32 binding, const IVulkanBuffer& buffer, UInt32 bufferElement, UInt32 elements, UInt32 firstDescriptor) const

--- a/src/Rendering/include/litefx/rendering.hpp
+++ b/src/Rendering/include/litefx/rendering.hpp
@@ -1525,7 +1525,7 @@ namespace LiteFX::Rendering {
         virtual void computeAccelerationStructureSizes(const top_level_acceleration_structure_type& tlas, UInt64 & bufferSize, UInt64 & scratchSize, bool forUpdate = false) const = 0;
 
         /// <inheritdoc />
-        virtual void allocateGlobalDescriptors(const descriptor_set_type& descriptorSet, UInt32& heapOffset, UInt32& heapSize) const = 0;
+        virtual void allocateGlobalDescriptors(const descriptor_set_type& descriptorSet, DescriptorHeapType heapType, UInt32& heapOffset, UInt32& heapSize) const = 0;
 
         /// <inheritdoc />
         virtual void releaseGlobalDescriptors(const descriptor_set_type& descriptorSet) const = 0;
@@ -1548,8 +1548,8 @@ namespace LiteFX::Rendering {
             this->computeAccelerationStructureSizes(dynamic_cast<const top_level_acceleration_structure_type&>(tlas), bufferSize, scratchSize, forUpdate);
         }
         
-        inline void doAllocateGlobalDescriptors(const IDescriptorSet& descriptorSet, UInt32& heapOffset, UInt32& heapSize) const override {
-            this->allocateGlobalDescriptors(dynamic_cast<const descriptor_set_type&>(descriptorSet), heapOffset, heapSize);
+        inline void doAllocateGlobalDescriptors(const IDescriptorSet& descriptorSet, DescriptorHeapType heapType, UInt32& heapOffset, UInt32& heapSize) const override {
+            this->allocateGlobalDescriptors(dynamic_cast<const descriptor_set_type&>(descriptorSet), heapType, heapOffset, heapSize);
         }
 
         inline void doReleaseGlobalDescriptors(const IDescriptorSet& descriptorSet) const override {

--- a/src/Rendering/include/litefx/rendering_api.hpp
+++ b/src/Rendering/include/litefx/rendering_api.hpp
@@ -533,6 +533,12 @@ namespace LiteFX::Rendering {
         AccelerationStructure = 0x00000008
     };
 
+    enum class DescriptorHeapType {
+        None = 0x00,
+        Resource = 0x01,
+        Sampler = 0x02
+    };
+
     /// <summary>
     /// Describes the type of a <see cref="IBuffer" />.
     /// </summary>
@@ -5321,8 +5327,9 @@ namespace LiteFX::Rendering {
         /// <remarks>
         /// The heap offset may differ between used backends and does not necessarily correspond to memory.
         /// </remarks>
+        /// <param name="heapType">The type of the descriptor heap for which to obtain the heap offset.</param>
         /// <returns>The offset into the global descriptor heap.</returns>
-        virtual UInt32 globalHeapOffset() const noexcept = 0;
+        virtual UInt32 globalHeapOffset(DescriptorHeapType heapType) const noexcept = 0;
 
         /// <summary>
         /// Returns the amount size of the range in the global descriptor heap address space.
@@ -5330,9 +5337,10 @@ namespace LiteFX::Rendering {
         /// <remarks>
         /// The heap size may differ between used backends and does not necessarily correspond to memory.
         /// </remarks>
+        /// <param name="heapType">The type of the descriptor heap for which to obtain the heap size.</param>
         /// <returns>The size of the range in the global descriptor heap.</returns>
         /// <seealso cref="globalHeapOffset" />
-        virtual UInt32 globalHeapAddressRange() const noexcept = 0;
+        virtual UInt32 globalHeapAddressRange(DescriptorHeapType heapType) const noexcept = 0;
 
         /// <summary>
         /// Updates one or more buffer descriptors within the current descriptor set.
@@ -5574,6 +5582,21 @@ namespace LiteFX::Rendering {
         /// <param name="element">The index of the array element of a descriptor array.</param>
         /// <returns>The offset from the beginning of the descriptor set.</returns>
         virtual UInt32 getDescriptorOffset(UInt32 binding, UInt32 element = 0) const = 0;
+
+        /// <summary>
+        /// Returns `true` if the descriptor set layout contains bindings for resources (i.e., bindings that aren't samplers) and `false` otherwise.
+        /// </summary>
+        /// <returns>`true` if the descriptor set layout contains bindings for resources and `false` otherwise.</returns>
+        virtual bool bindsResources() const noexcept = 0;
+
+        /// <summary>
+        /// Returns `true` if the descriptor set layout contains bindings for samplers and `false` otherwise.
+        /// </summary>
+        /// <remarks>
+        /// Note that this method only returns `true` if the layout binds samplers, that is, if they are not static/immutable.
+        /// </remarks>
+        /// <returns>`true` if the descriptor set layout contains bindings for samplers and `false` otherwise.</returns>
+        virtual bool bindsSamplers() const noexcept = 0;
 
     public:
         /// <summary>
@@ -9546,10 +9569,11 @@ namespace LiteFX::Rendering {
         /// Allocates a range of descriptors in the global descriptor heaps for the provided <paramref name="descriptorSet" />.
         /// </summary>
         /// <param name="descriptorSet">The descriptor set containing the descriptors to update.</param>
+        /// <param name="heapType">The type of the descriptor heap to allocate descriptors on.</param>
         /// <param name="heapOffset">The offset of the descriptor range in the global descriptor heap.</param>
         /// <param name="heapSize">The size of the address range in the global descriptor heap.</param>
-        inline void allocateGlobalDescriptors(const IDescriptorSet& descriptorSet, UInt32& heapOffset, UInt32& heapSize) const {
-            this->doAllocateGlobalDescriptors(descriptorSet, heapOffset, heapSize);
+        inline void allocateGlobalDescriptors(const IDescriptorSet& descriptorSet, DescriptorHeapType heapType, UInt32& heapOffset, UInt32& heapSize) const {
+            this->doAllocateGlobalDescriptors(descriptorSet, heapType, heapOffset, heapSize);
         }
 
         /// <summary>
@@ -9601,7 +9625,7 @@ namespace LiteFX::Rendering {
     private:
         virtual void getAccelerationStructureSizes(const IBottomLevelAccelerationStructure& blas, UInt64& bufferSize, UInt64& scratchSize, bool forUpdate) const = 0;
         virtual void getAccelerationStructureSizes(const ITopLevelAccelerationStructure& tlas, UInt64& bufferSize, UInt64& scratchSize, bool forUpdate) const = 0;
-        virtual void doAllocateGlobalDescriptors(const IDescriptorSet& descriptorSet, UInt32& heapOffset, UInt32& heapSize) const = 0;
+        virtual void doAllocateGlobalDescriptors(const IDescriptorSet& descriptorSet, DescriptorHeapType heapType, UInt32& heapOffset, UInt32& heapSize) const = 0;
         virtual void doReleaseGlobalDescriptors(const IDescriptorSet& descriptorSet) const = 0;
         virtual void doUpdateGlobalDescriptors(const IDescriptorSet& descriptorSet, UInt32 binding, UInt32 offset, UInt32 descriptors) const = 0;
         virtual void doBindDescriptorSet(const ICommandBuffer& commandBuffer, const IDescriptorSet& descriptorSet, const IPipeline& pipeline) const noexcept = 0;

--- a/src/Rendering/include/litefx/rendering_formatters.hpp
+++ b/src/Rendering/include/litefx/rendering_formatters.hpp
@@ -243,6 +243,21 @@ struct LITEFX_RENDERING_API std::formatter<DescriptorType> : std::formatter<std:
 };
 
 template <>
+struct LITEFX_RENDERING_API std::formatter<DescriptorHeapType> : std::formatter<std::string_view> {
+	auto format(DescriptorHeapType t, std::format_context& ctx) const {
+		string_view name = "Invalid";
+		switch (t) {
+		using enum DescriptorHeapType;
+		case Sampler: name = "Sampler"; break;
+		case Resource: name = "Resource"; break;
+		case None: name = "None"; break;
+		default: name = "Invalid"; break;
+		}
+		return formatter<string_view>::format(name, ctx);
+	}
+};
+
+template <>
 struct LITEFX_RENDERING_API std::formatter<BufferType> : std::formatter<std::string_view> {
 	auto format(BufferType t, std::format_context& ctx) const {
 		string_view name = "Invalid";

--- a/src/Samples/Textures/shaders/textures_fs.hlsl
+++ b/src/Samples/Textures/shaders/textures_fs.hlsl
@@ -14,7 +14,7 @@ struct FragmentData
 };
 
 Texture2D diffuseMap : register(t1, space0);
-SamplerState diffuse : register(s0, space1);
+SamplerState diffuse : register(s2, space0);
 
 FragmentData main(VertexData input)
 {

--- a/src/Samples/Textures/shaders/textures_vs.hlsl
+++ b/src/Samples/Textures/shaders/textures_vs.hlsl
@@ -30,7 +30,7 @@ struct TransformData
 };
 
 ConstantBuffer<CameraData>    camera    : register(b0, space0);
-ConstantBuffer<TransformData> transform : register(b0, space2);
+ConstantBuffer<TransformData> transform : register(b0, space1);
 
 VertexData main(in VertexInput input)
 {

--- a/src/Samples/Textures/src/sample.cpp
+++ b/src/Samples/Textures/src/sample.cpp
@@ -7,8 +7,7 @@
 enum DescriptorSets : UInt32 // NOLINT(performance-enum-size)
 {
     Constant = 0,                                       // All buffers that are immutable.
-    Samplers = 1,                                       // All samplers that are immutable.
-    PerFrame = 2,                                       // All buffers that are updated each frame.
+    PerFrame = 1,                                       // All buffers that are updated each frame.
 };
 
 const Array<Vertex> vertices =
@@ -190,8 +189,7 @@ UInt64 initBuffers(SampleApp& app, TDevice& device, const SharedPtr<IInputAssemb
     ::loadTexture<TBackend>(device, texture, sampler);
 
     // Allocate the descriptor sets.
-    auto staticBindings = staticBindingLayout.allocate({ { 0, *cameraBuffer }, { 1, *texture } });
-    auto samplerBindings = geometryPipeline.layout()->descriptorSet(DescriptorSets::Samplers).allocate({ { 0, *sampler } });
+    auto staticBindings = staticBindingLayout.allocate({ { 0, *cameraBuffer }, { 1, *texture }, { 2, *sampler } });
 
     // Next, we create the descriptor sets for the transform buffer. The transform changes with every frame. Since we have three frames in flight, we
     // create a buffer with three elements and bind the appropriate element to the descriptor set for every frame.
@@ -214,7 +212,6 @@ UInt64 initBuffers(SampleApp& app, TDevice& device, const SharedPtr<IInputAssemb
     device.state().add(std::move(texture));
     device.state().add(std::move(sampler));
     device.state().add("Static Bindings", std::move(staticBindings));
-    device.state().add("Sampler Bindings", std::move(samplerBindings));
     std::ranges::for_each(transformBindings, [&, i = 0](auto& binding) mutable { device.state().add(std::format("Transform Bindings {0}", i++), std::move(binding)); });
 
     // Return the fence.
@@ -438,14 +435,6 @@ void SampleApp::handleEvents()
     ::glfwPollEvents();
 }
 
-inline auto test(std::ranges::input_range auto&& descriptorSets) requires
-    std::derived_from<std::remove_cv_t<std::remove_pointer_t<std::iter_value_t<std::ranges::iterator_t<std::remove_cv_t<std::remove_reference_t<decltype(descriptorSets)>>>>>>, IDescriptorSet>
-{
-    using descriptor_set_type = std::remove_cv_t<std::remove_pointer_t<std::iter_value_t<std::ranges::iterator_t<std::remove_cv_t<std::remove_reference_t<decltype(descriptorSets)>>>>>>;
-    auto sets = descriptorSets | std::ranges::to<Array<const descriptor_set_type*>>();
-    return sets;
-}
-
 void SampleApp::drawFrame()
 {
     // Store the initial time this method has been called first.
@@ -460,7 +449,6 @@ void SampleApp::drawFrame()
     auto& geometryPipeline = m_device->state().pipeline("Geometry");
     auto& transformBuffer = m_device->state().buffer("Transform");
     auto& staticBindings = m_device->state().descriptorSet("Static Bindings");
-    auto& samplerBindings = m_device->state().descriptorSet("Sampler Bindings");
     auto& transformBindings = m_device->state().descriptorSet(std::format("Transform Bindings {0}", backBuffer));
     auto& vertexBuffer = m_device->state().vertexBuffer("Vertex Buffer");
     auto& indexBuffer = m_device->state().indexBuffer("Index Buffer");
@@ -484,7 +472,7 @@ void SampleApp::drawFrame()
     transformBuffer.map(static_cast<const void*>(&transform), sizeof(transform), backBuffer);
 
     // Bind both descriptor sets to the pipeline.
-    commandBuffer->bind({ &staticBindings, &samplerBindings, &transformBindings });
+    commandBuffer->bind({ &staticBindings, &transformBindings });
 
     // Bind the vertex and index buffers.
     commandBuffer->bind(vertexBuffer);


### PR DESCRIPTION
**Describe the pull request**

This PR overhauls the binding of descriptor sets containing both, samplers and resources. This was partially supported previously, but only for the DirectX 12 backend, where it too only worked under certain circumstances, due to root parameter indices not being properly mapped across multiple descriptor tables for a single descriptor set. #163 thus temporarily removed support entirely by throwing an exception during pipeline creation, if such a scenario was encountered. This PR now addresses those issues and implements proper support for such a use case.

For the Vulkan backend, this resulted in a refactoring of the descriptor buffer implementation, as descriptor sets must be fully bound to a descriptor buffer. This is different to D3D12, where a descriptor set can (and must) be split over two descriptor heaps (for samplers and resources), which is not possible in Vulkan. Fortunately, GPUinfo reports equal memory requirements for [samplerDescriptorBufferAddressSpaceSize](https://vulkan.gpuinfo.org/displayextensionproperty.php?extensionname=VK_EXT_descriptor_buffer&extensionproperty=samplerDescriptorBufferAddressSpaceSize&platform=all)/[resourceDescriptorBufferAddressSpaceSize](https://vulkan.gpuinfo.org/displayextensionproperty.php?extensionname=VK_EXT_descriptor_buffer&extensionproperty=resourceDescriptorBufferAddressSpaceSize&platform=all) and [descriptorBufferAddressSpaceSize](https://vulkan.gpuinfo.org/displayextensionproperty.php?extensionname=VK_EXT_descriptor_buffer&extensionproperty=descriptorBufferAddressSpaceSize&platform=all) over all devices that support `VK_EXT_descriptor_buffer`, so we can easily combine sampler and resource heaps into a single heap that binds all resource types.

**Related issues**

- This is a preliminary PR for implementing #164, as the default DXC behavior emits a mixed descriptor set when both `ResourceDescriptorHeap` and `SamplerDescriptorHeap` are used in a shader.