### PR TITLE
Query adapters from OS preferences.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,12 +29,6 @@ on:
         required: true
         default: 'checks' # Case sensitive. Must contain one or more of: 'checks', 'tests', 'tidy' or 'builds'.
 
-# Environment variables control which version of dependent software to install.
-env:
-  vulkanSdkVersion: '1.4.328.1'
-  mesaDriverVersion: '24.1.1'
-  llvmVersion: '20.1.8'
-
 # The following jobs are contained in this workflow:
 # - First, the `verify-permissions` job is executed. It checks if the comment user is a contributer or maintainer and if the comment refers to a pull request. It then parses the 
 # command string. If permission is granted, the result is then passed to the subsequent jobs, which only execute if this job outputs their respective launch command.
@@ -123,48 +117,30 @@ jobs:
             os: windows-latest
           #- name: ubuntu-latest
           #  os: ubuntu-latest
-      
+
     steps:
-      - name: Setup Vulkan SDK 
-        uses: jakoch/install-vulkan-sdk-action@v1
+      - name: Setup environment
+        run: echo "Setup environment"
+        env:
+          MESA_3D_VERSION: ${{ vars.MESA_3D_VERSION }}
+          VULKAN_SDK_VERSION: ${{ vars.VULKAN_SDK_VERSION }}
+
+          DEPENDENCY_DIR: ${{ runner.temp }}/dep/win
+          CACHE_KEY: windows-dependencies-mesa-${{ vars.MESA_3D_VERSION }}-vulkan-${{ vars.VULKAN_SDK_VERSION }}
+
+      - name: Lookup dependency cache (no restore use)
+        id: cache
+        uses: actions/cache/restore@v6
         with:
-          vulkan_version: ${{ env.vulkanSdkVersion }}
-          install_runtime: true
-          cache: true
-          stripdown: true
-          
-      - name: Lookup Mesa3D cache
-        uses: actions/cache@v4
-        id: lookup-mesa
-        with:
-          key: ${{ matrix.os }}-mesa3d-${{ env.mesaDriverVersion }}
-          path: ${{ github.workspace }}/dep/mesa/
+          path: ${{ env.DEPENDENCY_DIR }}
+          key: ${{ env.CACHE_KEY }}
           lookup-only: true
 
-      - name: Download Mesa3D driver
-        uses: robinraju/release-downloader@v1.10
-        if: steps.lookup-mesa.outputs.cache-hit != 'true'
-        with:
-          repository: 'pal1000/mesa-dist-win'
-          tag: '${{ env.mesaDriverVersion }}'
-          fileName: 'mesa3d-${{ env.mesaDriverVersion }}-release-msvc.7z'
-          out-file-path: 'dep/mesa/'  # ${{ github.workspace }} is prefixed automatically.
-          extract: false  # 7zip is not supported by this extension, so we have to do it on our own later.
-          
-      - name: Decompress Mesa3D driver
-        working-directory: '${{ github.workspace }}/dep/mesa/'
-        if: steps.lookup-mesa.outputs.cache-hit != 'true'
-        shell: bash
+      - name: Ensure cache exists
+        if: steps.cache.outputs.cache-hit != 'true'
         run: |
-          7z x '${{ github.workspace }}/dep/mesa/mesa3d-${{ env.mesaDriverVersion }}-release-msvc.7z'
-          rm '${{ github.workspace }}/dep/mesa/mesa3d-${{ env.mesaDriverVersion }}-release-msvc.7z'
-            
-      - name: Cache Mesa3D
-        uses: actions/cache/save@v4
-        if: steps.lookup-mesa.outputs.cache-hit != 'true'
-        with:
-          path: ${{ github.workspace }}/dep/mesa/
-          key: ${{ matrix.os }}-mesa3d-${{ env.mesaDriverVersion }}
+          echo "Cache is missing. Please run 'update_dependencies.yml' workflow first."
+          exit 1
           
   # ------------------------------------- Test job             -------------------------------------
   test:
@@ -186,8 +162,18 @@ jobs:
             os: windows-latest
             compiler: clang
             configuration: windows-clang-x64-test
-
+            
     steps:
+      - name: Setup environment
+        run: echo "Setup environment"
+        env:
+          MESA_3D_VERSION: ${{ vars.MESA_3D_VERSION }}
+          VULKAN_SDK_VERSION: ${{ vars.VULKAN_SDK_VERSION }}
+          LLVM_VERSION: ${{ vars.LLVM_VERSION }}
+
+          DEPENDENCY_DIR: ${{ runner.temp }}/dep/win
+          CACHE_KEY: windows-dependencies-mesa-${{ vars.MESA_3D_VERSION }}-vulkan-${{ vars.VULKAN_SDK_VERSION }}
+
       - name: Retrieve PR info
         id: retrieve-pr-from-issue-comment
         uses: actions/github-script@v3
@@ -237,14 +223,7 @@ jobs:
           ref: ${{ env.HEAD_SHA }}
           submodules: true
 
-      - name: Setup Vulkan SDK 
-        uses: jakoch/install-vulkan-sdk-action@v1
-        with:
-          vulkan_version: ${{ env.vulkanSdkVersion }}
-          install_runtime: true
-          cache: true
-          stripdown: false
-
+      # TODO: Move this into cache as well.
       - name: Install OpenCppCoverage
         id: install-opencppcoverage
         shell: bash
@@ -256,7 +235,13 @@ jobs:
         if: ${{ matrix.compiler == 'clang' }}
         uses: KyleMayes/install-llvm-action@v2.0.9
         with:
-          version: ${{ env.llvmVersion }}
+          version: ${{ env.LLVM_VERSION }}
+          
+      - name: Restore dependency cache
+        uses: actions/cache/restore@v6
+        with:
+          path: ${{ env.DEPENDENCY_DIR }}
+          key: ${{ env.CACHE_KEY }}
 
       - name: Setup build and test environment
         id: setup-environment
@@ -264,26 +249,20 @@ jobs:
         run: |
           echo "VCPKG_FEATURE_FLAGS=manifests" >> $env:GITHUB_ENV
           echo "C:\msys64\ucrt64\bin" >> $GITHUB_PATH
-          #echo "C:\VulkanSDK\${{ env.vulkanSdkVersion }}\runtime" >> $GITHUB_PATH  # Somehow does not get picked up by the MSVC development environment.
-          cp "C:\VulkanSDK\${{ env.vulkanSdkVersion }}\runtime\x64\vulkan-1.dll" "C:\Windows\System32\vulkan-1.dll"
-          cp "C:\VulkanSDK\${{ env.vulkanSdkVersion }}\runtime\x86\vulkan-1.dll" "C:\Windows\SysWOW64\vulkan-1.dll"
-
-      - name: Restore Mesa3D
-        uses: actions/cache/restore@v4
-        with:
-          path: ${{ github.workspace }}/dep/mesa/
-          key: ${{ matrix.os }}-mesa3d-${{ env.mesaDriverVersion }}
+          #echo "${{ env.DEPENDENCY_DIR }}/vulkan/${{ env.VULKAN_SDK_VERSION }}\runtime" >> $GITHUB_PATH  # Somehow does not get picked up by the MSVC development environment.
+          cp "${{ env.DEPENDENCY_DIR }}/vulkan/${{ env.VULKAN_SDK_VERSION }}\runtime\x64\vulkan-1.dll" "C:\Windows\System32\vulkan-1.dll"
+          cp "${{ env.DEPENDENCY_DIR }}/vulkan/${{ env.VULKAN_SDK_VERSION }}\runtime\x86\vulkan-1.dll" "C:\Windows\SysWOW64\vulkan-1.dll"
 
       - name: Install and Test Mesa3D driver
         working-directory: '${{ github.workspace }}/dep/mesa/'
         run: |         
-          reg add "HKLM\SOFTWARE\Khronos\Vulkan\Drivers" /v '${{ github.workspace }}\dep\mesa\x64\lvp_icd.x86_64.json' /t REG_DWORD /d 0 /f /reg:64
-          reg add "HKLM\SOFTWARE\Khronos\Vulkan\ExplicitLayers" /v 'C:\VulkanSDK\${{ env.vulkanSdkVersion }}\Bin\VkLayer_khronos_synchronization2.json' /t REG_DWORD /d 0 /f /reg:64
-          reg add "HKLM\SOFTWARE\Khronos\Vulkan\ExplicitLayers" /v 'C:\VulkanSDK\${{ env.vulkanSdkVersion }}\Bin\VkLayer_khronos_validation.json' /t REG_DWORD /d 0 /f /reg:64
-          reg add "HKLM\SOFTWARE\WOW6432Node\Khronos\Vulkan\Drivers" /v '${{ github.workspace }}\dep\mesa\x86\lvp_icd.x86.json' /t REG_DWORD /d 0 /f /reg:64
-          reg add "HKLM\SOFTWARE\WOW6432Node\Khronos\Vulkan\ExplicitLayers" /v 'C:\VulkanSDK\${{ env.vulkanSdkVersion }}\Bin32\VkLayer_khronos_synchronization2.json' /t REG_DWORD /d 0 /f /reg:64
-          reg add "HKLM\SOFTWARE\WOW6432Node\Khronos\Vulkan\ExplicitLayers" /v 'C:\VulkanSDK\${{ env.vulkanSdkVersion }}\Bin32\VkLayer_khronos_validation.json' /t REG_DWORD /d 0 /f /reg:64
-          C:\VulkanSDK\${{ env.vulkanSdkVersion }}\runtime\x64\vulkaninfo.exe --summary
+          reg add "HKLM\SOFTWARE\Khronos\Vulkan\Drivers" /v '${{ env.DEPENDENCY_DIR }}\mesa\x64\lvp_icd.x86_64.json' /t REG_DWORD /d 0 /f /reg:64
+          reg add "HKLM\SOFTWARE\Khronos\Vulkan\ExplicitLayers" /v '${{ env.DEPENDENCY_DIR }}\vulkan\${{ env.VULKAN_SDK_VERSION }}\Bin\VkLayer_khronos_synchronization2.json' /t REG_DWORD /d 0 /f /reg:64
+          reg add "HKLM\SOFTWARE\Khronos\Vulkan\ExplicitLayers" /v '${{ env.DEPENDENCY_DIR }}\vulkan\${{ env.VULKAN_SDK_VERSION }}\Bin\VkLayer_khronos_validation.json' /t REG_DWORD /d 0 /f /reg:64
+          reg add "HKLM\SOFTWARE\WOW6432Node\Khronos\Vulkan\Drivers" /v '${{ env.DEPENDENCY_DIR }}\mesa\x86\lvp_icd.x86.json' /t REG_DWORD /d 0 /f /reg:64
+          reg add "HKLM\SOFTWARE\WOW6432Node\Khronos\Vulkan\ExplicitLayers" /v '${{ env.DEPENDENCY_DIR }}\vulkan\${{ env.VULKAN_SDK_VERSION }}\Bin32\VkLayer_khronos_synchronization2.json' /t REG_DWORD /d 0 /f /reg:64
+          reg add "HKLM\SOFTWARE\WOW6432Node\Khronos\Vulkan\ExplicitLayers" /v '${{ env.DEPENDENCY_DIR }}\vulkan\${{ env.VULKAN_SDK_VERSION }}\Bin32\VkLayer_khronos_validation.json' /t REG_DWORD /d 0 /f /reg:64
+          ${{ env.DEPENDENCY_DIR }}\vulkan\${{ env.VULKAN_SDK_VERSION }}\runtime\x64\vulkaninfo.exe --summary
 
       - name: Restore or build vcpkg
         uses: lukka/run-vcpkg@v10
@@ -426,29 +405,27 @@ jobs:
         with:
           ref: ${{ env.HEAD_SHA }}
           submodules: true
-
-      - name: Setup Vulkan SDK 
-        uses: jakoch/install-vulkan-sdk-action@v1
-        with:
-          vulkan_version: ${{ env.vulkanSdkVersion }}
-          install_runtime: true
-          cache: true
-          stripdown: false
           
       - name: Update LLVM
         if: ${{ matrix.compiler == 'clang' }}
         uses: KyleMayes/install-llvm-action@v2.0.9
         with:
-          version: ${{ env.llvmVersion }}
+          version: ${{ env.LLVM_VERSION }}
         
+      - name: Restore dependency cache
+        uses: actions/cache/restore@v6
+        with:
+          path: ${{ env.DEPENDENCY_DIR }}
+          key: ${{ env.CACHE_KEY }}
+
       - name: Setup build and test environment
         id: setup-environment
         shell: bash
         run: |
           echo "VCPKG_FEATURE_FLAGS=manifests" >> $env:GITHUB_ENV
-          #echo "C:\VulkanSDK\${{ env.vulkanSdkVersion }}\runtime" >> $GITHUB_PATH  # Somehow does not get picked up by the MSVC development environment.
-          cp "C:\VulkanSDK\${{ env.vulkanSdkVersion }}\runtime\x64\vulkan-1.dll" "C:\Windows\System32\vulkan-1.dll"
-          cp "C:\VulkanSDK\${{ env.vulkanSdkVersion }}\runtime\x86\vulkan-1.dll" "C:\Windows\SysWOW64\vulkan-1.dll"
+          #echo "${{ env.DEPENDENCY_DIR }}\vulkan\${{ env.VULKAN_SDK_VERSION }}\runtime" >> $GITHUB_PATH  # Somehow does not get picked up by the MSVC development environment.
+          cp "${{ env.DEPENDENCY_DIR }}\vulkan\${{ env.VULKAN_SDK_VERSION }}\runtime\x64\vulkan-1.dll" "C:\Windows\System32\vulkan-1.dll"
+          cp "${{ env.DEPENDENCY_DIR }}\vulkan\${{ env.VULKAN_SDK_VERSION }}\runtime\x86\vulkan-1.dll" "C:\Windows\SysWOW64\vulkan-1.dll"
           echo "C:\msys64\ucrt64\bin" >> $GITHUB_PATH
 
       - name: Retrieve latest CMake build
@@ -532,11 +509,17 @@ jobs:
             triplet: x64-windows
             configuration: windows-clang-x64-release-static
 
-    env:
-      VCPKG_DEFAULT_TRIPLET: ${{ matrix.triplet }}-rel
-      VCPKG_FEATURE_FLAGS: 'manifests'
-
     steps:
+      - name: Setup environment
+        run: echo "Setup environment"
+        env:
+          MESA_3D_VERSION: ${{ vars.MESA_3D_VERSION }}
+          VULKAN_SDK_VERSION: ${{ vars.VULKAN_SDK_VERSION }}
+          LLVM_VERSION: ${{ vars.LLVM_VERSION }}
+
+          DEPENDENCY_DIR: ${{ runner.temp }}/dep/win
+          CACHE_KEY: windows-dependencies-mesa-${{ vars.MESA_3D_VERSION }}-vulkan-${{ vars.VULKAN_SDK_VERSION }}
+
       - name: Retrieve PR info
         id: retrieve-pr-from-issue-comment
         uses: actions/github-script@v3
@@ -580,27 +563,25 @@ jobs:
           sha: ${{ env.HEAD_SHA }}
           status: in_progress
           
-      - name: Setup Vulkan SDK 
-        uses: jakoch/install-vulkan-sdk-action@v1
+      - name: Restore dependency cache
+        uses: actions/cache/restore@v6
         with:
-          vulkan_version: ${{ env.vulkanSdkVersion }}
-          install_runtime: true
-          cache: true
-          stripdown: false
+          path: ${{ env.DEPENDENCY_DIR }}
+          key: ${{ env.CACHE_KEY }}
           
       - name: Setup build and test environment
         id: setup-environment
         shell: bash
         run: |
-          #echo "C:\VulkanSDK\${{ env.vulkanSdkVersion }}\runtime" >> $GITHUB_PATH  # Somehow does not get picked up by the MSVC development environment.
-          cp "C:\VulkanSDK\${{ env.vulkanSdkVersion }}\runtime\x64\vulkan-1.dll" "C:\Windows\System32\vulkan-1.dll"
-          cp "C:\VulkanSDK\${{ env.vulkanSdkVersion }}\runtime\x86\vulkan-1.dll" "C:\Windows\SysWOW64\vulkan-1.dll"
+          #echo "${{ env.DEPENDENCY_DIR }}\vulkan\${{ env.VULKAN_SDK_VERSION }}\runtime" >> $GITHUB_PATH  # Somehow does not get picked up by the MSVC development environment.
+          cp "${{ env.DEPENDENCY_DIR }}\vulkan\${{ env.VULKAN_SDK_VERSION }}\runtime\x64\vulkan-1.dll" "C:\Windows\System32\vulkan-1.dll"
+          cp "${{ env.DEPENDENCY_DIR }}\vulkan\${{ env.VULKAN_SDK_VERSION }}\runtime\x86\vulkan-1.dll" "C:\Windows\SysWOW64\vulkan-1.dll"
           
       - name: Update LLVM
         if: ${{ matrix.compiler == 'clang' }}
         uses: KyleMayes/install-llvm-action@v2.0.9
         with:
-          version: ${{ env.llvmVersion }}
+          version: ${{ env.LLVM_VERSION }}
           
       - name: Checking out sources
         uses: actions/checkout@master

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -160,7 +160,7 @@ jobs:
           rm '${{ github.workspace }}/dep/mesa/mesa3d-${{ env.mesaDriverVersion }}-release-msvc.7z'
             
       - name: Cache Mesa3D
-        uses: actions/cache/save@v4
+        uses: actions/cache/save@v6
         if: steps.lookup-mesa.outputs.cache-hit != 'true'
         with:
           path: ${{ github.workspace }}/dep/mesa/
@@ -269,7 +269,7 @@ jobs:
           cp "C:\VulkanSDK\${{ env.vulkanSdkVersion }}\runtime\x86\vulkan-1.dll" "C:\Windows\SysWOW64\vulkan-1.dll"
 
       - name: Restore Mesa3D
