### PR TITLE
Add `tryAllocate` overload to virtual allocators.

### DIFF
--- a/docs/release-logs/0.6.1.md
+++ b/docs/release-logs/0.6.1.md
@@ -3,6 +3,7 @@
 - Update toolchain to LLVM 21. (See [PR #197](https://github.com/crud89/LiteFX/pull/197))
 - Add missing primitive topologies for adjacency and patch lists. (See [PR #201](https://github.com/crud89/LiteFX/pull/201))
 - Allow overlapping push constants ranges between shader stages. (See [PR #205](https://github.com/crud89/LiteFX/pull/205))
+- Add `tryAllocate` method to virtual allocators. (See [PR #207](https://github.com/crud89/LiteFX/pull/207))
 
 **🌋 Vulkan:**
 

--- a/src/Backends/DirectX12/src/virtual_allocator.hpp
+++ b/src/Backends/DirectX12/src/virtual_allocator.hpp
@@ -40,6 +40,16 @@ public:
 
 	inline Allocation allocate(UInt64 size, UInt32 alignment, AllocationStrategy strategy = AllocationStrategy::OptimizePacking, void* privateData = nullptr) const override
 	{
+		auto allocation = this->tryAllocate(size, alignment, strategy, privateData);
+
+		if (allocation.has_value()) [[likely]]
+			return allocation.value();
+		else
+			throw RuntimeException("An allocation from a virtual allocator failed.");
+	}
+
+	inline Optional<Allocation> tryAllocate(UInt64 size, UInt32 alignment = 1u, AllocationStrategy strategy = AllocationStrategy::OptimizePacking, void* privateData = nullptr) const override 
+	{
 		D3D12MA::VIRTUAL_ALLOCATION_DESC allocDesc = {
 			.Flags = strategy == AllocationStrategy::OptimizeTime ?
 				D3D12MA::VIRTUAL_ALLOCATION_FLAG_STRATEGY_MIN_TIME :
@@ -53,12 +63,12 @@ public:
 		auto result = m_block->Allocate(&allocDesc, &allocation, &offset);
 
 		if (FAILED(result)) [[unlikely]]
-			throw RuntimeException("An allocation from a virtual allocator failed.");
+			return std::nullopt;
 
 		if (privateData != nullptr)
 			m_block->SetAllocationPrivateData(allocation, privateData);
 
-		return { .Handle = allocation.AllocHandle, .Size = size, .Offset = offset };
+		return Allocation { .Handle = allocation.AllocHandle, .Size = size, .Offset = offset };
 	}
 
 	inline void free(Allocation&& allocation) const override

--- a/src/Backends/Vulkan/src/virtual_allocator.hpp
+++ b/src/Backends/Vulkan/src/virtual_allocator.hpp
@@ -38,6 +38,16 @@ public:
 
 	inline Allocation allocate(UInt64 size, UInt32 alignment, AllocationStrategy strategy = AllocationStrategy::OptimizePacking, void* privateData = nullptr) const override
 	{
+		auto allocation = this->tryAllocate(size, alignment, strategy, privateData);
+
+		if (allocation.has_value()) [[likely]]
+			return allocation.value();
+		else
+			throw RuntimeException("An allocation from a virtual allocator failed.");
+	}
+
+	inline Optional<Allocation> tryAllocate(UInt64 size, UInt32 alignment = 1u, AllocationStrategy strategy = AllocationStrategy::OptimizePacking, void* privateData = nullptr) const override
+	{
 		VmaVirtualAllocationCreateInfo allocationInfo = {
 			.size = size,
 			.alignment = alignment,
@@ -57,10 +67,11 @@ public:
 			if (privateData != nullptr)
 				::vmaSetVirtualAllocationUserData(m_block, allocation, privateData);
 
-			return Allocation{ .Handle = std::bit_cast<UInt64>(allocation), .Size = size, .Offset = static_cast<UInt64>(offset) };
+			return Allocation { .Handle = std::bit_cast<UInt64>(allocation), .Size = size, .Offset = static_cast<UInt64>(offset) };
 		}
 		else [[unlikely]]
-			throw RuntimeException("An allocation from a virtual allocator failed.");
+			return std::nullopt;
+
 	}
 
 	inline void free(Allocation&& allocation) const override

--- a/src/Rendering/include/litefx/rendering_api.hpp
+++ b/src/Rendering/include/litefx/rendering_api.hpp
@@ -3136,6 +3136,16 @@ namespace LiteFX::Rendering {
             [[nodiscard]] virtual Allocation allocate(UInt64 size, UInt32 alignment = 1u, AllocationStrategy strategy = AllocationStrategy::OptimizePacking, void* privateData = nullptr) const = 0;
 
             /// <summary>
+            /// Attempts to allocate a piece of memory of <paramref name="size" /> bytes, aligned to <paramref name="alignment" />. If the allocation fails `std::nullopt` is returned.
+            /// </summary>
+            /// <param name="size">The size (in bytes) of the resource to place in the allocation.</param>
+            /// <param name="alignment">The alignment requirements of the resource.</param>
+            /// <param name="strategy">The strategy to look for a place to put the allocation in.</param>
+            /// <param name="privateData">A pointer to an object that should be internally associated with the allocation.</param>
+            /// <returns>An object that contains details about the allocation, or `std::nullopt` if the allocation fails.</returns>
+            [[nodiscard]] virtual Optional<Allocation> tryAllocate(UInt64 size, UInt32 alignment = 1u, AllocationStrategy strategy = AllocationStrategy::OptimizePacking, void* privateData = nullptr) const = 0;
+
+            /// <summary>
             /// Releases an allocation from the allocator, so that its memory can be re-used later.
             /// </summary>
             /// <param name="allocation">The allocation to release.</param>
@@ -3218,6 +3228,18 @@ namespace LiteFX::Rendering {
         /// <returns>An object that contains details about the allocation.</returns>
         [[nodiscard]] inline Allocation allocate(UInt64 size, UInt32 alignment = 1u, AllocationStrategy strategy = AllocationStrategy::OptimizePacking, void* privateData = nullptr) const {
             return m_impl->allocate(size, alignment, strategy, privateData);
+        }
+
+        /// <summary>
+        /// Attempts to allocate a piece of memory of <paramref name="size" /> bytes, aligned to <paramref name="alignment" />. If the allocation fails `std::nullopt` is returned.
+        /// </summary>
+        /// <param name="size">The size (in bytes) of the resource to place in the allocation.</param>
+        /// <param name="alignment">The alignment requirements of the resource.</param>
+        /// <param name="strategy">The strategy to look for a place to put the allocation in.</param>
+        /// <param name="privateData">A pointer to an object that should be internally associated with the allocation.</param>
+        /// <returns>An object that contains details about the allocation, or `std::nullopt` if the allocation fails.</returns>
+        [[nodiscard]] virtual Optional<Allocation> tryAllocate(UInt64 size, UInt32 alignment = 1u, AllocationStrategy strategy = AllocationStrategy::OptimizePacking, void* privateData = nullptr) const {
+            return m_impl->tryAllocate(size, alignment, strategy, privateData);
         }
 
         /// <summary>


### PR DESCRIPTION
#188 introduced virtual allocators for user-managed memory blocks. One drawback of their implementation was, that one could only allocate from them directly, without any ability to check if the allocation would succeed. This PR adds a `tryAllocate` method which can be used in such a circumstance. It returns an `Optional` that either contains `std::nullopt` or the allocation, if the operation succeeded.