### PR TITLE
Fix Vulkan render pipeline constructor argument order.

### DIFF
--- a/docs/release-logs/0.6.1.md
+++ b/docs/release-logs/0.6.1.md
@@ -8,6 +8,7 @@
 
 - Update Vulkan SDK to 1.4. (See [PR #196](https://github.com/crud89/LiteFX/pull/196))
 - Allow to supply custom instance and device extensions. (See [PR #198](https://github.com/crud89/LiteFX/pull/198), [PR #203](https://github.com/crud89/LiteFX/pull/203) and [PR #204](https://github.com/crud89/LiteFX/pull/204))
+- Fix render pipeline constructor argument order. (See [PR #206](https://github.com/crud89/LiteFX/pull/206))
 
 **👥 Contributors:**
 

--- a/src/Backends/Vulkan/include/litefx/backends/vulkan.hpp
+++ b/src/Backends/Vulkan/include/litefx/backends/vulkan.hpp
@@ -1879,15 +1879,15 @@ namespace LiteFX::Rendering::Backends {
         /// Initializes a new Vulkan render pipeline.
         /// </summary>
         /// <param name="renderPass">The parent render pass.</param>
-        /// <param name="shaderProgram">The shader program used by the pipeline.</param>
         /// <param name="layout">The layout of the pipeline.</param>
+        /// <param name="shaderProgram">The shader program used by the pipeline.</param>
         /// <param name="inputAssembler">The input assembler state of the pipeline.</param>
         /// <param name="rasterizer">The rasterizer state of the pipeline.</param>
         /// <param name="samples">The initial multi-sampling level of the render pipeline.</param>
         /// <param name="enableAlphaToCoverage">Whether or not to enable Alpha-to-Coverage multi-sampling.</param>
         /// <param name="name">The optional name of the render pipeline.</param>
-        explicit VulkanRenderPipeline(const VulkanRenderPass& renderPass, const SharedPtr<VulkanShaderProgram>& shaderProgram, const SharedPtr<VulkanPipelineLayout>& layout, const SharedPtr<VulkanInputAssembler>& inputAssembler, const SharedPtr<VulkanRasterizer>& rasterizer, MultiSamplingLevel samples = MultiSamplingLevel::x1, bool enableAlphaToCoverage = false, const String& name = "");
-
+        explicit VulkanRenderPipeline(const VulkanRenderPass& renderPass, const SharedPtr<VulkanPipelineLayout>& layout, const SharedPtr<VulkanShaderProgram>& shaderProgram, const SharedPtr<VulkanInputAssembler>& inputAssembler, const SharedPtr<VulkanRasterizer>& rasterizer, MultiSamplingLevel samples = MultiSamplingLevel::x1, bool enableAlphaToCoverage = false, const String& name = "");
+        
         /// <inheritdoc />
         VulkanRenderPipeline(VulkanRenderPipeline&&) noexcept = delete;
 

--- a/src/Backends/Vulkan/src/render_pipeline.cpp
+++ b/src/Backends/Vulkan/src/render_pipeline.cpp
@@ -476,7 +476,7 @@ public:
 // Interface.
 // ------------------------------------------------------------------------------------------------
 
-VulkanRenderPipeline::VulkanRenderPipeline(const VulkanRenderPass& renderPass, const SharedPtr<VulkanShaderProgram>& shaderProgram, const SharedPtr<VulkanPipelineLayout>& layout, const SharedPtr<VulkanInputAssembler>& inputAssembler, const SharedPtr<VulkanRasterizer>& rasterizer, MultiSamplingLevel samples, bool enableAlphaToCoverage, const String& name) :
+VulkanRenderPipeline::VulkanRenderPipeline(const VulkanRenderPass& renderPass, const SharedPtr<VulkanPipelineLayout>& layout, const SharedPtr<VulkanShaderProgram>& shaderProgram, const SharedPtr<VulkanInputAssembler>& inputAssembler, const SharedPtr<VulkanRasterizer>& rasterizer, MultiSamplingLevel samples, bool enableAlphaToCoverage, const String& name) :
 	VulkanPipelineState(VK_NULL_HANDLE), m_impl(renderPass, enableAlphaToCoverage, layout, shaderProgram, inputAssembler, rasterizer)
 {
 	this->handle() = m_impl->initialize(*this, samples);


### PR DESCRIPTION
**Describe the pull request**

The Vulkan render pipeline constructor used a different argument order compared to the compute pipeline or the D3D12 backend pipelines. This required extra work to get them initialized when not using builders. This PR corrects the order of the arguments.