### PR TITLE
Fix missing primitive topology type in Vulkan converter. 

### DIFF
--- a/docs/release-logs/0.6.1.md
+++ b/docs/release-logs/0.6.1.md
@@ -1,7 +1,7 @@
 ﻿# LiteFX 0.6.1 - Alpha 06
 
 - Update toolchain to LLVM 21. (See [PR #197](https://github.com/crud89/LiteFX/pull/197))
-- Add missing primitive topologies for adjacency and patch lists. (See [PR #201](https://github.com/crud89/LiteFX/pull/201))
+- Add missing primitive topologies for adjacency and patch lists. (See [PR #201](https://github.com/crud89/LiteFX/pull/201) and [PR #209](https://github.com/crud89/LiteFX/pull/209))
 - Allow overlapping push constants ranges between shader stages. (See [PR #205](https://github.com/crud89/LiteFX/pull/205))
 - Add `tryAllocate` method to virtual allocators. (See [PR #207](https://github.com/crud89/LiteFX/pull/207))
 

--- a/src/Backends/Vulkan/src/convert.cpp
+++ b/src/Backends/Vulkan/src/convert.cpp
@@ -770,6 +770,8 @@ VkPrimitiveTopology LiteFX::Rendering::Backends::Vk::getPrimitiveTopology(Primit
 		return VkPrimitiveTopology::VK_PRIMITIVE_TOPOLOGY_TRIANGLE_LIST;
 	case PrimitiveTopology::TriangleListWithAdjacency:
 		return VkPrimitiveTopology::VK_PRIMITIVE_TOPOLOGY_TRIANGLE_LIST_WITH_ADJACENCY;
+	case PrimitiveTopology::TriangleStrip:
+		return VkPrimitiveTopology::VK_PRIMITIVE_TOPOLOGY_TRIANGLE_STRIP;
 	case PrimitiveTopology::TriangleStripWithAdjacency:
 		return VkPrimitiveTopology::VK_PRIMITIVE_TOPOLOGY_TRIANGLE_STRIP_WITH_ADJACENCY;
 	case PrimitiveTopology::PointList:


### PR DESCRIPTION
**Describe the pull request**

#201 introduced new primitive types. Due to an oversight, triangle strips were missing from one of the Vulkan conversion functions. This PR addresses that issue and adds back in triangle strips.