### PR TITLE
Allow overlapping push constants ranges.

### DIFF
--- a/docs/release-logs/0.6.1.md
+++ b/docs/release-logs/0.6.1.md
@@ -2,6 +2,7 @@
 
 - Update toolchain to LLVM 21. (See [PR #197](https://github.com/crud89/LiteFX/pull/197))
 - Add missing primitive topologies for adjacency and patch lists. (See [PR #201](https://github.com/crud89/LiteFX/pull/201))
+- Allow overlapping push constants ranges between shader stages. (See [PR #205](https://github.com/crud89/LiteFX/pull/205))
 
 **🌋 Vulkan:**
 

--- a/src/Backends/DirectX12/include/litefx/backends/dx12.hpp
+++ b/src/Backends/DirectX12/include/litefx/backends/dx12.hpp
@@ -1056,7 +1056,7 @@ namespace LiteFX::Rendering::Backends {
         UInt32 size() const noexcept override;
 
         /// <inheritdoc />
-        ShaderStage stage() const noexcept override;
+        ShaderStage stageMask() const noexcept override;
     };
 
     /// <summary>
@@ -1108,9 +1108,6 @@ namespace LiteFX::Rendering::Backends {
     public:
         /// <inheritdoc />
         UInt32 size() const noexcept override;
-
-        /// <inheritdoc />
-        const DirectX12PushConstantsRange& range(ShaderStage stage) const override;
 
         /// <inheritdoc />
         const Array<UniquePtr<DirectX12PushConstantsRange>>& ranges() const override;

--- a/src/Backends/DirectX12/src/pipeline_layout.cpp
+++ b/src/Backends/DirectX12/src/pipeline_layout.cpp
@@ -128,7 +128,7 @@ public:
             std::ranges::for_each(pushConstantsLayout->ranges(), [&](const auto& range) {
                 CD3DX12_ROOT_PARAMETER1 rootParameter = {};
 
-                switch (range->stage())
+                switch (range->stageMask())
                 {
                 case ShaderStage::Vertex: rootParameter.InitAsConstants(range->size() / 4, range->binding(), range->space(), D3D12_SHADER_VISIBILITY_VERTEX); break;
                 case ShaderStage::Geometry: rootParameter.InitAsConstants(range->size() / 4, range->binding(), range->space(), D3D12_SHADER_VISIBILITY_GEOMETRY); break;

--- a/src/Backends/DirectX12/src/push_constants_layout.cpp
+++ b/src/Backends/DirectX12/src/push_constants_layout.cpp
@@ -13,7 +13,6 @@ public:
     friend class DirectX12PushConstantsLayout;
 
 private:
-    Dictionary<ShaderStage, DirectX12PushConstantsRange*> m_ranges;
     Array<UniquePtr<DirectX12PushConstantsRange>> m_rangePointers;
     UInt32 m_size;
 
@@ -32,13 +31,6 @@ private:
     void setRanges(Enumerable<UniquePtr<DirectX12PushConstantsRange>>&& ranges)
     {
         m_rangePointers = std::move(ranges) | std::views::as_rvalue | std::ranges::to<std::vector>();
-
-        std::ranges::for_each(m_rangePointers, [this](const UniquePtr<DirectX12PushConstantsRange>& range) {
-            if (m_ranges.contains(static_cast<ShaderStage>(range->stage())))
-                throw InvalidArgumentException("ranges", "Only one push constant range can be mapped to a shader stage.");
-
-            m_ranges[range->stage()] = range.get();
-        });
     }
 };
 
@@ -64,19 +56,6 @@ DirectX12PushConstantsLayout::~DirectX12PushConstantsLayout() noexcept = default
 UInt32 DirectX12PushConstantsLayout::size() const noexcept
 {
     return m_impl->m_size;
-}
-
-const DirectX12PushConstantsRange& DirectX12PushConstantsLayout::range(ShaderStage stage) const
-{
-    auto bits = std::to_underlying(stage);
-
-    if (!(bits && !(bits & (bits - 1))))
-        throw InvalidArgumentException("stage", "The stage mask must only contain one shader stage.");
-
-    if (!m_impl->m_ranges.contains(stage))
-        throw InvalidArgumentException("stage", "No push constant range has been associated with the provided shader stage.");
-
-    return *m_impl->m_ranges[stage];
 }
 
 const Array<UniquePtr<DirectX12PushConstantsRange>>& DirectX12PushConstantsLayout::ranges() const

--- a/src/Backends/DirectX12/src/push_constants_range.cpp
+++ b/src/Backends/DirectX12/src/push_constants_range.cpp
@@ -11,21 +11,18 @@ public:
     friend class DirectX12PushConstantsRange;
 
 private:
-    ShaderStage m_stage;
+    ShaderStage m_stageMask;
     UInt32 m_offset, m_size, m_space, m_binding;
 
 public:
-    DirectX12PushConstantsRangeImpl(ShaderStage shaderStage, UInt32 offset, UInt32 size, UInt32 space, UInt32 binding) :
-        m_stage(shaderStage), m_offset(offset), m_size(size), m_space(space), m_binding(binding)
+    DirectX12PushConstantsRangeImpl(ShaderStage shaderStageMask, UInt32 offset, UInt32 size, UInt32 space, UInt32 binding) :
+        m_stageMask(shaderStageMask), m_offset(offset), m_size(size), m_space(space), m_binding(binding)
     {
         if (offset % 4 != 0)
             throw InvalidArgumentException("offset", "The push constants range offset must be a multiple of 4 bytes.");
 
         if (size % 4 != 0)
             throw InvalidArgumentException("size", "The push constants range size must be a multiple of 4 bytes.");
-
-        if (!(std::to_underlying(shaderStage) && !(std::to_underlying(shaderStage) & (std::to_underlying(shaderStage) - 1))))
-            throw InvalidArgumentException("shaderStage", "A push constant range is only allowed to be associated with one shader stage.");
     }
 };
 
@@ -33,8 +30,8 @@ public:
 // Shared interface.
 // ------------------------------------------------------------------------------------------------
 
-DirectX12PushConstantsRange::DirectX12PushConstantsRange(ShaderStage shaderStage, UInt32 offset, UInt32 size, UInt32 space, UInt32 binding) :
-    m_impl(shaderStage, offset, size, space, binding)
+DirectX12PushConstantsRange::DirectX12PushConstantsRange(ShaderStage shaderStageMask, UInt32 offset, UInt32 size, UInt32 space, UInt32 binding) :
+    m_impl(shaderStageMask, offset, size, space, binding)
 {
 }
 
@@ -64,7 +61,7 @@ UInt32 DirectX12PushConstantsRange::size() const noexcept
     return m_impl->m_size;
 }
 
-ShaderStage DirectX12PushConstantsRange::stage() const noexcept
+ShaderStage DirectX12PushConstantsRange::stageMask() const noexcept
 {
-    return m_impl->m_stage;
+    return m_impl->m_stageMask;
 }

--- a/src/Backends/DirectX12/src/shader_program.cpp
+++ b/src/Backends/DirectX12/src/shader_program.cpp
@@ -69,7 +69,6 @@ private:
     struct PushConstantRangeInfo {
     public:
         ShaderStage stage{ ShaderStage::Other };
-        UInt32 offset{ 0 };
         UInt32 size{ 0 };
         UInt32 location{ 0 };
         UInt32 space{ 0 };
@@ -210,8 +209,6 @@ public:
         }
 
         // Iterate the root parameters.
-        UInt32 pushConstantOffset = 0;
-
         for (UInt32 i(0); i < description->NumParameters; ++i)
         {
             auto rootParameter = description->pParameters[i]; // NOLINT(cppcoreguidelines-pro-bounds-pointer-arithmetic)
@@ -244,12 +241,11 @@ public:
                     case D3D12_SHADER_VISIBILITY_PIXEL:         stage = ShaderStage::Fragment; break;
                     case D3D12_SHADER_VISIBILITY_AMPLIFICATION: stage = ShaderStage::Task; break;
                     case D3D12_SHADER_VISIBILITY_MESH:          stage = ShaderStage::Mesh; break;
-                    case D3D12_SHADER_VISIBILITY_ALL:           stage = ShaderStage::Any; break; // TODO: Might not work as intended.
-                    default: throw InvalidArgumentException("pushConstantRanges", "The push constants for a shader are defined for invalid or unsupported shader stages. Note that a push constant must only be defined for a single shader stage.");
+                    case D3D12_SHADER_VISIBILITY_ALL:           stage = ShaderStage::Any; break;
+                    default: throw InvalidArgumentException("pushConstantRanges", "The push constants for a shader are defined for invalid or unsupported shader stages.");
                     }
 
-                    pushConstantRanges.push_back(PushConstantRangeInfo{ .stage = stage, .offset = pushConstantOffset, .size = rootParameter.Constants.Num32BitValues * 4, .location = rootParameter.Descriptor.ShaderRegister, .space = rootParameter.Descriptor.RegisterSpace });
-                    pushConstantOffset += rootParameter.Constants.Num32BitValues * 4;
+                    pushConstantRanges.push_back(PushConstantRangeInfo{ .stage = stage, .size = rootParameter.Constants.Num32BitValues * 4, .location = rootParameter.Descriptor.ShaderRegister, .space = rootParameter.Descriptor.RegisterSpace });
                     
                     // Remove the descriptor from the descriptor set.
                     descriptorSetLayouts[rootParameter.Descriptor.RegisterSpace].descriptors.erase(match);
@@ -512,13 +508,8 @@ public:
                         else
                         {
                             // Lookup the last registered range to compute the highest offset.
-                            UInt32 pushConstantOffset = 0;
-
-                            if (!pushConstantRanges.empty())
-                                pushConstantOffset = pushConstantRanges.back().offset + pushConstantRanges.back().size;
-
                             auto rangeSize = descriptor.elements * descriptor.elementSize;
-                            pushConstantRanges.push_back(PushConstantRangeInfo{ .stage = descriptorSet.stage, .offset = pushConstantOffset, .size = rangeSize, .location = descriptor.location, .space = descriptorSet.space });
+                            pushConstantRanges.push_back(PushConstantRangeInfo{ .stage = descriptorSet.stage, .size = rangeSize, .location = descriptor.location, .space = descriptorSet.space });
 
                             // Remove the descriptor from the descriptor set.
                             descriptorSet.descriptors.erase(std::next(std::begin(descriptorSet.descriptors), i--));
@@ -647,12 +638,38 @@ public:
         }(m_device, std::move(descriptorSetLayouts)) | std::ranges::to<Array<SharedPtr<DirectX12DescriptorSetLayout>>>();
 
         // Create the push constants layout.
-        auto overallSize = std::accumulate(pushConstantRanges.begin(), pushConstantRanges.end(), 0, [](UInt32 currentSize, const auto& range) { return currentSize + range.size; });
+        // NOTE: In D3D12, push constants are treated as a usual descriptor binding. We thus assume, that mixing different push constant layouts at the same binding over different shader stages 
+        //       is not allowed. This allows us to iterate the ranges based on binding space and register, match them and accumulate the overall size simply by adding up the filtered sizes of
+        //       each range afterwards.
         auto pushConstants = [](Array<PushConstantRangeInfo> pushConstantRanges) -> std::generator<UniquePtr<DirectX12PushConstantsRange>> {
-            for (auto range = pushConstantRanges.begin(); range != pushConstantRanges.end(); ++range)
-                co_yield makeUnique<DirectX12PushConstantsRange>(range->stage, range->offset, range->size, range->space, range->location);
+            UInt32 accumulatedOffset{ 0u };
+
+            while (!pushConstantRanges.empty())
+            {
+                auto range = pushConstantRanges.front();
+                auto match = [&range](const PushConstantRangeInfo& r) { return r.space == range.space && r.location == range.location; };
+                
+                // Find all ranges in the same space and location, get the stages and maximum size.
+                // NOTE: This also matches the front range itself, but we don't care.
+                for (auto& r : pushConstantRanges | std::views::filter(match))
+                {
+                    range.size = std::max(r.size, range.size);
+                    range.stage |= r.stage;
+                }
+
+                // Remove all ranges at the current binding.
+                auto [from, to] = std::ranges::remove_if(pushConstantRanges, match);
+                pushConstantRanges.erase(from, to);
+
+                // Return the range.
+                co_yield makeUnique<DirectX12PushConstantsRange>(range.stage, accumulatedOffset, range.size, range.space, range.location);
+
+                // Accumulate the offset for the next
+                accumulatedOffset += range.size;
+            }
         }(std::move(pushConstantRanges)) | std::ranges::to<Array<UniquePtr<DirectX12PushConstantsRange>>>();
 
+        auto overallSize = std::accumulate(pushConstants.begin(), pushConstants.end(), 0, [](UInt32 currentSize, const auto& range) { return currentSize + range->size(); });
         auto pushConstantsLayout = makeUnique<DirectX12PushConstantsLayout>(pushConstants | std::views::as_rvalue, overallSize);
 
         // Return the pipeline layout.

--- a/src/Backends/Vulkan/include/litefx/backends/vulkan.hpp
+++ b/src/Backends/Vulkan/include/litefx/backends/vulkan.hpp
@@ -1071,12 +1071,12 @@ namespace LiteFX::Rendering::Backends {
         /// <summary>
         /// Initializes a new push constants range.
         /// </summary>
-        /// <param name="shaderStage">The shader stage, that access the push constants from the range.</param>
+        /// <param name="shaderStage">The shader stages, that access the push constants from the range.</param>
         /// <param name="offset">The offset relative to the parent push constants backing memory that marks the beginning of the range.</param>
         /// <param name="size">The size of the push constants range.</param>
         /// <param name="space">The space from which the push constants of the range will be accessible in the shader.</param>
         /// <param name="binding">The register from which the push constants of the range will be accessible in the shader.</param>
-        explicit VulkanPushConstantsRange(ShaderStage shaderStage, UInt32 offset, UInt32 size, UInt32 space, UInt32 binding);
+        explicit VulkanPushConstantsRange(ShaderStage shaderStages, UInt32 offset, UInt32 size, UInt32 space, UInt32 binding);
 
         /// <inheritdoc />
         VulkanPushConstantsRange(VulkanPushConstantsRange&&) noexcept;
@@ -1107,7 +1107,7 @@ namespace LiteFX::Rendering::Backends {
         UInt32 size() const noexcept override;
 
         /// <inheritdoc />
-        ShaderStage stage() const noexcept override;
+        ShaderStage stageMask() const noexcept override;
     };
 
     /// <summary>
@@ -1154,9 +1154,6 @@ namespace LiteFX::Rendering::Backends {
     public:
         /// <inheritdoc />
         UInt32 size() const noexcept override;
-
-        /// <inheritdoc />
-        const VulkanPushConstantsRange& range(ShaderStage stage) const override;
 
         /// <inheritdoc />
         const Array<UniquePtr<VulkanPushConstantsRange>>& ranges() const override;

--- a/src/Backends/Vulkan/src/command_buffer.cpp
+++ b/src/Backends/Vulkan/src/command_buffer.cpp
@@ -780,7 +780,7 @@ void VulkanCommandBuffer::pushConstants(const VulkanPushConstantsLayout& layout,
 		throw RuntimeException("No pipeline has been used on the command buffer before attempting to bind the push constants range.");
 
 	std::ranges::for_each(layout.ranges(), [&](const auto& range) { 
-		::vkCmdPushConstants(this->handle(), std::as_const(*m_impl->m_lastPipeline->layout()).handle(), static_cast<VkShaderStageFlags>(Vk::getShaderStage(range->stage())), range->offset(), range->size(), memory);
+		::vkCmdPushConstants(this->handle(), std::as_const(*m_impl->m_lastPipeline->layout()).handle(), static_cast<VkShaderStageFlags>(std::to_underlying(range->stageMask())), range->offset(), range->size(), memory);
 	});
 }
 

--- a/src/Backends/Vulkan/src/device.cpp
+++ b/src/Backends/Vulkan/src/device.cpp
@@ -266,24 +266,19 @@ public:
     }
 
     template <typename T>
-    static T findOrCreateExtension(VkStructureType structureType, void* deviceExtensionChain, bool& added) {
+    static T* findExtension(VkStructureType structureType, void* deviceExtensionChain) {
         // NOTE: Only use this at the beginning of an extension chain!
         auto next = reinterpret_cast<VkBaseOutStructure*>(deviceExtensionChain); // NOLINT(cppcoreguidelines-pro-type-reinterpret-cast)
-        added = false;
 
         while (next != nullptr)
         {
             if (next->sType == structureType)
-                return *reinterpret_cast<T*>(next); // NOLINT(cppcoreguidelines-pro-type-reinterpret-cast)
+                return reinterpret_cast<T*>(next); // NOLINT(cppcoreguidelines-pro-type-reinterpret-cast)
 
             next = reinterpret_cast<VkBaseOutStructure*>(next->pNext); // NOLINT(cppcoreguidelines-pro-type-reinterpret-cast)
         }
 
-        added = true;
-        return {
-            .sType = structureType,
-            .pNext = deviceExtensionChain
-        };
+        return nullptr;
     }
 
     VkDevice initialize(const GraphicsDeviceFeatures& features, void* deviceExtensionObjects)
@@ -315,172 +310,215 @@ public:
         // Enable requested features. Look up if they are already provided in the extension chain and overwrite them if necessary. We only enable features for compatibility 
         // reasons. Only exceptions are GraphicsDeviceFeatures, which are provided by different means.
         // Start enabling ray-tracing features.
-        bool added{ false };
-        auto rayQueryFeatures = findOrCreateExtension<VkPhysicalDeviceRayQueryFeaturesKHR>(VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_RAY_QUERY_FEATURES_KHR, deviceExtensionObjects, added);
-        
-        if (features.RayQueries) {
-            rayQueryFeatures.rayQuery = true;
+        VkPhysicalDeviceRayQueryFeaturesKHR rayQueryFeatures{ .sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_RAY_QUERY_FEATURES_KHR, .pNext = deviceExtensionObjects };
+        auto pRayQueryFeatures = findExtension<VkPhysicalDeviceRayQueryFeaturesKHR>(VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_RAY_QUERY_FEATURES_KHR, deviceExtensionObjects);
 
-            if (added)
-                deviceExtensionObjects = &rayQueryFeatures;
+        if (pRayQueryFeatures == nullptr) {
+            pRayQueryFeatures = &rayQueryFeatures;
+            deviceExtensionObjects = pRayQueryFeatures;
         }
 
-        auto rayTracingMaintenanceFeatures = findOrCreateExtension<VkPhysicalDeviceRayTracingMaintenance1FeaturesKHR>(VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_RAY_TRACING_MAINTENANCE_1_FEATURES_KHR, deviceExtensionObjects, added);
+        if (features.RayQueries) {
+            pRayQueryFeatures->rayQuery = true;
+        }
+
+        VkPhysicalDeviceRayTracingMaintenance1FeaturesKHR rayTracingMaintenanceFeatures{ .sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_RAY_TRACING_MAINTENANCE_1_FEATURES_KHR, .pNext = deviceExtensionObjects };
+        auto pRayTracingMaintenanceFeatures = findExtension<VkPhysicalDeviceRayTracingMaintenance1FeaturesKHR>(VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_RAY_TRACING_MAINTENANCE_1_FEATURES_KHR, deviceExtensionObjects);
+
+        if (pRayTracingMaintenanceFeatures == nullptr) {
+            pRayTracingMaintenanceFeatures = &rayTracingMaintenanceFeatures;
+            deviceExtensionObjects = pRayTracingMaintenanceFeatures;
+        }
 
         if (features.RayTracing || features.RayQueries) {
-            rayTracingMaintenanceFeatures.rayTracingMaintenance1 = true;
-            rayTracingMaintenanceFeatures.rayTracingPipelineTraceRaysIndirect2 = features.RayQueries;
-        
-            if (added)
-                deviceExtensionObjects = &rayTracingMaintenanceFeatures;
+            pRayTracingMaintenanceFeatures->rayTracingMaintenance1 = true;
+            pRayTracingMaintenanceFeatures->rayTracingPipelineTraceRaysIndirect2 = features.RayQueries;
         }
 
-        auto accelerationStructureFeatures = findOrCreateExtension<VkPhysicalDeviceAccelerationStructureFeaturesKHR>(VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_ACCELERATION_STRUCTURE_FEATURES_KHR, deviceExtensionObjects, added);
+        VkPhysicalDeviceAccelerationStructureFeaturesKHR accelerationStructureFeatures{ .sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_ACCELERATION_STRUCTURE_FEATURES_KHR, .pNext = deviceExtensionObjects };
+        auto pAccelerationStructureFeatures = findExtension<VkPhysicalDeviceAccelerationStructureFeaturesKHR>(VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_ACCELERATION_STRUCTURE_FEATURES_KHR, deviceExtensionObjects);
+
+        if (pAccelerationStructureFeatures == nullptr) {
+            pAccelerationStructureFeatures = &accelerationStructureFeatures;
+            deviceExtensionObjects = pAccelerationStructureFeatures;
+        }
 
         if (features.RayQueries || features.RayTracing) {
-            accelerationStructureFeatures.accelerationStructure = true;
-            accelerationStructureFeatures.descriptorBindingAccelerationStructureUpdateAfterBind = true;
-        
-            if (added)
-                deviceExtensionObjects = &accelerationStructureFeatures;
+            pAccelerationStructureFeatures->accelerationStructure = true;
+            pAccelerationStructureFeatures->descriptorBindingAccelerationStructureUpdateAfterBind = true;
         }
 
-        auto rayTracingPipelineFeatures = findOrCreateExtension<VkPhysicalDeviceRayTracingPipelineFeaturesKHR>(VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_RAY_TRACING_PIPELINE_FEATURES_KHR, deviceExtensionObjects, added);
+        VkPhysicalDeviceRayTracingPipelineFeaturesKHR rayTracingPipelineFeatures{ .sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_RAY_TRACING_PIPELINE_FEATURES_KHR, .pNext = deviceExtensionObjects };
+        auto pRayTracingPipelineFeatures = findExtension<VkPhysicalDeviceRayTracingPipelineFeaturesKHR>(VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_RAY_TRACING_PIPELINE_FEATURES_KHR, deviceExtensionObjects);
+
+        if (pRayTracingPipelineFeatures == nullptr) {
+            pRayTracingPipelineFeatures = &rayTracingPipelineFeatures;
+            deviceExtensionObjects = pRayTracingPipelineFeatures;
+        }
 
         if (features.RayTracing) {
-            rayTracingPipelineFeatures.rayTracingPipeline = true;
-        
-            if (added)
-                deviceExtensionObjects = &rayTracingPipelineFeatures;
+            pRayTracingPipelineFeatures->rayTracingPipeline = true;
         }
 
-        auto meshShaderFeatures = findOrCreateExtension<VkPhysicalDeviceMeshShaderFeaturesEXT>(VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_MESH_SHADER_FEATURES_EXT, deviceExtensionObjects, added);
+        VkPhysicalDeviceMeshShaderFeaturesEXT meshShaderFeatures{ .sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_MESH_SHADER_FEATURES_EXT, .pNext = deviceExtensionObjects };
+        auto pMeshShaderFeatures = findExtension<VkPhysicalDeviceMeshShaderFeaturesEXT>(VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_MESH_SHADER_FEATURES_EXT, deviceExtensionObjects);
+
+        if (pMeshShaderFeatures == nullptr) {
+            pMeshShaderFeatures = &meshShaderFeatures;
+            deviceExtensionObjects = pMeshShaderFeatures;
+        }
 
         if (features.MeshShaders) {
-            meshShaderFeatures.taskShader = true;
-            meshShaderFeatures.meshShader = true;
-        
-            if (added)
-                deviceExtensionObjects = &meshShaderFeatures;
+            pMeshShaderFeatures->taskShader = true;
+            pMeshShaderFeatures->meshShader = true;
         }
 
-        auto mutableDescriptorTypeFeatures = findOrCreateExtension<VkPhysicalDeviceMutableDescriptorTypeFeaturesEXT>(VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_MUTABLE_DESCRIPTOR_TYPE_FEATURES_EXT, deviceExtensionObjects, added);
+        VkPhysicalDeviceMutableDescriptorTypeFeaturesEXT mutableDescriptorTypeFeatures{ .sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_MUTABLE_DESCRIPTOR_TYPE_FEATURES_EXT, .pNext = deviceExtensionObjects };
+        auto pMutableDescriptorTypeFeatures = findExtension<VkPhysicalDeviceMutableDescriptorTypeFeaturesEXT>(VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_MUTABLE_DESCRIPTOR_TYPE_FEATURES_EXT, deviceExtensionObjects);
+
+        if (pMutableDescriptorTypeFeatures == nullptr) {
+            pMutableDescriptorTypeFeatures = &mutableDescriptorTypeFeatures;
+            deviceExtensionObjects = pMutableDescriptorTypeFeatures;
+        }
 
         if (features.DynamicDescriptors) {
-            mutableDescriptorTypeFeatures.mutableDescriptorType = true;
-        
-            if (added)
-                deviceExtensionObjects = &mutableDescriptorTypeFeatures;
+            pMutableDescriptorTypeFeatures->mutableDescriptorType = true;
         }
 
-        auto multiViewFeatures = findOrCreateExtension<VkPhysicalDeviceMultiviewFeatures>(VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_MULTIVIEW_FEATURES, deviceExtensionObjects, added);
+        VkPhysicalDeviceMaintenance5FeaturesKHR maintenance5Features{ .sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_MAINTENANCE_5_FEATURES_KHR, .pNext = deviceExtensionObjects };
+        auto pMaintenance5Features = findExtension<VkPhysicalDeviceMaintenance5FeaturesKHR>(VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_MAINTENANCE_5_FEATURES_KHR, deviceExtensionObjects);
 
-        if (features.ViewInstancing) {
-            multiViewFeatures.multiview = true;
-#ifndef LITEFX_BUILD_TESTS
-            multiViewFeatures.multiviewGeometryShader = true;
-            multiViewFeatures.multiviewTessellationShader = true;
-#endif // LITEFX_BUILD_TESTS
-        
-            if (added)
-                deviceExtensionObjects = &multiViewFeatures;
+        if (pMaintenance5Features == nullptr) {
+            pMaintenance5Features = &maintenance5Features;
+            deviceExtensionObjects = pMaintenance5Features;
         }
-
-        auto maintenance5Features = findOrCreateExtension<VkPhysicalDeviceMaintenance5FeaturesKHR>(VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_MAINTENANCE_5_FEATURES_KHR, deviceExtensionObjects, added);
 
         if (std::ranges::find_if(m_extensions, [](auto& ext) { return ext == VK_KHR_MAINTENANCE_5_EXTENSION_NAME; }) != m_extensions.end()) {
-            maintenance5Features.maintenance5 = true;
-        
-            if (added)
-                deviceExtensionObjects = &maintenance5Features;
+            pMaintenance5Features->maintenance5 = true;
         }
 
-        auto deviceFeatures = findOrCreateExtension<VkPhysicalDeviceFeatures2>(VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_FEATURES_2, deviceExtensionObjects, added);
-        deviceFeatures.features.fullDrawIndexUint32 = true;
-        deviceFeatures.features.independentBlend = true;
+        VkPhysicalDeviceFeatures2 deviceFeatures{ .sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_FEATURES_2, .pNext = deviceExtensionObjects };
+        auto pDeviceFeatures = findExtension<VkPhysicalDeviceFeatures2>(VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_FEATURES_2, deviceExtensionObjects);
+
+        if (pDeviceFeatures == nullptr) {
+            pDeviceFeatures = &deviceFeatures;
+            deviceExtensionObjects = pDeviceFeatures;
+        }
+
+        pDeviceFeatures->features.fullDrawIndexUint32 = true;
+        pDeviceFeatures->features.independentBlend = true;
 #ifndef LITEFX_BUILD_TESTS
-        deviceFeatures.features.geometryShader = true;
-        deviceFeatures.features.tessellationShader = true;
+        pDeviceFeatures->features.geometryShader = true;
+        pDeviceFeatures->features.tessellationShader = true;
 #endif // LITEFX_BUILD_TESTS
-        deviceFeatures.features.dualSrcBlend = true;
-        deviceFeatures.features.logicOp = true;
-        deviceFeatures.features.drawIndirectFirstInstance = features.DrawIndirect;
-        deviceFeatures.features.depthClamp = true;
-        deviceFeatures.features.depthBounds = features.DepthBoundsTest;
-        deviceFeatures.features.alphaToOne = true;
-        deviceFeatures.features.multiViewport = true;
-        deviceFeatures.features.samplerAnisotropy = true;
-        deviceFeatures.features.shaderFloat64 = true;
-        deviceFeatures.features.shaderInt64 = true;
-        deviceFeatures.features.shaderInt16 = true;
-        
-        if (added)
-            deviceExtensionObjects = &deviceFeatures;
+        pDeviceFeatures->features.dualSrcBlend = true;
+        pDeviceFeatures->features.logicOp = true;
+        pDeviceFeatures->features.drawIndirectFirstInstance = features.DrawIndirect;
+        pDeviceFeatures->features.depthClamp = true;
+        pDeviceFeatures->features.depthBounds = features.DepthBoundsTest;
+        pDeviceFeatures->features.alphaToOne = true;
+        pDeviceFeatures->features.multiViewport = true;
+        pDeviceFeatures->features.samplerAnisotropy = true;
+        pDeviceFeatures->features.shaderFloat64 = true;
+        pDeviceFeatures->features.shaderInt64 = true;
+        pDeviceFeatures->features.shaderInt16 = true;
 
-        auto deviceFeatures13 = findOrCreateExtension<VkPhysicalDeviceVulkan13Features>(VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_VULKAN_1_3_FEATURES, deviceExtensionObjects, added);
-        deviceFeatures13.synchronization2 = true;
-        deviceFeatures13.dynamicRendering = true;
-        deviceFeatures13.maintenance4 = true;
-        
-        if (added)
-            deviceExtensionObjects = &deviceFeatures13;
+        VkPhysicalDeviceVulkan13Features deviceFeatures13{ .sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_VULKAN_1_3_FEATURES, .pNext = deviceExtensionObjects };
+        auto pDeviceFeatures13 = findExtension<VkPhysicalDeviceVulkan13Features>(VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_VULKAN_1_3_FEATURES, deviceExtensionObjects);
 
-        auto deviceFeatures12 = findOrCreateExtension<VkPhysicalDeviceVulkan12Features>(VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_VULKAN_1_2_FEATURES, deviceExtensionObjects, added);
-        deviceFeatures12.drawIndirectCount = features.DrawIndirect;
-        deviceFeatures12.descriptorIndexing = true;
+        if (pDeviceFeatures13 == nullptr) {
+            pDeviceFeatures13 = &deviceFeatures13;
+            deviceExtensionObjects = pDeviceFeatures13;
+        }
+
+        pDeviceFeatures13->synchronization2 = true;
+        pDeviceFeatures13->dynamicRendering = true;
+        pDeviceFeatures13->maintenance4 = true;
+
+        VkPhysicalDeviceVulkan12Features deviceFeatures12{ .sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_VULKAN_1_2_FEATURES, .pNext = deviceExtensionObjects };
+        auto pDeviceFeatures12 = findExtension<VkPhysicalDeviceVulkan12Features>(VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_VULKAN_1_2_FEATURES, deviceExtensionObjects);
+
+        if (pDeviceFeatures12 == nullptr) {
+            pDeviceFeatures12 = &deviceFeatures12;
+            deviceExtensionObjects = pDeviceFeatures12;
+        }
+
+        pDeviceFeatures12->drawIndirectCount = features.DrawIndirect;
+        pDeviceFeatures12->descriptorIndexing = true;
         //deviceFeatures12.shaderInputAttachmentArrayDynamicIndexing = true; // Not supported by Intel ARC drivers and SwiftShader and since we're now using dynamic rendering anyway, this became (even) less important.
-        deviceFeatures12.shaderUniformTexelBufferArrayDynamicIndexing = true;
-        deviceFeatures12.shaderStorageTexelBufferArrayDynamicIndexing = true;
-        deviceFeatures12.shaderUniformBufferArrayNonUniformIndexing = true;
-        deviceFeatures12.shaderSampledImageArrayNonUniformIndexing = true;
-        deviceFeatures12.shaderStorageBufferArrayNonUniformIndexing = true;
-        deviceFeatures12.shaderStorageImageArrayNonUniformIndexing = true;
+        pDeviceFeatures12->shaderUniformTexelBufferArrayDynamicIndexing = true;
+        pDeviceFeatures12->shaderStorageTexelBufferArrayDynamicIndexing = true;
+        pDeviceFeatures12->shaderUniformBufferArrayNonUniformIndexing = true;
+        pDeviceFeatures12->shaderSampledImageArrayNonUniformIndexing = true;
+        pDeviceFeatures12->shaderStorageBufferArrayNonUniformIndexing = true;
+        pDeviceFeatures12->shaderStorageImageArrayNonUniformIndexing = true;
         //deviceFeatures12.shaderInputAttachmentArrayNonUniformIndexing = true; // See above.
-        deviceFeatures12.shaderUniformTexelBufferArrayNonUniformIndexing = true;
-        deviceFeatures12.shaderStorageTexelBufferArrayNonUniformIndexing = true;
+        pDeviceFeatures12->shaderUniformTexelBufferArrayNonUniformIndexing = true;
+        pDeviceFeatures12->shaderStorageTexelBufferArrayNonUniformIndexing = true;
         //deviceFeatures12.descriptorBindingUniformBufferUpdateAfterBind = true; // Not supported on NVidia Pascal and earlier, as well as SwiftShader.
-        deviceFeatures12.descriptorBindingSampledImageUpdateAfterBind = true;
-        deviceFeatures12.descriptorBindingStorageImageUpdateAfterBind = true;
-        deviceFeatures12.descriptorBindingStorageBufferUpdateAfterBind = true;
-        deviceFeatures12.descriptorBindingUniformTexelBufferUpdateAfterBind = true;
-        deviceFeatures12.descriptorBindingStorageTexelBufferUpdateAfterBind = true;
-        deviceFeatures12.descriptorBindingUpdateUnusedWhilePending = true;
-        deviceFeatures12.descriptorBindingPartiallyBound = true;
-        deviceFeatures12.descriptorBindingVariableDescriptorCount = true;
-        deviceFeatures12.runtimeDescriptorArray = true;
-        deviceFeatures12.separateDepthStencilLayouts = true;
-        deviceFeatures12.hostQueryReset = true;
-        deviceFeatures12.timelineSemaphore = true;
-        deviceFeatures12.bufferDeviceAddress = true;
-        deviceFeatures12.shaderOutputViewportIndex = features.ViewInstancing;
-        deviceFeatures12.shaderOutputLayer = features.ViewInstancing;
-        
-        if (added)
-            deviceExtensionObjects = &deviceFeatures12;
+        pDeviceFeatures12->descriptorBindingSampledImageUpdateAfterBind = true;
+        pDeviceFeatures12->descriptorBindingStorageImageUpdateAfterBind = true;
+        pDeviceFeatures12->descriptorBindingStorageBufferUpdateAfterBind = true;
+        pDeviceFeatures12->descriptorBindingUniformTexelBufferUpdateAfterBind = true;
+        pDeviceFeatures12->descriptorBindingStorageTexelBufferUpdateAfterBind = true;
+        pDeviceFeatures12->descriptorBindingUpdateUnusedWhilePending = true;
+        pDeviceFeatures12->descriptorBindingPartiallyBound = true;
+        pDeviceFeatures12->descriptorBindingVariableDescriptorCount = true;
+        pDeviceFeatures12->runtimeDescriptorArray = true;
+        pDeviceFeatures12->separateDepthStencilLayouts = true;
+        pDeviceFeatures12->hostQueryReset = true;
+        pDeviceFeatures12->timelineSemaphore = true;
+        pDeviceFeatures12->bufferDeviceAddress = true;
+        pDeviceFeatures12->shaderOutputViewportIndex = features.ViewInstancing;
+        pDeviceFeatures12->shaderOutputLayer = features.ViewInstancing;
 
-        auto deviceFeatures11 = findOrCreateExtension<VkPhysicalDeviceVulkan11Features>(VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_VULKAN_1_1_FEATURES, deviceExtensionObjects, added);
-        deviceFeatures11.shaderDrawParameters = true;
-        
-        if (added)
-            deviceExtensionObjects = &deviceFeatures11;
+        VkPhysicalDeviceVulkan11Features deviceFeatures11{ .sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_VULKAN_1_1_FEATURES, .pNext = deviceExtensionObjects };
+        auto pDeviceFeatures11 = findExtension<VkPhysicalDeviceVulkan11Features>(VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_VULKAN_1_1_FEATURES, deviceExtensionObjects);
 
-        auto depthClipEnableFeatures = findOrCreateExtension<VkPhysicalDeviceDepthClipEnableFeaturesEXT>(VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_DEPTH_CLIP_ENABLE_FEATURES_EXT, deviceExtensionObjects, added);
-        depthClipEnableFeatures.depthClipEnable = true;
-        
-        if (added)
-            deviceExtensionObjects = &depthClipEnableFeatures;
+        if (pDeviceFeatures11 == nullptr) {
+            pDeviceFeatures11 = &deviceFeatures11;
+            deviceExtensionObjects = pDeviceFeatures11;
+        }
 
-        auto extendedDynamicStateFeatures = findOrCreateExtension<VkPhysicalDeviceExtendedDynamicStateFeaturesEXT>(VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_EXTENDED_DYNAMIC_STATE_FEATURES_EXT, deviceExtensionObjects, added);
-        extendedDynamicStateFeatures.extendedDynamicState = true;
-        
-        if (added)
-            deviceExtensionObjects = &extendedDynamicStateFeatures;
+        pDeviceFeatures11->shaderDrawParameters = true;
 
-        auto descriptorBufferFeatures = findOrCreateExtension<VkPhysicalDeviceDescriptorBufferFeaturesEXT>(VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_DESCRIPTOR_BUFFER_FEATURES_EXT, deviceExtensionObjects, added);
-        descriptorBufferFeatures.descriptorBuffer = true;
-        
-        if (added)
-            deviceExtensionObjects = &descriptorBufferFeatures;
+        if (features.ViewInstancing) {
+            pDeviceFeatures11->multiview = true;
+#ifndef LITEFX_BUILD_TESTS
+            pDeviceFeatures11->multiviewGeometryShader = true;
+            pDeviceFeatures11->multiviewTessellationShader = true;
+#endif // LITEFX_BUILD_TESTS
+        }
+
+        VkPhysicalDeviceDepthClipEnableFeaturesEXT depthClipEnableFeatures{ .sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_DEPTH_CLIP_ENABLE_FEATURES_EXT, .pNext = deviceExtensionObjects };
+        auto pDepthClipEnableFeatures = findExtension<VkPhysicalDeviceDepthClipEnableFeaturesEXT>(VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_DEPTH_CLIP_ENABLE_FEATURES_EXT, deviceExtensionObjects);
+
+        if (pDepthClipEnableFeatures == nullptr) {
+            pDepthClipEnableFeatures = &depthClipEnableFeatures;
+            deviceExtensionObjects = pDepthClipEnableFeatures;
+        }
+
+        pDepthClipEnableFeatures->depthClipEnable = true;
+
+        VkPhysicalDeviceExtendedDynamicStateFeaturesEXT extendedDynamicStateFeatures{ .sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_EXTENDED_DYNAMIC_STATE_FEATURES_EXT, .pNext = deviceExtensionObjects };
+        auto pExtendedDynamicStateFeatures = findExtension<VkPhysicalDeviceExtendedDynamicStateFeaturesEXT>(VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_EXTENDED_DYNAMIC_STATE_FEATURES_EXT, deviceExtensionObjects);
+
+        if (pExtendedDynamicStateFeatures == nullptr) {
+            pExtendedDynamicStateFeatures = &extendedDynamicStateFeatures;
+            deviceExtensionObjects = pExtendedDynamicStateFeatures;
+        }
+
+        pExtendedDynamicStateFeatures->extendedDynamicState = true;
+
+        VkPhysicalDeviceDescriptorBufferFeaturesEXT descriptorBufferFeatures{ .sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_DESCRIPTOR_BUFFER_FEATURES_EXT, .pNext = deviceExtensionObjects };
+        auto pDescriptorBufferFeatures = findExtension<VkPhysicalDeviceDescriptorBufferFeaturesEXT>(VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_DESCRIPTOR_BUFFER_FEATURES_EXT, deviceExtensionObjects);
+
+        if (pDescriptorBufferFeatures == nullptr) {
+            pDescriptorBufferFeatures = &descriptorBufferFeatures;
+            deviceExtensionObjects = pDescriptorBufferFeatures;
+        }
+
+        pDescriptorBufferFeatures->descriptorBuffer = true;
 
         // Define the device itself.
         VkDeviceCreateInfo createInfo = {
@@ -582,7 +620,7 @@ public:
             vkCmdSetDescriptorBufferOffsets = reinterpret_cast<PFN_vkCmdSetDescriptorBufferOffsetsEXT>(::vkGetDeviceProcAddr(device, "vkCmdSetDescriptorBufferOffsetsEXT"));
 
         // NOLINTEND(cppcoreguidelines-pro-type-reinterpret-cast)
-        
+
         // Return the device instance.
         return device;
     }

--- a/src/Backends/Vulkan/src/pipeline_layout.cpp
+++ b/src/Backends/Vulkan/src/pipeline_layout.cpp
@@ -73,7 +73,7 @@ public:
         {
             rangeHandles = pushConstantsLayout->ranges()
                 | std::views::transform([](const auto& range) -> VkPushConstantRange {
-                        return { .stageFlags = static_cast<VkShaderStageFlags>(Vk::getShaderStage(range->stage())), .offset = range->offset(), .size = range->size() };
+                        return { .stageFlags = static_cast<VkShaderStageFlags>(std::to_underlying(range->stageMask())), .offset = range->offset(), .size = range->size() };
                     })
                 | std::ranges::to<Array<VkPushConstantRange>>();
         }

--- a/src/Backends/Vulkan/src/push_constants_layout.cpp
+++ b/src/Backends/Vulkan/src/push_constants_layout.cpp
@@ -13,7 +13,6 @@ public:
     friend class VulkanPushConstantsLayout;
 
 private:
-    Dictionary<ShaderStage, VulkanPushConstantsRange*> m_ranges;
     Array<UniquePtr<VulkanPushConstantsRange>> m_rangePointers;
     UInt32 m_size;
 
@@ -32,13 +31,6 @@ private:
     void setRanges(Enumerable<UniquePtr<VulkanPushConstantsRange>>&& ranges)
     {
         m_rangePointers = std::move(ranges) | std::views::as_rvalue | std::ranges::to<std::vector>();
-
-        std::ranges::for_each(m_rangePointers, [this](const UniquePtr<VulkanPushConstantsRange>& range) {
-            if (m_ranges.contains(static_cast<ShaderStage>(range->stage())))
-                throw InvalidArgumentException("ranges", "Only one push constant range can be mapped to a shader stage.");
-
-            m_ranges[range->stage()] = range.get();
-        });
     }
 };
 
@@ -64,17 +56,6 @@ VulkanPushConstantsLayout::~VulkanPushConstantsLayout() noexcept = default;
 UInt32 VulkanPushConstantsLayout::size() const noexcept
 {
     return m_impl->m_size;
-}
-
-const VulkanPushConstantsRange& VulkanPushConstantsLayout::range(ShaderStage stage) const
-{
-    if (!(std::to_underlying(stage) && !(std::to_underlying(stage) & (std::to_underlying(stage) - 1))))
-        throw InvalidArgumentException("stage", "The stage mask must only contain one shader stage.");
-
-    if (!m_impl->m_ranges.contains(stage))
-        throw InvalidArgumentException("stage", "No push constant range has been associated with the provided shader stage.");
-
-    return *m_impl->m_ranges[stage];
 }
 
 const Array<UniquePtr<VulkanPushConstantsRange>>& VulkanPushConstantsLayout::ranges() const

--- a/src/Backends/Vulkan/src/push_constants_range.cpp
+++ b/src/Backends/Vulkan/src/push_constants_range.cpp
@@ -11,21 +11,18 @@ public:
     friend class VulkanPushConstantsRange;
 
 private:
-    ShaderStage m_stage;
+    ShaderStage m_stageMask;
     UInt32 m_offset, m_size, m_space, m_binding;
 
 public:
-    VulkanPushConstantsRangeImpl(ShaderStage shaderStage, UInt32 offset, UInt32 size, UInt32 space, UInt32 binding) :
-        m_stage(shaderStage), m_offset(offset), m_size(size), m_space(space), m_binding(binding)
+    VulkanPushConstantsRangeImpl(ShaderStage shaderStageMask, UInt32 offset, UInt32 size, UInt32 space, UInt32 binding) :
+        m_stageMask(shaderStageMask), m_offset(offset), m_size(size), m_space(space), m_binding(binding)
     {
         if (offset % 4 != 0)
             throw InvalidArgumentException("offset", "The push constants range offset must be a multiple of 4 bytes.");
 
         if (size % 4 != 0)
             throw InvalidArgumentException("size", "The push constants range size must be a multiple of 4 bytes.");
-
-        if (!(std::to_underlying(shaderStage) && !(std::to_underlying(shaderStage) & (std::to_underlying(shaderStage) - 1))))
-            throw InvalidArgumentException("shaderStage", "A push constant range is only allowed to be associated with one shader stage.");
     }
 };
 
@@ -33,8 +30,8 @@ public:
 // Shared interface.
 // ------------------------------------------------------------------------------------------------
 
-VulkanPushConstantsRange::VulkanPushConstantsRange(ShaderStage shaderStage, UInt32 offset, UInt32 size, UInt32 space, UInt32 binding) :
-    m_impl(shaderStage, offset, size, space, binding)
+VulkanPushConstantsRange::VulkanPushConstantsRange(ShaderStage shaderStageMask, UInt32 offset, UInt32 size, UInt32 space, UInt32 binding) :
+    m_impl(shaderStageMask, offset, size, space, binding)
 {
 }
 
@@ -64,7 +61,7 @@ UInt32 VulkanPushConstantsRange::size() const noexcept
     return m_impl->m_size;
 }
 
-ShaderStage VulkanPushConstantsRange::stage() const noexcept
+ShaderStage VulkanPushConstantsRange::stageMask() const noexcept
 {
-    return m_impl->m_stage;
+    return m_impl->m_stageMask;
 }

--- a/src/Backends/Vulkan/src/queue.cpp
+++ b/src/Backends/Vulkan/src/queue.cpp
@@ -139,23 +139,26 @@ void VulkanQueue::beginDebugRegion(const String& label, const Vectors::ByteVecto
 		.color = { static_cast<float>(color.x()) / static_cast<float>(std::numeric_limits<UInt8>::max()), static_cast<float>(color.y()) / static_cast<float>(std::numeric_limits<UInt8>::max()), static_cast<float>(color.z()) / static_cast<float>(std::numeric_limits<UInt8>::max()), 1.0f }
 	};
 	
-	::vkQueueBeginDebugUtilsLabel(this->handle(), &labelInfo);
+	if (::vkQueueBeginDebugUtilsLabel)
+		::vkQueueBeginDebugUtilsLabel(this->handle(), &labelInfo);
 }
 
 void VulkanQueue::endDebugRegion() const noexcept
 {
-	::vkQueueEndDebugUtilsLabel(this->handle());
+	if (::vkQueueEndDebugUtilsLabel)
+		::vkQueueEndDebugUtilsLabel(this->handle());
 }
 
 void VulkanQueue::setDebugMarker(const String& label, const Vectors::ByteVector3& color) const noexcept
 {
-	VkDebugUtilsLabelEXT labelInfo{
+	VkDebugUtilsLabelEXT labelInfo {
 		.sType = VK_STRUCTURE_TYPE_DEBUG_UTILS_LABEL_EXT,
 		.pLabelName = label.c_str(),
 		.color = { static_cast<float>(color.x()) / static_cast<float>(std::numeric_limits<UInt8>::max()), static_cast<float>(color.y()) / static_cast<float>(std::numeric_limits<UInt8>::max()), static_cast<float>(color.z()) / static_cast<float>(std::numeric_limits<UInt8>::max()), 1.0f }
 	};
 
-	::vkQueueInsertDebugUtilsLabel(this->handle(), &labelInfo);
+	if (::vkQueueInsertDebugUtilsLabel)
+		::vkQueueInsertDebugUtilsLabel(this->handle(), &labelInfo);
 }
 #endif // LITEFX_BUILD_SUPPORT_DEBUG_MARKERS
 

--- a/src/Backends/Vulkan/src/shader_program.cpp
+++ b/src/Backends/Vulkan/src/shader_program.cpp
@@ -500,7 +500,7 @@ public:
             }
         }(std::move(pushConstantRanges)) | std::ranges::to<Array<UniquePtr<VulkanPushConstantsRange>>>();
 
-        auto overallSize = std::ranges::max(pushConstants | std::views::transform([](const auto& r) { return r->offset() + r->size(); }));
+        auto overallSize = pushConstants.empty() ? 0u : std::ranges::max(pushConstants | std::views::transform([](const auto& r) { return r->offset() + r->size(); }));
         auto pushConstantsLayout = makeUnique<VulkanPushConstantsLayout>(pushConstants | std::views::as_rvalue, overallSize);
 
         // Return the pipeline layout.

--- a/src/Backends/Vulkan/src/shader_program.cpp
+++ b/src/Backends/Vulkan/src/shader_program.cpp
@@ -456,7 +456,7 @@ public:
                         })
                     | std::ranges::to<std::vector>();
 
-                pushConstantRanges.erase(pushConstantRanges.begin(), pushConstantRanges.begin() + overlaps.size());
+                pushConstantRanges.erase(pushConstantRanges.begin(), pushConstantRanges.begin() + static_cast<decltype(pushConstantRanges)::difference_type>(overlaps.size()));
 
                 // Next, we need to resolve the overlaps. The idea is to walk through the address space incrementally. With each step, we evaluate the size of the 
                 // overlapping region, as well as the affected shader stages. We keep track of the offset and yield a new range at each step.

--- a/src/Backends/Vulkan/src/shader_program.cpp
+++ b/src/Backends/Vulkan/src/shader_program.cpp
@@ -326,13 +326,8 @@ public:
             });
 
             // Parse push constants.
-            // NOTE: Block variables are not exposing the shader stage, they are used from. If there are two shader modules created from the same source, but with different 
-            //       entry points, each using their own push constants, it would be valid, but we are not able to tell which push constant range belongs to which stage.
-            if (pushConstantCount > 1)
-                LITEFX_WARNING(VULKAN_LOG, "More than one push constant range detected for shader stage {0}. If you have multiple entry points, you may be able to split them up into different shader files.", shaderModule->type());
-
             std::ranges::for_each(pushConstants, [&shaderModule, &pushConstantRanges](const SpvReflectBlockVariable* pushConstant) {
-                pushConstantRanges.push_back(PushConstantRangeInfo{ .stage = shaderModule->type(), .offset = pushConstant->absolute_offset, .size = pushConstant->padded_size });
+                pushConstantRanges.emplace_back(shaderModule->type(), pushConstant->absolute_offset, pushConstant->padded_size);
             });
         });
 