-        uses: actions/cache/restore@v4
+        uses: actions/cache/restore@v6
         with:
           path: ${{ github.workspace }}/dep/mesa/
           key: ${{ matrix.os }}-mesa3d-${{ env.mesaDriverVersion }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,12 +29,6 @@ on:
         required: true
         default: 'checks' # Case sensitive. Must contain one or more of: 'checks', 'tests', 'tidy' or 'builds'.
 
-# Environment variables control which version of dependent software to install.
-env:
-  vulkanSdkVersion: '1.4.328.1'
-  mesaDriverVersion: '24.1.1'
-  llvmVersion: '20.1.8'
-
 # The following jobs are contained in this workflow:
 # - First, the `verify-permissions` job is executed. It checks if the comment user is a contributer or maintainer and if the comment refers to a pull request. It then parses the 
 # command string. If permission is granted, the result is then passed to the subsequent jobs, which only execute if this job outputs their respective launch command.
@@ -123,48 +117,29 @@ jobs:
             os: windows-latest
           #- name: ubuntu-latest
           #  os: ubuntu-latest
-      
+
+    env:
+      MESA_3D_VERSION: ${{ vars.MESA_3D_VERSION }}
+      VULKAN_SDK_VERSION: ${{ vars.VULKAN_SDK_VERSION }}
+      CACHE_KEY: windows-dependencies-mesa-${{ vars.MESA_3D_VERSION }}-vulkan-${{ vars.VULKAN_SDK_VERSION }}
+
     steps:
-      - name: Setup Vulkan SDK 
-        uses: jakoch/install-vulkan-sdk-action@v1
+      - name: Setup dependency directory
+        run: echo "DEPENDENCY_DIR=$env:RUNNER_TEMP/dep/win" >> $env:GITHUB_ENV
+
+      - name: Lookup dependency cache (no restore use)
+        id: cache
+        uses: actions/cache/restore@v6
         with:
-          vulkan_version: ${{ env.vulkanSdkVersion }}
-          install_runtime: true
-          cache: true
-          stripdown: true
-          
-      - name: Lookup Mesa3D cache
-        uses: actions/cache@v4
-        id: lookup-mesa
-        with:
-          key: ${{ matrix.os }}-mesa3d-${{ env.mesaDriverVersion }}
-          path: ${{ github.workspace }}/dep/mesa/
+          path: ${{ env.DEPENDENCY_DIR }}
+          key: ${{ env.CACHE_KEY }}
           lookup-only: true
 
-      - name: Download Mesa3D driver
-        uses: robinraju/release-downloader@v1.10
-        if: steps.lookup-mesa.outputs.cache-hit != 'true'
-        with:
-          repository: 'pal1000/mesa-dist-win'
-          tag: '${{ env.mesaDriverVersion }}'
-          fileName: 'mesa3d-${{ env.mesaDriverVersion }}-release-msvc.7z'
-          out-file-path: 'dep/mesa/'  # ${{ github.workspace }} is prefixed automatically.
-          extract: false  # 7zip is not supported by this extension, so we have to do it on our own later.
-          
-      - name: Decompress Mesa3D driver
-        working-directory: '${{ github.workspace }}/dep/mesa/'
-        if: steps.lookup-mesa.outputs.cache-hit != 'true'
-        shell: bash
+      - name: Ensure cache exists
+        if: steps.cache.outputs.cache-hit != 'true'
         run: |
-          7z x '${{ github.workspace }}/dep/mesa/mesa3d-${{ env.mesaDriverVersion }}-release-msvc.7z'
-          rm '${{ github.workspace }}/dep/mesa/mesa3d-${{ env.mesaDriverVersion }}-release-msvc.7z'
-            
-      - name: Cache Mesa3D
-        uses: actions/cache/save@v4
-        if: steps.lookup-mesa.outputs.cache-hit != 'true'
-        with:
-          path: ${{ github.workspace }}/dep/mesa/
-          key: ${{ matrix.os }}-mesa3d-${{ env.mesaDriverVersion }}
+          echo "Cache is missing. Please run 'update_dependencies.yml' workflow first."
+          exit 1
           
   # ------------------------------------- Test job             -------------------------------------
   test:
@@ -186,8 +161,17 @@ jobs:
             os: windows-latest
             compiler: clang
             configuration: windows-clang-x64-test
+            
+    env:
+      MESA_3D_VERSION: ${{ vars.MESA_3D_VERSION }}
+      VULKAN_SDK_VERSION: ${{ vars.VULKAN_SDK_VERSION }}
+      LLVM_VERSION: ${{ vars.LLVM_VERSION }}
+      CACHE_KEY: windows-dependencies-mesa-${{ vars.MESA_3D_VERSION }}-vulkan-${{ vars.VULKAN_SDK_VERSION }}
 
     steps:
+      - name: Setup dependency directory
+        run: echo "DEPENDENCY_DIR=$env:RUNNER_TEMP/dep/win" >> $env:GITHUB_ENV
+
       - name: Retrieve PR info
         id: retrieve-pr-from-issue-comment
         uses: actions/github-script@v3
@@ -237,14 +221,7 @@ jobs:
           ref: ${{ env.HEAD_SHA }}
           submodules: true
 
-      - name: Setup Vulkan SDK 
-        uses: jakoch/install-vulkan-sdk-action@v1
-        with:
-          vulkan_version: ${{ env.vulkanSdkVersion }}
-          install_runtime: true
-          cache: true
-          stripdown: false
-
+      # TODO: Move this into cache as well.
       - name: Install OpenCppCoverage
         id: install-opencppcoverage
         shell: bash
@@ -256,7 +233,13 @@ jobs:
         if: ${{ matrix.compiler == 'clang' }}
         uses: KyleMayes/install-llvm-action@v2.0.9
         with:
-          version: ${{ env.llvmVersion }}
+          version: ${{ env.LLVM_VERSION }}
+          
+      - name: Restore dependency cache
+        uses: actions/cache/restore@v6
+        with:
+          path: ${{ env.DEPENDENCY_DIR }}
+          key: ${{ env.CACHE_KEY }}
 
       - name: Setup build and test environment
         id: setup-environment
@@ -264,26 +247,20 @@ jobs:
         run: |
           echo "VCPKG_FEATURE_FLAGS=manifests" >> $env:GITHUB_ENV
           echo "C:\msys64\ucrt64\bin" >> $GITHUB_PATH
-          #echo "C:\VulkanSDK\${{ env.vulkanSdkVersion }}\runtime" >> $GITHUB_PATH  # Somehow does not get picked up by the MSVC development environment.
-          cp "C:\VulkanSDK\${{ env.vulkanSdkVersion }}\runtime\x64\vulkan-1.dll" "C:\Windows\System32\vulkan-1.dll"
-          cp "C:\VulkanSDK\${{ env.vulkanSdkVersion }}\runtime\x86\vulkan-1.dll" "C:\Windows\SysWOW64\vulkan-1.dll"
-
-      - name: Restore Mesa3D
-        uses: actions/cache/restore@v4
-        with:
-          path: ${{ github.workspace }}/dep/mesa/
-          key: ${{ matrix.os }}-mesa3d-${{ env.mesaDriverVersion }}
+          #echo "${{ env.DEPENDENCY_DIR }}/vulkan/${{ env.VULKAN_SDK_VERSION }}\runtime" >> $GITHUB_PATH  # Somehow does not get picked up by the MSVC development environment.
+          cp "${{ env.DEPENDENCY_DIR }}/vulkan/${{ env.VULKAN_SDK_VERSION }}\runtime\x64\vulkan-1.dll" "C:\Windows\System32\vulkan-1.dll"
+          cp "${{ env.DEPENDENCY_DIR }}/vulkan/${{ env.VULKAN_SDK_VERSION }}\runtime\x86\vulkan-1.dll" "C:\Windows\SysWOW64\vulkan-1.dll"
 
       - name: Install and Test Mesa3D driver
         working-directory: '${{ github.workspace }}/dep/mesa/'
         run: |         
-          reg add "HKLM\SOFTWARE\Khronos\Vulkan\Drivers" /v '${{ github.workspace }}\dep\mesa\x64\lvp_icd.x86_64.json' /t REG_DWORD /d 0 /f /reg:64
-          reg add "HKLM\SOFTWARE\Khronos\Vulkan\ExplicitLayers" /v 'C:\VulkanSDK\${{ env.vulkanSdkVersion }}\Bin\VkLayer_khronos_synchronization2.json' /t REG_DWORD /d 0 /f /reg:64
-          reg add "HKLM\SOFTWARE\Khronos\Vulkan\ExplicitLayers" /v 'C:\VulkanSDK\${{ env.vulkanSdkVersion }}\Bin\VkLayer_khronos_validation.json' /t REG_DWORD /d 0 /f /reg:64
-          reg add "HKLM\SOFTWARE\WOW6432Node\Khronos\Vulkan\Drivers" /v '${{ github.workspace }}\dep\mesa\x86\lvp_icd.x86.json' /t REG_DWORD /d 0 /f /reg:64
-          reg add "HKLM\SOFTWARE\WOW6432Node\Khronos\Vulkan\ExplicitLayers" /v 'C:\VulkanSDK\${{ env.vulkanSdkVersion }}\Bin32\VkLayer_khronos_synchronization2.json' /t REG_DWORD /d 0 /f /reg:64
-          reg add "HKLM\SOFTWARE\WOW6432Node\Khronos\Vulkan\ExplicitLayers" /v 'C:\VulkanSDK\${{ env.vulkanSdkVersion }}\Bin32\VkLayer_khronos_validation.json' /t REG_DWORD /d 0 /f /reg:64
-          C:\VulkanSDK\${{ env.vulkanSdkVersion }}\runtime\x64\vulkaninfo.exe --summary
+          reg add "HKLM\SOFTWARE\Khronos\Vulkan\Drivers" /v '${{ env.DEPENDENCY_DIR }}\mesa\x64\lvp_icd.x86_64.json' /t REG_DWORD /d 0 /f /reg:64
+          reg add "HKLM\SOFTWARE\Khronos\Vulkan\ExplicitLayers" /v '${{ env.DEPENDENCY_DIR }}\vulkan\${{ env.VULKAN_SDK_VERSION }}\Bin\VkLayer_khronos_synchronization2.json' /t REG_DWORD /d 0 /f /reg:64
+          reg add "HKLM\SOFTWARE\Khronos\Vulkan\ExplicitLayers" /v '${{ env.DEPENDENCY_DIR }}\vulkan\${{ env.VULKAN_SDK_VERSION }}\Bin\VkLayer_khronos_validation.json' /t REG_DWORD /d 0 /f /reg:64
+          reg add "HKLM\SOFTWARE\WOW6432Node\Khronos\Vulkan\Drivers" /v '${{ env.DEPENDENCY_DIR }}\mesa\x86\lvp_icd.x86.json' /t REG_DWORD /d 0 /f /reg:64
+          reg add "HKLM\SOFTWARE\WOW6432Node\Khronos\Vulkan\ExplicitLayers" /v '${{ env.DEPENDENCY_DIR }}\vulkan\${{ env.VULKAN_SDK_VERSION }}\Bin32\VkLayer_khronos_synchronization2.json' /t REG_DWORD /d 0 /f /reg:64
+          reg add "HKLM\SOFTWARE\WOW6432Node\Khronos\Vulkan\ExplicitLayers" /v '${{ env.DEPENDENCY_DIR }}\vulkan\${{ env.VULKAN_SDK_VERSION }}\Bin32\VkLayer_khronos_validation.json' /t REG_DWORD /d 0 /f /reg:64
+          ${{ env.DEPENDENCY_DIR }}\vulkan\${{ env.VULKAN_SDK_VERSION }}\runtime\x64\vulkaninfo.exe --summary
 
       - name: Restore or build vcpkg
         uses: lukka/run-vcpkg@v10
@@ -426,29 +403,27 @@ jobs:
         with:
           ref: ${{ env.HEAD_SHA }}
           submodules: true
-
-      - name: Setup Vulkan SDK 
-        uses: jakoch/install-vulkan-sdk-action@v1
-        with:
-          vulkan_version: ${{ env.vulkanSdkVersion }}
-          install_runtime: true
-          cache: true
-          stripdown: false
           
       - name: Update LLVM
         if: ${{ matrix.compiler == 'clang' }}
         uses: KyleMayes/install-llvm-action@v2.0.9
         with:
-          version: ${{ env.llvmVersion }}
+          version: ${{ env.LLVM_VERSION }}
         
+      - name: Restore dependency cache
+        uses: actions/cache/restore@v6
+        with:
+          path: ${{ env.DEPENDENCY_DIR }}
+          key: ${{ env.CACHE_KEY }}
+
       - name: Setup build and test environment
         id: setup-environment
         shell: bash
         run: |
           echo "VCPKG_FEATURE_FLAGS=manifests" >> $env:GITHUB_ENV
-          #echo "C:\VulkanSDK\${{ env.vulkanSdkVersion }}\runtime" >> $GITHUB_PATH  # Somehow does not get picked up by the MSVC development environment.
-          cp "C:\VulkanSDK\${{ env.vulkanSdkVersion }}\runtime\x64\vulkan-1.dll" "C:\Windows\System32\vulkan-1.dll"
-          cp "C:\VulkanSDK\${{ env.vulkanSdkVersion }}\runtime\x86\vulkan-1.dll" "C:\Windows\SysWOW64\vulkan-1.dll"
+          #echo "${{ env.DEPENDENCY_DIR }}\vulkan\${{ env.VULKAN_SDK_VERSION }}\runtime" >> $GITHUB_PATH  # Somehow does not get picked up by the MSVC development environment.
+          cp "${{ env.DEPENDENCY_DIR }}\vulkan\${{ env.VULKAN_SDK_VERSION }}\runtime\x64\vulkan-1.dll" "C:\Windows\System32\vulkan-1.dll"
+          cp "${{ env.DEPENDENCY_DIR }}\vulkan\${{ env.VULKAN_SDK_VERSION }}\runtime\x86\vulkan-1.dll" "C:\Windows\SysWOW64\vulkan-1.dll"
           echo "C:\msys64\ucrt64\bin" >> $GITHUB_PATH
 
       - name: Retrieve latest CMake build
@@ -531,12 +506,17 @@ jobs:
             compiler: clang
             triplet: x64-windows
             configuration: windows-clang-x64-release-static
-
+            
     env:
-      VCPKG_DEFAULT_TRIPLET: ${{ matrix.triplet }}-rel
-      VCPKG_FEATURE_FLAGS: 'manifests'
+      MESA_3D_VERSION: ${{ vars.MESA_3D_VERSION }}
+      VULKAN_SDK_VERSION: ${{ vars.VULKAN_SDK_VERSION }}
+      LLVM_VERSION: ${{ vars.LLVM_VERSION }}
+      CACHE_KEY: windows-dependencies-mesa-${{ vars.MESA_3D_VERSION }}-vulkan-${{ vars.VULKAN_SDK_VERSION }}
 
     steps:
+      - name: Setup dependency directory
+        run: echo "DEPENDENCY_DIR=$env:RUNNER_TEMP/dep/win" >> $env:GITHUB_ENV
+
       - name: Retrieve PR info
         id: retrieve-pr-from-issue-comment
         uses: actions/github-script@v3
@@ -580,27 +560,25 @@ jobs:
           sha: ${{ env.HEAD_SHA }}
           status: in_progress
           
-      - name: Setup Vulkan SDK 
-        uses: jakoch/install-vulkan-sdk-action@v1
+      - name: Restore dependency cache
+        uses: actions/cache/restore@v6
         with:
-          vulkan_version: ${{ env.vulkanSdkVersion }}
-          install_runtime: true
-          cache: true
-          stripdown: false
+          path: ${{ env.DEPENDENCY_DIR }}
+          key: ${{ env.CACHE_KEY }}
           
       - name: Setup build and test environment
         id: setup-environment
         shell: bash
         run: |
-          #echo "C:\VulkanSDK\${{ env.vulkanSdkVersion }}\runtime" >> $GITHUB_PATH  # Somehow does not get picked up by the MSVC development environment.
-          cp "C:\VulkanSDK\${{ env.vulkanSdkVersion }}\runtime\x64\vulkan-1.dll" "C:\Windows\System32\vulkan-1.dll"
-          cp "C:\VulkanSDK\${{ env.vulkanSdkVersion }}\runtime\x86\vulkan-1.dll" "C:\Windows\SysWOW64\vulkan-1.dll"
+          #echo "${{ env.DEPENDENCY_DIR }}\vulkan\${{ env.VULKAN_SDK_VERSION }}\runtime" >> $GITHUB_PATH  # Somehow does not get picked up by the MSVC development environment.
+          cp "${{ env.DEPENDENCY_DIR }}\vulkan\${{ env.VULKAN_SDK_VERSION }}\runtime\x64\vulkan-1.dll" "C:\Windows\System32\vulkan-1.dll"
+          cp "${{ env.DEPENDENCY_DIR }}\vulkan\${{ env.VULKAN_SDK_VERSION }}\runtime\x86\vulkan-1.dll" "C:\Windows\SysWOW64\vulkan-1.dll"
           
       - name: Update LLVM
         if: ${{ matrix.compiler == 'clang' }}
         uses: KyleMayes/install-llvm-action@v2.0.9
         with:
-          version: ${{ env.llvmVersion }}
+          version: ${{ env.LLVM_VERSION }}
           
       - name: Checking out sources
         uses: actions/checkout@master

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,13 +17,49 @@ on:
         description: 'Location of the Release Log file.'
         required: true
 
-env:
-  vulkanSdkVersion: '1.4.328.1'
-  llvmVersion: '20.1.8'
-
 jobs:
+  # ------------------------------------- Toolchain setup      -------------------------------------
+  setup:
+    name: run-setup
+    runs-on: ${{ matrix.os }}
+    timeout-minutes: 10
+    strategy:
+      fail-fast: true
+      matrix:
+        name: [ windows-latest ]
+        include:
+          - name: windows-latest
+            os: windows-latest
+          #- name: ubuntu-latest
+          #  os: ubuntu-latest
+          
+    env:
+      MESA_3D_VERSION: ${{ vars.MESA_3D_VERSION }}
+      VULKAN_SDK_VERSION: ${{ vars.VULKAN_SDK_VERSION }}
+      CACHE_KEY: windows-dependencies-mesa-${{ vars.MESA_3D_VERSION }}-vulkan-${{ vars.VULKAN_SDK_VERSION }}
+
+    steps:
+      - name: Setup dependency directory
+        run: echo "DEPENDENCY_DIR=$env:RUNNER_TEMP/dep/win" >> $env:GITHUB_ENV
+
+      - name: Lookup dependency cache (no restore use)
+        id: cache
+        uses: actions/cache/restore@v6
+        with:
+          path: ${{ env.DEPENDENCY_DIR }}
+          key: ${{ env.CACHE_KEY }}
+          lookup-only: true
+
+      - name: Ensure cache exists
+        if: steps.cache.outputs.cache-hit != 'true'
+        run: |
+          echo "Cache is missing. Please run 'update_dependencies.yml' workflow first."
+          exit 1
+          
+  # ------------------------------------- Build job            -------------------------------------
   build:
     name: Build ${{ matrix.profile }}
+    needs: [ setup ]
     runs-on: windows-latest
     strategy:
       fail-fast: true
@@ -50,26 +86,32 @@ jobs:
       VCPKG_DEFAULT_TRIPLET: ${{ matrix.triplet }}-rel
       VCPKG_FEATURE_FLAGS: 'manifests'
 
+      MESA_3D_VERSION: ${{ vars.MESA_3D_VERSION }}
+      VULKAN_SDK_VERSION: ${{ vars.VULKAN_SDK_VERSION }}
+      LLVM_VERSION: ${{ vars.LLVM_VERSION }}
+      CACHE_KEY: windows-dependencies-mesa-${{ vars.MESA_3D_VERSION }}-vulkan-${{ vars.VULKAN_SDK_VERSION }}
+
     steps:
-      - name: Setup Vulkan SDK 
-        uses: jakoch/install-vulkan-sdk-action@v1
+      - name: Setup dependency directory
+        run: echo "DEPENDENCY_DIR=$env:RUNNER_TEMP/dep/win" >> $env:GITHUB_ENV
+
+      - name: Restore dependency cache
+        uses: actions/cache/restore@v6
         with:
-          vulkan_version: ${{ env.vulkanSdkVersion }}
-          install_runtime: true
-          cache: true
-          stripdown: false
-       
+          path: ${{ env.DEPENDENCY_DIR }}
+          key: ${{ env.CACHE_KEY }}
+
       - name: Setup build environment
         id: setup-environment
         run: |
-          cp "C:\VulkanSDK\${{ env.vulkanSdkVersion }}\runtime\x64\vulkan-1.dll" "C:\Windows\System32\vulkan-1.dll"
-          cp "C:\VulkanSDK\${{ env.vulkanSdkVersion }}\runtime\x86\vulkan-1.dll" "C:\Windows\SysWOW64\vulkan-1.dll"
+          cp "${{ env.DEPENDENCY_DIR }}/vulkan/${{ env.VULKAN_SDK_VERSION }}\runtime\x64\vulkan-1.dll" "C:\Windows\System32\vulkan-1.dll"
+          cp "${{ env.DEPENDENCY_DIR }}/vulkan/${{ env.VULKAN_SDK_VERSION }}\runtime\x86\vulkan-1.dll" "C:\Windows\SysWOW64\vulkan-1.dll"
           
       - name: Update LLVM
         if: ${{ matrix.compiler == 'clang' }}
         uses: KyleMayes/install-llvm-action@v2.0.9
         with:
-          version: ${{ env.llvmVersion }}
+          version: ${{ env.LLVM_VERSION }}
           
       - name: Checking out sources
         uses: actions/checkout@master
@@ -133,7 +175,7 @@ jobs:
       - name: Download windows-msvc-x86 artifacts...
         uses: actions/download-artifact@v4
         with:
-          name: LiteFX_win_x64_msvc
+          name: LiteFX_win_x86_msvc
           path: ${{ github.workspace }}/../.artifacts/msvc/x86/
           
       - name: Download windows-clang-x64 artifacts...

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,13 +17,50 @@ on:
         description: 'Location of the Release Log file.'
         required: true
 
-env:
-  vulkanSdkVersion: '1.4.328.1'
-  llvmVersion: '20.1.8'
-
 jobs:
+  # ------------------------------------- Toolchain setup      -------------------------------------
+  setup:
+    name: run-setup
+    runs-on: ${{ matrix.os }}
+    timeout-minutes: 10
+    strategy:
+      fail-fast: true
+      matrix:
+        name: [ windows-latest ]
+        include:
+          - name: windows-latest
+            os: windows-latest
+          #- name: ubuntu-latest
+          #  os: ubuntu-latest
+
+    steps:
+      - name: Setup environment
+        run: echo "Setup environment"
+        env:
+          MESA_3D_VERSION: ${{ vars.MESA_3D_VERSION }}
+          VULKAN_SDK_VERSION: ${{ vars.VULKAN_SDK_VERSION }}
+
+          DEPENDENCY_DIR: ${{ runner.temp }}/dep/win
+          CACHE_KEY: windows-dependencies-mesa-${{ vars.MESA_3D_VERSION }}-vulkan-${{ vars.VULKAN_SDK_VERSION }}
+
+      - name: Lookup dependency cache (no restore use)
+        id: cache
+        uses: actions/cache/restore@v6
+        with:
+          path: ${{ env.DEPENDENCY_DIR }}
+          key: ${{ env.CACHE_KEY }}
+          lookup-only: true
+
+      - name: Ensure cache exists
+        if: steps.cache.outputs.cache-hit != 'true'
+        run: |
+          echo "Cache is missing. Please run 'update_dependencies.yml' workflow first."
+          exit 1
+          
+  # ------------------------------------- Build job            -------------------------------------
   build:
     name: Build ${{ matrix.profile }}
+    needs: [ setup ]
     runs-on: windows-latest
     strategy:
       fail-fast: true
@@ -51,25 +88,33 @@ jobs:
       VCPKG_FEATURE_FLAGS: 'manifests'
 
     steps:
-      - name: Setup Vulkan SDK 
-        uses: jakoch/install-vulkan-sdk-action@v1
+      - name: Setup environment
+        run: echo "Setup environment"
+        env:
+          MESA_3D_VERSION: ${{ vars.MESA_3D_VERSION }}
+          VULKAN_SDK_VERSION: ${{ vars.VULKAN_SDK_VERSION }}
+          LLVM_VERSION: ${{ vars.LLVM_VERSION }}
+
+          DEPENDENCY_DIR: ${{ runner.temp }}/dep/win
+          CACHE_KEY: windows-dependencies-mesa-${{ vars.MESA_3D_VERSION }}-vulkan-${{ vars.VULKAN_SDK_VERSION }}
+
+      - name: Restore dependency cache
+        uses: actions/cache/restore@v6
         with:
-          vulkan_version: ${{ env.vulkanSdkVersion }}
-          install_runtime: true
-          cache: true
-          stripdown: false
-       
+          path: ${{ env.DEPENDENCY_DIR }}
+          key: ${{ env.CACHE_KEY }}
+
       - name: Setup build environment
         id: setup-environment
         run: |
-          cp "C:\VulkanSDK\${{ env.vulkanSdkVersion }}\runtime\x64\vulkan-1.dll" "C:\Windows\System32\vulkan-1.dll"
-          cp "C:\VulkanSDK\${{ env.vulkanSdkVersion }}\runtime\x86\vulkan-1.dll" "C:\Windows\SysWOW64\vulkan-1.dll"
+          cp "${{ env.DEPENDENCY_DIR }}/vulkan/${{ env.VULKAN_SDK_VERSION }}\runtime\x64\vulkan-1.dll" "C:\Windows\System32\vulkan-1.dll"
+          cp "${{ env.DEPENDENCY_DIR }}/vulkan/${{ env.VULKAN_SDK_VERSION }}\runtime\x86\vulkan-1.dll" "C:\Windows\SysWOW64\vulkan-1.dll"
           
       - name: Update LLVM
         if: ${{ matrix.compiler == 'clang' }}
         uses: KyleMayes/install-llvm-action@v2.0.9
         with:
-          version: ${{ env.llvmVersion }}
+          version: ${{ env.LLVM_VERSION }}
           
       - name: Checking out sources
         uses: actions/checkout@master
@@ -133,7 +178,7 @@ jobs:
       - name: Download windows-msvc-x86 artifacts...
         uses: actions/download-artifact@v4
         with:
-          name: LiteFX_win_x64_msvc
+          name: LiteFX_win_x86_msvc
           path: ${{ github.workspace }}/../.artifacts/msvc/x86/
           
       - name: Download windows-clang-x64 artifacts...

--- a/.github/workflows/update_dependencies.yml
+++ b/.github/workflows/update_dependencies.yml
@@ -1,0 +1,70 @@
+name: Update Dependencies Cache
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  update-cache:
+    runs-on: windows-latest
+
+    steps:
+      - name: Setup environment
+        run: echo "Setup environment"
+        env:
+          MESA_3D_VERSION: ${{ vars.MESA_3D_VERSION }}
+          VULKAN_SDK_VERSION: ${{ vars.VULKAN_SDK_VERSION }}
+
+          DEPENDENCY_DIR: ${{ runner.temp }}/dep/win
+          CACHE_KEY: windows-dependencies-mesa-${{ vars.MESA_3D_VERSION }}-vulkan-${{ vars.VULKAN_SDK_VERSION }}
+
+      - name: Restore dependency cache
+        id: cache
+        uses: actions/cache/restore@v6
+        with:
+          path: ${{ env.DEPENDENCY_DIR }}
+          key: ${{ env.CACHE_KEY }}
+      
+      - name: Create dependency directory
+        if: steps.cache.outputs.cache-hit != 'true'
+        shell: bash
+        run: mkdir -p "${DEPENDENCY_DIR}"
+
+      # Download dependencies.
+
+      - name: Setup Vulkan SDK 
+        if: steps.cache.outputs.cache-hit != 'true'
+        uses: jakoch/install-vulkan-sdk-action@v1
+        with:
+          destination: ${{ env.DEPENDENCY_DIR }}/vulkan/
+          vulkan_version: ${{ env.VULKAN_SDK_VERSION }}
+          install_runtime: true
+          #cache: true
+          stripdown: true
+
+      - name: Download Mesa3D driver
+        if: steps.cache.outputs.cache-hit != 'true'
+        uses: robinraju/release-downloader@v1.10
+        with:
+          repository: 'pal1000/mesa-dist-win'
+          tag: '${{ env.MESA_3D_VERSION }}'
+          fileName: 'mesa3d-${{ env.MESA_3D_VERSION }}-release-msvc.7z'
+          out-file-path: ${{ env.DEPENDENCY_DIR }}/mesa/
+          extract: false  # 7zip is not supported by this extension, so we have to do it on our own later.
+          
+      - name: Decompress Mesa3D driver
+        if: steps.cache.outputs.cache-hit != 'true'
+        working-directory: '${{ env.DEPENDENCY_DIR }}/mesa/'
+        shell: bash
+        run: |
+          7z x '${{ env.DEPENDENCY_DIR }}/mesa/mesa3d-${{ env.MESA_3D_VERSION }}-release-msvc.7z'
+          rm '${{ env.DEPENDENCY_DIR }}/mesa/mesa3d-${{ env.MESA_3D_VERSION }}-release-msvc.7z'
+          
+      - name: Save dependency cache
+        if: steps.cache.outputs.cache-hit != 'true'
+        uses: actions/cache/save@v6
+        with:
+          path: ${{ env.DEPENDENCY_DIR }}
+          key: ${{ env.CACHE_KEY }}

--- a/.github/workflows/update_dependencies.yml
+++ b/.github/workflows/update_dependencies.yml
@@ -1,0 +1,69 @@
+name: Update Dependencies Cache
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  update-cache:
+    runs-on: windows-latest
+
+    env:
+      MESA_3D_VERSION: ${{ vars.MESA_3D_VERSION }}
+      VULKAN_SDK_VERSION: ${{ vars.VULKAN_SDK_VERSION }}
+      CACHE_KEY: windows-dependencies-mesa-${{ vars.MESA_3D_VERSION }}-vulkan-${{ vars.VULKAN_SDK_VERSION }}
+
+    steps:
+      - name: Setup dependency directory
+        run: echo "DEPENDENCY_DIR=$env:RUNNER_TEMP/dep/win" >> $env:GITHUB_ENV
+
+      - name: Restore dependency cache
+        id: cache
+        uses: actions/cache/restore@v6
+        with:
+          path: ${{ env.DEPENDENCY_DIR }}
+          key: ${{ env.CACHE_KEY }}
+      
+      - name: Create dependency directory
+        if: steps.cache.outputs.cache-hit != 'true'
+        shell: bash
+        run: mkdir -p "${DEPENDENCY_DIR}"
+
+      # Download dependencies.
+
+      - name: Setup Vulkan SDK 
+        if: steps.cache.outputs.cache-hit != 'true'
+        uses: jakoch/install-vulkan-sdk-action@v1
+        with:
+          destination: ${{ env.DEPENDENCY_DIR }}/vulkan/
+          vulkan_version: ${{ env.VULKAN_SDK_VERSION }}
+          install_runtime: true
+          #cache: true
+          stripdown: true
+
+      - name: Download Mesa3D driver
+        if: steps.cache.outputs.cache-hit != 'true'
+        uses: robinraju/release-downloader@v1.10
+        with:
+          repository: 'pal1000/mesa-dist-win'
+          tag: '${{ env.MESA_3D_VERSION }}'
+          fileName: 'mesa3d-${{ env.MESA_3D_VERSION }}-release-msvc.7z'
+          out-file-path: ${{ env.DEPENDENCY_DIR }}/mesa/
+          extract: false  # 7zip is not supported by this extension, so we have to do it on our own later.
+          
+      - name: Decompress Mesa3D driver
+        if: steps.cache.outputs.cache-hit != 'true'
+        working-directory: '${{ env.DEPENDENCY_DIR }}/mesa/'
+        shell: bash
+        run: |
+          7z x '${{ env.DEPENDENCY_DIR }}/mesa/mesa3d-${{ env.MESA_3D_VERSION }}-release-msvc.7z'
+          rm '${{ env.DEPENDENCY_DIR }}/mesa/mesa3d-${{ env.MESA_3D_VERSION }}-release-msvc.7z'
+          
+      - name: Save dependency cache
+        if: steps.cache.outputs.cache-hit != 'true'
+        uses: actions/cache/save@v6
+        with:
+          path: ${{ env.DEPENDENCY_DIR }}
+          key: ${{ env.CACHE_KEY }}

--- a/.github/workflows/weekly.yml
+++ b/.github/workflows/weekly.yml
@@ -12,13 +12,49 @@ on:
   schedule: 
     - cron: '1 0 * * 1'         # Run every monday night at 00:01 AM (UTC).
     
-env:
-  vulkanSdkVersion: '1.4.328.1'
-  llvmVersion: '20.1.8'
-
 jobs:
+  # ------------------------------------- Toolchain setup      -------------------------------------
+  setup:
+    name: run-setup
+    runs-on: ${{ matrix.os }}
+    timeout-minutes: 10
+    strategy:
+      fail-fast: true
+      matrix:
+        name: [ windows-latest ]
+        include:
+          - name: windows-latest
+            os: windows-latest
+          #- name: ubuntu-latest
+          #  os: ubuntu-latest
+          
+    env:
+      MESA_3D_VERSION: ${{ vars.MESA_3D_VERSION }}
+      VULKAN_SDK_VERSION: ${{ vars.VULKAN_SDK_VERSION }}
+      CACHE_KEY: windows-dependencies-mesa-${{ vars.MESA_3D_VERSION }}-vulkan-${{ vars.VULKAN_SDK_VERSION }}
+      
+    steps:
+      - name: Setup dependency directory
+        run: echo "DEPENDENCY_DIR=$env:RUNNER_TEMP/dep/win" >> $env:GITHUB_ENV
+
+      - name: Lookup dependency cache (no restore use)
+        id: cache
+        uses: actions/cache/restore@v6
+        with:
+          path: ${{ env.DEPENDENCY_DIR }}
+          key: ${{ env.CACHE_KEY }}
+          lookup-only: true
+
+      - name: Ensure cache exists
+        if: steps.cache.outputs.cache-hit != 'true'
+        run: |
+          echo "Cache is missing. Please run 'update_dependencies.yml' workflow first."
+          exit 1
+          
+  # ------------------------------------- Build job            -------------------------------------
   job:
     name: windows-latest-weekly
+    needs: [ setup ]
     runs-on: windows-latest
     strategy:
       fail-fast: false
@@ -40,31 +76,37 @@ jobs:
             triplet: x64-windows
             configuration: windows-clang-x64-release
             architecture: x64
-            
+
     env:
       VCPKG_DEFAULT_TRIPLET: ${{ matrix.triplet }}-rel
       VCPKG_FEATURE_FLAGS: 'manifests'
-      
+          
+      MESA_3D_VERSION: ${{ vars.MESA_3D_VERSION }}
+      VULKAN_SDK_VERSION: ${{ vars.VULKAN_SDK_VERSION }}
+      LLVM_VERSION: ${{ vars.LLVM_VERSION }}
+      CACHE_KEY: windows-dependencies-mesa-${{ vars.MESA_3D_VERSION }}-vulkan-${{ vars.VULKAN_SDK_VERSION }}
+
     steps:
-      - name: Setup Vulkan SDK 
-        uses: jakoch/install-vulkan-sdk-action@v1
+      - name: Setup dependency directory
+        run: echo "DEPENDENCY_DIR=$env:RUNNER_TEMP/dep/win" >> $env:GITHUB_ENV
+
+      - name: Restore dependency cache
+        uses: actions/cache/restore@v6
         with:
-          vulkan_version: ${{ env.vulkanSdkVersion }}
-          install_runtime: true
-          cache: true
-          stripdown: false
-       
+          path: ${{ env.DEPENDENCY_DIR }}
+          key: ${{ env.CACHE_KEY }}
+
       - name: Setup build environment
         id: setup-environment
         run: |
-          cp "C:\VulkanSDK\${{ env.vulkanSdkVersion }}\runtime\x64\vulkan-1.dll" "C:\Windows\System32\vulkan-1.dll"
-          cp "C:\VulkanSDK\${{ env.vulkanSdkVersion }}\runtime\x86\vulkan-1.dll" "C:\Windows\SysWOW64\vulkan-1.dll"
+          cp "${{ env.DEPENDENCY_DIR }}/vulkan/${{ env.VULKAN_SDK_VERSION }}\runtime\x64\vulkan-1.dll" "C:\Windows\System32\vulkan-1.dll"
+          cp "${{ env.DEPENDENCY_DIR }}/vulkan/${{ env.VULKAN_SDK_VERSION }}\runtime\x86\vulkan-1.dll" "C:\Windows\SysWOW64\vulkan-1.dll"
           
       - name: Update LLVM
         if: ${{ matrix.compiler == 'clang' }}
         uses: KyleMayes/install-llvm-action@v2.0.9
         with:
-          version: ${{ env.llvmVersion }}
+          version: ${{ env.LLVM_VERSION }}
 
       - name: Checking out sources
         uses: actions/checkout@master

--- a/.github/workflows/weekly.yml
+++ b/.github/workflows/weekly.yml
@@ -12,13 +12,50 @@ on:
   schedule: 
     - cron: '1 0 * * 1'         # Run every monday night at 00:01 AM (UTC).
     
-env:
-  vulkanSdkVersion: '1.4.328.1'
-  llvmVersion: '20.1.8'
-
 jobs:
+  # ------------------------------------- Toolchain setup      -------------------------------------
+  setup:
+    name: run-setup
+    runs-on: ${{ matrix.os }}
+    timeout-minutes: 10
+    strategy:
+      fail-fast: true
+      matrix:
+        name: [ windows-latest ]
+        include:
+          - name: windows-latest
+            os: windows-latest
+          #- name: ubuntu-latest
+          #  os: ubuntu-latest
+                
+    steps:
+      - name: Setup environment
+        run: echo "Setup environment"
+        env:
+          MESA_3D_VERSION: ${{ vars.MESA_3D_VERSION }}
+          VULKAN_SDK_VERSION: ${{ vars.VULKAN_SDK_VERSION }}
+
+          DEPENDENCY_DIR: ${{ runner.temp }}/dep/win
+          CACHE_KEY: windows-dependencies-mesa-${{ vars.MESA_3D_VERSION }}-vulkan-${{ vars.VULKAN_SDK_VERSION }}
+
+      - name: Lookup dependency cache (no restore use)
+        id: cache
+        uses: actions/cache/restore@v6
+        with:
+          path: ${{ env.DEPENDENCY_DIR }}
+          key: ${{ env.CACHE_KEY }}
+          lookup-only: true
+
+      - name: Ensure cache exists
+        if: steps.cache.outputs.cache-hit != 'true'
+        run: |
+          echo "Cache is missing. Please run 'update_dependencies.yml' workflow first."
+          exit 1
+          
+  # ------------------------------------- Build job            -------------------------------------
   job:
     name: windows-latest-weekly
+    needs: [ setup ]
     runs-on: windows-latest
     strategy:
       fail-fast: false
@@ -40,31 +77,38 @@ jobs:
             triplet: x64-windows
             configuration: windows-clang-x64-release
             architecture: x64
-            
-    env:
-      VCPKG_DEFAULT_TRIPLET: ${{ matrix.triplet }}-rel
-      VCPKG_FEATURE_FLAGS: 'manifests'
-      
+                  
     steps:
-      - name: Setup Vulkan SDK 
-        uses: jakoch/install-vulkan-sdk-action@v1
+      - name: Setup environment
+        run: echo "Setup environment"
+        env:
+          VCPKG_DEFAULT_TRIPLET: ${{ matrix.triplet }}-rel
+          VCPKG_FEATURE_FLAGS: 'manifests'
+          
+          MESA_3D_VERSION: ${{ vars.MESA_3D_VERSION }}
+          VULKAN_SDK_VERSION: ${{ vars.VULKAN_SDK_VERSION }}
+          LLVM_VERSION: ${{ vars.LLVM_VERSION }}
+
+          DEPENDENCY_DIR: ${{ runner.temp }}/dep/win
+          CACHE_KEY: windows-dependencies-mesa-${{ vars.MESA_3D_VERSION }}-vulkan-${{ vars.VULKAN_SDK_VERSION }}
+
+      - name: Restore dependency cache
+        uses: actions/cache/restore@v6
         with:
-          vulkan_version: ${{ env.vulkanSdkVersion }}
-          install_runtime: true
-          cache: true
-          stripdown: false
-       
+          path: ${{ env.DEPENDENCY_DIR }}
+          key: ${{ env.CACHE_KEY }}
+
       - name: Setup build environment
         id: setup-environment
         run: |
-          cp "C:\VulkanSDK\${{ env.vulkanSdkVersion }}\runtime\x64\vulkan-1.dll" "C:\Windows\System32\vulkan-1.dll"
-          cp "C:\VulkanSDK\${{ env.vulkanSdkVersion }}\runtime\x86\vulkan-1.dll" "C:\Windows\SysWOW64\vulkan-1.dll"
+          cp "${{ env.DEPENDENCY_DIR }}/vulkan/${{ env.VULKAN_SDK_VERSION }}\runtime\x64\vulkan-1.dll" "C:\Windows\System32\vulkan-1.dll"
+          cp "${{ env.DEPENDENCY_DIR }}/vulkan/${{ env.VULKAN_SDK_VERSION }}\runtime\x86\vulkan-1.dll" "C:\Windows\SysWOW64\vulkan-1.dll"
           
       - name: Update LLVM
         if: ${{ matrix.compiler == 'clang' }}
         uses: KyleMayes/install-llvm-action@v2.0.9
         with:
-          version: ${{ env.llvmVersion }}
+          version: ${{ env.LLVM_VERSION }}
 
       - name: Checking out sources
         uses: actions/checkout@master

--- a/docs/release-logs/0.6.1.md
+++ b/docs/release-logs/0.6.1.md
@@ -4,6 +4,7 @@
 - Add missing primitive topologies for adjacency and patch lists. (See [PR #201](https://github.com/crud89/LiteFX/pull/201) and [PR #209](https://github.com/crud89/LiteFX/pull/209))
 - Allow overlapping push constants ranges between shader stages. (See [PR #205](https://github.com/crud89/LiteFX/pull/205))
 - Add `tryAllocate` method to virtual allocators. (See [PR #207](https://github.com/crud89/LiteFX/pull/207))
+- Add method to query adapters using a user preference. (See [PR #210](https://github.com/crud89/LiteFX/pull/210))
 
 **🌋 Vulkan:**
 

--- a/docs/tutorials/quick-start.markdown
+++ b/docs/tutorials/quick-start.markdown
@@ -235,11 +235,7 @@ void MyApp::onInit()
     m_scissor = makeShared<Scissor>(RectF(0.f, 0.f, static_cast<Float>(width), static_cast<Float>(height)));
 
     // Find the adapter, create a surface and initialize the device.
-    auto adapter = backend->findAdapter(m_adapterId);
-
-    if (adapter == nullptr)
-        adapter = backend->findAdapter(std::nullopt);
-
+    auto adapter = m_adapterId.has_value() ? backend->findAdapter(m_adapterId) : backend->findAdapter(GpuPreference::Performance);
     auto surface = backend->createSurface(::glfwGetWin32Window(window));
 
     // Create the device.

--- a/src/Backends/DirectX12/CMakeLists.txt
+++ b/src/Backends/DirectX12/CMakeLists.txt
@@ -90,7 +90,7 @@ TARGET_INCLUDE_DIRECTORIES(${PROJECT_NAME}
 
 # Link project dependencies.
 TARGET_LINK_LIBRARIES(${PROJECT_NAME}
-    PUBLIC LiteFX.Core LiteFX.Math LiteFX.Rendering LiteFX.AppModel Microsoft::DirectX-Headers Microsoft::DirectX-Guids dxgi Microsoft::DirectX12-Agility Microsoft::DirectXShaderCompiler Microsoft::DXIL 
+    PUBLIC LiteFX.Core LiteFX.Math LiteFX.Rendering LiteFX.AppModel Microsoft::DirectX-Headers Microsoft::DirectX-Guids dxgi dxcore Microsoft::DirectX12-Agility Microsoft::DirectXShaderCompiler Microsoft::DXIL
     PRIVATE GPUOpen::D3D12MemoryAllocator
 )
 

--- a/src/Backends/DirectX12/include/litefx/backends/dx12.hpp
+++ b/src/Backends/DirectX12/include/litefx/backends/dx12.hpp
@@ -8,6 +8,8 @@
 #pragma warning(push)
 #pragma warning(disable:4250) // Base class members are inherited via dominance.
 
+// NOLINTBEGIN(bugprone-derived-method-shadowing-base-method)
+
 namespace LiteFX::Rendering::Backends {
     using namespace LiteFX::Math;
     using namespace LiteFX::Rendering;
@@ -682,7 +684,7 @@ namespace LiteFX::Rendering::Backends {
         const Array<UniquePtr<const DirectX12ShaderModule>>& modules() const noexcept override;
 
         /// <inheritdoc />
-        virtual SharedPtr<DirectX12PipelineLayout> reflectPipelineLayout(Enumerable<PipelineBindingHint> hints = {}) const;
+        SharedPtr<DirectX12PipelineLayout> reflectPipelineLayout(Enumerable<PipelineBindingHint> hints = {}) const;
 
     private:
         SharedPtr<IPipelineLayout> parsePipelineLayout(Enumerable<PipelineBindingHint> hints) const override {
@@ -730,7 +732,7 @@ namespace LiteFX::Rendering::Backends {
         /// Returns the parent descriptor set layout.
         /// </summary>
         /// <returns>The parent descriptor set layout.</returns>
-        virtual const DirectX12DescriptorSetLayout& layout() const noexcept;
+        const DirectX12DescriptorSetLayout& layout() const noexcept;
 
     public:
         /// <inheritdoc />
@@ -763,7 +765,7 @@ namespace LiteFX::Rendering::Backends {
         /// </summary>
         /// <param name="heapType">The type of the descriptor heap to obtain.</param>
         /// <returns>The local (CPU-visible) heap that contains the set's descriptors.</returns>
-        virtual const ComPtr<ID3D12DescriptorHeap> localHeap(DescriptorHeapType heapType) const noexcept;
+        const ComPtr<ID3D12DescriptorHeap> localHeap(DescriptorHeapType heapType) const noexcept;
     };
 
     /// <summary>
@@ -935,7 +937,7 @@ namespace LiteFX::Rendering::Backends {
         /// Returns the parent device or `nullptr`, if it has been released.
         /// </summary>
         /// <returns>A pointer to the parent device or `nullptr`, if it has been released.</returns>
-        virtual SharedPtr<const DirectX12Device> device() const noexcept;
+        SharedPtr<const DirectX12Device> device() const noexcept;
 
     public:
         /// <inheritdoc />
@@ -1756,7 +1758,7 @@ namespace LiteFX::Rendering::Backends {
         /// Returns a pointer to the device that provides this queue or `nullptr`, if the device has already been released.
         /// </summary>
         /// <returns>A reference to the queue's parent device or `nullptr`, if the device has already been released.</returns>
-        virtual SharedPtr<const DirectX12Device> device() const noexcept;
+        SharedPtr<const DirectX12Device> device() const noexcept;
 
         // CommandQueue interface.
     public:
@@ -2460,13 +2462,13 @@ namespace LiteFX::Rendering::Backends {
         /// Returns <c>true</c>, if the adapter supports variable refresh rates (i.e. tearing is allowed).
         /// </summary>
         /// <returns><c>true</c>, if the adapter supports variable refresh rates (i.e. tearing is allowed).</returns>
-        virtual bool supportsVariableRefreshRate() const noexcept;
+        bool supportsVariableRefreshRate() const noexcept;
 
         /// <summary>
         /// Returns the query heap for the current frame.
         /// </summary>
         /// <returns>A pointer to the query heap for the current frame.</returns>
-        virtual ID3D12QueryHeap* timestampQueryHeap() const noexcept;
+        ID3D12QueryHeap* timestampQueryHeap() const noexcept;
 
         // SwapChain interface.
     public:
@@ -2859,7 +2861,7 @@ namespace LiteFX::Rendering::Backends {
 
         /// <inheritdoc />
         /// <seealso href="https://docs.microsoft.com/en-us/windows/win32/api/d3d11/ne-d3d11-d3d11_standard_multisample_quality_levels" />
-        MultiSamplingLevel maximumMultiSamplingLevel(Format format) const noexcept override;
+        MultiSamplingLevel maximumMultiSamplingLevel(Format format) const override;
 
         /// <inheritdoc />
         double ticksPerMillisecond() const noexcept override;
@@ -2883,7 +2885,7 @@ namespace LiteFX::Rendering::Backends {
         void updateGlobalDescriptors(const DirectX12DescriptorSet& descriptorSet, UInt32 binding, UInt32 offset, UInt32 descriptors) const override;
 
         /// <inheritdoc />
-        void bindDescriptorSet(const DirectX12CommandBuffer& commandBuffer, const DirectX12DescriptorSet& descriptorSet, const DirectX12PipelineState& pipeline) const noexcept override;
+        void bindDescriptorSet(const DirectX12CommandBuffer& commandBuffer, const DirectX12DescriptorSet& descriptorSet, const DirectX12PipelineState& pipeline) const override;
 
         /// <inheritdoc />
         void bindGlobalDescriptorHeaps(const DirectX12CommandBuffer& commandBuffer) const noexcept override;
@@ -2973,10 +2975,10 @@ namespace LiteFX::Rendering::Backends {
         const Array<SharedPtr<const DirectX12GraphicsAdapter>>& adapters() const override;
 
         /// <inheritdoc />
-        const DirectX12GraphicsAdapter* findAdapter(const Optional<UInt64>& adapterId = std::nullopt) const noexcept override;
+        const DirectX12GraphicsAdapter* findAdapter(const Optional<UInt64>& adapterId = std::nullopt) const override;
 
         /// <inheritdoc />
-        const DirectX12GraphicsAdapter* findAdapter(GpuPreference preference) const noexcept override;
+        const DirectX12GraphicsAdapter* findAdapter(GpuPreference preference) const override;
 
         /// <inheritdoc />
         void registerDevice(const String& name, SharedPtr<DirectX12Device>&& device) override;
@@ -2985,10 +2987,10 @@ namespace LiteFX::Rendering::Backends {
         void releaseDevice(const String& name) override;
 
         /// <inheritdoc />
-        DirectX12Device* device(const String& name) noexcept override;
+        DirectX12Device* device(const String& name) override;
 
         /// <inheritdoc />
-        const DirectX12Device* device(const String& name) const noexcept override;
+        const DirectX12Device* device(const String& name) const override;
 
     public:
         /// <summary>
@@ -3006,9 +3008,11 @@ namespace LiteFX::Rendering::Backends {
         /// will only return WARP-compatible adapters.
         /// </remarks>
         /// <param name="enable"><c>true</c>, if advanced software rasterization should be used.</param>
-        virtual void enableAdvancedSoftwareRasterizer(bool enable = false);
+        void enableAdvancedSoftwareRasterizer(bool enable = false);
     };
 
 }
+
+// NOLINTEND(bugprone-derived-method-shadowing-base-method)
 
 #pragma warning(pop)

--- a/src/Backends/DirectX12/include/litefx/backends/dx12.hpp
+++ b/src/Backends/DirectX12/include/litefx/backends/dx12.hpp
@@ -2976,6 +2976,9 @@ namespace LiteFX::Rendering::Backends {
         const DirectX12GraphicsAdapter* findAdapter(const Optional<UInt64>& adapterId = std::nullopt) const noexcept override;
 
         /// <inheritdoc />
+        const DirectX12GraphicsAdapter* findAdapter(GpuPreference preference) const noexcept override;
+
+        /// <inheritdoc />
         void registerDevice(const String& name, SharedPtr<DirectX12Device>&& device) override;
 
         /// <inheritdoc />

--- a/src/Backends/DirectX12/src/adapter.cpp
+++ b/src/Backends/DirectX12/src/adapter.cpp
@@ -1,5 +1,6 @@
 #include <litefx/backends/dx12.hpp>
 #include <tchar.h>
+#include <dxcore.h>
 
 using namespace LiteFX::Rendering::Backends;
 
@@ -15,6 +16,7 @@ private:
 	DXGI_ADAPTER_DESC1 m_properties{};
 	UInt64 m_driverVersion{ 0 };
 	UInt32 m_apiVersion{ D3D12_SDK_VERSION };
+	GraphicsAdapterType m_type{};
 
 public:
     DirectX12GraphicsAdapterImpl(const DirectX12GraphicsAdapter& adapter) noexcept
@@ -35,6 +37,40 @@ public:
 			LITEFX_WARNING(DIRECTX12_LOG, "Unable to query adapter driver version (HRESULT = {})", hr);
 		else
 			m_driverVersion = umdVersion.QuadPart;
+
+		// Get the graphics adapter type.
+		if (m_properties.Flags & DXGI_ADAPTER_FLAG3_SOFTWARE)
+			m_type = GraphicsAdapterType::Software;
+		else
+		{
+			// DXGI is quite limited in the information it provides about an adapter. To determine the GPU type, query DXCore instead.
+			ComPtr<IDXCoreAdapterFactory1> adapterFactory;
+			ComPtr<IDXCoreAdapter1> coreAdapter;
+
+			if (FAILED(hr = ::DXCoreCreateAdapterFactory(IID_PPV_ARGS(&adapterFactory))))
+			{
+				LITEFX_WARNING(DIRECTX12_LOG, "Unable to acquire GPU type for adapter {}: core adapter factory creation returned {}.", adapter.uniqueId(), hr);
+				return;
+			}
+
+			if (FAILED(hr = adapterFactory->GetAdapterByLuid(m_properties.AdapterLuid, IID_PPV_ARGS(&coreAdapter))))
+			{
+				LITEFX_WARNING(DIRECTX12_LOG, "Unable to acquire GPU type for adapter {}: core adapter query returned {}.", adapter.uniqueId(), hr);
+				return;
+			}
+
+			bool integrated{}, hardware{};
+
+			if (FAILED(hr = coreAdapter->GetProperty(DXCoreAdapterProperty::IsIntegrated, &integrated)) ||
+				FAILED(hr = coreAdapter->GetProperty(DXCoreAdapterProperty::IsHardware, &hardware)))
+			{
+				LITEFX_WARNING(DIRECTX12_LOG, "Unable to acquire GPU type for adapter {}: core adapter property query returned {}.", adapter.uniqueId(), hr);
+				return;
+			}
+
+			// NOTE: We treat all non-integrated hardware adapters as dedicated GPU and all other devices as CPU (iGPU).
+			m_type = hardware && !integrated ? GraphicsAdapterType::GPU : GraphicsAdapterType::CPU;
+		}
 	}
 };
 
@@ -71,7 +107,7 @@ UInt32 DirectX12GraphicsAdapter::deviceId() const noexcept
 
 GraphicsAdapterType DirectX12GraphicsAdapter::type() const noexcept
 {
-    return m_impl->m_properties.Flags & DXGI_ADAPTER_FLAG3_SOFTWARE ? GraphicsAdapterType::CPU : GraphicsAdapterType::GPU;
+	return m_impl->m_type;
 }
 
 UInt64 DirectX12GraphicsAdapter::driverVersion() const noexcept

--- a/src/Backends/DirectX12/src/adapter.cpp
+++ b/src/Backends/DirectX12/src/adapter.cpp
@@ -19,7 +19,7 @@ private:
 	GraphicsAdapterType m_type{};
 
 public:
-    DirectX12GraphicsAdapterImpl(const DirectX12GraphicsAdapter& adapter) noexcept
+    DirectX12GraphicsAdapterImpl(const DirectX12GraphicsAdapter& adapter)
 	{
 		// Store adapter properties.
 		HRESULT hr = adapter.handle()->GetDesc1(&m_properties);
@@ -47,13 +47,13 @@ public:
 			ComPtr<IDXCoreAdapterFactory1> adapterFactory;
 			ComPtr<IDXCoreAdapter1> coreAdapter;
 
-			if (FAILED(hr = ::DXCoreCreateAdapterFactory(IID_PPV_ARGS(&adapterFactory))))
+			if (FAILED(hr = ::DXCoreCreateAdapterFactory(IID_PPV_ARGS(&adapterFactory)))) // NOLINT(bugprone-assignment-in-if-condition)
 			{
 				LITEFX_WARNING(DIRECTX12_LOG, "Unable to acquire GPU type for adapter {}: core adapter factory creation returned {}.", adapter.uniqueId(), hr);
 				return;
 			}
 
-			if (FAILED(hr = adapterFactory->GetAdapterByLuid(m_properties.AdapterLuid, IID_PPV_ARGS(&coreAdapter))))
+			if (FAILED(hr = adapterFactory->GetAdapterByLuid(m_properties.AdapterLuid, IID_PPV_ARGS(&coreAdapter)))) // NOLINT(bugprone-assignment-in-if-condition)
 			{
 				LITEFX_WARNING(DIRECTX12_LOG, "Unable to acquire GPU type for adapter {}: core adapter query returned {}.", adapter.uniqueId(), hr);
 				return;
@@ -61,8 +61,8 @@ public:
 
 			bool integrated{}, hardware{};
 
-			if (FAILED(hr = coreAdapter->GetProperty(DXCoreAdapterProperty::IsIntegrated, &integrated)) ||
-				FAILED(hr = coreAdapter->GetProperty(DXCoreAdapterProperty::IsHardware, &hardware)))
+			if (FAILED(hr = coreAdapter->GetProperty(DXCoreAdapterProperty::IsIntegrated, &integrated)) || // NOLINT(bugprone-assignment-in-if-condition)
+				FAILED(hr = coreAdapter->GetProperty(DXCoreAdapterProperty::IsHardware, &hardware))) // NOLINT(bugprone-assignment-in-if-condition)
 			{
 				LITEFX_WARNING(DIRECTX12_LOG, "Unable to acquire GPU type for adapter {}: core adapter property query returned {}.", adapter.uniqueId(), hr);
 				return;

--- a/src/Backends/DirectX12/src/backend.cpp
+++ b/src/Backends/DirectX12/src/backend.cpp
@@ -105,7 +105,7 @@ const Array<SharedPtr<const DirectX12GraphicsAdapter>>& DirectX12Backend::adapte
     return m_impl->m_adapters;
 }
 
-const DirectX12GraphicsAdapter* DirectX12Backend::findAdapter(const Optional<UInt64>& adapterId) const noexcept
+const DirectX12GraphicsAdapter* DirectX12Backend::findAdapter(const Optional<UInt64>& adapterId) const
 {
     // We create a temporary copy of the adapters array here, which we can sort by the adapter type. This way we return dedicated GPUs before integrated GPUs, before software rasterizers and so on, if no
     // adapter ID is specified.
@@ -118,7 +118,7 @@ const DirectX12GraphicsAdapter* DirectX12Backend::findAdapter(const Optional<UIn
     return nullptr;
 }
 
-const DirectX12GraphicsAdapter* DirectX12Backend::findAdapter(GpuPreference preference) const noexcept 
+const DirectX12GraphicsAdapter* DirectX12Backend::findAdapter(GpuPreference preference) const
 {
     // Get the first adapter for the preference.
     ComPtr<IDXGIAdapter1> adapterInterface;
@@ -161,7 +161,7 @@ void DirectX12Backend::releaseDevice(const String& name)
     m_impl->m_devices.erase(name);
 }
 
-DirectX12Device* DirectX12Backend::device(const String& name) noexcept
+DirectX12Device* DirectX12Backend::device(const String& name)
 {
     if (!m_impl->m_devices.contains(name)) [[unlikely]]
         return nullptr;
@@ -169,7 +169,7 @@ DirectX12Device* DirectX12Backend::device(const String& name) noexcept
     return m_impl->m_devices[name].get();
 }
 
-const DirectX12Device* DirectX12Backend::device(const String& name) const noexcept
+const DirectX12Device* DirectX12Backend::device(const String& name) const
 {
     if (!m_impl->m_devices.contains(name)) [[unlikely]]
         return nullptr;

--- a/src/Backends/DirectX12/src/backend.cpp
+++ b/src/Backends/DirectX12/src/backend.cpp
@@ -107,7 +107,12 @@ const Array<SharedPtr<const DirectX12GraphicsAdapter>>& DirectX12Backend::adapte
 
 const DirectX12GraphicsAdapter* DirectX12Backend::findAdapter(const Optional<UInt64>& adapterId) const noexcept
 {
-    if (auto match = std::ranges::find_if(m_impl->m_adapters, [&adapterId](const auto& adapter) { return !adapterId.has_value() || adapter->uniqueId() == adapterId; }); match != m_impl->m_adapters.end()) [[likely]]
+    // We create a temporary copy of the adapters array here, which we can sort by the adapter type. This way we return dedicated GPUs before integrated GPUs, before software rasterizers and so on, if no
+    // adapter ID is specified.
+    auto adapters = m_impl->m_adapters;
+    std::ranges::sort(adapters, std::ranges::greater{}, &DirectX12GraphicsAdapter::type);
+
+    if (auto match = std::ranges::find_if(adapters, [&adapterId](const auto& adapter) { return !adapterId.has_value() || adapter->uniqueId() == adapterId; }); match != adapters.end()) [[likely]]
         return match->get();
 
     return nullptr;

--- a/src/Backends/DirectX12/src/backend.cpp
+++ b/src/Backends/DirectX12/src/backend.cpp
@@ -118,6 +118,25 @@ const DirectX12GraphicsAdapter* DirectX12Backend::findAdapter(const Optional<UIn
     return nullptr;
 }
 
+const DirectX12GraphicsAdapter* DirectX12Backend::findAdapter(GpuPreference preference) const noexcept 
+{
+    // Get the first adapter for the preference.
+    ComPtr<IDXGIAdapter1> adapterInterface;
+    
+    if (FAILED(this->handle()->EnumAdapterByGpuPreference(0u, static_cast<DXGI_GPU_PREFERENCE>(preference), IID_PPV_ARGS(&adapterInterface))))
+        return this->findAdapter();
+    
+    // Get the LUID.
+    UInt64 adapterId{};
+    DXGI_ADAPTER_DESC1 adapterDecriptor;
+    
+    if (FAILED(adapterInterface->GetDesc1(&adapterDecriptor)))
+        return this->findAdapter();
+
+    std::memcpy(&adapterId, &adapterDecriptor.AdapterLuid, sizeof(LUID));
+    return this->findAdapter(adapterId);
+}
+
 void DirectX12Backend::registerDevice(const String& name, SharedPtr<DirectX12Device>&& device)
 {
     if (m_impl->m_devices.contains(name)) [[unlikely]]

--- a/src/Backends/DirectX12/src/buffer.cpp
+++ b/src/Backends/DirectX12/src/buffer.cpp
@@ -48,7 +48,7 @@ DirectX12Buffer::DirectX12Buffer(ComPtr<ID3D12Resource>&& buffer, BufferType typ
 		m_impl->m_allocation->SetPrivateData(static_cast<IDeviceMemory*>(this));
 }
 
-DirectX12Buffer::~DirectX12Buffer() noexcept
+DirectX12Buffer::~DirectX12Buffer() // NOLINT(bugprone-exception-escape)
 {
 	LITEFX_TRACE(DIRECTX12_LOG, "Destroyed buffer {}", this->name());
 }

--- a/src/Backends/DirectX12/src/buffer.h
+++ b/src/Backends/DirectX12/src/buffer.h
@@ -36,7 +36,7 @@ namespace LiteFX::Rendering::Backends {
 		DirectX12Buffer& operator=(const DirectX12Buffer&) = delete;
 
 	public:
-		~DirectX12Buffer() noexcept override;
+		~DirectX12Buffer() override;
 
 		// IBuffer interface.
 	public:

--- a/src/Backends/DirectX12/src/compute_pipeline.cpp
+++ b/src/Backends/DirectX12/src/compute_pipeline.cpp
@@ -86,7 +86,7 @@ DirectX12ComputePipeline::DirectX12ComputePipeline(const DirectX12Device& device
 	this->handle() = m_impl->initialize(*this);
 }
 
-DirectX12ComputePipeline::DirectX12ComputePipeline(const DirectX12Device& device) noexcept :
+DirectX12ComputePipeline::DirectX12ComputePipeline(const DirectX12Device& device) noexcept : // NOLINT(bugprone-exception-escape)
 	DirectX12PipelineState(nullptr), m_impl(device)
 {
 }

--- a/src/Backends/DirectX12/src/device.cpp
+++ b/src/Backends/DirectX12/src/device.cpp
@@ -379,7 +379,7 @@ void DirectX12Device::updateGlobalDescriptors(const DirectX12DescriptorSet& desc
 	}
 }
 
-void DirectX12Device::bindDescriptorSet(const DirectX12CommandBuffer& commandBuffer, const DirectX12DescriptorSet& descriptorSet, const DirectX12PipelineState& pipeline) const noexcept
+void DirectX12Device::bindDescriptorSet(const DirectX12CommandBuffer& commandBuffer, const DirectX12DescriptorSet& descriptorSet, const DirectX12PipelineState& pipeline) const
 {
 	// Deduct, whether to set the graphics or compute descriptor tables.
 	// TODO: Maybe we could store a simple boolean on the pipeline state to make this easier.
@@ -579,20 +579,20 @@ SharedPtr<DirectX12FrameBuffer> DirectX12Device::makeFrameBuffer(StringView name
 	return DirectX12FrameBuffer::create(*this, renderArea, allocationCallback, name);
 }
 
-MultiSamplingLevel DirectX12Device::maximumMultiSamplingLevel(Format format) const noexcept
+MultiSamplingLevel DirectX12Device::maximumMultiSamplingLevel(Format format) const
 {
 	constexpr auto allLevels = std::array { MultiSamplingLevel::x64, MultiSamplingLevel::x32, MultiSamplingLevel::x16, MultiSamplingLevel::x8, MultiSamplingLevel::x4, MultiSamplingLevel::x2, MultiSamplingLevel::x1 };
 	D3D12_FEATURE_DATA_MULTISAMPLE_QUALITY_LEVELS levels{ .Format = DX12::getFormat(format) };
 
 	for (size_t level(0); level < allLevels.size(); ++level)
 	{
-		levels.SampleCount = std::to_underlying(allLevels[level]); // NOLINT(cppcoreguidelines-pro-bounds-constant-array-index)
+		levels.SampleCount = std::to_underlying(allLevels[level]); // NOLINT(cppcoreguidelines-pro-bounds-constant-array-index, cppcoreguidelines-pro-bounds-avoid-unchecked-container-access)
 		
 		if (FAILED(this->handle()->CheckFeatureSupport(D3D12_FEATURE_MULTISAMPLE_QUALITY_LEVELS, &levels, sizeof(levels))))
 			continue;
 
 		if (levels.NumQualityLevels > 0)
-			return allLevels[level]; // NOLINT(cppcoreguidelines-pro-bounds-constant-array-index)
+			return allLevels[level]; // NOLINT(cppcoreguidelines-pro-bounds-constant-array-index, cppcoreguidelines-pro-bounds-avoid-unchecked-container-access)
 	}
 
 	LITEFX_WARNING(DIRECTX12_LOG, "No supported multi-sampling levels could be queried. Assuming that multi-sampling is disabled.");
@@ -631,7 +631,7 @@ void DirectX12Device::wait() const
 	}
 
 	// Signal the event value on the graphics queue.
-		hr = std::as_const(*m_impl->m_queues[i++]).handle()->Signal(fence.Get(), 1);
+		hr = std::as_const(*m_impl->m_queues[i++]).handle()->Signal(fence.Get(), 1); // NOLINT(cppcoreguidelines-pro-bounds-avoid-unchecked-container-access)
 	
 	if (FAILED(hr))
 	{

--- a/src/Backends/DirectX12/src/factory.cpp
+++ b/src/Backends/DirectX12/src/factory.cpp
@@ -85,7 +85,7 @@ D3D12_RESOURCE_DESC1 getResourceDesc(const ResourceAllocationInfo::ImageInfo& im
 
 D3D12MA::ALLOCATION_DESC getAllocationDesc(ResourceHeap heap, AllocationBehavior allocationBehavior) {
 
-	D3D12MA::ALLOCATION_DESC allocationDesc{};
+	D3D12MA::ALLOCATION_DESC allocationDesc{ .HeapType = D3D12_HEAP_TYPE_DEFAULT };
 
 	if (allocationBehavior == AllocationBehavior::DontExpandCache)
 		allocationDesc.Flags = D3D12MA::ALLOCATION_FLAGS::ALLOCATION_FLAG_NEVER_ALLOCATE;
@@ -239,6 +239,7 @@ void DirectX12GraphicsFactory::beginDefragmentation(const ICommandQueue& queue, 
 
 	// Initialize a defragmentation context.
 	D3D12MA::DEFRAGMENTATION_DESC defragDesc = {
+		.Flags = D3D12MA::DEFRAGMENTATION_FLAG_ALGORITHM_BALANCED,
 		.MaxBytesPerPass = maxBytesToMove,
 		.MaxAllocationsPerPass = maxAllocationsToMove
 	};
@@ -399,6 +400,7 @@ bool DirectX12GraphicsFactory::supportsResizableBaseAddressRegister() const noex
 
 Array<MemoryHeapStatistics> DirectX12GraphicsFactory::memoryStatistics() const
 {
+	// NOLINTBEGIN(cppcoreguidelines-pro-bounds-avoid-unchecked-container-access)
 	// Query the current memory statistics.
 	auto budgets = std::array<D3D12MA::Budget, 2u>{};
 	m_impl->m_allocator->GetBudget(&budgets[0], &budgets[1]);
@@ -426,6 +428,7 @@ Array<MemoryHeapStatistics> DirectX12GraphicsFactory::memoryStatistics() const
 			.availableMemory = budgets[1].BudgetBytes
 		},
 	};
+	// NOLINTEND(cppcoreguidelines-pro-bounds-avoid-unchecked-container-access)
 }
 
 DetailedMemoryStatistics DirectX12GraphicsFactory::detailedMemoryStatistics() const

--- a/src/Backends/DirectX12/src/frame_buffer.cpp
+++ b/src/Backends/DirectX12/src/frame_buffer.cpp
@@ -165,7 +165,7 @@ D3D12_CPU_DESCRIPTOR_HANDLE DirectX12FrameBuffer::descriptorHandle(UInt32 imageI
     if (imageIndex >= m_impl->m_images.size()) [[unlikely]]
         throw ArgumentOutOfRangeException("imageIndex", std::make_pair(0uz, m_impl->m_images.size()), static_cast<size_t>(imageIndex), "The frame buffer does not contain an image at index {0}.", imageIndex);
 
-    return m_impl->m_renderTargetHandles.at(m_impl->m_images[imageIndex]);
+    return m_impl->m_renderTargetHandles.at(m_impl->m_images[imageIndex]); // NOLINT(cppcoreguidelines-pro-bounds-avoid-unchecked-container-access)
 }
 
 D3D12_CPU_DESCRIPTOR_HANDLE DirectX12FrameBuffer::descriptorHandle(StringView imageName) const
@@ -206,10 +206,12 @@ void DirectX12FrameBuffer::mapRenderTarget(const RenderTarget& renderTarget, UIn
     if (index >= m_impl->m_images.size()) [[unlikely]]
         throw ArgumentOutOfRangeException("index", std::make_pair(0uz, m_impl->m_images.size()), static_cast<size_t>(index), "The frame buffer does not contain an image at index {0}.", index);
 
+    // NOLINTBEGIN(cppcoreguidelines-pro-bounds-avoid-unchecked-container-access)
     if (m_impl->m_images[index]->format() != renderTarget.format()) [[unlikely]]
         LITEFX_WARNING(DIRECTX12_LOG, "The render target format {0} does not match the image format {1} for image {2}.", renderTarget.format(), m_impl->m_images[index]->format(), index);
 
     m_impl->m_mappedRenderTargets[renderTarget.identifier()] = m_impl->m_images[index];
+    // NOLINTEND(cppcoreguidelines-pro-bounds-avoid-unchecked-container-access)
 }
 
 void DirectX12FrameBuffer::mapRenderTarget(const RenderTarget& renderTarget, StringView name)
@@ -237,7 +239,7 @@ const IDirectX12Image& DirectX12FrameBuffer::image(UInt32 index) const
     if (index >= m_impl->m_images.size()) [[unlikely]]
         throw ArgumentOutOfRangeException("index", std::make_pair(0uz, m_impl->m_images.size()), static_cast<size_t>(index), "The frame buffer does not contain an image at index {0}.", index);
 
-    return *m_impl->m_images[index];
+    return *m_impl->m_images[index]; // NOLINT(cppcoreguidelines-pro-bounds-avoid-unchecked-container-access)
 }
 
 const IDirectX12Image& DirectX12FrameBuffer::image(const RenderTarget& renderTarget) const

--- a/src/Backends/DirectX12/src/image.cpp
+++ b/src/Backends/DirectX12/src/image.cpp
@@ -55,7 +55,7 @@ DirectX12Image::DirectX12Image(const DirectX12Device& device, ComPtr<ID3D12Resou
 		m_impl->m_allocation->SetPrivateData(static_cast<IDeviceMemory*>(this));
 }
 
-DirectX12Image::~DirectX12Image() noexcept
+DirectX12Image::~DirectX12Image() // NOLINT(bugprone-exception-escape)
 {
 	LITEFX_TRACE(DIRECTX12_LOG, "Destroyed image {}", this->name());
 }
@@ -65,7 +65,7 @@ UInt32 DirectX12Image::elements() const noexcept
 	return m_impl->m_elements;
 }
 
-size_t DirectX12Image::size() const noexcept
+size_t DirectX12Image::size() const noexcept // NOLINT(bugprone-exception-escape)
 {
 	// Attempt to get the pixel size. This ensures the nothrow guarantee.
 	size_t pixelSize{ };
@@ -129,7 +129,7 @@ UInt64 DirectX12Image::virtualAddress() const noexcept
 	return static_cast<UInt64>(this->handle()->GetGPUVirtualAddress());
 }
 
-size_t DirectX12Image::size(UInt32 level) const noexcept
+size_t DirectX12Image::size(UInt32 level) const
 {
 	if (level >= m_impl->m_levels)
 		return 0;

--- a/src/Backends/DirectX12/src/image.h
+++ b/src/Backends/DirectX12/src/image.h
@@ -27,7 +27,7 @@ namespace LiteFX::Rendering::Backends {
 		DirectX12Image(const DirectX12Image&) = delete;
 		DirectX12Image& operator=(DirectX12Image&&) noexcept = delete;
 		DirectX12Image& operator=(const DirectX12Image&) = delete;
-		~DirectX12Image() noexcept override;
+		~DirectX12Image() override;
 
 		// IDeviceMemory interface.
 	public:
@@ -55,7 +55,7 @@ namespace LiteFX::Rendering::Backends {
 		// IImage interface.
 	public:
 		/// <inheritdoc />
-		size_t size(UInt32 level) const noexcept override;
+		size_t size(UInt32 level) const override;
 
 		/// <inheritdoc />
 		Size3d extent(UInt32 level = 0) const noexcept override;

--- a/src/Backends/DirectX12/src/input_assembler.cpp
+++ b/src/Backends/DirectX12/src/input_assembler.cpp
@@ -13,7 +13,7 @@ public:
 private:
     Dictionary<UInt32, SharedPtr<DirectX12VertexBufferLayout>> m_vertexBufferLayouts{};
     SharedPtr<DirectX12IndexBufferLayout> m_indexBufferLayout{};
-    PrimitiveTopology m_primitiveTopology{};
+    PrimitiveTopology m_primitiveTopology{ PrimitiveTopology::PointList };
     UInt32 m_controlPoints{ 0u };
 
 public:

--- a/src/Backends/DirectX12/src/ray_tracing_pipeline.cpp
+++ b/src/Backends/DirectX12/src/ray_tracing_pipeline.cpp
@@ -515,7 +515,7 @@ DirectX12RayTracingPipeline::DirectX12RayTracingPipeline(const DirectX12Device& 
 	m_impl->initialize(*this);
 }
 
-DirectX12RayTracingPipeline::DirectX12RayTracingPipeline(const DirectX12Device& device, ShaderRecordCollection&& shaderRecords) noexcept :
+DirectX12RayTracingPipeline::DirectX12RayTracingPipeline(const DirectX12Device& device, ShaderRecordCollection&& shaderRecords) noexcept : // NOLINT(bugprone-exception-escape)
 	DirectX12PipelineState(nullptr), m_impl(device, std::move(shaderRecords))
 {
 }

--- a/src/Backends/DirectX12/src/render_pass.cpp
+++ b/src/Backends/DirectX12/src/render_pass.cpp
@@ -331,7 +331,7 @@ const RenderPassDependency& DirectX12RenderPass::inputAttachment(UInt32 location
     if (location >= m_impl->m_inputAttachments.size()) [[unlikely]]
         throw ArgumentOutOfRangeException("location", std::make_pair(0uz, m_impl->m_inputAttachments.size()), static_cast<size_t>(location), "The render pass does not contain an input attachment at location {0}.", location);
 
-    return m_impl->m_inputAttachments[location];
+    return m_impl->m_inputAttachments[location]; // NOLINT(cppcoreguidelines-pro-bounds-avoid-unchecked-container-access)
 }
 
 const Optional<DescriptorBindingPoint>& DirectX12RenderPass::inputAttachmentSamplerBinding() const noexcept 
@@ -364,7 +364,7 @@ void DirectX12RenderPass::begin(const DirectX12FrameBuffer& frameBuffer) const
     DirectX12Barrier renderTargetBarrier(PipelineStage::None, PipelineStage::RenderTarget), depthStencilBarrier(PipelineStage::None, PipelineStage::DepthStencil);
 
     std::ranges::for_each(m_impl->m_renderTargets, [&renderTargetBarrier, &depthStencilBarrier, &frameBuffer](const RenderTarget& renderTarget) {
-        auto& image = frameBuffer[renderTarget];
+        auto& image = frameBuffer[renderTarget]; // NOLINT(cppcoreguidelines-pro-bounds-avoid-unchecked-container-access)
 
         if (renderTarget.type() == RenderTargetType::DepthStencil)
             depthStencilBarrier.transition(image, ResourceAccess::None, ResourceAccess::DepthStencilWrite, ImageLayout::Undefined, ImageLayout::DepthWrite);
@@ -377,7 +377,7 @@ void DirectX12RenderPass::begin(const DirectX12FrameBuffer& frameBuffer) const
     DirectX12Barrier inputAttachmentBarrier(PipelineStage::None, PipelineStage::All);
 
     std::ranges::for_each(m_impl->m_inputAttachments, [&inputAttachmentBarrier, &frameBuffer](const RenderPassDependency& dependency) {
-        inputAttachmentBarrier.transition(frameBuffer[dependency.renderTarget()], ResourceAccess::None, ResourceAccess::ShaderRead, ImageLayout::Undefined, ImageLayout::ShaderResource);
+        inputAttachmentBarrier.transition(frameBuffer[dependency.renderTarget()], ResourceAccess::None, ResourceAccess::ShaderRead, ImageLayout::Undefined, ImageLayout::ShaderResource); // NOLINT(cppcoreguidelines-pro-bounds-avoid-unchecked-container-access)
     });
 
     beginCommandBuffer->barrier(renderTargetBarrier);
@@ -426,7 +426,7 @@ UInt64 DirectX12RenderPass::end() const
 
     // If the present target is multi-sampled, we need to resolve it to the back buffer.
     const auto& backBufferImage = swapChain.image();
-    bool requiresResolve{ this->hasPresentTarget() && frameBuffer[*m_impl->m_presentTarget].samples() > MultiSamplingLevel::x1 };
+    bool requiresResolve{ this->hasPresentTarget() && frameBuffer[*m_impl->m_presentTarget].samples() > MultiSamplingLevel::x1 }; // NOLINT(cppcoreguidelines-pro-bounds-avoid-unchecked-container-access)
 
     // Transition the present and depth/stencil views.
     // NOTE: Ending the render pass implicitly barriers with legacy resource state?!
@@ -436,6 +436,7 @@ UInt64 DirectX12RenderPass::end() const
         //if (renderTarget.multiQueueAccess())
         //    return;  // Resources with simultaneous access enabled don't need to be transitioned.
 
+        // NOLINTBEGIN(cppcoreguidelines-pro-bounds-avoid-unchecked-container-access)
         switch (renderTarget.type())
         {
         default:
@@ -453,6 +454,7 @@ UInt64 DirectX12RenderPass::end() const
 
             break;
         }
+        // NOLINTEND(cppcoreguidelines-pro-bounds-avoid-unchecked-container-access)
     });
 
     endCommandBuffer->barrier(renderTargetBarrier);
@@ -465,7 +467,7 @@ UInt64 DirectX12RenderPass::end() const
         resolveBarrier.transition(backBufferImage, ResourceAccess::Common, ResourceAccess::ResolveWrite, ImageLayout::Common, ImageLayout::ResolveDestination);
         endCommandBuffer->barrier(resolveBarrier);
 
-        auto& multiSampledImage = frameBuffer[*m_impl->m_presentTarget];
+        auto& multiSampledImage = frameBuffer[*m_impl->m_presentTarget]; // NOLINT(cppcoreguidelines-pro-bounds-avoid-unchecked-container-access)
         std::as_const(*endCommandBuffer).handle()->ResolveSubresource(backBufferImage.handle().Get(), 0, multiSampledImage.handle().Get(), 0, DX12::getFormat(multiSampledImage.format()));
 
         // Transition the present target back to the present state.
@@ -480,7 +482,7 @@ UInt64 DirectX12RenderPass::end() const
         beginPresentBarrier.transition(backBufferImage, ResourceAccess::None, ResourceAccess::TransferWrite, ImageLayout::Undefined, ImageLayout::CopyDestination);
         endCommandBuffer->barrier(beginPresentBarrier);
 
-        auto& presentTarget = frameBuffer[*m_impl->m_presentTarget];
+        auto& presentTarget = frameBuffer[*m_impl->m_presentTarget]; // NOLINT(cppcoreguidelines-pro-bounds-avoid-unchecked-container-access)
         endCommandBuffer->transfer(presentTarget, backBufferImage);
 
         DirectX12Barrier endPresentBarrier(PipelineStage::Transfer, PipelineStage::None);

--- a/src/Backends/DirectX12/src/render_pipeline.cpp
+++ b/src/Backends/DirectX12/src/render_pipeline.cpp
@@ -138,8 +138,8 @@ public:
 
 		// Setup render target states.
 		// NOTE: We assume, that the targets are returned sorted by location and the location range is contiguous.
-		D3D12_BLEND_DESC blendState = {};
-		D3D12_DEPTH_STENCIL_DESC1 depthStencilState = {};
+		D3D12_BLEND_DESC blendState = {}; // NOLINT(bugprone-invalid-enum-default-initialization)
+		D3D12_DEPTH_STENCIL_DESC1 depthStencilState = {}; // NOLINT(bugprone-invalid-enum-default-initialization)
 		auto targets = m_renderPass->renderTargets();
 		UInt32 renderTargets = static_cast<UInt32>(std::ranges::count_if(targets, [](auto& renderTarget) { return renderTarget.type() != RenderTargetType::DepthStencil; }));
 		UInt32 depthStencilTargets = static_cast<UInt32>(targets.size()) - renderTargets;
@@ -182,7 +182,7 @@ public:
 			{
 				// Setup target formats.
 				UInt32 target = i++;
-				rtvFormats[target] = DX12::getFormat(renderTarget.format()); // NOLINT(cppcoreguidelines-pro-bounds-constant-array-index)
+				rtvFormats[target] = DX12::getFormat(renderTarget.format()); // NOLINT(cppcoreguidelines-pro-bounds-constant-array-index, cppcoreguidelines-pro-bounds-avoid-unchecked-container-access)
 
 				// Setup the blend state.
 				auto& targetBlendState = blendState.RenderTarget[target];
@@ -235,6 +235,7 @@ public:
 	ComPtr<ID3D12PipelineState> initializeMeshPipeline([[maybe_unused]] const DirectX12RenderPipeline& pipeline, const D3D12_BLEND_DESC& blendState, const D3D12_RASTERIZER_DESC& rasterizerState, const D3D12_DEPTH_STENCIL_DESC1& depthStencilState, D3D12_PRIMITIVE_TOPOLOGY_TYPE topologyType, UINT renderTargets, const std::array<DXGI_FORMAT, D3D12_SIMULTANEOUS_RENDER_TARGET_COUNT>& renderTargetFormats, DXGI_FORMAT depthStencilFormat, const DXGI_SAMPLE_DESC& multisamplingState, const Optional<D3D12_VIEW_INSTANCING_DESC>& viewInstancingDesc)
 	{
 		// Create a pipeline state description.
+		// NOLINTBEGIN(bugprone-invalid-enum-default-initialization)
 		D3DX12_MESH_SHADER_PIPELINE_STATE_DESC pipelineStateDescription = {
 			.pRootSignature = std::as_const(*m_layout).handle().Get(),
 			.BlendState = blendState,
@@ -245,6 +246,7 @@ public:
 			.DSVFormat = depthStencilFormat,
 			.SampleDesc = multisamplingState
 		};
+		// NOLINTEND(bugprone-invalid-enum-default-initialization)
 
 		std::memcpy(&pipelineStateDescription.RTVFormats, renderTargetFormats.data(), renderTargetFormats.size() * sizeof(DXGI_FORMAT));
 
@@ -307,6 +309,7 @@ public:
 	ComPtr<ID3D12PipelineState> initializeGraphicsPipeline([[maybe_unused]] const DirectX12RenderPipeline& pipeline, const D3D12_BLEND_DESC& blendState, const D3D12_RASTERIZER_DESC& rasterizerState, const D3D12_DEPTH_STENCIL_DESC1& depthStencilState, const D3D12_INPUT_LAYOUT_DESC& inputLayout, D3D12_PRIMITIVE_TOPOLOGY_TYPE topologyType, UINT renderTargets, const std::array<DXGI_FORMAT, D3D12_SIMULTANEOUS_RENDER_TARGET_COUNT>& renderTargetFormats, DXGI_FORMAT depthStencilFormat, const DXGI_SAMPLE_DESC& multisamplingState, const Optional<D3D12_VIEW_INSTANCING_DESC>& viewInstancingDesc)
 	{
 		// Create a pipeline state description.
+		// NOLINTBEGIN(bugprone-invalid-enum-default-initialization)
 		D3D12_GRAPHICS_PIPELINE_STATE_DESC pipelineStateDescription = {
 			.pRootSignature = std::as_const(*m_layout).handle().Get(),
 			.BlendState = blendState,
@@ -318,6 +321,7 @@ public:
 			.DSVFormat = depthStencilFormat,
 			.SampleDesc = multisamplingState
 		};
+		// NOLINTEND(bugprone-invalid-enum-default-initialization)
 
 		std::memcpy(&pipelineStateDescription.RTVFormats, renderTargetFormats.data(), renderTargetFormats.size() * sizeof(DXGI_FORMAT));
 		
@@ -463,7 +467,7 @@ public:
 				if (binding->layout().space() == dependency.binding().Space)
 				{
 					// Resolve the image and update the binding.
-					auto& image = frameBuffer[dependency.renderTarget()];
+					auto& image = frameBuffer[dependency.renderTarget()]; // NOLINT(cppcoreguidelines-pro-bounds-avoid-unchecked-container-access)
 
 					if (image.samples() != m_samples) [[unlikely]]
 						LITEFX_WARNING(DIRECTX12_LOG, "The image multi sampling level {0} does not match the render pipeline multi sampling state {1}.", image.samples(), m_samples);

--- a/src/Backends/DirectX12/src/shader_program.cpp
+++ b/src/Backends/DirectX12/src/shader_program.cpp
@@ -181,7 +181,7 @@ public:
     {
         // NOLINTBEGIN(cppcoreguidelines-pro-type-union-access)
         // Collect the shader stages.
-        ShaderStage stages{ };
+        ShaderStage stages{ ShaderStage::Other };
         std::ranges::for_each(m_modules, [&stages](const auto& shaderModule) { stages = stages | shaderModule->type(); });
 
         // Get the root signature description.
@@ -230,7 +230,7 @@ public:
                 else
                 {
                     // Convert the descriptor to a push constant range.
-                    ShaderStage stage{ };
+                    ShaderStage stage{ ShaderStage::Other };
 
                     switch (rootParameter.ShaderVisibility)
                     {
@@ -280,7 +280,7 @@ public:
     DescriptorInfo getReflectionDescriptorDesc(D3D12_SHADER_INPUT_BIND_DESC inputDesc, TReflection* shaderReflection)
     {
         // First, create a description of the descriptor.
-        DescriptorType type{ };
+        DescriptorType type{ DescriptorType::ConstantBuffer };
         UInt32 elementSize = 0;
 
         switch (inputDesc.Type)
@@ -477,7 +477,7 @@ public:
             for (size_t i{ 0 }; i < descriptorSet.descriptors.size(); ++i)
             {
                 // Get the current descriptor.
-                auto& descriptor = descriptorSet.descriptors[i];
+                auto& descriptor = descriptorSet.descriptors[i]; // NOLINT(cppcoreguidelines-pro-bounds-avoid-unchecked-container-access)
 
                 // See if there's a hint about the binding.
                 auto hint = PipelineBindingHint::hint_type{ };
@@ -687,7 +687,7 @@ DirectX12ShaderProgram::DirectX12ShaderProgram(const DirectX12Device& device, En
     m_impl->validate();
 }
 
-DirectX12ShaderProgram::DirectX12ShaderProgram(const DirectX12Device& device) noexcept :
+DirectX12ShaderProgram::DirectX12ShaderProgram(const DirectX12Device& device) noexcept : // NOLINT(bugprone-exception-escape)
     m_impl(device)
 {
 }

--- a/src/Backends/DirectX12/src/swapchain.cpp
+++ b/src/Backends/DirectX12/src/swapchain.cpp
@@ -195,11 +195,11 @@ public:
 		m_currentImage = swapChain.handle()->GetCurrentBackBufferIndex();
 
 		// Wait for all rendering commands to finish on the image index (otherwise we would not be able to re-use the command buffers).
-		device->defaultQueue(QueueType::Graphics).waitFor(m_presentFences[m_currentImage]);
+		device->defaultQueue(QueueType::Graphics).waitFor(m_presentFences[m_currentImage]); // NOLINT(cppcoreguidelines-pro-bounds-avoid-unchecked-container-access)
 
 		// Read back the timestamps.
 		if (!m_timestamps.empty())
-			m_timingQueryReadbackBuffers[m_currentImage]->map(m_timestamps.data(), sizeof(UInt64) * m_timestamps.size(), 0, false);
+			m_timingQueryReadbackBuffers[m_currentImage]->map(m_timestamps.data(), sizeof(UInt64) * m_timestamps.size(), 0, false); // NOLINT(cppcoreguidelines-pro-bounds-avoid-unchecked-container-access)
 
 		return m_currentImage;
 	}
@@ -234,7 +234,7 @@ bool DirectX12SwapChain::supportsVariableRefreshRate() const noexcept
 
 ID3D12QueryHeap* DirectX12SwapChain::timestampQueryHeap() const noexcept
 {
-	return m_impl->m_timingQueryHeaps[m_impl->m_currentImage].Get();
+	return m_impl->m_timingQueryHeaps[m_impl->m_currentImage].Get(); // NOLINT(cppcoreguidelines-pro-bounds-avoid-unchecked-container-access)
 }
 
 const Array<SharedPtr<const TimingEvent>>& DirectX12SwapChain::timingEvents() const
@@ -247,7 +247,7 @@ SharedPtr<const TimingEvent> DirectX12SwapChain::timingEvent(UInt32 queryId) con
 	if (queryId >= m_impl->m_timingEvents.size())
 		throw ArgumentOutOfRangeException("queryId", std::make_pair(0uz, m_impl->m_timingEvents.size()), static_cast<size_t>(queryId), "No timing event has been registered for query ID {0}.", queryId);
 
-	return m_impl->m_timingEvents[queryId];
+	return m_impl->m_timingEvents[queryId]; // NOLINT(cppcoreguidelines-pro-bounds-avoid-unchecked-container-access)
 }
 
 UInt64 DirectX12SwapChain::readTimingEvent(SharedPtr<const TimingEvent> timingEvent) const
@@ -256,7 +256,7 @@ UInt64 DirectX12SwapChain::readTimingEvent(SharedPtr<const TimingEvent> timingEv
 		throw ArgumentNotInitializedException("timingEvent", "The timing event must be initialized.");
 
 	if (auto match = std::find(m_impl->m_timingEvents.begin(), m_impl->m_timingEvents.end(), timingEvent); match != m_impl->m_timingEvents.end()) [[likely]]
-		return m_impl->m_timestamps[std::distance(m_impl->m_timingEvents.begin(), match)];
+		return m_impl->m_timestamps[std::distance(m_impl->m_timingEvents.begin(), match)]; // NOLINT(cppcoreguidelines-pro-bounds-avoid-unchecked-container-access)
 
 	throw InvalidArgumentException("timingEvent", "The timing event is not registered on the swap chain.");
 }
@@ -307,12 +307,12 @@ IDirectX12Image* DirectX12SwapChain::image(UInt32 backBuffer) const
 	if (backBuffer >= m_impl->m_presentImages.size()) [[unlikely]]
 		throw ArgumentOutOfRangeException("backBuffer", std::make_pair(0uz, m_impl->m_presentImages.size()), static_cast<size_t>(backBuffer), "The back buffer must be a valid index.");
 
-	return m_impl->m_presentImages[backBuffer].get();
+	return m_impl->m_presentImages[backBuffer].get(); // NOLINT(cppcoreguidelines-pro-bounds-avoid-unchecked-container-access)
 }
 
 const IDirectX12Image& DirectX12SwapChain::image() const noexcept
 {
-	return *m_impl->m_presentImages[m_impl->m_currentImage];
+	return *m_impl->m_presentImages[m_impl->m_currentImage]; // NOLINT(cppcoreguidelines-pro-bounds-avoid-unchecked-container-access)
 }
 
 const Array<SharedPtr<IDirectX12Image>>& DirectX12SwapChain::images() const noexcept
@@ -324,7 +324,7 @@ void DirectX12SwapChain::present(UInt64 fence) const
 {
 	// Store the last fence here that marks the end of the rendering to this frame buffer. Presenting is queued after rendering anyway, but when swapping the back buffers buffers,
 	// we need to wait for all commands to finish before being able to re-use the command buffers associated with queued commands.
-	m_impl->m_presentFences[m_impl->m_currentImage] = fence;
+	m_impl->m_presentFences[m_impl->m_currentImage] = fence; // NOLINT(cppcoreguidelines-pro-bounds-avoid-unchecked-container-access)
 
 	if (m_impl->m_vsync)
 		raiseIfFailed(this->handle()->Present(1, 0), "Unable to present swap chain");
@@ -377,8 +377,10 @@ void DirectX12SwapChain::resolveQueryHeaps(const DirectX12CommandBuffer& command
 	if (m_impl->m_timingEvents.empty())
 		return;
 
+	// NOLINTBEGIN(cppcoreguidelines-pro-bounds-avoid-unchecked-container-access)
 	commandBuffer.handle()->ResolveQueryData(
 		m_impl->m_timingQueryHeaps[m_impl->m_currentImage].Get(), 
 		D3D12_QUERY_TYPE_TIMESTAMP, 0, static_cast<UINT>(m_impl->m_timestamps.size()), 
 		std::as_const(*m_impl->m_timingQueryReadbackBuffers[m_impl->m_currentImage]).handle().Get(), 0);
+	// NOLINTEND(cppcoreguidelines-pro-bounds-avoid-unchecked-container-access)
 }

--- a/src/Backends/Vulkan/include/litefx/backends/vulkan.hpp
+++ b/src/Backends/Vulkan/include/litefx/backends/vulkan.hpp
@@ -3107,6 +3107,9 @@ namespace LiteFX::Rendering::Backends {
         const VulkanGraphicsAdapter* findAdapter(const Optional<UInt64>& adapterId = std::nullopt) const noexcept override;
 
         /// <inheritdoc />
+        const VulkanGraphicsAdapter* findAdapter(GpuPreference preference) const noexcept override;
+
+        /// <inheritdoc />
         void registerDevice(const String& name, SharedPtr<VulkanDevice>&& device) override;
 
         /// <inheritdoc />

--- a/src/Backends/Vulkan/include/litefx/backends/vulkan.hpp
+++ b/src/Backends/Vulkan/include/litefx/backends/vulkan.hpp
@@ -8,6 +8,8 @@
 #pragma warning(push)
 #pragma warning(disable:4250) // Base class members are inherited via dominance.
 
+// NOLINTBEGIN(bugprone-derived-method-shadowing-base-method)
+
 namespace LiteFX::Rendering::Backends {
     using namespace LiteFX::Math;
     using namespace LiteFX::Rendering;
@@ -631,13 +633,13 @@ namespace LiteFX::Rendering::Backends {
         /// Returns the shader byte code.
         /// </summary>
         /// <returns>The shader byte code.</returns>
-        virtual const Array<UInt32>& bytecode() const noexcept;
+        const Array<UInt32>& bytecode() const noexcept;
 
         /// <summary>
         /// Returns the shader stage creation info for convenience.
         /// </summary>
         /// <returns>The shader stage creation info for convenience.</returns>
-        virtual VkPipelineShaderStageCreateInfo shaderStageDefinition() const;
+        VkPipelineShaderStageCreateInfo shaderStageDefinition() const;
     };
 
     /// <summary>
@@ -708,7 +710,7 @@ namespace LiteFX::Rendering::Backends {
         const Array<UniquePtr<const VulkanShaderModule>>& modules() const noexcept override;
 
         /// <inheritdoc />
-        virtual SharedPtr<VulkanPipelineLayout> reflectPipelineLayout(Enumerable<PipelineBindingHint> hints = {}) const;
+        SharedPtr<VulkanPipelineLayout> reflectPipelineLayout(Enumerable<PipelineBindingHint> hints = {}) const;
 
     private:
         SharedPtr<IPipelineLayout> parsePipelineLayout(Enumerable<PipelineBindingHint> hints) const override {
@@ -764,7 +766,7 @@ namespace LiteFX::Rendering::Backends {
         /// Returns the parent descriptor set layout.
         /// </summary>
         /// <returns>The parent descriptor set layout.</returns>
-        virtual const VulkanDescriptorSetLayout& layout() const noexcept;
+        const VulkanDescriptorSetLayout& layout() const noexcept;
 
     private:
         /// <summary>
@@ -1439,7 +1441,7 @@ namespace LiteFX::Rendering::Backends {
         /// </remarks>
         /// <returns>A reference to the line width.</returns>
         /// <seealso href="https://www.khronos.org/registry/vulkan/specs/1.2-extensions/html/vkspec.html#features-wideLines" />
-        virtual void updateLineWidth(Float lineWidth) noexcept;
+        void updateLineWidth(Float lineWidth) noexcept;
     };
 
     /// <summary>
@@ -1543,7 +1545,7 @@ namespace LiteFX::Rendering::Backends {
         /// Begins the command buffer as a secondary command buffer that inherits the state of <paramref name="renderPass" />.
         /// </summary>
         /// <param name="renderPass">The render pass state to inherit.</param>
-        virtual void begin(const VulkanRenderPass& renderPass) const;
+        void begin(const VulkanRenderPass& renderPass) const;
 
         // CommandBuffer interface.
     public:
@@ -2501,7 +2503,7 @@ namespace LiteFX::Rendering::Backends {
         /// Returns the query pool for the current frame.
         /// </summary>
         /// <returns>A reference of the query pool for the current frame.</returns>
-        virtual const VkQueryPool& timestampQueryPool() const noexcept;
+        const VkQueryPool& timestampQueryPool() const noexcept;
 
         // SwapChain interface.
     public:
@@ -2850,7 +2852,7 @@ namespace LiteFX::Rendering::Backends {
         /// <param name="objectType">The type of the object.</param>
         /// <param name="objectHandle">The handle of the object casted to an integer.</param>
         /// <param name="name">The debug name of the object.</param>
-        void setDebugName(VkDebugReportObjectTypeEXT objectType, UInt64 objectHandle, StringView name) const noexcept;
+        void setDebugName(VkDebugReportObjectTypeEXT objectType, UInt64 objectHandle, StringView name) const;
 
     public:
         /// <summary>
@@ -2871,7 +2873,7 @@ namespace LiteFX::Rendering::Backends {
         /// <param name="objectType">The type of the object.</param>
         /// <param name="name">The debug name of the object.</param>
         template <typename THandle>
-        inline void setDebugName(THandle objectHandle, VkDebugReportObjectTypeEXT objectType, StringView name) const noexcept {
+        inline void setDebugName(THandle objectHandle, VkDebugReportObjectTypeEXT objectType, StringView name) const {
             this->setDebugName(objectType, Vk::handleAddress(objectHandle), name); // NOLINT(cppcoreguidelines-pro-type-reinterpret-cast)
         }
 
@@ -2925,7 +2927,7 @@ namespace LiteFX::Rendering::Backends {
         [[nodiscard]] SharedPtr<VulkanFrameBuffer> makeFrameBuffer(StringView name, const Size2d& renderArea, VulkanFrameBuffer::allocation_callback_type allocationCallback) const override;
 
         /// <inheritdoc />
-        MultiSamplingLevel maximumMultiSamplingLevel(Format format) const noexcept override;
+        MultiSamplingLevel maximumMultiSamplingLevel(Format format) const override;
 
         /// <inheritdoc />
         double ticksPerMillisecond() const noexcept override;
@@ -2949,7 +2951,7 @@ namespace LiteFX::Rendering::Backends {
         void updateGlobalDescriptors(const VulkanDescriptorSet& descriptorSet, UInt32 binding, UInt32 offset, UInt32 descriptors) const override;
 
         /// <inheritdoc />
-        void bindDescriptorSet(const VulkanCommandBuffer& commandBuffer, const VulkanDescriptorSet& descriptorSet, const VulkanPipelineState& pipeline) const noexcept override;
+        void bindDescriptorSet(const VulkanCommandBuffer& commandBuffer, const VulkanDescriptorSet& descriptorSet, const VulkanPipelineState& pipeline) const override;
 
         /// <inheritdoc />
         void bindGlobalDescriptorHeaps(const VulkanCommandBuffer& commandBuffer) const noexcept override;
@@ -3030,7 +3032,7 @@ namespace LiteFX::Rendering::Backends {
         /// Returns the validation layers that are enabled on the backend.
         /// </summary>
         /// <returns>An array of validation layers that are enabled on the backend.</returns>
-        virtual Span<const String> getEnabledValidationLayers() const noexcept;
+        Span<const String> getEnabledValidationLayers() const noexcept;
 
 #ifdef VK_USE_PLATFORM_WIN32_KHR
         /// <summary>
@@ -3104,10 +3106,10 @@ namespace LiteFX::Rendering::Backends {
         const Array<SharedPtr<const VulkanGraphicsAdapter>>& adapters() const override;
 
         /// <inheritdoc />
-        const VulkanGraphicsAdapter* findAdapter(const Optional<UInt64>& adapterId = std::nullopt) const noexcept override;
+        const VulkanGraphicsAdapter* findAdapter(const Optional<UInt64>& adapterId = std::nullopt) const override;
 
         /// <inheritdoc />
-        const VulkanGraphicsAdapter* findAdapter(GpuPreference preference) const noexcept override;
+        const VulkanGraphicsAdapter* findAdapter(GpuPreference preference) const override;
 
         /// <inheritdoc />
         void registerDevice(const String& name, SharedPtr<VulkanDevice>&& device) override;
@@ -3116,12 +3118,14 @@ namespace LiteFX::Rendering::Backends {
         void releaseDevice(const String& name) override;
 
         /// <inheritdoc />
-        VulkanDevice* device(const String& name) noexcept override;
+        VulkanDevice* device(const String& name) override;
 
         /// <inheritdoc />
-        const VulkanDevice* device(const String& name) const noexcept override;
+        const VulkanDevice* device(const String& name) const override;
     };
 
 }
+
+// NOLINTEND(bugprone-derived-method-shadowing-base-method)
 
 #pragma warning(pop)

--- a/src/Backends/Vulkan/src/adaper.cpp
+++ b/src/Backends/Vulkan/src/adaper.cpp
@@ -46,11 +46,13 @@ public:
         switch (properties.deviceType)
         {
         case VK_PHYSICAL_DEVICE_TYPE_CPU:
+            m_type = GraphicsAdapterType::Software;
+            break;
+        case VK_PHYSICAL_DEVICE_TYPE_INTEGRATED_GPU:
             m_type = GraphicsAdapterType::CPU;
             break;
         case VK_PHYSICAL_DEVICE_TYPE_VIRTUAL_GPU:
         case VK_PHYSICAL_DEVICE_TYPE_DISCRETE_GPU:
-        case VK_PHYSICAL_DEVICE_TYPE_INTEGRATED_GPU:
             m_type = GraphicsAdapterType::GPU;
             break;
         default:

--- a/src/Backends/Vulkan/src/backend.cpp
+++ b/src/Backends/Vulkan/src/backend.cpp
@@ -278,7 +278,7 @@ const Array<SharedPtr<const VulkanGraphicsAdapter>>& VulkanBackend::adapters() c
     return m_impl->m_adapters;
 }
 
-const VulkanGraphicsAdapter* VulkanBackend::findAdapter(const Optional<UInt64>& adapterId) const noexcept
+const VulkanGraphicsAdapter* VulkanBackend::findAdapter(const Optional<UInt64>& adapterId) const
 {
     // We create a temporary copy of the adapters array here, which we can sort by the adapter type. This way we return dedicated GPUs before integrated GPUs, before software rasterizers and so on, if no
     // adapter ID is specified.
@@ -291,7 +291,7 @@ const VulkanGraphicsAdapter* VulkanBackend::findAdapter(const Optional<UInt64>& 
     return nullptr;
 }
 
-const VulkanGraphicsAdapter* VulkanBackend::findAdapter(GpuPreference preference) const noexcept
+const VulkanGraphicsAdapter* VulkanBackend::findAdapter(GpuPreference preference) const
 {
 #ifdef LITEFX_BUILD_DIRECTX_12_BACKEND
     // Get the first adapter for the preference.
@@ -351,7 +351,7 @@ void VulkanBackend::releaseDevice(const String& name)
     m_impl->m_devices.erase(name);
 }
 
-VulkanDevice* VulkanBackend::device(const String& name) noexcept
+VulkanDevice* VulkanBackend::device(const String& name)
 {
     if (!m_impl->m_devices.contains(name)) [[unlikely]]
         return nullptr;
@@ -359,7 +359,7 @@ VulkanDevice* VulkanBackend::device(const String& name) noexcept
     return m_impl->m_devices[name].get();
 }
 
-const VulkanDevice* VulkanBackend::device(const String& name) const noexcept
+const VulkanDevice* VulkanBackend::device(const String& name) const
 {
     if (!m_impl->m_devices.contains(name)) [[unlikely]]
         return nullptr;

--- a/src/Backends/Vulkan/src/backend.cpp
+++ b/src/Backends/Vulkan/src/backend.cpp
@@ -275,7 +275,12 @@ const Array<SharedPtr<const VulkanGraphicsAdapter>>& VulkanBackend::adapters() c
 
 const VulkanGraphicsAdapter* VulkanBackend::findAdapter(const Optional<UInt64>& adapterId) const noexcept
 {
-    if (auto match = std::ranges::find_if(m_impl->m_adapters, [&adapterId](const auto& adapter) { return !adapterId.has_value() || adapter->uniqueId() == adapterId; }); match != m_impl->m_adapters.end()) [[likely]]
+    // We create a temporary copy of the adapters array here, which we can sort by the adapter type. This way we return dedicated GPUs before integrated GPUs, before software rasterizers and so on, if no
+    // adapter ID is specified.
+    auto adapters = m_impl->m_adapters;
+    std::ranges::sort(adapters, std::ranges::greater{}, &VulkanGraphicsAdapter::type);
+
+    if (auto match = std::ranges::find_if(adapters, [&adapterId](const auto& adapter) { return !adapterId.has_value() || adapter->uniqueId() == adapterId; }); match != adapters.end()) [[likely]]
         return match->get();
 
     return nullptr;

--- a/src/Backends/Vulkan/src/backend.cpp
+++ b/src/Backends/Vulkan/src/backend.cpp
@@ -1,5 +1,10 @@
 #include <litefx/backends/vulkan.hpp>
 
+#ifdef LITEFX_BUILD_DIRECTX_12_BACKEND
+#include <dxgi1_6.h>
+#include <wrl/client.h>
+#endif // LITEFX_BUILD_DIRECTX_12_BACKEND
+
 using namespace LiteFX::Rendering::Backends;
 
 // Exported extensions (we should probably find a better solution for this).
@@ -284,6 +289,42 @@ const VulkanGraphicsAdapter* VulkanBackend::findAdapter(const Optional<UInt64>& 
         return match->get();
 
     return nullptr;
+}
+
+const VulkanGraphicsAdapter* VulkanBackend::findAdapter(GpuPreference preference) const noexcept
+{
+#ifdef LITEFX_BUILD_DIRECTX_12_BACKEND
+    // Get the first adapter for the preference.
+    Microsoft::WRL::ComPtr<IDXGIFactory7> factory;
+    Microsoft::WRL::ComPtr<IDXGIAdapter1> adapterInterface;
+
+    if (FAILED(::CreateDXGIFactory2(DXGI_CREATE_FACTORY_DEBUG, IID_PPV_ARGS(&factory))))
+    {
+        LITEFX_WARNING(VULKAN_LOG, "Unable to create DXGI factory for retrieving adapter preferences. Falling back to default adapter order.");
+        return this->findAdapter();
+    }
+
+    if (FAILED(factory->EnumAdapterByGpuPreference(0u, static_cast<DXGI_GPU_PREFERENCE>(preference), IID_PPV_ARGS(&adapterInterface))))
+    {
+        LITEFX_WARNING(VULKAN_LOG, "Unable acquire adapter preferences. Falling back to default adapter order.");
+        return this->findAdapter();
+    }
+
+    // Get the LUID.
+    UInt64 adapterId{};
+    DXGI_ADAPTER_DESC1 adapterDecriptor;
+
+    if (FAILED(adapterInterface->GetDesc1(&adapterDecriptor)))
+    {
+        LITEFX_WARNING(VULKAN_LOG, "Unable obtain LUID from preferred adapter. Falling back to default adapter order.");
+        return this->findAdapter();
+    }
+
+    std::memcpy(&adapterId, &adapterDecriptor.AdapterLuid, sizeof(LUID));
+    return this->findAdapter(adapterId);
+#else  // LITEFX_BUILD_DIRECTX_12_BACKEND
+    return this->findAdapter();
+#endif // LITEFX_BUILD_DIRECTX_12_BACKEND
 }
 
 void VulkanBackend::registerDevice(const String& name, SharedPtr<VulkanDevice>&& device)

--- a/src/Backends/Vulkan/src/blas.cpp
+++ b/src/Backends/Vulkan/src/blas.cpp
@@ -310,17 +310,19 @@ void VulkanBottomLevelAccelerationStructure::copy(const VulkanCommandBuffer& com
     auto device = commandBuffer.queue()->device();
 
     if (!LITEFX_FLAG_IS_SET(m_impl->m_flags, AccelerationStructureFlags::AllowCompaction))
-        device->computeAccelerationStructureSizes(*this, requiredMemory[0], requiredMemory[1], true);
+        device->computeAccelerationStructureSizes(*this, requiredMemory[0], requiredMemory[1], true);// NOLINT(cppcoreguidelines-pro-bounds-avoid-unchecked-container-access)
     else
         raiseIfFailed(::vkGetQueryPoolResults(device->handle(), m_impl->m_queryPool, 0, 1, sizeof(UInt64), &requiredMemory, 0, VkQueryResultFlagBits::VK_QUERY_RESULT_64_BIT), "Unable to query for compressed acceleration structure size.");
 
     // Validate the input arguments.
     auto memory = buffer;
 
+    // NOLINTBEGIN(cppcoreguidelines-pro-bounds-avoid-unchecked-container-access)
     if (buffer == nullptr)
         memory = destination.m_impl->m_buffer->size() >= requiredMemory[0] ? destination.m_impl->m_buffer : device->factory().createBuffer(BufferType::AccelerationStructure, ResourceHeap::Resource, static_cast<size_t>(requiredMemory[0]), 1, ResourceUsage::AllowWrite);
     else if (buffer->size() < offset + requiredMemory[0]) [[unlikely]]
         throw ArgumentOutOfRangeException("buffer", std::make_pair<UInt64, UInt64>(0u, buffer->size()), offset + requiredMemory[0], "The buffer does not contain enough memory after offset {0} to fully contain the acceleration structure.", offset);
+    // NOLINTEND(cppcoreguidelines-pro-bounds-avoid-unchecked-container-access)
 
     // Create or reset query pool on destination, if required. 
     if (LITEFX_FLAG_IS_SET(destination.flags(), AccelerationStructureFlags::AllowCompaction))
@@ -348,7 +350,7 @@ void VulkanBottomLevelAccelerationStructure::copy(const VulkanCommandBuffer& com
         .sType = VK_STRUCTURE_TYPE_ACCELERATION_STRUCTURE_CREATE_INFO_KHR,
         .buffer = memory->handle(),
         .offset = offset,
-        .size = requiredMemory[0],
+        .size = requiredMemory[0], // NOLINT(cppcoreguidelines-pro-bounds-avoid-unchecked-container-access)
         .type = VK_ACCELERATION_STRUCTURE_TYPE_BOTTOM_LEVEL_KHR
     };
 
@@ -357,7 +359,7 @@ void VulkanBottomLevelAccelerationStructure::copy(const VulkanCommandBuffer& com
     // Store the buffer and the offset.
     destination.m_impl->m_offset = offset;
     destination.m_impl->m_buffer = memory;
-    destination.m_impl->m_size = requiredMemory[0];
+    destination.m_impl->m_size = requiredMemory[0]; // NOLINT(cppcoreguidelines-pro-bounds-avoid-unchecked-container-access)
     destination.m_impl->m_device = m_impl->m_device;
 
     // Perform the update.

--- a/src/Backends/Vulkan/src/buffer.cpp
+++ b/src/Backends/Vulkan/src/buffer.cpp
@@ -54,7 +54,7 @@ VulkanBuffer::VulkanBuffer(VkBuffer buffer, BufferType type, UInt32 elements, si
 		::vmaSetAllocationUserData(m_impl->m_allocator, m_impl->m_allocation.get(), static_cast<IDeviceMemory*>(this));
 }
 
-VulkanBuffer::~VulkanBuffer() noexcept
+VulkanBuffer::~VulkanBuffer() noexcept // NOLINT(bugprone-exception-escape)
 {	
 	if (m_impl->m_allocator != nullptr)
 	{

--- a/src/Backends/Vulkan/src/command_buffer.cpp
+++ b/src/Backends/Vulkan/src/command_buffer.cpp
@@ -240,7 +240,7 @@ VulkanCommandBuffer::VulkanCommandBuffer(const VulkanQueue& queue, bool begin, b
 		this->begin();
 }
 
-VulkanCommandBuffer::~VulkanCommandBuffer() noexcept
+VulkanCommandBuffer::~VulkanCommandBuffer() noexcept // NOLINT(bugprone-exception-escape)
 {
 	m_impl->release(*this);
 }

--- a/src/Backends/Vulkan/src/compute_pipeline.cpp
+++ b/src/Backends/Vulkan/src/compute_pipeline.cpp
@@ -76,7 +76,7 @@ VulkanComputePipeline::VulkanComputePipeline(const VulkanDevice& device, const S
 	this->handle() = m_impl->initialize(*this);
 }
 
-VulkanComputePipeline::VulkanComputePipeline(const VulkanDevice& device) noexcept :
+VulkanComputePipeline::VulkanComputePipeline(const VulkanDevice& device) noexcept : // NOLINT(bugprone-exception-escape)
 	VulkanPipelineState(VK_NULL_HANDLE), m_impl(device)
 {
 }

--- a/src/Backends/Vulkan/src/descriptor_set_layout.cpp
+++ b/src/Backends/Vulkan/src/descriptor_set_layout.cpp
@@ -20,7 +20,7 @@ public:
 private:
     Array<VulkanDescriptorLayout> m_descriptorLayouts;
     Queue<Array<Byte>> m_freeDescriptorSets;
-    ShaderStage m_stages{};
+    ShaderStage m_stages{ ShaderStage::Other };
     UInt32 m_space{}, m_maxUnboundedArraySize{};
     mutable std::mutex m_mutex;
     SharedPtr<const VulkanDevice> m_device;
@@ -295,7 +295,7 @@ public:
             m_maxUnboundedArraySize = descriptorCountSupportInfo.maxVariableDescriptorCount;
 
             // Reset the unbounded array descriptor count.
-            bindings[unboundedDescriptorIndex].descriptorCount = std::min(m_maxUnboundedArraySize, unboundedDescriptorCount);
+            bindings[unboundedDescriptorIndex].descriptorCount = std::min(m_maxUnboundedArraySize, unboundedDescriptorCount); // NOLINT(cppcoreguidelines-pro-bounds-avoid-unchecked-container-access)
         }
 
         VkDescriptorSetLayout layout{};
@@ -581,7 +581,7 @@ Generator<UniquePtr<VulkanDescriptorSet>> VulkanDescriptorSetLayout::allocate(UI
             }
 
             // Advance to next provided binding set.
-            bindings++;
+            bindings++; // NOLINT(cppcoreguidelines-pro-bounds-pointer-arithmetic)
         }
 
         co_yield std::move(descriptorSet);

--- a/src/Backends/Vulkan/src/device.cpp
+++ b/src/Backends/Vulkan/src/device.cpp
@@ -648,7 +648,7 @@ public:
         }
     }
 
-    inline void initializeResourceHeaps() noexcept
+    inline void initializeResourceHeaps()
     {
         // NOTE: Check the notes in `VulkanGraphicsFactory::createDescriptorHeap` for an explanation why we only use one descriptor heap in the Vulkan backend!
 
@@ -753,7 +753,7 @@ Span<const String> VulkanDevice::enabledExtensions() const noexcept
     return m_impl->m_extensions;
 }
 
-void VulkanDevice::setDebugName([[maybe_unused]] VkDebugReportObjectTypeEXT type, [[maybe_unused]] UInt64 handle, [[maybe_unused]] StringView name) const noexcept
+void VulkanDevice::setDebugName([[maybe_unused]] VkDebugReportObjectTypeEXT type, [[maybe_unused]] UInt64 handle, [[maybe_unused]] StringView name) const
 {
 #ifndef NDEBUG
     if (m_impl->debugMarkerSetObjectName != nullptr)
@@ -857,7 +857,7 @@ void VulkanDevice::updateGlobalDescriptors(const VulkanDescriptorSet& descriptor
             static_cast<size_t>(descriptorSet.globalHeapAllocation(DescriptorHeapType::Resource).Offset) + firstDescriptor);
 }
 
-void VulkanDevice::bindDescriptorSet(const VulkanCommandBuffer& commandBuffer, const VulkanDescriptorSet& descriptorSet, const VulkanPipelineState& pipeline) const noexcept
+void VulkanDevice::bindDescriptorSet(const VulkanCommandBuffer& commandBuffer, const VulkanDescriptorSet& descriptorSet, const VulkanPipelineState& pipeline) const
 {
     // Copy the descriptors to the global heaps and set the root table parameters.
     if (descriptorSet.layout().bindsResources() || descriptorSet.layout().bindsSamplers()) // Discard empty sets.
@@ -1002,7 +1002,7 @@ SharedPtr<VulkanFrameBuffer> VulkanDevice::makeFrameBuffer(StringView name, cons
     return VulkanFrameBuffer::create(*this, renderArea, allocationCallback, name);
 }
 
-MultiSamplingLevel VulkanDevice::maximumMultiSamplingLevel(Format format) const noexcept
+MultiSamplingLevel VulkanDevice::maximumMultiSamplingLevel(Format format) const
 {
     auto limits = m_impl->m_adapter->limits();
     VkSampleCountFlags sampleCounts = limits.framebufferColorSampleCounts;

--- a/src/Backends/Vulkan/src/factory.cpp
+++ b/src/Backends/Vulkan/src/factory.cpp
@@ -556,14 +556,14 @@ bool VulkanGraphicsFactory::supportsResizableBaseAddressRegister() const noexcep
 	// Check the heap sizes for all memory types that are both, DEVICE_LOCAL and HOST_VISIBLE. Default BAR size is 256 Mb. If we found a
 	// heap that has equal or less than that, we ignore it, even if it might still be ReBAR-supported, but with that small BAR memory we
 	// might as well assume non-support.
-	auto memTypes = Span{ memProps[0]->memoryTypes, memProps[0]->memoryTypeCount }; // NOLINT(cppcoreguidelines-pro-bounds-array-to-pointer-decay)
+	auto memTypes = Span{ memProps[0]->memoryTypes, memProps[0]->memoryTypeCount }; // NOLINT(cppcoreguidelines-pro-bounds-array-to-pointer-decay, cppcoreguidelines-pro-bounds-avoid-unchecked-container-access)
 
 	for (auto& memType : memTypes
 		| std::views::filter([](const auto& type) { return
 			(type.propertyFlags & VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT) == VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT &&
 			(type.propertyFlags & VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT) == VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT; }))
 	{
-		if (memProps[0]->memoryHeaps[memType.heapIndex].size > DEFAULT_BAR_SIZE) // NOLINT(cppcoreguidelines-pro-bounds-constant-array-index)
+		if (memProps[0]->memoryHeaps[memType.heapIndex].size > DEFAULT_BAR_SIZE) // NOLINT(cppcoreguidelines-pro-bounds-constant-array-index, cppcoreguidelines-pro-bounds-avoid-unchecked-container-access)
 			return true;
 	}
 
@@ -575,10 +575,10 @@ Array<MemoryHeapStatistics> VulkanGraphicsFactory::memoryStatistics() const
 	// Query the memory properties from VMA to get the number of heaps.
 	std::array<const VkPhysicalDeviceMemoryProperties*, 1> memProps{};
 	::vmaGetMemoryProperties(m_impl->m_allocator, memProps.data());
-	auto memoryTypes = Span{ memProps[0]->memoryTypes, memProps[0]->memoryTypeCount }; // NOLINT(cppcoreguidelines-pro-bounds-array-to-pointer-decay)
+	auto memoryTypes = Span{ memProps[0]->memoryTypes, memProps[0]->memoryTypeCount }; // NOLINT(cppcoreguidelines-pro-bounds-array-to-pointer-decay, cppcoreguidelines-pro-bounds-avoid-unchecked-container-access)
 
 	// Allocate array for heap statistics.
-	Array<VmaBudget> heapBudgets(memProps[0]->memoryHeapCount); // NOLINT(cppcoreguidelines-pro-bounds-array-to-pointer-decay)
+	Array<VmaBudget> heapBudgets(memProps[0]->memoryHeapCount); // NOLINT(cppcoreguidelines-pro-bounds-array-to-pointer-decay, cppcoreguidelines-pro-bounds-avoid-unchecked-container-access)
 	::vmaGetHeapBudgets(m_impl->m_allocator, heapBudgets.data());
 
 	// Convert the heap budgets to the API types.
@@ -626,8 +626,8 @@ DetailedMemoryStatistics VulkanGraphicsFactory::detailedMemoryStatistics() const
 	// Query the memory properties from VMA to get the number of heaps.
 	std::array<const VkPhysicalDeviceMemoryProperties*, 1> memProps{};
 	::vmaGetMemoryProperties(m_impl->m_allocator, memProps.data());
-	UInt32 heapCount = memProps[0]->memoryHeapCount, typeCount = memProps[0]->memoryTypeCount; // NOLINT(cppcoreguidelines-pro-bounds-array-to-pointer-decay)
-	auto memoryTypes = Span{ memProps[0]->memoryTypes, memProps[0]->memoryTypeCount }; // NOLINT(cppcoreguidelines-pro-bounds-array-to-pointer-decay)
+	UInt32 heapCount = memProps[0]->memoryHeapCount, typeCount = memProps[0]->memoryTypeCount; // NOLINT(cppcoreguidelines-pro-bounds-array-to-pointer-decay, cppcoreguidelines-pro-bounds-avoid-unchecked-container-access)
+	auto memoryTypes = Span{ memProps[0]->memoryTypes, memProps[0]->memoryTypeCount }; // NOLINT(cppcoreguidelines-pro-bounds-array-to-pointer-decay, cppcoreguidelines-pro-bounds-avoid-unchecked-container-access)
 
 	// Query the total memory statistics.
 	VmaTotalStatistics stats{};
@@ -651,7 +651,7 @@ DetailedMemoryStatistics VulkanGraphicsFactory::detailedMemoryStatistics() const
 		.perResourceHeap = stats.memoryType
 			| std::views::take(typeCount)
 			| std::views::transform([&, i = 0](const auto& stats) mutable -> DetailedMemoryStatistics::StatisticsBlock {
-					const auto& type = memoryTypes[i++];
+					const auto& type = memoryTypes[i++]; // NOLINT(cppcoreguidelines-pro-bounds-avoid-unchecked-container-access)
 					return convertStats(stats, (type.propertyFlags & VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT) == VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT, (type.propertyFlags & VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT) == VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT);
 				})
 			| std::ranges::to<Array<DetailedMemoryStatistics::StatisticsBlock>>(),

--- a/src/Backends/Vulkan/src/frame_buffer.cpp
+++ b/src/Backends/Vulkan/src/frame_buffer.cpp
@@ -29,7 +29,7 @@ public:
     VulkanFrameBufferImpl& operator=(VulkanFrameBufferImpl&&) noexcept = default;
     VulkanFrameBufferImpl& operator=(const VulkanFrameBufferImpl&) = delete;
 
-    ~VulkanFrameBufferImpl() noexcept
+    ~VulkanFrameBufferImpl() // NOLINT(bugprone-exception-escape)
     {
         // Check if the device is still valid.
         auto device = m_device.lock();
@@ -198,7 +198,7 @@ VkImageView VulkanFrameBuffer::imageView(UInt32 imageIndex) const
     if (imageIndex >= m_impl->m_images.size()) [[unlikely]]
         throw ArgumentOutOfRangeException("imageIndex", std::make_pair(0uz, m_impl->m_images.size()), static_cast<size_t>(imageIndex), "The frame buffer does not contain an image at index {0}.", imageIndex);
 
-    return m_impl->m_renderTargetHandles.at(m_impl->m_images[imageIndex]);
+    return m_impl->m_renderTargetHandles.at(m_impl->m_images[imageIndex]); // NOLINT(cppcoreguidelines-pro-bounds-avoid-unchecked-container-access)
 }
 
 VkImageView VulkanFrameBuffer::imageView(StringView imageName) const
@@ -236,6 +236,7 @@ size_t VulkanFrameBuffer::getHeight() const noexcept
 
 void VulkanFrameBuffer::mapRenderTarget(const RenderTarget& renderTarget, UInt32 index)
 {
+    // NOLINTBEGIN(cppcoreguidelines-pro-bounds-avoid-unchecked-container-access)
     if (index >= m_impl->m_images.size()) [[unlikely]]
         throw ArgumentOutOfRangeException("index", std::make_pair(0uz, m_impl->m_images.size()), static_cast<size_t>(index), "The frame buffer does not contain an image at index {0}.", index);
 
@@ -243,6 +244,7 @@ void VulkanFrameBuffer::mapRenderTarget(const RenderTarget& renderTarget, UInt32
         LITEFX_WARNING(VULKAN_LOG, "The render target format {0} does not match the image format {1} for image {2}.", renderTarget.format(), m_impl->m_images[index]->format(), index);
 
     m_impl->m_mappedRenderTargets[renderTarget.identifier()] = m_impl->m_images[index];
+    // NOLINTEND(cppcoreguidelines-pro-bounds-avoid-unchecked-container-access)
 }
 
 void VulkanFrameBuffer::mapRenderTarget(const RenderTarget& renderTarget, StringView name)
@@ -270,7 +272,7 @@ const IVulkanImage& VulkanFrameBuffer::image(UInt32 index) const
     if (index >= m_impl->m_images.size())
         throw ArgumentOutOfRangeException("index", std::make_pair(0uz, m_impl->m_images.size()), static_cast<size_t>(index), "The frame buffer does not contain an image at index {0}.", index);
 
-    return *m_impl->m_images[index];
+    return *m_impl->m_images[index]; // NOLINT(cppcoreguidelines-pro-bounds-avoid-unchecked-container-access)
 }
 
 const IVulkanImage& VulkanFrameBuffer::image(const RenderTarget& renderTarget) const

--- a/src/Backends/Vulkan/src/image.cpp
+++ b/src/Backends/Vulkan/src/image.cpp
@@ -56,7 +56,7 @@ VulkanImage::VulkanImage(VkImage image, const Size3d& extent, Format format, Ima
 		::vmaSetAllocationUserData(m_impl->m_allocator, m_impl->m_allocation.get(), static_cast<IDeviceMemory*>(this));
 }
 
-VulkanImage::~VulkanImage() noexcept 
+VulkanImage::~VulkanImage() noexcept // NOLINT(bugprone-exception-escape)
 {
 	if (m_impl->m_allocator != nullptr)
 	{
@@ -70,7 +70,7 @@ UInt32 VulkanImage::elements() const noexcept
 	return m_impl->m_elements;
 }
 
-size_t VulkanImage::size() const noexcept
+size_t VulkanImage::size() const noexcept // NOLINT(bugprone-exception-escape)
 {
 	if (m_impl->m_allocation) [[likely]]
 		return static_cast<size_t>(m_impl->m_allocation->GetSize());
@@ -128,7 +128,7 @@ ResourceUsage VulkanImage::usage() const noexcept
 	return m_impl->m_usage;
 }
 
-UInt64 VulkanImage::virtualAddress() const noexcept
+UInt64 VulkanImage::virtualAddress() const noexcept // NOLINT(bugprone-exception-escape)
 {
 	// NOTE: There is a vendor-specific extension to support this but for the time being, we simply warn (https://registry.khronos.org/vulkan/specs/1.3-extensions/man/html/vkGetImageViewAddressNVX.html).
 	LITEFX_WARNING(VULKAN_LOG, "Vulkan does not allow to query virtual addresses of images.");
@@ -136,7 +136,7 @@ UInt64 VulkanImage::virtualAddress() const noexcept
 	return 0ul;
 }
 
-size_t VulkanImage::size(UInt32 level) const noexcept
+size_t VulkanImage::size(UInt32 level) const
 {
 	if (level >= m_impl->m_levels)
 		return 0;
@@ -215,7 +215,7 @@ MultiSamplingLevel VulkanImage::samples() const noexcept
 	return m_impl->m_samples;
 }
 
-VkImageAspectFlags VulkanImage::aspectMask() const noexcept
+VkImageAspectFlags VulkanImage::aspectMask() const noexcept // NOLINT(bugprone-exception-escape)
 {
 	// Get the aspect mask for all sub-resources.
 	if (::hasDepth(m_impl->m_format) && ::hasStencil(m_impl->m_format))
@@ -539,7 +539,7 @@ VulkanSampler::VulkanSampler(const VulkanDevice& device, FilterMode magFilter, F
 		this->name() = name;
 }
 
-VulkanSampler::~VulkanSampler() noexcept
+VulkanSampler::~VulkanSampler() noexcept // NOLINT(bugprone-exception-escape)
 {
 	// Check if the device is still valid.
 	auto device = m_impl->m_device.lock();

--- a/src/Backends/Vulkan/src/image.h
+++ b/src/Backends/Vulkan/src/image.h
@@ -56,7 +56,7 @@ namespace LiteFX::Rendering::Backends {
 		// IImage interface.
 	public:
 		/// <inheritdoc />
-		size_t size(UInt32 level) const noexcept override;
+		size_t size(UInt32 level) const override;
 
 		/// <inheritdoc />
 		Size3d extent(UInt32 level = 0) const noexcept override;

--- a/src/Backends/Vulkan/src/pipeline_layout.cpp
+++ b/src/Backends/Vulkan/src/pipeline_layout.cpp
@@ -109,7 +109,7 @@ VulkanPipelineLayout::VulkanPipelineLayout(const VulkanDevice& device, const Enu
     this->handle() = m_impl->initialize(*this, descriptorSetLayouts | std::ranges::to<std::vector>(), std::move(pushConstantsLayout));
 }
 
-VulkanPipelineLayout::VulkanPipelineLayout(const VulkanDevice& device) noexcept :
+VulkanPipelineLayout::VulkanPipelineLayout(const VulkanDevice& device) noexcept : // NOLINT(bugprone-exception-escape)
     Resource<VkPipelineLayout>(VK_NULL_HANDLE), m_impl(device)
 {
 }

--- a/src/Backends/Vulkan/src/queue.cpp
+++ b/src/Backends/Vulkan/src/queue.cpp
@@ -100,7 +100,7 @@ VulkanQueue::VulkanQueue(const VulkanDevice& device, QueueType type, QueuePriori
 	this->handle() = m_impl->initialize(device);
 }
 
-VulkanQueue::~VulkanQueue() noexcept
+VulkanQueue::~VulkanQueue() noexcept // NOLINT(bugprone-exception-escape)
 {
 	m_impl->release();
 }

--- a/src/Backends/Vulkan/src/ray_tracing_pipeline.cpp
+++ b/src/Backends/Vulkan/src/ray_tracing_pipeline.cpp
@@ -279,7 +279,7 @@ VulkanRayTracingPipeline::VulkanRayTracingPipeline(const VulkanDevice& device, c
 	this->handle() = m_impl->initialize(*this);
 }
 
-VulkanRayTracingPipeline::VulkanRayTracingPipeline(const VulkanDevice& device, ShaderRecordCollection&& shaderRecords) noexcept :
+VulkanRayTracingPipeline::VulkanRayTracingPipeline(const VulkanDevice& device, ShaderRecordCollection&& shaderRecords) noexcept : // NOLINT(bugprone-exception-escape)
 	VulkanPipelineState(VK_NULL_HANDLE), m_impl(device, std::move(shaderRecords))
 {
 }

--- a/src/Backends/Vulkan/src/render_pass.cpp
+++ b/src/Backends/Vulkan/src/render_pass.cpp
@@ -171,7 +171,7 @@ public:
                 };
 
                 // Get the image and check if we need to resolve it.
-                if (renderTarget.type() == RenderTargetType::Present && frameBuffer[renderTarget].samples() > MultiSamplingLevel::x1)
+                if (renderTarget.type() == RenderTargetType::Present && frameBuffer[renderTarget].samples() > MultiSamplingLevel::x1) // NOLINT(cppcoreguidelines-pro-bounds-avoid-unchecked-container-access)
                 {
                     auto getImageView = [&](const IVulkanImage& image) -> VkImageView {
                         VkImageViewCreateInfo createInfo = {
@@ -360,7 +360,7 @@ const RenderPassDependency& VulkanRenderPass::inputAttachment(UInt32 location) c
     if (location >= m_impl->m_inputAttachments.size()) [[unlikely]]
         throw ArgumentOutOfRangeException("location", std::make_pair(0uz, m_impl->m_inputAttachments.size()), static_cast<size_t>(location), "The render pass does not contain an input attachment at location {0}.", location);
 
-    return m_impl->m_inputAttachments[location];
+    return m_impl->m_inputAttachments[location]; // NOLINT(cppcoreguidelines-pro-bounds-avoid-unchecked-container-access)
 }
 
 const Optional<DescriptorBindingPoint>& VulkanRenderPass::inputAttachmentSamplerBinding() const noexcept
@@ -410,7 +410,7 @@ void VulkanRenderPass::begin(const VulkanFrameBuffer& frameBuffer) const
     VulkanBarrier renderTargetBarrier(PipelineStage::None, PipelineStage::RenderTarget), depthStencilBarrier(PipelineStage::None, PipelineStage::DepthStencil);
 
     std::ranges::for_each(m_impl->m_renderTargets, [&renderTargetBarrier, &depthStencilBarrier, &frameBuffer](const RenderTarget& renderTarget) {
-        auto& image = frameBuffer[renderTarget];
+        auto& image = frameBuffer[renderTarget]; // NOLINT(cppcoreguidelines-pro-bounds-avoid-unchecked-container-access)
 
         if (renderTarget.type() == RenderTargetType::DepthStencil)
             depthStencilBarrier.transition(image, ResourceAccess::None, ResourceAccess::DepthStencilWrite, ImageLayout::DepthRead, ImageLayout::DepthWrite);
@@ -420,7 +420,7 @@ void VulkanRenderPass::begin(const VulkanFrameBuffer& frameBuffer) const
 
     // If the present target is multi-sampled, transition the back buffer image into resolve state.
     const auto& backBufferImage = m_impl->m_device->swapChain().image();
-    bool requiresResolve{ this->hasPresentTarget() && frameBuffer[*m_impl->m_presentTarget].samples() > MultiSamplingLevel::x1 };
+    bool requiresResolve{ this->hasPresentTarget() && frameBuffer[*m_impl->m_presentTarget].samples() > MultiSamplingLevel::x1 }; // NOLINT(cppcoreguidelines-pro-bounds-avoid-unchecked-container-access)
 
     if (requiresResolve)
     {
@@ -466,12 +466,13 @@ UInt64 VulkanRenderPass::end() const
 
     // If the present target is multi-sampled, we need to resolve it to the back buffer.
     const auto& backBufferImage = swapChain.image();
-    bool requiresResolve{ this->hasPresentTarget() && frameBuffer[*m_impl->m_presentTarget].samples() > MultiSamplingLevel::x1 };
+    bool requiresResolve{ this->hasPresentTarget() && frameBuffer[*m_impl->m_presentTarget].samples() > MultiSamplingLevel::x1 }; // NOLINT(cppcoreguidelines-pro-bounds-avoid-unchecked-container-access)
 
     // Transition the present and depth/stencil views.
     VulkanBarrier renderTargetBarrier(PipelineStage::RenderTarget, PipelineStage::None), depthStencilBarrier(PipelineStage::DepthStencil, PipelineStage::None),
         resolveBarrier(PipelineStage::RenderTarget, PipelineStage::None), presentBarrier(PipelineStage::RenderTarget, PipelineStage::Transfer);
     std::ranges::for_each(m_impl->m_renderTargets, [&](const RenderTarget& renderTarget) {
+        // NOLINTBEGIN(cppcoreguidelines-pro-bounds-avoid-unchecked-container-access)
         switch (renderTarget.type())
         {
         default:
@@ -489,6 +490,7 @@ UInt64 VulkanRenderPass::end() const
 
             break;
         }
+        // NOLINTEND(cppcoreguidelines-pro-bounds-avoid-unchecked-container-access)
     });
 
     primaryCommandBuffer->barrier(renderTargetBarrier);
@@ -511,7 +513,7 @@ UInt64 VulkanRenderPass::end() const
         beginPresentBarrier.transition(backBufferImage, ResourceAccess::None, ResourceAccess::TransferWrite, ImageLayout::Undefined, ImageLayout::CopyDestination);
         primaryCommandBuffer->barrier(beginPresentBarrier);
 
-        auto& presentTarget = frameBuffer[*m_impl->m_presentTarget];
+        auto& presentTarget = frameBuffer[*m_impl->m_presentTarget]; // NOLINT(cppcoreguidelines-pro-bounds-avoid-unchecked-container-access)
         primaryCommandBuffer->transfer(presentTarget, backBufferImage);
 
         VulkanBarrier endPresentBarrier(PipelineStage::Transfer, PipelineStage::None);

--- a/src/Backends/Vulkan/src/render_pipeline.cpp
+++ b/src/Backends/Vulkan/src/render_pipeline.cpp
@@ -211,14 +211,15 @@ public:
 		VkPipelineViewportStateCreateInfo viewportState = { .sType = VK_STRUCTURE_TYPE_PIPELINE_VIEWPORT_STATE_CREATE_INFO };
 
 		// Setup multisampling state.
-		VkPipelineMultisampleStateCreateInfo multisampling = {};
-		multisampling.sType = VK_STRUCTURE_TYPE_PIPELINE_MULTISAMPLE_STATE_CREATE_INFO;
-		multisampling.sampleShadingEnable = VK_FALSE;
-		multisampling.rasterizationSamples = Vk::getSamples(m_samples);
-		multisampling.minSampleShading = 1.0f;
-		multisampling.pSampleMask = nullptr;
-		multisampling.alphaToCoverageEnable = m_alphaToCoverage;
-		multisampling.alphaToOneEnable = VK_FALSE;
+		VkPipelineMultisampleStateCreateInfo multisampling = {
+			.sType = VK_STRUCTURE_TYPE_PIPELINE_MULTISAMPLE_STATE_CREATE_INFO,
+			.rasterizationSamples = Vk::getSamples(m_samples),
+			.sampleShadingEnable = VK_FALSE,
+			.minSampleShading = 1.0f,
+			.pSampleMask = nullptr,
+			.alphaToCoverageEnable = m_alphaToCoverage,
+			.alphaToOneEnable = VK_FALSE
+		};
 
 		// Setup color blend state.
 		auto renderTargets = m_renderPass->renderTargets();
@@ -399,7 +400,7 @@ public:
 				if (binding->layout().space() == dependency.binding().Space)
 				{
 					// Resolve the image and update the binding.
-					auto& image = frameBuffer[dependency.renderTarget()];
+					auto& image = frameBuffer[dependency.renderTarget()]; // NOLINT(cppcoreguidelines-pro-bounds-avoid-unchecked-container-access)
 
 					if (image.samples() != m_samples) [[unlikely]]
 						LITEFX_WARNING(VULKAN_LOG, "The image multi sampling level {0} does not match the render pipeline multi sampling state {1}.", image.samples(), m_samples);

--- a/src/Backends/Vulkan/src/shader_module.cpp
+++ b/src/Backends/Vulkan/src/shader_module.cpp
@@ -121,11 +121,12 @@ const Array<UInt32>& VulkanShaderModule::bytecode() const noexcept
 
 VkPipelineShaderStageCreateInfo VulkanShaderModule::shaderStageDefinition() const
 {
-	VkPipelineShaderStageCreateInfo shaderStageDefinition = {};
-	shaderStageDefinition.sType = VK_STRUCTURE_TYPE_PIPELINE_SHADER_STAGE_CREATE_INFO;
-	shaderStageDefinition.module = this->handle();
-	shaderStageDefinition.pName = this->entryPoint().c_str();
-	shaderStageDefinition.stage = Vk::getShaderStage(this->type());
+	VkPipelineShaderStageCreateInfo shaderStageDefinition = {
+		.sType = VK_STRUCTURE_TYPE_PIPELINE_SHADER_STAGE_CREATE_INFO,
+		.stage = Vk::getShaderStage(this->type()),
+		.module = this->handle(),
+		.pName = this->entryPoint().c_str()
+	};
 
 	return shaderStageDefinition;
 }

--- a/src/Backends/Vulkan/src/shader_program.cpp
+++ b/src/Backends/Vulkan/src/shader_program.cpp
@@ -65,7 +65,7 @@ private:
         UInt32 elementSize{};
         UInt32 elements{};
         UInt32 inputAttachmentIndex{};
-        DescriptorType type{};
+        DescriptorType type{ DescriptorType::ConstantBuffer };
         SharedPtr<IVulkanSampler> staticSampler{};
         bool unbounded{false};
 
@@ -83,7 +83,7 @@ private:
     struct DescriptorSetInfo {
     public:
         UInt32 space{};
-        ShaderStage stage{};
+        ShaderStage stage{ ShaderStage::Other };
         Array<DescriptorInfo> descriptors;
     };
 
@@ -248,7 +248,7 @@ public:
                     auto descriptor = descriptorSet->bindings[i++]; // NOLINT(cppcoreguidelines-pro-bounds-pointer-arithmetic)
 
                     // Filter the descriptor type.
-                    DescriptorType type{};
+                    DescriptorType type{ DescriptorType::ConstantBuffer };
                     UInt32 inputAttachmentIndex = 0;
 
                     switch (descriptor->descriptor_type)
@@ -336,7 +336,7 @@ public:
             for (size_t i{ 0 }; i < descriptorSet.descriptors.size(); ++i)
             {
                 // Get the current descriptor.
-                auto& descriptor = descriptorSet.descriptors[i];
+                auto& descriptor = descriptorSet.descriptors[i]; // NOLINT(cppcoreguidelines-pro-bounds-avoid-unchecked-container-access)
 
                 // See if there's a hint about the binding.
                 auto hint = PipelineBindingHint::hint_type{ };

--- a/src/Backends/Vulkan/src/swapchain.cpp
+++ b/src/Backends/Vulkan/src/swapchain.cpp
@@ -166,7 +166,7 @@ public:
 		::vkGetSwapchainImagesKHR(device.handle(), swapChain, &images, imageChain.data());
 
 		m_presentImages = imageChain |
-			std::views::transform([&actualRenderArea, &selectedFormat](const VkImage& image) { return VulkanImage::create(image, Size3d{ actualRenderArea.width(), actualRenderArea.height(), 1 }, selectedFormat, ImageDimensions::DIM_2, 1, 1, MultiSamplingLevel::x1, ResourceUsage::TransferDestination, {}); }) |
+			std::views::transform([&actualRenderArea, &selectedFormat](const VkImage& image) { return VulkanImage::create(image, Size3d{ actualRenderArea.width(), actualRenderArea.height(), 1 }, selectedFormat, ImageDimensions::DIM_2, 1, 1, MultiSamplingLevel::x1, ResourceUsage::TransferDestination, {}); }) | // NOLINT(bugprone-invalid-enum-default-initialization)
 			std::ranges::to<Array<SharedPtr<IVulkanImage>>>();
 
 		// Store state variables.
@@ -395,7 +395,7 @@ private:
 		ImageResource& operator=(ImageResource&&) noexcept = default;
 		ImageResource& operator=(const ImageResource&) = delete;
 
-		~ImageResource() noexcept
+		~ImageResource() // NOLINT(bugprone-exception-escape)
 		{
 			image.Reset();
 			::vkFreeMemory(device, memory, nullptr);
@@ -458,7 +458,7 @@ public:
 	VulkanSwapChainImpl& operator=(VulkanSwapChainImpl&&) noexcept = default;
 	VulkanSwapChainImpl& operator=(const VulkanSwapChainImpl&) = delete;
 
-	~VulkanSwapChainImpl()
+	~VulkanSwapChainImpl() // NOLINT(bugprone-exception-escape)
 	{
 		// Check if the device is still valid.
 		auto device = m_device.lock();
@@ -647,8 +647,10 @@ public:
 
 		for (UInt32 i{ 0 }; i < images; ++i)
 		{
+			// NOLINTBEGIN(cppcoreguidelines-pro-bounds-avoid-unchecked-container-access)
 			D3D::raiseIfFailed(m_d3dDevice->CreateCommandAllocator(D3D12_COMMAND_LIST_TYPE_DIRECT, IID_PPV_ARGS(&m_presentCommandAllocators[i])), "Unable to create command allocator for present queue commands.");
 			D3D::raiseIfFailed(m_d3dDevice->CreateCommandList1(0, D3D12_COMMAND_LIST_TYPE_DIRECT, D3D12_COMMAND_LIST_FLAG_NONE, IID_PPV_ARGS(&m_presentCommandLists[i])), "Unable to create command list for present queue commands.");
+			// NOLINTEND(cppcoreguidelines-pro-bounds-avoid-unchecked-container-access)
 		}
 	}
 
@@ -718,8 +720,10 @@ public:
 
 		for (UInt32 i{ 0 }; i < images; ++i)
 		{
+			// NOLINTBEGIN(cppcoreguidelines-pro-bounds-avoid-unchecked-container-access)
 			D3D::raiseIfFailed(m_d3dDevice->CreateCommandAllocator(D3D12_COMMAND_LIST_TYPE_DIRECT, IID_PPV_ARGS(&m_presentCommandAllocators[i])), "Unable to create command allocator for present queue commands.");
 			D3D::raiseIfFailed(m_d3dDevice->CreateCommandList1(0, D3D12_COMMAND_LIST_TYPE_DIRECT, D3D12_COMMAND_LIST_FLAG_NONE, IID_PPV_ARGS(&m_presentCommandLists[i])), "Unable to create command list for present queue commands.");
+			// NOLINTEND(cppcoreguidelines-pro-bounds-avoid-unchecked-container-access)
 		}
 
 		// Store vsync flag.
@@ -828,12 +832,14 @@ public:
 			raiseIfFailed(::vkBindImageMemory(device.handle(), backBuffer, imageMemory, 0), "Unable to bind back-buffer.");
 
 			// Return the image instance.
+			// NOLINTBEGIN(cppcoreguidelines-pro-bounds-avoid-unchecked-container-access)
 			m_imageResources[image].device = device.handle();
 			m_imageResources[image].memory = imageMemory;
 			m_imageResources[image].handle = resourceHandle;
 			m_imageResources[image].image = std::move(resource);
+			// NOLINTEND(cppcoreguidelines-pro-bounds-avoid-unchecked-container-access)
 
-			return VulkanImage::create(backBuffer, Size3d{ imageInfo.extent.width, imageInfo.extent.height, imageInfo.extent.depth }, format, ImageDimensions::DIM_2, 1, 1, MultiSamplingLevel::x1, ResourceUsage::TransferDestination, {});
+			return VulkanImage::create(backBuffer, Size3d{ imageInfo.extent.width, imageInfo.extent.height, imageInfo.extent.depth }, format, ImageDimensions::DIM_2, 1, 1, MultiSamplingLevel::x1, ResourceUsage::TransferDestination, {}); // NOLINT(bugprone-invalid-enum-default-initialization)
 		});
 
 		// Store state variables.
@@ -882,6 +888,7 @@ public:
 
 	UInt32 swapBackBuffer()
 	{
+		// NOLINTBEGIN(cppcoreguidelines-pro-bounds-avoid-unchecked-container-access)
 		// Check if the device is still valid.
 		auto device = m_device.lock();
 
@@ -919,6 +926,8 @@ public:
 			::vkResetQueryPool(device->handle(), m_timingQueryPools[m_currentImage], 0, static_cast<UInt32>(m_timestamps.size()));
 		}
 
+		// NOLINTEND(cppcoreguidelines-pro-bounds-avoid-unchecked-container-access)
+
 		// Return the new back buffer index.
 		return m_currentImage;
 	}
@@ -927,6 +936,7 @@ public:
 	{
 		// Wait for all commands to finish on the default graphics queue. We assume that this is the last queue that receives (synchronized) workloads, as it is expected to
 		// handle presentation by convention. Note that this performs a GPU-side wait for the fence and does not block.
+		// NOLINTBEGIN(cppcoreguidelines-pro-bounds-avoid-unchecked-container-access)
 		m_presentQueue->Wait(m_workloadFence.Get(), m_presentFences[m_currentImage] = fence);
 
 		// Copy shared images to back buffers. See `createImages` for details on why we do this.
@@ -986,11 +996,12 @@ public:
 			D3D::raiseIfFailed(m_swapChain->Present(0, m_supportsTearing ? DXGI_PRESENT_ALLOW_TEARING : 0), "Unable to queue present event on swap chain.");
 
 		D3D::raiseIfFailed(m_presentQueue->Signal(m_presentationFence.Get(), m_presentFences[m_currentImage]), "Unable to signal presentation fence.");
+		// NOLINTEND(cppcoreguidelines-pro-bounds-avoid-unchecked-container-access)
 	}
 	
 	const VkQueryPool& currentTimestampQueryPool()
 	{
-		return m_timingQueryPools[m_currentImage];
+		return m_timingQueryPools[m_currentImage]; // NOLINT(cppcoreguidelines-pro-bounds-avoid-unchecked-container-access)
 	}
 
 public:
@@ -1085,7 +1096,7 @@ SharedPtr<const TimingEvent> VulkanSwapChain::timingEvent(UInt32 queryId) const
 	if (queryId >= m_impl->m_timingEvents.size())
 		throw ArgumentOutOfRangeException("queryId", std::make_pair(0uz, m_impl->m_timingEvents.size()), static_cast<size_t>(queryId), "No timing event has been registered for query ID {0}.", queryId);
 
-	return m_impl->m_timingEvents[queryId];
+	return m_impl->m_timingEvents[queryId]; // NOLINT(cppcoreguidelines-pro-bounds-avoid-unchecked-container-access)
 }
 
 UInt64 VulkanSwapChain::readTimingEvent(SharedPtr<const TimingEvent> timingEvent) const
@@ -1097,7 +1108,7 @@ UInt64 VulkanSwapChain::readTimingEvent(SharedPtr<const TimingEvent> timingEvent
 		throw ArgumentNotInitializedException("timingEvent", "The timing event must be initialized.");
 
 	if (auto match = std::find(m_impl->m_timingEvents.begin(), m_impl->m_timingEvents.end(), timingEvent); match != m_impl->m_timingEvents.end()) [[likely]]
-		return m_impl->m_timestamps[std::distance(m_impl->m_timingEvents.begin(), match)];
+		return m_impl->m_timestamps[std::distance(m_impl->m_timingEvents.begin(), match)]; // NOLINT(cppcoreguidelines-pro-bounds-avoid-unchecked-container-access)
 
 	throw InvalidArgumentException("timingEvent", "The timing event is not registered on the swap chain.");
 }
@@ -1151,12 +1162,12 @@ IVulkanImage* VulkanSwapChain::image(UInt32 backBuffer) const
 	if (backBuffer >= m_impl->m_presentImages.size()) [[unlikely]]
 		throw ArgumentOutOfRangeException("backBuffer", std::make_pair(0uz, m_impl->m_presentImages.size()), static_cast<size_t>(backBuffer), "The back buffer must be a valid index.");
 
-	return m_impl->m_presentImages[backBuffer].get();
+	return m_impl->m_presentImages[backBuffer].get(); // NOLINT(cppcoreguidelines-pro-bounds-avoid-unchecked-container-access)
 }
 
 const IVulkanImage& VulkanSwapChain::image() const noexcept
 {
-	return *m_impl->m_presentImages[m_impl->m_currentImage];
+	return *m_impl->m_presentImages[m_impl->m_currentImage]; // NOLINT(cppcoreguidelines-pro-bounds-avoid-unchecked-container-access)
 }
 
 const Array<SharedPtr<IVulkanImage>>& VulkanSwapChain::images() const noexcept

--- a/src/Backends/Vulkan/src/tlas.cpp
+++ b/src/Backends/Vulkan/src/tlas.cpp
@@ -221,17 +221,19 @@ void VulkanTopLevelAccelerationStructure::copy(const VulkanCommandBuffer& comman
     auto device = commandBuffer.queue()->device();
 
     if (!LITEFX_FLAG_IS_SET(m_impl->m_flags, AccelerationStructureFlags::AllowCompaction))
-        device->computeAccelerationStructureSizes(*this, requiredMemory[0], requiredMemory[1], true);
+        device->computeAccelerationStructureSizes(*this, requiredMemory[0], requiredMemory[1], true); // NOLINT(cppcoreguidelines-pro-bounds-avoid-unchecked-container-access)
     else
         raiseIfFailed(::vkGetQueryPoolResults(device->handle(), m_impl->m_queryPool, 0, 1, sizeof(UInt64), &requiredMemory, 0, VkQueryResultFlagBits::VK_QUERY_RESULT_64_BIT), "Unable to query for compressed acceleration structure size.");
 
     // Validate the input arguments.
     auto memory = buffer;
 
+    // NOLINTBEGIN(cppcoreguidelines-pro-bounds-avoid-unchecked-container-access)
     if (buffer == nullptr)
         memory = destination.m_impl->m_buffer->size() >= requiredMemory[0] ? destination.m_impl->m_buffer : device->factory().createBuffer(BufferType::AccelerationStructure, ResourceHeap::Resource, static_cast<size_t>(requiredMemory[0]), 1, ResourceUsage::AllowWrite);
     else if (buffer->size() < offset + requiredMemory[0]) [[unlikely]]
         throw ArgumentOutOfRangeException("buffer", std::make_pair<UInt64, UInt64>(0u, buffer->size()), offset + requiredMemory[0], "The buffer does not contain enough memory after offset {0} to fully contain the acceleration structure.", offset);
+    // NOLINTEND(cppcoreguidelines-pro-bounds-avoid-unchecked-container-access)
 
     // Create or reset query pool on destination, if required. 
     if (LITEFX_FLAG_IS_SET(destination.flags(), AccelerationStructureFlags::AllowCompaction))
@@ -259,7 +261,7 @@ void VulkanTopLevelAccelerationStructure::copy(const VulkanCommandBuffer& comman
         .sType = VK_STRUCTURE_TYPE_ACCELERATION_STRUCTURE_CREATE_INFO_KHR,
         .buffer = memory->handle(),
         .offset = offset,
-        .size = requiredMemory[0],
+        .size = requiredMemory[0], // NOLINT(cppcoreguidelines-pro-bounds-avoid-unchecked-container-access)
         .type = VK_ACCELERATION_STRUCTURE_TYPE_TOP_LEVEL_KHR
     };
 
@@ -268,7 +270,7 @@ void VulkanTopLevelAccelerationStructure::copy(const VulkanCommandBuffer& comman
     // Store the buffer and the offset.
     destination.m_impl->m_offset = offset;
     destination.m_impl->m_buffer = memory;
-    destination.m_impl->m_size = requiredMemory[0];
+    destination.m_impl->m_size = requiredMemory[0]; // NOLINT(cppcoreguidelines-pro-bounds-avoid-unchecked-container-access)
     destination.m_impl->m_device = m_impl->m_device;
 
     // Perform the update.

--- a/src/Core/include/litefx/containers.hpp
+++ b/src/Core/include/litefx/containers.hpp
@@ -1120,7 +1120,7 @@ namespace LiteFX {
 		/// Returns a shared pointer to the current object instance.
 		/// </summary>
 		template <typename TSelf>
-		[[nodiscard]] auto inline shared_from_this(this TSelf&& self) noexcept
+		[[nodiscard]] auto inline shared_from_this(this TSelf&& self)
 		{
 			// TODO: In C++26 we should be able to use `std::is_virtual_base_of<SharedObject, TSelf>` here to prefer a `static_pointer_cast`, if possible.
 

--- a/src/Math/include/litefx/matrix.hpp
+++ b/src/Math/include/litefx/matrix.hpp
@@ -152,7 +152,7 @@ namespace LiteFX::Math {
 			std::array<scalar_type, mat_rows * mat_cols> data { };
 
 			for (size_t i = 0; i < mat_rows && i < mat_cols; ++i)
-				data[i * mat_cols + i] = 1.0f; // NOLINT(cppcoreguidelines-pro-bounds-constant-array-index)
+				data[i * mat_cols + i] = 1.0f; // NOLINT(cppcoreguidelines-pro-bounds-constant-array-index, cppcoreguidelines-pro-bounds-avoid-unchecked-container-access)
 
 			return mat_type(std::move(data));
 		}
@@ -409,7 +409,7 @@ namespace LiteFX::Math {
 		constexpr Matrix(glm::mat<mat_cols, mat_rows, scalar_type>&& mat) noexcept {
 			for (size_t r { 0 }; r < mat_rows; ++r)
 				for (size_t c { 0 }; c < mat_cols; ++c)
-					m_elements[r * mat_cols + c] = std::move(mat[c][r]); // NOLINT(cppcoreguidelines-pro-bounds-constant-array-index)
+					m_elements[r * mat_cols + c] = std::move(mat[c][r]); // NOLINT(cppcoreguidelines-pro-bounds-constant-array-index, cppcoreguidelines-pro-bounds-avoid-unchecked-container-access)
 		}
 
 		/// <summary>

--- a/src/Math/include/litefx/vector.hpp
+++ b/src/Math/include/litefx/vector.hpp
@@ -94,8 +94,10 @@ namespace LiteFX::Math {
         constexpr Vector(T x, T y) noexcept requires(DIM == 2)
         {
             // NOLINTBEGIN(cppcoreguidelines-pro-bounds-constant-array-index)
+            // NOLINTBEGIN(cppcoreguidelines-pro-bounds-avoid-unchecked-container-access)
             m_elements[0] = x;
             m_elements[1] = y;
+            // NOLINTEND(cppcoreguidelines-pro-bounds-avoid-unchecked-container-access)
             // NOLINTEND(cppcoreguidelines-pro-bounds-constant-array-index)
         }
 
@@ -108,9 +110,11 @@ namespace LiteFX::Math {
         constexpr Vector(T x, T y, T z) noexcept requires(DIM == 3)
         {
             // NOLINTBEGIN(cppcoreguidelines-pro-bounds-constant-array-index)
+            // NOLINTBEGIN(cppcoreguidelines-pro-bounds-avoid-unchecked-container-access)
             m_elements[0] = x;
             m_elements[1] = y;
             m_elements[2] = z;
+            // NOLINTEND(cppcoreguidelines-pro-bounds-avoid-unchecked-container-access)
             // NOLINTEND(cppcoreguidelines-pro-bounds-constant-array-index)
         }
 
@@ -124,10 +128,12 @@ namespace LiteFX::Math {
         constexpr Vector(T x, T y, T z, T w) noexcept requires(DIM == 4)
         {
             // NOLINTBEGIN(cppcoreguidelines-pro-bounds-constant-array-index)
+            // NOLINTBEGIN(cppcoreguidelines-pro-bounds-avoid-unchecked-container-access)
             m_elements[0] = x;
             m_elements[1] = y;
             m_elements[2] = z;
             m_elements[3] = w;
+            // NOLINTEND(cppcoreguidelines-pro-bounds-avoid-unchecked-container-access)
             // NOLINTEND(cppcoreguidelines-pro-bounds-constant-array-index)
         }
 
@@ -250,7 +256,7 @@ namespace LiteFX::Math {
         /// </summary>
         /// <returns>The value of the x component of the vector.</returns>
         constexpr scalar_type x() const noexcept requires (DIM > 0) {
-            return m_elements[0]; // NOLINT(cppcoreguidelines-pro-bounds-constant-array-index)
+            return m_elements[0]; // NOLINT(cppcoreguidelines-pro-bounds-constant-array-index, cppcoreguidelines-pro-bounds-avoid-unchecked-container-access)
         }
 
         /// <summary>
@@ -258,7 +264,7 @@ namespace LiteFX::Math {
         /// </summary>
         /// <returns>The a reference of the value of the x component of the vector.</returns>
         constexpr scalar_type& x() noexcept requires (DIM > 0) {
-            return m_elements[0]; // NOLINT(cppcoreguidelines-pro-bounds-constant-array-index)
+            return m_elements[0]; // NOLINT(cppcoreguidelines-pro-bounds-constant-array-index, cppcoreguidelines-pro-bounds-avoid-unchecked-container-access)
         }
 
         /// <summary>
@@ -266,7 +272,7 @@ namespace LiteFX::Math {
         /// </summary>
         /// <returns>The value of the y component of the vector.</returns>
         constexpr scalar_type y() const noexcept requires (DIM > 1) {
-            return m_elements[1]; // NOLINT(cppcoreguidelines-pro-bounds-constant-array-index)
+            return m_elements[1]; // NOLINT(cppcoreguidelines-pro-bounds-constant-array-index, cppcoreguidelines-pro-bounds-avoid-unchecked-container-access)
         }
 
         /// <summary>
@@ -274,7 +280,7 @@ namespace LiteFX::Math {
         /// </summary>
         /// <returns>The a reference of the value of the y component of the vector.</returns>
         constexpr scalar_type& y() noexcept requires (DIM > 1) {
-            return m_elements[1]; // NOLINT(cppcoreguidelines-pro-bounds-constant-array-index)
+            return m_elements[1]; // NOLINT(cppcoreguidelines-pro-bounds-constant-array-index, cppcoreguidelines-pro-bounds-avoid-unchecked-container-access)
         }
 
         /// <summary>
@@ -282,7 +288,7 @@ namespace LiteFX::Math {
         /// </summary>
         /// <returns>The value of the z component of the vector.</returns>
         constexpr scalar_type z() const noexcept requires (DIM > 2) {
-            return m_elements[2]; // NOLINT(cppcoreguidelines-pro-bounds-constant-array-index)
+            return m_elements[2]; // NOLINT(cppcoreguidelines-pro-bounds-constant-array-index, cppcoreguidelines-pro-bounds-avoid-unchecked-container-access)
         }
 
         /// <summary>
@@ -290,7 +296,7 @@ namespace LiteFX::Math {
         /// </summary>
         /// <returns>The a reference of the value of the z component of the vector.</returns>
         constexpr scalar_type& z() noexcept requires (DIM > 2) {
-            return m_elements[2]; // NOLINT(cppcoreguidelines-pro-bounds-constant-array-index)
+            return m_elements[2]; // NOLINT(cppcoreguidelines-pro-bounds-constant-array-index, cppcoreguidelines-pro-bounds-avoid-unchecked-container-access)
         }
 
         /// <summary>
@@ -298,7 +304,7 @@ namespace LiteFX::Math {
         /// </summary>
         /// <returns>The value of the w component of the vector.</returns>
         constexpr scalar_type w() const noexcept requires (DIM > 3) {
-            return m_elements[3]; // NOLINT(cppcoreguidelines-pro-bounds-constant-array-index)
+            return m_elements[3]; // NOLINT(cppcoreguidelines-pro-bounds-constant-array-index, cppcoreguidelines-pro-bounds-avoid-unchecked-container-access)
         }
 
         /// <summary>
@@ -306,7 +312,7 @@ namespace LiteFX::Math {
         /// </summary>
         /// <returns>The a reference of the value of the w component of the vector.</returns>
         constexpr scalar_type& w() noexcept requires (DIM > 3) {
-            return m_elements[3]; // NOLINT(cppcoreguidelines-pro-bounds-constant-array-index)
+            return m_elements[3]; // NOLINT(cppcoreguidelines-pro-bounds-constant-array-index, cppcoreguidelines-pro-bounds-avoid-unchecked-container-access)
         }
     };
 

--- a/src/Math/src/vector.cpp
+++ b/src/Math/src/vector.cpp
@@ -10,15 +10,15 @@ using namespace LiteFX::Math;
 
 #if defined(LITEFX_BUILD_WITH_GLM)
 Vector1f::Vector1f(const glm::f32vec1& v) noexcept {
-    std::generate(std::begin(m_elements), std::end(m_elements), [&, i = 0]() mutable { return v[i++]; });
+    std::generate(std::begin(m_elements), std::end(m_elements), [&, i = 0]() mutable { return v[i++]; }); // NOLINT(cppcoreguidelines-pro-bounds-avoid-unchecked-container-access)
 }
 
 Vector1f::Vector1f(glm::f32vec1&& v) noexcept {
-    std::generate(std::begin(m_elements), std::end(m_elements), [&, i = 0]() mutable { return std::move(v[i++]); });
+    std::generate(std::begin(m_elements), std::end(m_elements), [&, i = 0]() mutable { return std::move(v[i++]); }); // NOLINT(cppcoreguidelines-pro-bounds-avoid-unchecked-container-access)
 }
 
 Vector1f::operator glm::f32vec1() const noexcept {
-    return glm::f32vec1(m_elements[0]);
+    return glm::f32vec1(m_elements[0]); // NOLINT(cppcoreguidelines-pro-bounds-avoid-unchecked-container-access)
 }
 #endif
 
@@ -42,15 +42,15 @@ Vector1f::operator DirectX::XMVECTOR() const noexcept {
 
 #if defined(LITEFX_BUILD_WITH_GLM)
 Vector1u::Vector1u(const glm::u32vec1& v) noexcept {
-    std::generate(std::begin(m_elements), std::end(m_elements), [&, i = 0]() mutable { return v[i++]; });
+    std::generate(std::begin(m_elements), std::end(m_elements), [&, i = 0]() mutable { return v[i++]; }); // NOLINT(cppcoreguidelines-pro-bounds-avoid-unchecked-container-access)
 }
 
 Vector1u::Vector1u(glm::u32vec1&& v) noexcept {
-    std::generate(std::begin(m_elements), std::end(m_elements), [&, i = 0]() mutable { return std::move(v[i++]); });
+    std::generate(std::begin(m_elements), std::end(m_elements), [&, i = 0]() mutable { return std::move(v[i++]); }); // NOLINT(cppcoreguidelines-pro-bounds-avoid-unchecked-container-access)
 }
 
 Vector1u::operator glm::u32vec1() const noexcept {
-    return glm::u32vec1(m_elements[0]);
+    return glm::u32vec1(m_elements[0]); // NOLINT(cppcoreguidelines-pro-bounds-avoid-unchecked-container-access)
 }
 #endif
 
@@ -74,15 +74,15 @@ Vector1u::operator DirectX::XMVECTOR() const noexcept {
 
 #if defined(LITEFX_BUILD_WITH_GLM)
 Vector2f::Vector2f(const glm::f32vec2& v) noexcept {
-    std::generate(std::begin(m_elements), std::end(m_elements), [&, i = 0]() mutable { return v[i++]; });
+    std::generate(std::begin(m_elements), std::end(m_elements), [&, i = 0]() mutable { return v[i++]; }); // NOLINT(cppcoreguidelines-pro-bounds-avoid-unchecked-container-access)
 }
 
 Vector2f::Vector2f(glm::f32vec2&& v) noexcept {
-    std::generate(std::begin(m_elements), std::end(m_elements), [&, i = 0]() mutable { return std::move(v[i++]); });
+    std::generate(std::begin(m_elements), std::end(m_elements), [&, i = 0]() mutable { return std::move(v[i++]); }); // NOLINT(cppcoreguidelines-pro-bounds-avoid-unchecked-container-access)
 }
 
 Vector2f::operator glm::f32vec2() const noexcept {
-    return { m_elements[0], m_elements[1] };
+    return { m_elements[0], m_elements[1] }; // NOLINT(cppcoreguidelines-pro-bounds-avoid-unchecked-container-access)
 }
 #endif
 
@@ -129,15 +129,15 @@ Vector2f::operator DirectX::XMFLOAT2() const noexcept {
 
 #if defined(LITEFX_BUILD_WITH_GLM)
 Vector2u::Vector2u(const glm::u32vec2& v) noexcept {
-    std::generate(std::begin(m_elements), std::end(m_elements), [&, i = 0]() mutable { return v[i++]; });
+    std::generate(std::begin(m_elements), std::end(m_elements), [&, i = 0]() mutable { return v[i++]; }); // NOLINT(cppcoreguidelines-pro-bounds-avoid-unchecked-container-access)
 }
 
 Vector2u::Vector2u(glm::u32vec2&& v) noexcept {
-    std::generate(std::begin(m_elements), std::end(m_elements), [&, i = 0]() mutable { return std::move(v[i++]); });
+    std::generate(std::begin(m_elements), std::end(m_elements), [&, i = 0]() mutable { return std::move(v[i++]); }); // NOLINT(cppcoreguidelines-pro-bounds-avoid-unchecked-container-access)
 }
 
 Vector2u::operator glm::u32vec2() const noexcept {
-    return { m_elements[0], m_elements[1] };
+    return { m_elements[0], m_elements[1] }; // NOLINT(cppcoreguidelines-pro-bounds-avoid-unchecked-container-access)
 }
 #endif
 
@@ -184,15 +184,15 @@ Vector2u::operator DirectX::XMUINT2() const noexcept {
 
 #if defined(LITEFX_BUILD_WITH_GLM)
 Vector2i::Vector2i(const glm::i32vec2& v) noexcept {
-    std::generate(std::begin(m_elements), std::end(m_elements), [&, i = 0]() mutable { return v[i++]; });
+    std::generate(std::begin(m_elements), std::end(m_elements), [&, i = 0]() mutable { return v[i++]; }); // NOLINT(cppcoreguidelines-pro-bounds-avoid-unchecked-container-access)
 }
 
 Vector2i::Vector2i(glm::i32vec2&& v) noexcept {
-    std::generate(std::begin(m_elements), std::end(m_elements), [&, i = 0]() mutable { return std::move(v[i++]); });
+    std::generate(std::begin(m_elements), std::end(m_elements), [&, i = 0]() mutable { return std::move(v[i++]); }); // NOLINT(cppcoreguidelines-pro-bounds-avoid-unchecked-container-access)
 }
 
 Vector2i::operator glm::i32vec2() const noexcept {
-    return { m_elements[0], m_elements[1] };
+    return { m_elements[0], m_elements[1] }; // NOLINT(cppcoreguidelines-pro-bounds-avoid-unchecked-container-access)
 }
 #endif
 
@@ -239,15 +239,15 @@ Vector2i::operator DirectX::XMINT2() const noexcept {
 
 #if defined(LITEFX_BUILD_WITH_GLM)
 Vector3f::Vector3f(const glm::f32vec3& v) noexcept {
-    std::generate(std::begin(m_elements), std::end(m_elements), [&, i = 0]() mutable { return v[i++]; });
+    std::generate(std::begin(m_elements), std::end(m_elements), [&, i = 0]() mutable { return v[i++]; }); // NOLINT(cppcoreguidelines-pro-bounds-avoid-unchecked-container-access)
 }
 
 Vector3f::Vector3f(glm::f32vec3&& v) noexcept {
-    std::generate(std::begin(m_elements), std::end(m_elements), [&, i = 0]() mutable { return std::move(v[i++]); });
+    std::generate(std::begin(m_elements), std::end(m_elements), [&, i = 0]() mutable { return std::move(v[i++]); }); // NOLINT(cppcoreguidelines-pro-bounds-avoid-unchecked-container-access)
 }
 
 Vector3f::operator glm::f32vec3() const noexcept {
-    return { m_elements[0], m_elements[1], m_elements[2] };
+    return { m_elements[0], m_elements[1], m_elements[2] }; // NOLINT(cppcoreguidelines-pro-bounds-avoid-unchecked-container-access)
 }
 #endif
 
@@ -298,15 +298,15 @@ Vector3f::operator DirectX::XMFLOAT3() const noexcept {
 
 #if defined(LITEFX_BUILD_WITH_GLM)
 Vector3u::Vector3u(const glm::u32vec3& v) noexcept {
-    std::generate(std::begin(m_elements), std::end(m_elements), [&, i = 0]() mutable { return v[i++]; });
+    std::generate(std::begin(m_elements), std::end(m_elements), [&, i = 0]() mutable { return v[i++]; }); // NOLINT(cppcoreguidelines-pro-bounds-avoid-unchecked-container-access)
 }
 
 Vector3u::Vector3u(glm::u32vec3&& v) noexcept {
-    std::generate(std::begin(m_elements), std::end(m_elements), [&, i = 0]() mutable { return std::move(v[i++]); });
+    std::generate(std::begin(m_elements), std::end(m_elements), [&, i = 0]() mutable { return std::move(v[i++]); }); // NOLINT(cppcoreguidelines-pro-bounds-avoid-unchecked-container-access)
 }
 
 Vector3u::operator glm::u32vec3() const noexcept {
-    return { m_elements[0], m_elements[1], m_elements[2] };
+    return { m_elements[0], m_elements[1], m_elements[2] }; // NOLINT(cppcoreguidelines-pro-bounds-avoid-unchecked-container-access)
 }
 #endif
 
@@ -357,15 +357,15 @@ Vector3u::operator DirectX::XMUINT3() const noexcept {
 
 #if defined(LITEFX_BUILD_WITH_GLM)
 Vector3i::Vector3i(const glm::i32vec3& v) noexcept {
-    std::generate(std::begin(m_elements), std::end(m_elements), [&, i = 0]() mutable { return v[i++]; });
+    std::generate(std::begin(m_elements), std::end(m_elements), [&, i = 0]() mutable { return v[i++]; }); // NOLINT(cppcoreguidelines-pro-bounds-avoid-unchecked-container-access)
 }
 
 Vector3i::Vector3i(glm::i32vec3&& v) noexcept {
-    std::generate(std::begin(m_elements), std::end(m_elements), [&, i = 0]() mutable { return std::move(v[i++]); });
+    std::generate(std::begin(m_elements), std::end(m_elements), [&, i = 0]() mutable { return std::move(v[i++]); }); // NOLINT(cppcoreguidelines-pro-bounds-avoid-unchecked-container-access)
 }
 
 Vector3i::operator glm::i32vec3() const noexcept {
-    return { m_elements[0], m_elements[1], m_elements[2] };
+    return { m_elements[0], m_elements[1], m_elements[2] }; // NOLINT(cppcoreguidelines-pro-bounds-avoid-unchecked-container-access)
 }
 #endif
 
@@ -416,15 +416,15 @@ Vector3i::operator DirectX::XMINT3() const noexcept {
 
 #if defined(LITEFX_BUILD_WITH_GLM)
 Vector4f::Vector4f(const glm::f32vec4& v) noexcept {
-    std::generate(std::begin(m_elements), std::end(m_elements), [&, i = 0]() mutable { return v[i++]; });
+    std::generate(std::begin(m_elements), std::end(m_elements), [&, i = 0]() mutable { return v[i++]; }); // NOLINT(cppcoreguidelines-pro-bounds-avoid-unchecked-container-access)
 }
 
 Vector4f::Vector4f(glm::f32vec4&& v) noexcept {
-    std::generate(std::begin(m_elements), std::end(m_elements), [&, i = 0]() mutable { return std::move(v[i++]); });
+    std::generate(std::begin(m_elements), std::end(m_elements), [&, i = 0]() mutable { return std::move(v[i++]); }); // NOLINT(cppcoreguidelines-pro-bounds-avoid-unchecked-container-access)
 }
 
 Vector4f::operator glm::f32vec4() const noexcept {
-    return { m_elements[0], m_elements[1], m_elements[2], m_elements[3] };
+    return { m_elements[0], m_elements[1], m_elements[2], m_elements[3] }; // NOLINT(cppcoreguidelines-pro-bounds-avoid-unchecked-container-access)
 }
 #endif
 
@@ -479,15 +479,15 @@ Vector4f::operator DirectX::XMFLOAT4() const noexcept {
 
 #if defined(LITEFX_BUILD_WITH_GLM)
 Vector4u::Vector4u(const glm::u32vec4& v) noexcept {
-    std::generate(std::begin(m_elements), std::end(m_elements), [&, i = 0]() mutable { return v[i++]; });
+    std::generate(std::begin(m_elements), std::end(m_elements), [&, i = 0]() mutable { return v[i++]; }); // NOLINT(cppcoreguidelines-pro-bounds-avoid-unchecked-container-access)
 }
 
 Vector4u::Vector4u(glm::u32vec4&& v) noexcept {
-    std::generate(std::begin(m_elements), std::end(m_elements), [&, i = 0]() mutable { return std::move(v[i++]); });
+    std::generate(std::begin(m_elements), std::end(m_elements), [&, i = 0]() mutable { return std::move(v[i++]); }); // NOLINT(cppcoreguidelines-pro-bounds-avoid-unchecked-container-access)
 }
 
 Vector4u::operator glm::u32vec4() const noexcept {
-    return { m_elements[0], m_elements[1], m_elements[2], m_elements[3] };
+    return { m_elements[0], m_elements[1], m_elements[2], m_elements[3] }; // NOLINT(cppcoreguidelines-pro-bounds-avoid-unchecked-container-access)
 }
 #endif
 
@@ -542,15 +542,15 @@ Vector4u::operator DirectX::XMUINT4() const noexcept {
 
 #if defined(LITEFX_BUILD_WITH_GLM)
 Vector4i::Vector4i(const glm::i32vec4& v) noexcept {
-    std::generate(std::begin(m_elements), std::end(m_elements), [&, i = 0]() mutable { return v[i++]; });
+    std::generate(std::begin(m_elements), std::end(m_elements), [&, i = 0]() mutable { return v[i++]; }); // NOLINT(cppcoreguidelines-pro-bounds-avoid-unchecked-container-access)
 }
 
 Vector4i::Vector4i(glm::i32vec4&& v) noexcept {
-    std::generate(std::begin(m_elements), std::end(m_elements), [&, i = 0]() mutable { return std::move(v[i++]); });
+    std::generate(std::begin(m_elements), std::end(m_elements), [&, i = 0]() mutable { return std::move(v[i++]); }); // NOLINT(cppcoreguidelines-pro-bounds-avoid-unchecked-container-access)
 }
 
 Vector4i::operator glm::i32vec4() const noexcept {
-    return { m_elements[0], m_elements[1], m_elements[2], m_elements[3] };
+    return { m_elements[0], m_elements[1], m_elements[2], m_elements[3] }; // NOLINT(cppcoreguidelines-pro-bounds-avoid-unchecked-container-access)
 }
 #endif
 

--- a/src/Rendering/include/litefx/rendering.hpp
+++ b/src/Rendering/include/litefx/rendering.hpp
@@ -1837,6 +1837,9 @@ namespace LiteFX::Rendering {
         const adapter_type* findAdapter(const Optional<UInt64>& adapterId = std::nullopt) const noexcept override = 0;
 
         /// <inheritdoc />
+        const adapter_type* findAdapter(GpuPreference preference) const noexcept override = 0;
+
+        /// <inheritdoc />
         virtual void registerDevice(const String& name, SharedPtr<device_type>&& device) = 0;
 
         /// <summary>

--- a/src/Rendering/include/litefx/rendering.hpp
+++ b/src/Rendering/include/litefx/rendering.hpp
@@ -3,6 +3,8 @@
 #include <litefx/rendering_api.hpp>
 #include <litefx/rendering_formatters.hpp>
 
+// NOLINTBEGIN(bugprone-derived-method-shadowing-base-method)
+
 namespace LiteFX::Rendering {
     using namespace LiteFX;
     using namespace LiteFX::Math;
@@ -1124,7 +1126,7 @@ namespace LiteFX::Rendering {
         CommandQueue& operator=(const CommandQueue&) = default;
 
     public:
-        ~CommandQueue() noexcept override = default;
+        ~CommandQueue() override = default;
 
     public:
         /// <inheritdoc />
@@ -1651,7 +1653,7 @@ namespace LiteFX::Rendering {
         virtual void updateGlobalDescriptors(const descriptor_set_type& descriptorSet, UInt32 binding, UInt32 offset, UInt32 descriptors) const = 0;
 
         /// <inheritdoc />
-        virtual void bindDescriptorSet(const command_buffer_type& commandBuffer, const descriptor_set_type& descriptorSet, const pipeline_type& pipeline) const noexcept = 0;
+        virtual void bindDescriptorSet(const command_buffer_type& commandBuffer, const descriptor_set_type& descriptorSet, const pipeline_type& pipeline) const = 0;
 
         /// <inheritdoc />
         virtual void bindGlobalDescriptorHeaps(const command_buffer_type& commandBuffer) const noexcept = 0;
@@ -1677,7 +1679,7 @@ namespace LiteFX::Rendering {
             this->updateGlobalDescriptors(dynamic_cast<const descriptor_set_type&>(descriptorSet), binding, offset, descriptors);
         }
 
-        inline void doBindDescriptorSet(const ICommandBuffer& commandBuffer, const IDescriptorSet& descriptorSet, const IPipeline& pipeline) const noexcept override {
+        inline void doBindDescriptorSet(const ICommandBuffer& commandBuffer, const IDescriptorSet& descriptorSet, const IPipeline& pipeline) const override {
             this->bindDescriptorSet(dynamic_cast<const command_buffer_type&>(commandBuffer), dynamic_cast<const descriptor_set_type&>(descriptorSet), dynamic_cast<const pipeline_type&>(pipeline));
         }
 
@@ -1834,10 +1836,10 @@ namespace LiteFX::Rendering {
         virtual const Array<SharedPtr<const adapter_type>>& adapters() const = 0;
 
         /// <inheritdoc />
-        const adapter_type* findAdapter(const Optional<UInt64>& adapterId = std::nullopt) const noexcept override = 0;
+        const adapter_type* findAdapter(const Optional<UInt64>& adapterId = std::nullopt) const override = 0;
 
         /// <inheritdoc />
-        const adapter_type* findAdapter(GpuPreference preference) const noexcept override = 0;
+        const adapter_type* findAdapter(GpuPreference preference) const override = 0;
 
         /// <inheritdoc />
         virtual void registerDevice(const String& name, SharedPtr<device_type>&& device) = 0;
@@ -1862,10 +1864,10 @@ namespace LiteFX::Rendering {
         virtual void releaseDevice(const String& name) = 0;
 
         /// <inheritdoc />
-        device_type* device(const String& name) noexcept override = 0;
+        device_type* device(const String& name) override = 0;
 
         /// <inheritdoc />
-        const device_type* device(const String& name) const noexcept override = 0;
+        const device_type* device(const String& name) const override = 0;
 
         /// <inheritdoc />
         inline const device_type* operator[](const String& name) const noexcept override {
@@ -1884,3 +1886,5 @@ namespace LiteFX::Rendering {
         }
     };
 }
+
+// NOLINTEND(bugprone-derived-method-shadowing-base-method)

--- a/src/Rendering/include/litefx/rendering_api.hpp
+++ b/src/Rendering/include/litefx/rendering_api.hpp
@@ -3263,7 +3263,7 @@ namespace LiteFX::Rendering {
         /// <param name="strategy">The strategy to look for a place to put the allocation in.</param>
         /// <param name="privateData">A pointer to an object that should be internally associated with the allocation.</param>
         /// <returns>An object that contains details about the allocation, or `std::nullopt` if the allocation fails.</returns>
-        [[nodiscard]] virtual Optional<Allocation> tryAllocate(UInt64 size, UInt32 alignment = 1u, AllocationStrategy strategy = AllocationStrategy::OptimizePacking, void* privateData = nullptr) const {
+        [[nodiscard]] Optional<Allocation> tryAllocate(UInt64 size, UInt32 alignment = 1u, AllocationStrategy strategy = AllocationStrategy::OptimizePacking, void* privateData = nullptr) const {
             return m_impl->tryAllocate(size, alignment, strategy, privateData);
         }
 
@@ -3989,26 +3989,26 @@ namespace LiteFX::Rendering {
         /// <summary>
         /// Destroys a depth/stencil state.
         /// </summary>
-        virtual ~DepthStencilState() noexcept;
+        ~DepthStencilState() noexcept;
 
     public:
         /// <summary>
         /// Returns the depth state.
         /// </summary>
         /// <returns>The depth state.</returns>
-        virtual DepthState& depthState() const noexcept;
+        DepthState& depthState() const noexcept;
 
         /// <summary>
         /// Returns the depth bias.
         /// </summary>
         /// <returns>The depth bias.</returns>
-        virtual DepthBias& depthBias() const noexcept;
+        DepthBias& depthBias() const noexcept;
 
         /// <summary>
         /// Returns the stencil state.
         /// </summary>
         /// <returns>The stencil state.</returns>
-        virtual StencilState& stencilState() const noexcept;
+        StencilState& stencilState() const noexcept;
     };
 
     /// <summary>
@@ -4558,7 +4558,7 @@ namespace LiteFX::Rendering {
         /// <summary>
         /// Releases the buffer attribute instance.
         /// </summary>
-        virtual ~BufferAttribute() noexcept;
+        ~BufferAttribute() noexcept;
 
     public:
         /// <summary>
@@ -4568,19 +4568,19 @@ namespace LiteFX::Rendering {
         /// Locations can only be specified in Vulkan and are implicitly generated based on semantics for DirectX. However, it is a good practice to provide them anyway.
         /// </remarks>
         /// <returns>The location of the buffer attribute.</returns>
-        virtual UInt32 location() const noexcept;
+        UInt32 location() const noexcept;
 
         /// <summary>
         /// Returns the format of the buffer attribute.
         /// </summary>
         /// <returns>The format of the buffer attribute.</returns>
-        virtual BufferFormat format() const noexcept;
+        BufferFormat format() const noexcept;
 
         /// <summary>
         /// Returns the offset of the buffer attribute.
         /// </summary>
         /// <returns>The offset of the buffer attribute.</returns>
-        virtual UInt32 offset() const noexcept;
+        UInt32 offset() const noexcept;
 
         /// <summary>
         /// Returns the semantic of the buffer attribute.
@@ -4590,7 +4590,7 @@ namespace LiteFX::Rendering {
         /// </remarks>
         /// <returns>The semantic of the buffer attribute.</returns>
         /// <seealso cref="semanticIndex" />
-        virtual AttributeSemantic semantic() const noexcept;
+        AttributeSemantic semantic() const noexcept;
 
         /// <summary>
         /// Returns the semantic index of the buffer attribute.
@@ -4600,7 +4600,7 @@ namespace LiteFX::Rendering {
         /// </remarks>
         /// <returns>The semantic index of the buffer attribute.</returns>
         /// <seealso cref="semantic" />
-        virtual UInt32 semanticIndex() const noexcept;
+        UInt32 semanticIndex() const noexcept;
     };
 
     /// <summary>
@@ -5116,7 +5116,7 @@ namespace LiteFX::Rendering {
         /// </remarks>
         /// <param name="level">The mip map level to return the size for.</param>
         /// <returns>The size (in bytes) of an image at a specified mip map level.</returns>
-        virtual size_t size(UInt32 level) const noexcept = 0;
+        virtual size_t size(UInt32 level) const = 0;
 
         /// <summary>
         /// Gets the extent of the image at a certain mip-map level.
@@ -6767,7 +6767,7 @@ namespace LiteFX::Rendering {
         /// Returns the type of the shader record.
         /// </summary>
         /// <returns>The type of the shader record.</returns>
-        constexpr ShaderRecordType type() const noexcept {
+        constexpr ShaderRecordType type() const {
             const auto& group = this->shaderGroup();
 
             if (std::holds_alternative<MeshGeometryHitGroup>(group))
@@ -7311,7 +7311,7 @@ namespace LiteFX::Rendering {
             /// <summary>
             /// A mask that contains the shader stages, that the descriptor set should be accessible from.
             /// </summary>
-            ShaderStage Stages{ };
+            ShaderStage Stages{ ShaderStage::Other };
         };
 
         /// <summary>
@@ -7589,7 +7589,7 @@ namespace LiteFX::Rendering {
         /// Builds a shader record collection based on the current shader program.
         /// </summary>
         /// <returns>The shader record collection instance.</returns>
-        [[nodiscard]] inline ShaderRecordCollection buildShaderRecordCollection() const noexcept {
+        [[nodiscard]] inline ShaderRecordCollection buildShaderRecordCollection() const {
             return { this->shared_from_this() };
         }
 
@@ -11244,7 +11244,7 @@ namespace LiteFX::Rendering {
         /// </remarks>
         /// <param name="format">The target (i.e. back-buffer) format.</param>
         /// <returns>The maximum multi-sampling level.</returns>
-        virtual MultiSamplingLevel maximumMultiSamplingLevel(Format format) const noexcept = 0;
+        virtual MultiSamplingLevel maximumMultiSamplingLevel(Format format) const = 0;
 
         /// <summary>
         /// Returns the number of GPU ticks per milliseconds.
@@ -11333,7 +11333,7 @@ namespace LiteFX::Rendering {
         /// <param name="commandBuffer">The command buffer to bind the descriptor set on.</param>
         /// <param name="descriptorSet">The descriptor set to bind.</param>
         /// <param name="pipeline">The pipeline to bind the descriptor set to.</param>
-        inline void bindDescriptorSet(const ICommandBuffer& commandBuffer, const IDescriptorSet& descriptorSet, const IPipeline& pipeline) const noexcept {
+        inline void bindDescriptorSet(const ICommandBuffer& commandBuffer, const IDescriptorSet& descriptorSet, const IPipeline& pipeline) const {
             this->doBindDescriptorSet(commandBuffer, descriptorSet, pipeline);
         }
 
@@ -11351,7 +11351,7 @@ namespace LiteFX::Rendering {
         virtual VirtualAllocator::Allocation doAllocateGlobalDescriptors(const IDescriptorSet& descriptorSet, DescriptorHeapType heapType) const = 0;
         virtual void doReleaseGlobalDescriptors(const IDescriptorSet& descriptorSet) const = 0;
         virtual void doUpdateGlobalDescriptors(const IDescriptorSet& descriptorSet, UInt32 binding, UInt32 offset, UInt32 descriptors) const = 0;
-        virtual void doBindDescriptorSet(const ICommandBuffer& commandBuffer, const IDescriptorSet& descriptorSet, const IPipeline& pipeline) const noexcept = 0;
+        virtual void doBindDescriptorSet(const ICommandBuffer& commandBuffer, const IDescriptorSet& descriptorSet, const IPipeline& pipeline) const = 0;
         virtual void doBindGlobalDescriptorHeaps(const ICommandBuffer& commandBuffer) const noexcept = 0;
 
     public:
@@ -11405,7 +11405,7 @@ namespace LiteFX::Rendering {
         /// <param name="adapterId">The unique ID of the adapter, or <c>std::nullopt</c> to find the default adapter.</param>
         /// <returns>A pointer to a graphics adapter, or <c>nullptr</c>, if no adapter could be found.</returns>
         /// <seealso cref="IGraphicsAdapter" />
-        virtual const IGraphicsAdapter* findAdapter(const Optional<UInt64>& adapterId = std::nullopt) const noexcept = 0;
+        virtual const IGraphicsAdapter* findAdapter(const Optional<UInt64>& adapterId = std::nullopt) const = 0;
 
         /// <summary>
         /// Finds an adapter using a preference setting, based on the user preferences made in the operating system settings.
@@ -11419,21 +11419,21 @@ namespace LiteFX::Rendering {
         /// <param name="preference">The profile for the preferred adapter.</param>
         /// <returns>A pointer to a graphics adapter, or <c>nullptr</c>, if no adapter could be found.</returns>
         /// <seealso cref="IGraphicsAdapter" />
-        virtual const IGraphicsAdapter* findAdapter(GpuPreference preference) const noexcept = 0;
+        virtual const IGraphicsAdapter* findAdapter(GpuPreference preference) const = 0;
 
         /// <summary>
         /// Looks up a device and returns a pointer to it, or <c>nullptr</c>, if no device with the provided <paramref name="name" /> could be found.
         /// </summary>
         /// <param name="name">The name of the device.</param>
         /// <returns>A pointer to the device or <c>nullptr</c>, if no device could be found.</returns>
-        virtual IGraphicsDevice* device(const String& name) noexcept = 0;
+        virtual IGraphicsDevice* device(const String& name) = 0;
 
         /// <summary>
         /// Looks up a device and returns a pointer to it, or <c>nullptr</c>, if no device with the provided <paramref name="name" /> could be found.
         /// </summary>
         /// <param name="name">The name of the device.</param>
         /// <returns>A pointer to the device or <c>nullptr</c>, if no device could be found.</returns>
-        virtual const IGraphicsDevice* device(const String& name) const noexcept = 0;
+        virtual const IGraphicsDevice* device(const String& name) const = 0;
 
         /// <summary>
         /// Looks up a device and returns a pointer to it, or <c>nullptr</c>, if no device with the provided <paramref name="name" /> could be found.

--- a/src/Rendering/include/litefx/rendering_api.hpp
+++ b/src/Rendering/include/litefx/rendering_api.hpp
@@ -77,22 +77,27 @@ namespace LiteFX::Rendering {
         /// <summary>
         /// The adapter is not a valid graphics adapter.
         /// </summary>
-        None = 0x00000000,
-        
-        /// <summary>
-        /// The adapter is a dedicated GPU or integrated CPU adapter.
-        /// </summary>
-        GPU = 0x00000001,
-
-        /// <summary>
-        /// The adapter is a software driver.
-        /// </summary>
-        CPU = 0x00000002,
+        None = 0,
 
         /// <summary>
         /// The adapter type is not captured by this enum. This value is used internally to mark invalid adapters and should not be used.
         /// </summary>
-        Other = 0x7FFFFFFF,
+        Other = 1,
+
+        /// <summary>
+        /// The adapter is a software driver.
+        /// </summary>
+        Software = 2,
+
+        /// <summary>
+        /// The adapter is a GPU integrated into the CPU.
+        /// </summary>
+        CPU = 3,
+        
+        /// <summary>
+        /// The adapter is a dedicated or external GPU.
+        /// </summary>
+        GPU = 4,
     };
 
     /// <summary>

--- a/src/Rendering/include/litefx/rendering_api.hpp
+++ b/src/Rendering/include/litefx/rendering_api.hpp
@@ -101,6 +101,26 @@ namespace LiteFX::Rendering {
     };
 
     /// <summary>
+    /// Provides a preference setting when selecting an adapter.
+    /// </summary>
+    enum class GpuPreference {
+        /// <summary>
+        /// Returns the first adapter in the list without any preference.
+        /// </summary>
+        None = 0,
+
+        /// <summary>
+        /// Returns the preferred adapter for minimum power consumption.
+        /// </summary>
+        Power = 1,
+
+        /// <summary>
+        /// Returns the preferred adapter for maximum performance.
+        /// </summary>
+        Performance = 2
+    };
+
+    /// <summary>
     /// Represents the type of a <see cref="CommandQueue" />.
     /// </summary>
     /// <remarks>
@@ -11386,6 +11406,20 @@ namespace LiteFX::Rendering {
         /// <returns>A pointer to a graphics adapter, or <c>nullptr</c>, if no adapter could be found.</returns>
         /// <seealso cref="IGraphicsAdapter" />
         virtual const IGraphicsAdapter* findAdapter(const Optional<UInt64>& adapterId = std::nullopt) const noexcept = 0;
+
+        /// <summary>
+        /// Finds an adapter using a preference setting, based on the user preferences made in the operating system settings.
+        /// </summary>
+        /// <remarks>
+        /// Note that the backend might return any adapter if the operating system does not support GPU preference settings, or if the backend does not support querying
+        /// adapters from such a setting.
+        /// 
+        /// The Vulkan backend only supports this method if the DirectX 12 backend is also available, as it performs the query through DXGI.
+        /// </remarks>
+        /// <param name="preference">The profile for the preferred adapter.</param>
+        /// <returns>A pointer to a graphics adapter, or <c>nullptr</c>, if no adapter could be found.</returns>
+        /// <seealso cref="IGraphicsAdapter" />
+        virtual const IGraphicsAdapter* findAdapter(GpuPreference preference) const noexcept = 0;
 
         /// <summary>
         /// Looks up a device and returns a pointer to it, or <c>nullptr</c>, if no device with the provided <paramref name="name" /> could be found.

--- a/src/Rendering/include/litefx/rendering_builders.hpp
+++ b/src/Rendering/include/litefx/rendering_builders.hpp
@@ -103,7 +103,7 @@ namespace LiteFX::Rendering {
             /// <param name="parent">The parent builder instance.</param>
             /// <param name="buffer">The buffer for this barrier.</param>
             /// <param name="access">The resource access state of the buffer to wait for with this barrier.</param>
-            constexpr BufferBarrierBuilder(TParent&& parent, IBuffer& buffer, ResourceAccess access) noexcept :
+            constexpr BufferBarrierBuilder(TParent&& parent, IBuffer& buffer, ResourceAccess access) :
                 m_parent(std::move(parent)), m_buffer(buffer.shared_from_this()), m_access(access) { }
 
         public:
@@ -145,7 +145,7 @@ namespace LiteFX::Rendering {
             /// <param name="layer">The layer of the first sub-resource to transition.</param>
             /// <param name="layers">The number of layers to transition.</param>
             /// <param name="plane">The plane of the sub-resource to transition.</param>
-            constexpr ImageLayoutBarrierBuilder(TParent&& parent, IImage& image, ResourceAccess access, ImageLayout layout, UInt32 level, UInt32 levels, UInt32 layer, UInt32 layers, UInt32 plane) noexcept :
+            constexpr ImageLayoutBarrierBuilder(TParent&& parent, IImage& image, ResourceAccess access, ImageLayout layout, UInt32 level, UInt32 levels, UInt32 layer, UInt32 layers, UInt32 plane) :
                 m_parent(std::move(parent)), m_access(access), m_image(image.shared_from_this()), m_layout(layout), m_level(level), m_levels(levels), m_layer(layer), m_layers(layers), m_plane(plane) { }
 
         public:
@@ -181,7 +181,7 @@ namespace LiteFX::Rendering {
             /// <param name="parent">The parent builder instance.</param>
             /// <param name="image">The image for this barrier.</param>
             /// <param name="access">The resource access state of the sub-resources in the image to wait for with this barrier.</param>
-            constexpr ImageBarrierBuilder(TParent&& parent, IImage& image, ResourceAccess access) noexcept :
+            constexpr ImageBarrierBuilder(TParent&& parent, IImage& image, ResourceAccess access) :
                 m_parent(std::move(parent)), m_access(access), m_image(image.shared_from_this()) { }
 
         public:
@@ -1065,7 +1065,7 @@ namespace LiteFX::Rendering {
             /// <summary>
             /// The shader stages, the descriptor set is accessible from.
             /// </summary>
-            ShaderStage stages{};
+            ShaderStage stages{ ShaderStage::Other };
 
             /// <summary>
             /// The layouts of the descriptors within the descriptor set.
@@ -1541,7 +1541,7 @@ namespace LiteFX::Rendering {
             /// <summary>
             /// The primitive topology.
             /// </summary>
-            PrimitiveTopology topology{};
+            PrimitiveTopology topology{ PrimitiveTopology::PointList };
 
             /// <summary>
             /// The vertex buffer layouts.

--- a/src/Rendering/include/litefx/rendering_formatters.hpp
+++ b/src/Rendering/include/litefx/rendering_formatters.hpp
@@ -12,6 +12,7 @@ struct LITEFX_RENDERING_API std::formatter<GraphicsAdapterType> : std::formatter
 		using enum GraphicsAdapterType;
 		case CPU: name = "CPU"; break;
 		case GPU: name = "GPU"; break;
+		case Software: name = "Software"; break;
 		case Other: name = "Other"; break;
 		case None: name = "None"; break;
 		}

--- a/src/Rendering/src/shader_record_collection.cpp
+++ b/src/Rendering/src/shader_record_collection.cpp
@@ -4,7 +4,7 @@ using namespace LiteFX::Rendering;
 
 const IShaderModule* ShaderRecordCollection::findShaderModule(StringView name) const noexcept
 {
-	return (*m_program)[name];
+	return (*m_program)[name]; // NOLINT(cppcoreguidelines-pro-bounds-avoid-unchecked-container-access)
 }
 
 const Array<UniquePtr<const IShaderRecord>>& ShaderRecordCollection::shaderRecords() const noexcept

--- a/src/Samples/BasicRendering/src/sample.cpp
+++ b/src/Samples/BasicRendering/src/sample.cpp
@@ -1,12 +1,13 @@
 #include "sample.h"
 #include <glm/gtc/matrix_transform.hpp>
 
-enum DescriptorSets : UInt32 // NOLINT(performance-enum-size)
+enum DescriptorSets : UInt32 // NOLINT(performance-enum-size, cppcoreguidelines-use-enum-class)
 {
     Constant = 0,                                       // All buffers that are immutable.
     PerFrame = 1,                                       // All buffers that are updated each frame.
 };
 
+// NOLINTBEGIN(bugprone-throwing-static-initialization)
 const Array<Vertex> vertices =
 {
     { { -0.5f, -0.5f, 0.5f }, { 1.0f, 0.0f, 0.0f, 1.0f }, { 0.0f, 0.0f, 0.0f }, { 0.0f, 0.0f } },
@@ -17,6 +18,7 @@ const Array<Vertex> vertices =
 
 const Array<UInt16> indices = { 0, 2, 1, 0, 1, 3, 0, 3, 2, 1, 2, 3 };
 
+// NOLINTEND(bugprone-throwing-static-initialization)
 // NOLINTBEGIN(cppcoreguidelines-avoid-non-const-global-variables)
 
 static struct CameraBuffer {
@@ -37,11 +39,11 @@ struct FileExtensions {
 
 #ifdef LITEFX_BUILD_VULKAN_BACKEND
 template<>
-const String FileExtensions<VulkanBackend>::SHADER = "spv";
+const String FileExtensions<VulkanBackend>::SHADER = "spv"; // NOLINT(bugprone-throwing-static-initialization)
 #endif // LITEFX_BUILD_VULKAN_BACKEND
 #ifdef LITEFX_BUILD_DIRECTX_12_BACKEND
 template<>
-const String FileExtensions<DirectX12Backend>::SHADER = "dxi";
+const String FileExtensions<DirectX12Backend>::SHADER = "dxi"; // NOLINT(bugprone-throwing-static-initialization)
 #endif // LITEFX_BUILD_DIRECTX_12_BACKEND
 
 template<typename TRenderBackend> requires

--- a/src/Samples/BasicRendering/src/sample.cpp
+++ b/src/Samples/BasicRendering/src/sample.cpp
@@ -208,11 +208,7 @@ void SampleApp::onInit()
         m_viewport = makeShared<Viewport>(RectF(0.f, 0.f, static_cast<Float>(width), static_cast<Float>(height)));
         m_scissor = makeShared<Scissor>(RectF(0.f, 0.f, static_cast<Float>(width), static_cast<Float>(height)));
 
-        auto adapter = backend->findAdapter(m_adapterId);
-
-        if (adapter == nullptr)
-            adapter = backend->findAdapter(std::nullopt);
-
+        auto adapter = m_adapterId.has_value() ? backend->findAdapter(m_adapterId) : backend->findAdapter(GpuPreference::Performance);
         auto surface = backend->createSurface(::glfwGetWin32Window(window));
 
         // Create the device.

--- a/src/Samples/Bindless/src/sample.cpp
+++ b/src/Samples/Bindless/src/sample.cpp
@@ -253,11 +253,7 @@ void SampleApp::onInit()
         m_viewport = makeShared<Viewport>(RectF(0.f, 0.f, static_cast<Float>(width), static_cast<Float>(height)));
         m_scissor = makeShared<Scissor>(RectF(0.f, 0.f, static_cast<Float>(width), static_cast<Float>(height)));
 
-        auto adapter = backend->findAdapter(m_adapterId);
-
-        if (adapter == nullptr)
-            adapter = backend->findAdapter(std::nullopt);
-
+        auto adapter = m_adapterId.has_value() ? backend->findAdapter(m_adapterId) : backend->findAdapter(GpuPreference::Performance);
         auto surface = backend->createSurface(::glfwGetWin32Window(window));
 
         // Create the device.

--- a/src/Samples/Bindless/src/sample.cpp
+++ b/src/Samples/Bindless/src/sample.cpp
@@ -2,13 +2,14 @@
 #include <glm/gtc/matrix_transform.hpp>
 #include <random>
 
-enum DescriptorSets : UInt32 // NOLINT(performance-enum-size)
+enum DescriptorSets : UInt32 // NOLINT(performance-enum-size, cppcoreguidelines-use-enum-class)
 {
     CameraData = 0,
     DrawData = 1,
     InstanceData = 2
 };
 
+// NOLINTBEGIN(bugprone-throwing-static-initialization)
 const Array<Vertex> vertices =
 {
     { { -0.5f, -0.5f, 0.5f }, { 1.0f, 0.0f, 0.0f, 1.0f }, { 0.0f, 0.0f, 0.0f }, { 0.0f, 0.0f } },
@@ -19,6 +20,7 @@ const Array<Vertex> vertices =
 
 const Array<UInt16> indices = { 0, 2, 1, 0, 1, 3, 0, 3, 2, 1, 2, 3 };
 
+// NOLINTEND(bugprone-throwing-static-initialization)
 // NOLINTBEGIN(cppcoreguidelines-avoid-non-const-global-variables)
 
 struct CameraBuffer {
@@ -48,16 +50,16 @@ struct FileExtensions {
 
 #ifdef LITEFX_BUILD_VULKAN_BACKEND
 template<>
-const String FileExtensions<VulkanBackend>::SHADER = "spv";
+const String FileExtensions<VulkanBackend>::SHADER = "spv"; // NOLINT(bugprone-throwing-static-initialization)
 #endif // LITEFX_BUILD_VULKAN_BACKEND
 #ifdef LITEFX_BUILD_DIRECTX_12_BACKEND
 template<>
-const String FileExtensions<DirectX12Backend>::SHADER = "dxi";
+const String FileExtensions<DirectX12Backend>::SHADER = "dxi"; // NOLINT(bugprone-throwing-static-initialization)
 #endif // LITEFX_BUILD_DIRECTX_12_BACKEND
 
 static void initInstanceData()
 {
-    std::srand(static_cast<UInt32>(std::time(nullptr)));
+    std::srand(static_cast<UInt32>(std::time(nullptr))); // NOLINT(bugprone-random-generator-seed)
     int i = 0;
 
     for (int z = 0; z < 10; z++) // NOLINT(cppcoreguidelines-avoid-magic-numbers)

--- a/src/Samples/Compute/src/sample.cpp
+++ b/src/Samples/Compute/src/sample.cpp
@@ -227,11 +227,7 @@ void SampleApp::onInit()
         m_viewport = makeShared<Viewport>(RectF(0.f, 0.f, static_cast<Float>(width), static_cast<Float>(height)));
         m_scissor = makeShared<Scissor>(RectF(0.f, 0.f, static_cast<Float>(width), static_cast<Float>(height)));
 
-        auto adapter = backend->findAdapter(m_adapterId);
-
-        if (adapter == nullptr)
-            adapter = backend->findAdapter(std::nullopt);
-
+        auto adapter = m_adapterId.has_value() ? backend->findAdapter(m_adapterId) : backend->findAdapter(GpuPreference::Performance);
         auto surface = backend->createSurface(::glfwGetWin32Window(window));
 
         // Create the device.

--- a/src/Samples/Compute/src/sample.cpp
+++ b/src/Samples/Compute/src/sample.cpp
@@ -1,12 +1,13 @@
 #include "sample.h"
 #include <glm/gtc/matrix_transform.hpp>
 
-enum DescriptorSets : UInt32 // NOLINT(performance-enum-size)
+enum DescriptorSets : UInt32 // NOLINT(performance-enum-size, cppcoreguidelines-use-enum-class)
 {
     Constant = 0,                                       // All buffers that are immutable.
     PerFrame = 1,                                       // All buffers that are updated each frame.
 };
 
+// NOLINTBEGIN(bugprone-throwing-static-initialization)
 const Array<Vertex> vertices =
 {
     { { -0.5f, -0.5f, 0.5f }, { 1.0f, 0.0f, 0.0f, 1.0f }, { 0.0f, 0.0f, 0.0f }, { 0.0f, 0.0f } },
@@ -17,6 +18,7 @@ const Array<Vertex> vertices =
 
 const Array<UInt16> indices = { 0, 2, 1, 0, 1, 3, 0, 3, 2, 1, 2, 3 };
 
+// NOLINTEND(bugprone-throwing-static-initialization)
 // NOLINTBEGIN(cppcoreguidelines-avoid-non-const-global-variables)
 
 struct CameraBuffer {
@@ -37,11 +39,11 @@ struct FileExtensions {
 
 #ifdef LITEFX_BUILD_VULKAN_BACKEND
 template<>
-const String FileExtensions<VulkanBackend>::SHADER = "spv";
+const String FileExtensions<VulkanBackend>::SHADER = "spv"; // NOLINT(bugprone-throwing-static-initialization)
 #endif // LITEFX_BUILD_VULKAN_BACKEND
 #ifdef LITEFX_BUILD_DIRECTX_12_BACKEND
 template<>
-const String FileExtensions<DirectX12Backend>::SHADER = "dxi";
+const String FileExtensions<DirectX12Backend>::SHADER = "dxi"; // NOLINT(bugprone-throwing-static-initialization)
 #endif // LITEFX_BUILD_DIRECTX_12_BACKEND
 
 template<typename TRenderBackend> requires
@@ -275,7 +277,7 @@ void SampleApp::onResize(const void* /*sender*/, const ResizeEventArgs& e)
         frameBuffer.resize(renderArea);
 
         // Update the post-processing bindings that reference the "opaque" frame buffer.
-        m_device->state().descriptorSet(std::format("Post Bindings {0}", i)).update(0, frameBuffer["Color Target"]);
+        m_device->state().descriptorSet(std::format("Post Bindings {0}", i)).update(0, frameBuffer["Color Target"]); // NOLINT(cppcoreguidelines-pro-bounds-avoid-unchecked-container-access)
     }
 
     // Also resize viewport and scissor.
@@ -450,7 +452,7 @@ void SampleApp::drawFrame()
         commandBuffer->use(postPipeline);
 
         // Get the image from the back buffer of the geometry pass.
-        auto& image = frameBuffer["Color Target"];
+        auto& image = frameBuffer["Color Target"]; // NOLINT(cppcoreguidelines-pro-bounds-avoid-unchecked-container-access)
 
         // Create a barrier that handles image transition.
         auto barrier = m_device->makeBarrier(PipelineStage::None, PipelineStage::Compute);

--- a/src/Samples/Defragmentation/src/sample.cpp
+++ b/src/Samples/Defragmentation/src/sample.cpp
@@ -2,11 +2,14 @@
 #include <glm/gtc/matrix_transform.hpp>
 #include <random>
 
-enum DescriptorSets : UInt32 // NOLINT(performance-enum-size)
+enum DescriptorSets : UInt32 // NOLINT(performance-enum-size, cppcoreguidelines-use-enum-class)
 {
     Constant = 0,                                       // All buffers that are immutable.
     PerFrame = 1,                                       // All buffers that are updated each frame.
 };
+
+// NOLINTBEGIN(bugprone-throwing-static-initialization)
+// NOLINTBEGIN(cppcoreguidelines-avoid-non-const-global-variables)
 
 const Array<Vertex> vertices =
 {
@@ -23,8 +26,6 @@ struct Allocation {
     UInt32 lifetime{};
 };
 
-// NOLINTBEGIN(cppcoreguidelines-avoid-non-const-global-variables)
-
 Array<::Allocation> allocations{};
 
 std::random_device rnd;
@@ -40,6 +41,7 @@ static struct TransformBuffer {
 } transform;
 
 // NOLINTEND(cppcoreguidelines-avoid-non-const-global-variables)
+// NOLINTEND(bugprone-throwing-static-initialization)
 
 template<typename TRenderBackend> requires
     meta::implements<TRenderBackend, IRenderBackend>
@@ -49,11 +51,11 @@ struct FileExtensions {
 
 #ifdef LITEFX_BUILD_VULKAN_BACKEND
 template<>
-const String FileExtensions<VulkanBackend>::SHADER = "spv";
+const String FileExtensions<VulkanBackend>::SHADER = "spv"; // NOLINT(bugprone-throwing-static-initialization)
 #endif // LITEFX_BUILD_VULKAN_BACKEND
 #ifdef LITEFX_BUILD_DIRECTX_12_BACKEND
 template<>
-const String FileExtensions<DirectX12Backend>::SHADER = "dxi";
+const String FileExtensions<DirectX12Backend>::SHADER = "dxi"; // NOLINT(bugprone-throwing-static-initialization)
 #endif // LITEFX_BUILD_DIRECTX_12_BACKEND
 
 static inline void setupPrepareMoveHandler(const SharedPtr<const IBuffer>& resource, ResourceAccess beforeAccess) {

--- a/src/Samples/Defragmentation/src/sample.cpp
+++ b/src/Samples/Defragmentation/src/sample.cpp
@@ -242,11 +242,7 @@ void SampleApp::onInit()
         m_viewport = makeShared<Viewport>(RectF(0.f, 0.f, static_cast<Float>(width), static_cast<Float>(height)));
         m_scissor = makeShared<Scissor>(RectF(0.f, 0.f, static_cast<Float>(width), static_cast<Float>(height)));
 
-        auto adapter = backend->findAdapter(m_adapterId);
-
-        if (adapter == nullptr)
-            adapter = backend->findAdapter(std::nullopt);
-
+        auto adapter = m_adapterId.has_value() ? backend->findAdapter(m_adapterId) : backend->findAdapter(GpuPreference::Performance);
         auto surface = backend->createSurface(::glfwGetWin32Window(window));
 
         // Create the device.

--- a/src/Samples/DynamicDescriptors/src/sample.cpp
+++ b/src/Samples/DynamicDescriptors/src/sample.cpp
@@ -2,12 +2,13 @@
 #include <glm/gtc/matrix_transform.hpp>
 #include <random>
 
-enum DescriptorSets : UInt32 // NOLINT(performance-enum-size)
+enum DescriptorSets : UInt32 // NOLINT(performance-enum-size, cppcoreguidelines-use-enum-class)
 {
     CameraData = 1,
     DrawData = 2
 };
 
+// NOLINTBEGIN(bugprone-throwing-static-initialization)
 const Array<Vertex> vertices =
 {
     { { -0.5f, -0.5f, 0.5f }, { 1.0f, 0.0f, 0.0f, 1.0f }, { 0.0f, 0.0f, 0.0f }, { 0.0f, 0.0f } },
@@ -18,6 +19,7 @@ const Array<Vertex> vertices =
 
 const Array<UInt16> indices = { 0, 2, 1, 0, 1, 3, 0, 3, 2, 1, 2, 3 };
 
+// NOLINTEND(bugprone-throwing-static-initialization)
 // NOLINTBEGIN(cppcoreguidelines-avoid-non-const-global-variables)
 
 struct CameraBuffer {
@@ -47,16 +49,16 @@ struct FileExtensions {
 
 #ifdef LITEFX_BUILD_VULKAN_BACKEND
 template<>
-const String FileExtensions<VulkanBackend>::SHADER = "spv";
+const String FileExtensions<VulkanBackend>::SHADER = "spv"; // NOLINT(bugprone-throwing-static-initialization)
 #endif // LITEFX_BUILD_VULKAN_BACKEND
 #ifdef LITEFX_BUILD_DIRECTX_12_BACKEND
 template<>
-const String FileExtensions<DirectX12Backend>::SHADER = "dxi";
+const String FileExtensions<DirectX12Backend>::SHADER = "dxi"; // NOLINT(bugprone-throwing-static-initialization)
 #endif // LITEFX_BUILD_DIRECTX_12_BACKEND
 
 static void initInstanceData()
 {
-    std::srand(static_cast<UInt32>(std::time(nullptr)));
+    std::srand(static_cast<UInt32>(std::time(nullptr))); // NOLINT(bugprone-random-generator-seed)
     int i = 0;
 
     for (int z = 0; z < 10; z++) // NOLINT(cppcoreguidelines-avoid-magic-numbers)

--- a/src/Samples/DynamicDescriptors/src/sample.cpp
+++ b/src/Samples/DynamicDescriptors/src/sample.cpp
@@ -253,11 +253,7 @@ void SampleApp::onInit()
         m_viewport = makeShared<Viewport>(RectF(0.f, 0.f, static_cast<Float>(width), static_cast<Float>(height)));
         m_scissor = makeShared<Scissor>(RectF(0.f, 0.f, static_cast<Float>(width), static_cast<Float>(height)));
 
-        auto adapter = backend->findAdapter(m_adapterId);
-
-        if (adapter == nullptr)
-            adapter = backend->findAdapter(std::nullopt);
-
+        auto adapter = m_adapterId.has_value() ? backend->findAdapter(m_adapterId) : backend->findAdapter(GpuPreference::Performance);
         auto surface = backend->createSurface(::glfwGetWin32Window(window));
 
         // Create the device.

--- a/src/Samples/ImGui/src/sample.cpp
+++ b/src/Samples/ImGui/src/sample.cpp
@@ -255,11 +255,7 @@ void SampleApp::onInit()
         m_viewport = makeShared<Viewport>(RectF(0.f, 0.f, static_cast<Float>(width), static_cast<Float>(height)));
         m_scissor = makeShared<Scissor>(RectF(0.f, 0.f, static_cast<Float>(width), static_cast<Float>(height)));
 
-        auto adapter = backend->findAdapter(m_adapterId);
-
-        if (adapter == nullptr)
-            adapter = backend->findAdapter(std::nullopt);
-
+        auto adapter = m_adapterId.has_value() ? backend->findAdapter(m_adapterId) : backend->findAdapter(GpuPreference::Performance);
         auto surface = backend->createSurface(::glfwGetWin32Window(window));
 
         // Create the device.

--- a/src/Samples/ImGui/src/sample.cpp
+++ b/src/Samples/ImGui/src/sample.cpp
@@ -1,11 +1,13 @@
 #include "sample.h"
 #include <glm/gtc/matrix_transform.hpp>
 
-enum DescriptorSets : UInt32 // NOLINT(performance-enum-size)
+enum DescriptorSets : UInt32 // NOLINT(performance-enum-size, cppcoreguidelines-use-enum-class)
 {
     Constant = 0,                                       // All buffers that are immutable.
     PerFrame = 1,                                       // All buffers that are updated each frame.
 };
+
+// NOLINTBEGIN(bugprone-throwing-static-initialization)
 
 const Array<Vertex> vertices =
 {
@@ -17,6 +19,7 @@ const Array<Vertex> vertices =
 
 const Array<UInt16> indices = { 0, 2, 1, 0, 1, 3, 0, 3, 2, 1, 2, 3 };
 
+// NOLINTEND(bugprone-throwing-static-initialization)
 // NOLINTBEGIN(cppcoreguidelines-avoid-non-const-global-variables)
 
 static struct CameraBuffer {
@@ -37,11 +40,11 @@ struct FileExtensions {
 
 #ifdef LITEFX_BUILD_VULKAN_BACKEND
 template<>
-const String FileExtensions<VulkanBackend>::SHADER = "spv";
+const String FileExtensions<VulkanBackend>::SHADER = "spv"; // NOLINT(bugprone-throwing-static-initialization)
 #endif // LITEFX_BUILD_VULKAN_BACKEND
 #ifdef LITEFX_BUILD_DIRECTX_12_BACKEND
 template<>
-const String FileExtensions<DirectX12Backend>::SHADER = "dxi";
+const String FileExtensions<DirectX12Backend>::SHADER = "dxi"; // NOLINT(bugprone-throwing-static-initialization)
 #endif // LITEFX_BUILD_DIRECTX_12_BACKEND
 
 #ifdef LITEFX_BUILD_DIRECTX_12_BACKEND
@@ -317,7 +320,7 @@ void SampleApp::onInit()
             auto stencilFormat = depthStencilFormats.size() > 0 && ::hasStencil(depthStencilFormats.front()) ? Vk::getFormat(depthStencilFormats.front()) : VK_FORMAT_UNDEFINED;
 
             // Setup Vulkan init info.
-            ImGui_ImplVulkan_InitInfo initInfo = {};
+            ImGui_ImplVulkan_InitInfo initInfo = {}; // NOLINT(bugprone-invalid-enum-default-initialization)
             initInfo.ApiVersion = VK_API_VERSION_1_3;
             initInfo.Instance = std::as_const(*backend).handle();
             initInfo.PhysicalDevice = std::as_const(*adapter).handle();

--- a/src/Samples/Indirect/src/sample.cpp
+++ b/src/Samples/Indirect/src/sample.cpp
@@ -339,11 +339,7 @@ void SampleApp::onInit()
         m_viewport = makeShared<Viewport>(RectF(0.f, 0.f, static_cast<Float>(width), static_cast<Float>(height)));
         m_scissor = makeShared<Scissor>(RectF(0.f, 0.f, static_cast<Float>(width), static_cast<Float>(height)));
 
-        auto adapter = backend->findAdapter(m_adapterId);
-
-        if (adapter == nullptr)
-            adapter = backend->findAdapter(std::nullopt);
-
+        auto adapter = m_adapterId.has_value() ? backend->findAdapter(m_adapterId) : backend->findAdapter(GpuPreference::Performance);
         auto surface = backend->createSurface(::glfwGetWin32Window(window));
 
         // Create the device.

--- a/src/Samples/Indirect/src/sample.cpp
+++ b/src/Samples/Indirect/src/sample.cpp
@@ -6,13 +6,14 @@
 
 constexpr UInt32 NUM_INSTANCES = 163840u;  // 10 * 128 * 128
 
-enum DescriptorSets : UInt32 // NOLINT(performance-enum-size)
+enum DescriptorSets : UInt32 // NOLINT(performance-enum-size, cppcoreguidelines-use-enum-class)
 {
     PerFrame = 0,
     Constant = 1,
     Indirect = 2
 };
 
+// NOLINTBEGIN(bugprone-throwing-static-initialization)
 const Array<Vertex> vertices =
 {
     { { -0.5f, -0.5f, 0.5f }, { 1.0f, 0.0f, 0.0f, 1.0f }, { 0.0f, 0.0f, 0.0f }, { 0.0f, 0.0f } },
@@ -23,6 +24,7 @@ const Array<Vertex> vertices =
 
 const Array<UInt16> indices = { 0, 2, 1, 0, 1, 3, 0, 3, 2, 1, 2, 3 };
 
+// NOLINTEND(bugprone-throwing-static-initialization)
 // NOLINTBEGIN(cppcoreguidelines-avoid-non-const-global-variables)
 // NOLINTBEGIN(cppcoreguidelines-avoid-c-arrays)
 
@@ -59,11 +61,11 @@ struct FileExtensions {
 
 #ifdef LITEFX_BUILD_VULKAN_BACKEND
 template<>
-const String FileExtensions<VulkanBackend>::SHADER = "spv";
+const String FileExtensions<VulkanBackend>::SHADER = "spv"; // NOLINT(bugprone-throwing-static-initialization)
 #endif // LITEFX_BUILD_VULKAN_BACKEND
 #ifdef LITEFX_BUILD_DIRECTX_12_BACKEND
 template<>
-const String FileExtensions<DirectX12Backend>::SHADER = "dxi";
+const String FileExtensions<DirectX12Backend>::SHADER = "dxi"; // NOLINT(bugprone-throwing-static-initialization)
 #endif // LITEFX_BUILD_DIRECTX_12_BACKEND
 
 static constexpr glm::vec4 normalizePlane(const glm::vec4& plane) {
@@ -71,7 +73,7 @@ static constexpr glm::vec4 normalizePlane(const glm::vec4& plane) {
 }
 
 static inline void initializeObjects() {
-    std::srand(static_cast<UInt32>(std::time(nullptr)));
+    std::srand(static_cast<UInt32>(std::time(nullptr))); // NOLINT(bugprone-random-generator-seed)
 
     for (int i{ 0 }; i < static_cast<int>(NUM_INSTANCES); ++i)
     {
@@ -277,7 +279,7 @@ void SampleApp::updateCamera(IBuffer& buffer, UInt32 backBuffer) const
     camera.FarPlane = farPlane;
     
     // Compute frustum side planes.
-    // NOLINTBEGIN(cppcoreguidelines-avoid-magic-numbers)
+    // NOLINTBEGIN(cppcoreguidelines-avoid-magic-numbers, cppcoreguidelines-pro-bounds-avoid-unchecked-container-access)
     auto projectionTransposed = glm::transpose(camera.ViewProjection); // GLM uses column-major matrices, transpose lets us index rows.
     camera.Frustum[0] = ::normalizePlane(projectionTransposed[3] + projectionTransposed[0]);  // Left
     camera.Frustum[1] = ::normalizePlane(projectionTransposed[3] - projectionTransposed[0]);  // Right
@@ -285,7 +287,7 @@ void SampleApp::updateCamera(IBuffer& buffer, UInt32 backBuffer) const
     camera.Frustum[3] = ::normalizePlane(projectionTransposed[3] - projectionTransposed[1]);  // Top
     camera.Frustum[4] = ::normalizePlane(projectionTransposed[3] + projectionTransposed[2]);  // Near
     camera.Frustum[5] = ::normalizePlane(projectionTransposed[3] - projectionTransposed[2]);  // Far
-    // NOLINTEND(cppcoreguidelines-avoid-magic-numbers)
+    // NOLINTEND(cppcoreguidelines-avoid-magic-numbers, cppcoreguidelines-pro-bounds-avoid-unchecked-container-access)
 
     // Create a staging buffer and use to transfer the new uniform buffer to.
     buffer.map(static_cast<const void*>(&camera), sizeof(camera), backBuffer);

--- a/src/Samples/MeshShader/src/sample.cpp
+++ b/src/Samples/MeshShader/src/sample.cpp
@@ -1,7 +1,7 @@
 #include "sample.h"
 #include <glm/gtc/matrix_transform.hpp>
 
-enum DescriptorSets : UInt32 // NOLINT(performance-enum-size)
+enum DescriptorSets : UInt32 // NOLINT(performance-enum-size, cppcoreguidelines-use-enum-class)
 {
     Constant = 0,                                       // All buffers that are immutable.
     PerFrame = 1,                                       // All buffers that are updated each frame.
@@ -27,11 +27,11 @@ struct FileExtensions {
 
 #ifdef LITEFX_BUILD_VULKAN_BACKEND
 template<>
-const String FileExtensions<VulkanBackend>::SHADER = "spv";
+const String FileExtensions<VulkanBackend>::SHADER = "spv"; // NOLINT(bugprone-throwing-static-initialization)
 #endif // LITEFX_BUILD_VULKAN_BACKEND
 #ifdef LITEFX_BUILD_DIRECTX_12_BACKEND
 template<>
-const String FileExtensions<DirectX12Backend>::SHADER = "dxi";
+const String FileExtensions<DirectX12Backend>::SHADER = "dxi"; // NOLINT(bugprone-throwing-static-initialization)
 #endif // LITEFX_BUILD_DIRECTX_12_BACKEND
 
 template<typename TRenderBackend> requires

--- a/src/Samples/MeshShader/src/sample.cpp
+++ b/src/Samples/MeshShader/src/sample.cpp
@@ -179,11 +179,7 @@ void SampleApp::onInit()
         m_viewport = makeShared<Viewport>(RectF(0.f, 0.f, static_cast<Float>(width), static_cast<Float>(height)));
         m_scissor = makeShared<Scissor>(RectF(0.f, 0.f, static_cast<Float>(width), static_cast<Float>(height)));
 
-        auto adapter = backend->findAdapter(m_adapterId);
-
-        if (adapter == nullptr)
-            adapter = backend->findAdapter(std::nullopt);
-
+        auto adapter = m_adapterId.has_value() ? backend->findAdapter(m_adapterId) : backend->findAdapter(GpuPreference::Performance);
         auto surface = backend->createSurface(::glfwGetWin32Window(window));
 
         // Create the device.

--- a/src/Samples/Multisampling/src/sample.cpp
+++ b/src/Samples/Multisampling/src/sample.cpp
@@ -1,12 +1,13 @@
 #include "sample.h"
 #include <glm/gtc/matrix_transform.hpp>
 
-enum DescriptorSets : UInt32 // NOLINT(performance-enum-size)
+enum DescriptorSets : UInt32 // NOLINT(performance-enum-size, cppcoreguidelines-use-enum-class)
 {
     Constant = 0,                                       // All buffers that are immutable.
     PerFrame = 1,                                       // All buffers that are updated each frame.
 };
 
+// NOLINTBEGIN(bugprone-throwing-static-initialization)
 const Array<Vertex> vertices =
 {
     { { -0.5f, -0.5f, 0.5f }, { 1.0f, 0.0f, 0.0f, 1.0f }, { 0.0f, 0.0f, 0.0f }, { 0.0f, 0.0f } },
@@ -17,6 +18,7 @@ const Array<Vertex> vertices =
 
 const Array<UInt16> indices = { 0, 2, 1, 0, 1, 3, 0, 3, 2, 1, 2, 3 };
 
+// NOLINTEND(bugprone-throwing-static-initialization)
 // NOLINTBEGIN(cppcoreguidelines-avoid-non-const-global-variables)
 
 struct CameraBuffer {
@@ -37,11 +39,11 @@ struct FileExtensions {
 
 #ifdef LITEFX_BUILD_VULKAN_BACKEND
 template<>
-const String FileExtensions<VulkanBackend>::SHADER = "spv";
+const String FileExtensions<VulkanBackend>::SHADER = "spv"; // NOLINT(bugprone-throwing-static-initialization)
 #endif // LITEFX_BUILD_VULKAN_BACKEND
 #ifdef LITEFX_BUILD_DIRECTX_12_BACKEND
 template<>
-const String FileExtensions<DirectX12Backend>::SHADER = "dxi";
+const String FileExtensions<DirectX12Backend>::SHADER = "dxi"; // NOLINT(bugprone-throwing-static-initialization)
 #endif // LITEFX_BUILD_DIRECTX_12_BACKEND
 
 template<typename TRenderBackend> requires

--- a/src/Samples/Multisampling/src/sample.cpp
+++ b/src/Samples/Multisampling/src/sample.cpp
@@ -207,11 +207,7 @@ void SampleApp::onInit()
         m_viewport = makeShared<Viewport>(RectF(0.f, 0.f, static_cast<Float>(width), static_cast<Float>(height)));
         m_scissor = makeShared<Scissor>(RectF(0.f, 0.f, static_cast<Float>(width), static_cast<Float>(height)));
 
-        auto adapter = backend->findAdapter(m_adapterId);
-
-        if (adapter == nullptr)
-            adapter = backend->findAdapter(std::nullopt);
-
+        auto adapter = m_adapterId.has_value() ? backend->findAdapter(m_adapterId) : backend->findAdapter(GpuPreference::Performance);
         auto surface = backend->createSurface(::glfwGetWin32Window(window));
 
         // Create the device.

--- a/src/Samples/Multithreading/src/sample.cpp
+++ b/src/Samples/Multithreading/src/sample.cpp
@@ -220,11 +220,7 @@ void SampleApp::onInit()
         m_viewport = makeShared<Viewport>(RectF(0.f, 0.f, static_cast<Float>(width), static_cast<Float>(height)));
         m_scissor = makeShared<Scissor>(RectF(0.f, 0.f, static_cast<Float>(width), static_cast<Float>(height)));
 
-        auto adapter = backend->findAdapter(m_adapterId);
-
-        if (adapter == nullptr)
-            adapter = backend->findAdapter(std::nullopt);
-
+        auto adapter = m_adapterId.has_value() ? backend->findAdapter(m_adapterId) : backend->findAdapter(GpuPreference::Performance);
         auto surface = backend->createSurface(::glfwGetWin32Window(window));
 
         // Create the device.

--- a/src/Samples/Multithreading/src/sample.cpp
+++ b/src/Samples/Multithreading/src/sample.cpp
@@ -1,11 +1,13 @@
 #include "sample.h"
 #include <glm/gtc/matrix_transform.hpp>
 
-enum DescriptorSets : UInt32 // NOLINT(performance-enum-size)
+enum DescriptorSets : UInt32 // NOLINT(performance-enum-size, cppcoreguidelines-use-enum-class)
 {
     Constant = 0,                                       // All buffers that are immutable.
     PerFrame = 1,                                       // All buffers that are updated each frame.
 };
+
+// NOLINTBEGIN(bugprone-throwing-static-initialization)
 
 const Array<Vertex> vertices =
 {
@@ -42,6 +44,8 @@ const Array<glm::vec3> translations =
     {  0.0f,  0.0f,  0.0f }
 };
 
+// NOLINTEND(bugprone-throwing-static-initialization)
+
 template<typename TRenderBackend> requires
     meta::implements<TRenderBackend, IRenderBackend>
 struct FileExtensions {
@@ -50,11 +54,11 @@ struct FileExtensions {
 
 #ifdef LITEFX_BUILD_VULKAN_BACKEND
 template<>
-const String FileExtensions<VulkanBackend>::SHADER = "spv";
+const String FileExtensions<VulkanBackend>::SHADER = "spv"; // NOLINT(bugprone-throwing-static-initialization)
 #endif // LITEFX_BUILD_VULKAN_BACKEND
 #ifdef LITEFX_BUILD_DIRECTX_12_BACKEND
 template<>
-const String FileExtensions<DirectX12Backend>::SHADER = "dxi";
+const String FileExtensions<DirectX12Backend>::SHADER = "dxi"; // NOLINT(bugprone-throwing-static-initialization)
 #endif // LITEFX_BUILD_DIRECTX_12_BACKEND
 
 template<typename TRenderBackend> requires
@@ -148,7 +152,7 @@ void SampleApp::initBuffers(IRenderBackend* /*backend*/)
     Array<SharedPtr<IBuffer>> transformBuffers(NUM_WORKERS);
     std::ranges::generate(transformBuffers, [&, i = 0]() mutable { return m_device->factory().createBuffer(std::format("Transform {0}", i++), transformBindingLayout, 0, ResourceHeap::Dynamic, 3); });
     auto transformBindings = transformBindingLayout.allocate(3 * NUM_WORKERS, [transformBuffers](UInt32 set) -> Generator<DescriptorBinding> { // NOLINT(cppcoreguidelines-avoid-capturing-lambda-coroutines)
-        co_yield { .binding = 0, .resource = *transformBuffers[set % NUM_WORKERS], .firstElement = set / NUM_WORKERS, .elements = 1 }; 
+        co_yield { .binding = 0, .resource = *transformBuffers[set % NUM_WORKERS], .firstElement = set / NUM_WORKERS, .elements = 1 }; // NOLINT(cppcoreguidelines-pro-bounds-avoid-unchecked-container-access)
     }) | std::ranges::to<Array<UniquePtr<IDescriptorSet>>>();
     
     // End and submit the command buffer.
@@ -395,7 +399,7 @@ void SampleApp::drawObject(const IRenderPass* renderPass, int index, int backBuf
 
     // Compute world transform and update the transform buffer.
     // NOLINTBEGIN(cppcoreguidelines-pro-bounds-constant-array-index)
-    transform[index].World = glm::translate(glm::rotate(glm::mat4(1.0f), time * glm::radians(42.0f), glm::vec3(0.0f, 0.0f, 1.0f)), translations[index]); // NOLINT(cppcoreguidelines-avoid-magic-numbers)
+    transform[index].World = glm::translate(glm::rotate(glm::mat4(1.0f), time * glm::radians(42.0f), glm::vec3(0.0f, 0.0f, 1.0f)), translations[index]); // NOLINT(cppcoreguidelines-avoid-magic-numbers, cppcoreguidelines-pro-bounds-avoid-unchecked-container-access)
     transformBuffer.map(static_cast<const void*>(&transform[index]), sizeof(TransformBuffer), backBuffer);
     // NOLINTEND(cppcoreguidelines-pro-bounds-constant-array-index)
 

--- a/src/Samples/PushConstants/src/sample.cpp
+++ b/src/Samples/PushConstants/src/sample.cpp
@@ -1,11 +1,13 @@
 #include "sample.h"
 #include <glm/gtc/matrix_transform.hpp>
 
-enum DescriptorSets : UInt32 // NOLINT(performance-enum-size)
+enum DescriptorSets : UInt32 // NOLINT(performance-enum-size, cppcoreguidelines-use-enum-class)
 {
     Constant = 0,                                       // All buffers that are immutable.
     PerFrame = 1,                                       // All buffers that are updated each frame.
 };
+
+// NOLINTBEGIN(bugprone-throwing-static-initialization)
 
 const Array<Vertex> vertices =
 {
@@ -56,6 +58,8 @@ const Array<glm::vec4> colors =
     { 0.230f, 0.238f, 0.652f, 1.f },
 };
 
+// NOLINTEND(bugprone-throwing-static-initialization)
+
 template<typename TRenderBackend> requires
     meta::implements<TRenderBackend, IRenderBackend>
 struct FileExtensions {
@@ -64,11 +68,11 @@ struct FileExtensions {
 
 #ifdef LITEFX_BUILD_VULKAN_BACKEND
 template<>
-const String FileExtensions<VulkanBackend>::SHADER = "spv";
+const String FileExtensions<VulkanBackend>::SHADER = "spv"; // NOLINT(bugprone-throwing-static-initialization)
 #endif // LITEFX_BUILD_VULKAN_BACKEND
 #ifdef LITEFX_BUILD_DIRECTX_12_BACKEND
 template<>
-const String FileExtensions<DirectX12Backend>::SHADER = "dxi";
+const String FileExtensions<DirectX12Backend>::SHADER = "dxi"; // NOLINT(bugprone-throwing-static-initialization)
 #endif // LITEFX_BUILD_DIRECTX_12_BACKEND
 
 template<typename TRenderBackend> requires
@@ -418,8 +422,8 @@ void SampleApp::drawFrame()
     {
         // Initialize the object buffer and push it to the command buffer.
         ObjectBuffer buffer{
-            .World = glm::translate(glm::rotate(glm::mat4(1.0f), time * glm::radians(42.0f), glm::vec3(0.0f, 0.0f, 1.0f)), translations[i]), // NOLINT(cppcoreguidelines-avoid-magic-numbers)
-            .Color = colors[i]
+            .World = glm::translate(glm::rotate(glm::mat4(1.0f), time * glm::radians(42.0f), glm::vec3(0.0f, 0.0f, 1.0f)), translations[i]), // NOLINT(cppcoreguidelines-avoid-magic-numbers, cppcoreguidelines-pro-bounds-avoid-unchecked-container-access)
+            .Color = colors[i] // NOLINT(cppcoreguidelines-pro-bounds-avoid-unchecked-container-access)
         };
 
         commandBuffer->pushConstants(*geometryPipeline.layout()->pushConstants(), &buffer);

--- a/src/Samples/PushConstants/src/sample.cpp
+++ b/src/Samples/PushConstants/src/sample.cpp
@@ -221,11 +221,7 @@ void SampleApp::onInit()
         m_viewport = makeShared<Viewport>(RectF(0.f, 0.f, static_cast<Float>(width), static_cast<Float>(height)));
         m_scissor = makeShared<Scissor>(RectF(0.f, 0.f, static_cast<Float>(width), static_cast<Float>(height)));
 
-        auto adapter = backend->findAdapter(m_adapterId);
-
-        if (adapter == nullptr)
-            adapter = backend->findAdapter(std::nullopt);
-
+        auto adapter = m_adapterId.has_value() ? backend->findAdapter(m_adapterId) : backend->findAdapter(GpuPreference::Performance);
         auto surface = backend->createSurface(::glfwGetWin32Window(window));
 
         // Create the device.

--- a/src/Samples/RayQueries/src/sample.cpp
+++ b/src/Samples/RayQueries/src/sample.cpp
@@ -386,11 +386,7 @@ void SampleApp::onInit()
         int width{}, height{};
         ::glfwGetFramebufferSize(window, &width, &height);
 
-        auto adapter = backend->findAdapter(m_adapterId);
-
-        if (adapter == nullptr)
-            adapter = backend->findAdapter(std::nullopt);
-
+        auto adapter = m_adapterId.has_value() ? backend->findAdapter(m_adapterId) : backend->findAdapter(GpuPreference::Performance);
         auto surface = backend->createSurface(::glfwGetWin32Window(window));
 
         // Create viewport and scissors.

--- a/src/Samples/RayQueries/src/sample.cpp
+++ b/src/Samples/RayQueries/src/sample.cpp
@@ -19,6 +19,9 @@ enum class DescriptorSets : UInt32 // NOLINT(performance-enum-size)
     Sampler      = 2  // Skybox sampler state.
 };
 
+// NOLINTBEGIN(bugprone-throwing-static-initialization)
+// NOLINTBEGIN(cppcoreguidelines-avoid-non-const-global-variables)
+
 const Array<Vertex> vertices =
 {
     { { -0.5f,  0.5f, -0.5f }, { 0.33f, 0.33f, 0.33f, 1.0f }, { 0.0f,  1.0f, 0.0f }, { 0.0f, 0.0f } },
@@ -56,8 +59,6 @@ const Array<UInt16> indices = {
     20, 22, 21, 21, 22, 23  // Top
 };
 
-// NOLINTBEGIN(cppcoreguidelines-avoid-non-const-global-variables)
-
 struct CameraBuffer {
     glm::mat4 ViewProjection;
     glm::mat4 InverseView;
@@ -70,6 +71,7 @@ struct MaterialData { // NOLINT(cppcoreguidelines-avoid-c-arrays)
 } materials[NUM_INSTANCES];
 
 // NOLINTEND(cppcoreguidelines-avoid-non-const-global-variables)
+// NOLINTEND(bugprone-throwing-static-initialization)
 
 template<typename TRenderBackend> requires
     meta::implements<TRenderBackend, IRenderBackend>
@@ -79,11 +81,11 @@ struct FileExtensions {
 
 #ifdef LITEFX_BUILD_VULKAN_BACKEND
 template<>
-const String FileExtensions<VulkanBackend>::SHADER = "spv";
+const String FileExtensions<VulkanBackend>::SHADER = "spv"; // NOLINT(bugprone-throwing-static-initialization)
 #endif // LITEFX_BUILD_VULKAN_BACKEND
 #ifdef LITEFX_BUILD_DIRECTX_12_BACKEND
 template<>
-const String FileExtensions<DirectX12Backend>::SHADER = "dxi";
+const String FileExtensions<DirectX12Backend>::SHADER = "dxi"; // NOLINT(bugprone-throwing-static-initialization)
 #endif // LITEFX_BUILD_DIRECTX_12_BACKEND
 
 template<typename TRenderBackend> requires
@@ -187,7 +189,7 @@ void SampleApp::initBuffers(IRenderBackend* /*backend*/)
     auto blasBuffer = m_device->factory().createBuffer("BLAS", BufferType::AccelerationStructure, ResourceHeap::Resource, static_cast<size_t>(reflectiveOffset + reflectiveSize), 1u, ResourceUsage::AllowWrite);
 
     // Orient instances randomly.
-    std::srand(static_cast<UInt32>(std::time(nullptr)));
+    std::srand(static_cast<UInt32>(std::time(nullptr))); // NOLINT(bugprone-random-generator-seed)
 
     // NOLINTBEGIN(cppcoreguidelines-avoid-magic-numbers)
     auto tlas = m_device->factory().createTopLevelAccelerationStructure("TLAS", AccelerationStructureFlags::AllowCompaction | AccelerationStructureFlags::MinimizeMemory);

--- a/src/Samples/RayTracing/src/sample.cpp
+++ b/src/Samples/RayTracing/src/sample.cpp
@@ -395,11 +395,7 @@ void SampleApp::onInit()
         int width{}, height{};
         ::glfwGetFramebufferSize(window, &width, &height);
 
-        auto adapter = backend->findAdapter(m_adapterId);
-
-        if (adapter == nullptr)
-            adapter = backend->findAdapter(std::nullopt);
-
+        auto adapter = m_adapterId.has_value() ? backend->findAdapter(m_adapterId) : backend->findAdapter(GpuPreference::Performance);
         auto surface = backend->createSurface(::glfwGetWin32Window(window));
 
         // Create the device.

--- a/src/Samples/RayTracing/src/sample.cpp
+++ b/src/Samples/RayTracing/src/sample.cpp
@@ -21,6 +21,9 @@ enum class DescriptorSets : UInt32 // NOLINT(performance-enum-size)
     Sampler      = 4  // Skybox sampler state.
 };
 
+// NOLINTBEGIN(bugprone-throwing-static-initialization)
+// NOLINTBEGIN(cppcoreguidelines-avoid-non-const-global-variables)
+
 const Array<Vertex> vertices {
     { { -0.5f,  0.5f, -0.5f }, { 0.33f, 0.33f, 0.33f, 1.0f }, { 0.0f,  1.0f, 0.0f }, { 0.0f, 0.0f } },
     { {  0.5f,  0.5f, -0.5f }, { 0.33f, 0.33f, 0.33f, 1.0f }, { 0.0f,  1.0f, 0.0f }, { 0.0f, 0.0f } },
@@ -57,8 +60,6 @@ const Array<UInt16> indices {
     20, 22, 21, 21, 22, 23  // Top
 };
 
-// NOLINTBEGIN(cppcoreguidelines-avoid-non-const-global-variables)
-
 struct CameraBuffer {
     glm::mat4 ViewProjection;
     glm::mat4 InverseView;
@@ -70,6 +71,7 @@ struct MaterialData { // NOLINT(cppcoreguidelines-avoid-c-arrays)
 } materials[NUM_INSTANCES];
 
 // NOLINTEND(cppcoreguidelines-avoid-non-const-global-variables)
+// NOLINTEND(bugprone-throwing-static-initialization)
 
 struct alignas(8) GeometryData { // NOLINT(cppcoreguidelines-avoid-magic-numbers)
     UInt32 Index;
@@ -85,11 +87,11 @@ struct FileExtensions {
 
 #ifdef LITEFX_BUILD_VULKAN_BACKEND
 template<>
-const String FileExtensions<VulkanBackend>::SHADER = "spv";
+const String FileExtensions<VulkanBackend>::SHADER = "spv"; // NOLINT(bugprone-throwing-static-initialization)
 #endif // LITEFX_BUILD_VULKAN_BACKEND
 #ifdef LITEFX_BUILD_DIRECTX_12_BACKEND
 template<>
-const String FileExtensions<DirectX12Backend>::SHADER = "dxi";
+const String FileExtensions<DirectX12Backend>::SHADER = "dxi"; // NOLINT(bugprone-throwing-static-initialization)
 #endif // LITEFX_BUILD_DIRECTX_12_BACKEND
 
 template<typename TRenderBackend> requires
@@ -182,7 +184,7 @@ void SampleApp::initBuffers(IRenderBackend* /*backend*/)
     auto blasBuffer = m_device->factory().createBuffer("BLAS", BufferType::AccelerationStructure, ResourceHeap::Resource, static_cast<size_t>(reflectiveOffset + reflectiveSize), 1u, ResourceUsage::AllowWrite);
 
     // Orient instances randomly.
-    std::srand(static_cast<UInt32>(std::time(nullptr)));
+    std::srand(static_cast<UInt32>(std::time(nullptr))); // NOLINT(bugprone-random-generator-seed)
 
     // NOLINTBEGIN(cppcoreguidelines-avoid-magic-numbers)
     auto tlas = m_device->factory().createTopLevelAccelerationStructure("TLAS", AccelerationStructureFlags::AllowCompaction | AccelerationStructureFlags::MinimizeMemory);

--- a/src/Samples/RenderPasses/src/sample.cpp
+++ b/src/Samples/RenderPasses/src/sample.cpp
@@ -281,11 +281,7 @@ void SampleApp::onInit()
         m_viewport = makeShared<Viewport>(RectF(0.f, 0.f, static_cast<Float>(width), static_cast<Float>(height)));
         m_scissor = makeShared<Scissor>(RectF(0.f, 0.f, static_cast<Float>(width), static_cast<Float>(height)));
 
-        auto adapter = backend->findAdapter(m_adapterId);
-
-        if (adapter == nullptr)
-            adapter = backend->findAdapter(std::nullopt);
-
+        auto adapter = m_adapterId.has_value() ? backend->findAdapter(m_adapterId) : backend->findAdapter(GpuPreference::Performance);
         auto surface = backend->createSurface(::glfwGetWin32Window(window));
 
         // Create the device.

--- a/src/Samples/RenderPasses/src/sample.cpp
+++ b/src/Samples/RenderPasses/src/sample.cpp
@@ -1,12 +1,13 @@
 #include "sample.h"
 #include <glm/gtc/matrix_transform.hpp>
 
-enum DescriptorSets : UInt32 // NOLINT(performance-enum-size)
+enum DescriptorSets : UInt32 // NOLINT(performance-enum-size, cppcoreguidelines-use-enum-class)
 {
     Constant = 0,                                       // All buffers that are immutable.
     PerFrame = 1,                                       // All buffers that are updated each frame.
 };
 
+// NOLINTBEGIN(bugprone-throwing-static-initialization)
 const Array<Vertex> vertices =
 {
     { { -0.5f, -0.5f, 0.5f }, { 1.0f, 0.0f, 0.0f, 1.0f }, { 0.0f, 0.0f, 0.0f }, { 0.0f, 0.0f } },
@@ -27,6 +28,7 @@ const Array<Vertex> viewPlaneVertices =
 
 const Array<UInt16> viewPlaneIndices = { 0, 1, 2, 1, 3, 2 };
 
+// NOLINTEND(bugprone-throwing-static-initialization)
 // NOLINTBEGIN(cppcoreguidelines-avoid-non-const-global-variables)
 
 struct CameraBuffer {
@@ -47,11 +49,11 @@ struct FileExtensions {
 
 #ifdef LITEFX_BUILD_VULKAN_BACKEND
 template<>
-const String FileExtensions<VulkanBackend>::SHADER = "spv";
+const String FileExtensions<VulkanBackend>::SHADER = "spv"; // NOLINT(bugprone-throwing-static-initialization)
 #endif // LITEFX_BUILD_VULKAN_BACKEND
 #ifdef LITEFX_BUILD_DIRECTX_12_BACKEND
 template<>
-const String FileExtensions<DirectX12Backend>::SHADER = "dxi";
+const String FileExtensions<DirectX12Backend>::SHADER = "dxi"; // NOLINT(bugprone-throwing-static-initialization)
 #endif // LITEFX_BUILD_DIRECTX_12_BACKEND
 
 template<typename TRenderBackend> requires

--- a/src/Samples/ResourceAliasing/src/sample.cpp
+++ b/src/Samples/ResourceAliasing/src/sample.cpp
@@ -272,11 +272,7 @@ void SampleApp::onInit()
         m_viewport = makeShared<Viewport>(RectF(0.f, 0.f, static_cast<Float>(width), static_cast<Float>(height)));
         m_scissor = makeShared<Scissor>(RectF(0.f, 0.f, static_cast<Float>(width), static_cast<Float>(height)));
 
-        auto adapter = backend->findAdapter(m_adapterId);
-
-        if (adapter == nullptr)
-            adapter = backend->findAdapter(std::nullopt);
-
+        auto adapter = m_adapterId.has_value() ? backend->findAdapter(m_adapterId) : backend->findAdapter(GpuPreference::Performance);
         auto surface = backend->createSurface(::glfwGetWin32Window(window));
 
         // Create the device.

--- a/src/Samples/ResourceAliasing/src/sample.cpp
+++ b/src/Samples/ResourceAliasing/src/sample.cpp
@@ -1,12 +1,13 @@
 #include "sample.h"
 #include <glm/gtc/matrix_transform.hpp>
 
-enum DescriptorSets : UInt32 // NOLINT(performance-enum-size)
+enum DescriptorSets : UInt32 // NOLINT(performance-enum-size, cppcoreguidelines-use-enum-class)
 {
     Constant = 0,                                       // All buffers that are immutable.
     PerFrame = 1,                                       // All buffers that are updated each frame.
 };
 
+// NOLINTBEGIN(bugprone-throwing-static-initialization)
 const Array<Vertex> vertices =
 {
     { { -0.5f, -0.5f, 0.5f }, { 1.0f, 0.0f, 0.0f, 1.0f }, { 0.0f, 0.0f, 0.0f }, { 0.0f, 0.0f } },
@@ -27,6 +28,7 @@ const Array<Vertex> viewPlaneVertices =
 
 const Array<UInt16> viewPlaneIndices = { 0, 1, 2, 1, 3, 2 };
 
+// NOLINTEND(bugprone-throwing-static-initialization)
 // NOLINTBEGIN(cppcoreguidelines-avoid-non-const-global-variables)
 
 struct CameraBuffer {
@@ -47,11 +49,11 @@ struct FileExtensions {
 
 #ifdef LITEFX_BUILD_VULKAN_BACKEND
 template<>
-const String FileExtensions<VulkanBackend>::SHADER = "spv";
+const String FileExtensions<VulkanBackend>::SHADER = "spv"; // NOLINT(bugprone-throwing-static-initialization)
 #endif // LITEFX_BUILD_VULKAN_BACKEND
 #ifdef LITEFX_BUILD_DIRECTX_12_BACKEND
 template<>
-const String FileExtensions<DirectX12Backend>::SHADER = "dxi";
+const String FileExtensions<DirectX12Backend>::SHADER = "dxi"; // NOLINT(bugprone-throwing-static-initialization)
 #endif // LITEFX_BUILD_DIRECTX_12_BACKEND
 
 template <typename TRenderBackend> requires

--- a/src/Samples/ResourceAliasing/src/sample.h
+++ b/src/Samples/ResourceAliasing/src/sample.h
@@ -133,8 +133,8 @@ public:
 		auto resources = m_device->factory().allocate(resourceInfos, AllocationBehavior::Default, canAlias)
 			| std::views::take(2)
 			| std::ranges::to<std::vector>();
-		m_depthBuffer = resources[0].image<const IImage>();
-		m_postColorBuffer = resources[1].image<const IImage>();
+		m_depthBuffer = resources[0].image<const IImage>(); // NOLINT(cppcoreguidelines-pro-bounds-avoid-unchecked-container-access)
+		m_postColorBuffer = resources[1].image<const IImage>(); // NOLINT(cppcoreguidelines-pro-bounds-avoid-unchecked-container-access)
 	}
 
 	void onFrameBufferResizing(const void* /*sender*/, const IFrameBuffer::ResizeEventArgs& e) {

--- a/src/Samples/Textures/src/sample.cpp
+++ b/src/Samples/Textures/src/sample.cpp
@@ -4,12 +4,13 @@
 #include "sample.h"
 #include <glm/gtc/matrix_transform.hpp>
 
-enum DescriptorSets : UInt32 // NOLINT(performance-enum-size)
+enum DescriptorSets : UInt32 // NOLINT(performance-enum-size, cppcoreguidelines-use-enum-class)
 {
     Constant = 0,                                       // All buffers that are immutable.
     PerFrame = 1,                                       // All buffers that are updated each frame.
 };
 
+// NOLINTBEGIN(bugprone-throwing-static-initialization)
 const Array<Vertex> vertices =
 {
     { { -0.5f, -0.5f, 0.0f }, { 1.0f, 1.0f, 0.0f, 1.0f }, { 0.0f, 0.0f, 0.0f }, { 0.0f, 0.0f } },
@@ -20,6 +21,7 @@ const Array<Vertex> vertices =
 
 const Array<UInt16> indices = { 2, 1, 0, 3, 2, 0 };
 
+// NOLINTEND(bugprone-throwing-static-initialization)
 // NOLINTBEGIN(cppcoreguidelines-avoid-non-const-global-variables)
 
 struct CameraBuffer {
@@ -40,11 +42,11 @@ struct FileExtensions {
 
 #ifdef LITEFX_BUILD_VULKAN_BACKEND
 template<>
-const String FileExtensions<VulkanBackend>::SHADER = "spv";
+const String FileExtensions<VulkanBackend>::SHADER = "spv"; // NOLINT(bugprone-throwing-static-initialization)
 #endif // LITEFX_BUILD_VULKAN_BACKEND
 #ifdef LITEFX_BUILD_DIRECTX_12_BACKEND
 template<>
-const String FileExtensions<DirectX12Backend>::SHADER = "dxi";
+const String FileExtensions<DirectX12Backend>::SHADER = "dxi"; // NOLINT(bugprone-throwing-static-initialization)
 #endif // LITEFX_BUILD_DIRECTX_12_BACKEND
 
 template<typename TRenderBackend> requires

--- a/src/Samples/Textures/src/sample.cpp
+++ b/src/Samples/Textures/src/sample.cpp
@@ -275,11 +275,7 @@ void SampleApp::onInit()
         m_viewport = makeShared<Viewport>(RectF(0.f, 0.f, static_cast<Float>(width), static_cast<Float>(height)));
         m_scissor = makeShared<Scissor>(RectF(0.f, 0.f, static_cast<Float>(width), static_cast<Float>(height)));
 
-        auto adapter = backend->findAdapter(m_adapterId);
-
-        if (adapter == nullptr)
-            adapter = backend->findAdapter(std::nullopt);
-
+        auto adapter = m_adapterId.has_value() ? backend->findAdapter(m_adapterId) : backend->findAdapter(GpuPreference::Performance);
         auto surface = backend->createSurface(::glfwGetWin32Window(window));
 
         // Create the device.

--- a/src/Samples/UniformArrays/src/sample.cpp
+++ b/src/Samples/UniformArrays/src/sample.cpp
@@ -261,11 +261,7 @@ void SampleApp::onInit()
         m_viewport = makeShared<Viewport>(RectF(0.f, 0.f, static_cast<Float>(width), static_cast<Float>(height)));
         m_scissor = makeShared<Scissor>(RectF(0.f, 0.f, static_cast<Float>(width), static_cast<Float>(height)));
 
-        auto adapter = backend->findAdapter(m_adapterId);
-
-        if (adapter == nullptr)
-            adapter = backend->findAdapter(std::nullopt);
-
+        auto adapter = m_adapterId.has_value() ? backend->findAdapter(m_adapterId) : backend->findAdapter(GpuPreference::Performance);
         auto surface = backend->createSurface(::glfwGetWin32Window(window));
 
         // Create the device.

--- a/src/Samples/UniformArrays/src/sample.cpp
+++ b/src/Samples/UniformArrays/src/sample.cpp
@@ -3,11 +3,15 @@
 
 constexpr UInt32 LIGHT_SOURCES = 8;
 
-enum DescriptorSets : UInt32 // NOLINT(performance-enum-size)
+enum DescriptorSets : UInt32 // NOLINT(performance-enum-size, cppcoreguidelines-use-enum-class)
 {
     Constant = 0,                                       // All buffers that are immutable.
     PerFrame = 1,                                       // All buffers that are updated each frame.
 };
+
+// NOLINTBEGIN(bugprone-throwing-static-initialization)
+// NOLINTBEGIN(cppcoreguidelines-avoid-non-const-global-variables)
+// NOLINTBEGIN(cppcoreguidelines-avoid-magic-numbers)
 
 const Array<Vertex> vertices =
 {
@@ -46,9 +50,6 @@ const Array<UInt16> indices = {
     20, 22, 21, 21, 22, 23  // Top
 };
 
-// NOLINTBEGIN(cppcoreguidelines-avoid-non-const-global-variables)
-// NOLINTBEGIN(cppcoreguidelines-avoid-magic-numbers)
-
 struct CameraBuffer {
     glm::mat4 ViewProjection;
     glm::vec4 Position;
@@ -75,6 +76,7 @@ struct LightBuffer { // NOLINT(cppcoreguidelines-avoid-c-arrays)
 
 // NOLINTEND(cppcoreguidelines-avoid-magic-numbers)
 // NOLINTEND(cppcoreguidelines-avoid-non-const-global-variables)
+// NOLINTEND(bugprone-throwing-static-initialization)
 
 template<typename TRenderBackend> requires
     meta::implements<TRenderBackend, IRenderBackend>
@@ -84,11 +86,11 @@ struct FileExtensions {
 
 #ifdef LITEFX_BUILD_VULKAN_BACKEND
 template<>
-const String FileExtensions<VulkanBackend>::SHADER = "spv";
+const String FileExtensions<VulkanBackend>::SHADER = "spv"; // NOLINT(bugprone-throwing-static-initialization)
 #endif // LITEFX_BUILD_VULKAN_BACKEND
 #ifdef LITEFX_BUILD_DIRECTX_12_BACKEND
 template<>
-const String FileExtensions<DirectX12Backend>::SHADER = "dxi";
+const String FileExtensions<DirectX12Backend>::SHADER = "dxi"; // NOLINT(bugprone-throwing-static-initialization)
 #endif // LITEFX_BUILD_DIRECTX_12_BACKEND
 
 template<typename TRenderBackend> requires


### PR DESCRIPTION
**Describe the pull request**

Currently the preferred adapter returned from `IRenderBackend::findAdapter()` was undefined. It simply returned the first adapter, the driver provided, if no explicit adapter ID was specified. This PR adds a new overload to this method, that can be parameterized with a `GpuPreference`. Internally this maps to a DXGI preference setting. Under Windows, this returns the preferred GPU for the provided setting. Vulkan does not provide a way to query adapter preferences currently, so it requires the DirectX 12 backend to be enabled. If it is, it uses DXGI to query the preferred adapter and obtains its LUID. Based on this identifier, it then queries the physical device through the Vulkan interface. If the DirectX 12 backend is not available, the function ignores the preference parameter and behaves like passing `std::nullopt` into `findAdapter`.