@@ -429,12 +424,83 @@ public:
         }(m_device, std::move(descriptorSetLayouts)) | std::ranges::to<Array<SharedPtr<VulkanDescriptorSetLayout>>>();
 
         // Create the push constants layout.
-        auto overallSize = std::accumulate(pushConstantRanges.begin(), pushConstantRanges.end(), 0, [](UInt32 currentSize, const auto& range) { return currentSize + range.size; });
+        // NOTE: In Vulkan, push constant ranges are a uniform memory block, that is accessed at different offsets from different stages. We thus need to iterate 
+        //       the ranges and potentially create new ones, where there's an overlap. We assume that the first range starts at offset 0x00. The overall size is
+        //       obtained by the maximum sum of offset and size over all ranges. In between, there can be multiple "partitions" that may be accessed from different
+        //       shader stages.
+        std::ranges::sort(pushConstantRanges, [](const auto& lhs, const auto& rhs) { return lhs.offset <= rhs.offset; });
+
         auto pushConstants = [](Array<PushConstantRangeInfo> pushConstantRanges) -> std::generator<UniquePtr<VulkanPushConstantsRange>> {
-            for (auto it = pushConstantRanges.begin(); it != pushConstantRanges.end(); ++it)
-                co_yield makeUnique<VulkanPushConstantsRange>(it->stage, it->offset, it->size, 0, 0);   // No space or binding for Vulkan push constants.
+            while (!pushConstantRanges.empty())
+            {
+                // Get the first range and remove it.
+                auto range = pushConstantRanges.front();
+                pushConstantRanges.erase(pushConstantRanges.begin());
+
+                // Check if the next range does not overlap - this is the most straightforward case, where we simply yield a 1-1 mapping between ranges and stages.
+                if (pushConstantRanges.empty() || pushConstantRanges.front().offset >= range.offset + range.size)
+                {
+                    co_yield makeUnique<VulkanPushConstantsRange>(range.stage, range.offset, range.size, 0, 0);
+                    continue;
+                }
+
+                // Now we need to remove all ranges until we find the first one again, that does no longer overlap.
+                UInt32 lastEnd = range.offset + range.size;
+                auto overlaps = pushConstantRanges 
+                    | std::views::take_while([&lastEnd](const auto& r) { 
+                            if (lastEnd <= r.offset)
+                                return false;
+
+                            lastEnd = r.offset + r.size;
+                            return true;
+                        })
+                    | std::ranges::to<std::vector>();
+
+                pushConstantRanges.erase(pushConstantRanges.begin(), pushConstantRanges.begin() + overlaps.size());
+
+                // Next, we need to resolve the overlaps. The idea is to walk through the address space incrementally. With each step, we evaluate the size of the 
+                // overlapping region, as well as the affected shader stages. We keep track of the offset and yield a new range at each step.
+                overlaps.insert(overlaps.begin(), range);
+
+                while (!overlaps.empty())
+                {
+                    UInt32 offset = overlaps.front().offset;
+                    ShaderStage stageMask = overlaps.front().stage;
+                    UInt32 size = 0u;
+
+                    // Search for the next overlap begin.
+                    for (auto& r : overlaps)
+                    {
+                        // Get the overlap size.
+                        size = r.offset - offset;
+
+                        // If the overlap size is 0, it means that the range starts at exactly the same position as the last one, so we need to include it into the range.
+                        if (size > 0)
+                            break;
+                        else
+                        {
+                            stageMask |= r.stage;
+                            continue;
+                        }
+                    }
+
+                    // If the size is 0, all overlaps start at the same offset, so we now need to find the smallest size.
+                    if (size == 0)
+                        size = std::ranges::min(overlaps | std::views::transform([](const auto& r) { return r.size; }));
+
+                    // Yield another range.
+                    co_yield makeUnique<VulkanPushConstantsRange>(stageMask, offset, size, 0, 0);
+
+                    // Increase the offset of each overlapping range by the size and remove the ones, where the remaining size gets 0.
+                    std::ranges::for_each(overlaps, [&size](auto& r) { r.offset += size; r.size -= size; });
+                    auto [from, to] = std::ranges::remove_if(overlaps, [](const auto& r) { return r.size == 0; });
+
+                    overlaps.erase(from, to);
+                }
+            }
         }(std::move(pushConstantRanges)) | std::ranges::to<Array<UniquePtr<VulkanPushConstantsRange>>>();
 
+        auto overallSize = std::ranges::max(pushConstants | std::views::transform([](const auto& r) { return r->offset() + r->size(); }));
         auto pushConstantsLayout = makeUnique<VulkanPushConstantsLayout>(pushConstants | std::views::as_rvalue, overallSize);
 
         // Return the pipeline layout.

--- a/src/Rendering/include/litefx/rendering_api.hpp
+++ b/src/Rendering/include/litefx/rendering_api.hpp
@@ -6629,7 +6629,7 @@ namespace LiteFX::Rendering {
         /// Returns the shader stage(s), the range is accessible from.
         /// </summary>
         /// <returns>The shader stage(s), the range is accessible from.</returns>
-        virtual ShaderStage stage() const noexcept = 0;
+        virtual ShaderStage stageMask() const noexcept = 0;
     };
 
     /// <summary>
@@ -6652,16 +6652,6 @@ namespace LiteFX::Rendering {
         /// </summary>
         /// <returns>The size (in bytes) of the push constants backing memory.</returns>
         virtual UInt32 size() const noexcept = 0;
-
-        /// <summary>
-        /// Returns the push constant range associated with the shader stage provided in <paramref name="stage" />.
-        /// </summary>
-        /// <param name="stage">The shader stage to request the associated push constant range for. Specifying multiple stages is not supported and will raise an exception.</param>
-        /// <returns>The push constant range associated with the provided shader stage.</returns>
-        /// <exception cref="ArgumentOutOfRangeException">Thrown, if no range is mapped to the provided shader stage.</exception>
-        /// <exception cref="InvalidArgumentException">Thrown, if <paramref name="stage" /> contains multiple shader stages.</exception>
-        /// <seealso cref="ranges" />
-        virtual const IPushConstantsRange& range(ShaderStage stage) const = 0;
 
         /// <summary>
         /// Returns all push constant ranges.

--- a/src/Tests/Backends.D3D12/setup_push_constants.cpp
+++ b/src/Tests/Backends.D3D12/setup_push_constants.cpp
@@ -75,7 +75,12 @@ void TestApp::onInit()
         if (std::ranges::distance(renderPipeline->layout()->pushConstants()->ranges()) != 1)
             LITEFX_TEST_FAIL("std::ranges::distance(renderPipeline->layout()->pushConstants()->ranges()) != 1");
 
-        auto& range = renderPipeline->layout()->pushConstants()->range(ShaderStage::Vertex);
+        auto& ranges = renderPipeline->layout()->pushConstants()->ranges();
+
+        if (ranges.size() != 1)
+            LITEFX_TEST_FAIL("ranges.size() != 1");
+
+        auto& range = *ranges.front();
 
         if (range.binding() != 0)
             LITEFX_TEST_FAIL("range.binding() != 0");
@@ -86,7 +91,7 @@ void TestApp::onInit()
         if (range.offset() != 0)
             LITEFX_TEST_FAIL("range.offset() != 0");
 
-        if (range.stage() != ShaderStage::Vertex)
+        if (range.stageMask() != ShaderStage::Vertex)
             LITEFX_TEST_FAIL("range.stage() != ShaderStage::Vertex");
 
         if (range.size() != sizeof(float) * 4 * 4)

--- a/src/Tests/Backends.Vk/setup_push_constants.cpp
+++ b/src/Tests/Backends.Vk/setup_push_constants.cpp
@@ -75,7 +75,12 @@ void TestApp::onInit()
         if (std::ranges::distance(renderPipeline->layout()->pushConstants()->ranges()) != 1)
             LITEFX_TEST_FAIL("std::ranges::distance(renderPipeline->layout()->pushConstants()->ranges()) != 1");
 
-        auto& range = renderPipeline->layout()->pushConstants()->range(ShaderStage::Vertex);
+        auto& ranges = renderPipeline->layout()->pushConstants()->ranges();
+
+        if (ranges.size() != 1)
+            LITEFX_TEST_FAIL("ranges.size() != 1");
+
+        auto& range = *ranges.front();
 
         if (range.binding() != 0)
             LITEFX_TEST_FAIL("range.binding() != 0");
@@ -87,7 +92,7 @@ void TestApp::onInit()
         if (range.offset() != 0)
             LITEFX_TEST_FAIL("range.offset() != 0");
 
-        if (range.stage() != ShaderStage::Vertex)
+        if (range.stageMask() != ShaderStage::Vertex)
             LITEFX_TEST_FAIL("range.stage() != ShaderStage::Vertex");
 
         if (range.size() != sizeof(float) * 4 * 4)


### PR DESCRIPTION
**Describe the pull request**

Earlier, push constants were only allowed to be passed on a per-stage. Especially in ray-tracing or tessellation pipelines, where multiple stages should read the same data ranges, this becomes inhandy, as one would have to set multiple copies of the same data for each stage. This PR removes this limitation. First, the shader stage mask returned by a push constants range can now contain multiple stages. Moreover, shader reflection has been extended to find overlapping areas. In D3D12, where root descriptor constants act similar to other descriptor bindings, overlapping bindings are simply merged and receive the appropriate shader stage mask. In Vulkan, where push constants are spans over a common block of memory, this process can be more involved. The new implementation now looks for overlapping regions and creates new ranges accordingly, such that each overlap will have the it's own region with the appropriate stage mask set. From an API-side, no further changes are required.
